### PR TITLE
Add tab selection shortcuts

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -7,8 +7,8 @@ const electron = require('electron')
 const ipcMain = electron.ipcMain
 const app = electron.app
 const BrowserWindow = electron.BrowserWindow
-const electronLocalshortcut = require('electron-localshortcut')
 const Menu = require('./menu')
+const LocalShortcuts = require('./localShortcuts')
 
 // Report crashes
 electron.crashReporter.start()
@@ -62,30 +62,6 @@ app.on('ready', function () {
   ipcMain.on('close-window', () => BrowserWindow.getFocusedWindow().close())
   process.on('close-window', () => BrowserWindow.getFocusedWindow().close())
 
-  // Most of these events will simply be listened to by the app store and acted
-  // upon.  However sometimes there are no state changes, for example with focusing
-  // the URL bar.  In those cases it's acceptable for the individual components to
-  // listen to the events.
-  const simpleWebContentEvents = [
-    ['CmdOrCtrl+L', 'shortcut-focus-url'],
-    ['Escape', 'shortcut-stop'],
-    ['Ctrl+Tab', 'shortcut-next-tab'],
-    ['Ctrl+Shift+Tab', 'shortcut-prev-tab'],
-    ['CmdOrCtrl+R', 'shortcut-reload'],
-    ['CmdOrCtrl+=', 'shortcut-zoom-in'],
-    ['CmdOrCtrl+-', 'shortcut-zoom-out'],
-    ['CmdOrCtrl+0', 'shortcut-zoom-reset'],
-    ['CmdOrCtrl+Alt+I', 'shortcut-toggle-dev-tools']
-  ]
-
-  simpleWebContentEvents.forEach((shortcutEventName) =>
-    electronLocalshortcut.register(shortcutEventName[0], () => {
-      BrowserWindow.getFocusedWindow().webContents.send(shortcutEventName[1])
-    }))
-
-  electronLocalshortcut.register('CmdOrCtrl+Shift+J', () => {
-    BrowserWindow.getFocusedWindow().toggleDevTools()
-  })
-
   Menu.init()
+  LocalShortcuts.init()
 })

--- a/app/localShortcuts.js
+++ b/app/localShortcuts.js
@@ -1,0 +1,41 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const electron = require('electron')
+const BrowserWindow = electron.BrowserWindow
+const electronLocalshortcut = require('electron-localshortcut')
+
+module.exports.init = () => {
+  // Most of these events will simply be listened to by the app store and acted
+  // upon.  However sometimes there are no state changes, for example with focusing
+  // the URL bar.  In those cases it's acceptable for the individual components to
+  // listen to the events.
+  const simpleWebContentEvents = [
+    ['CmdOrCtrl+L', 'shortcut-focus-url'],
+    ['Escape', 'shortcut-stop'],
+    ['Ctrl+Tab', 'shortcut-next-tab'],
+    ['Ctrl+Shift+Tab', 'shortcut-prev-tab'],
+    ['CmdOrCtrl+R', 'shortcut-reload'],
+    ['CmdOrCtrl+=', 'shortcut-zoom-in'],
+    ['CmdOrCtrl+-', 'shortcut-zoom-out'],
+    ['CmdOrCtrl+0', 'shortcut-zoom-reset'],
+    ['CmdOrCtrl+Alt+I', 'shortcut-toggle-dev-tools'],
+    ['CmdOrCtrl+9', 'shortcut-set-active-frame-to-last']
+  ]
+
+  // Tab ordering shortcuts
+  Array.from(new Array(8), (x, i) => i).reduce((list, i) => {
+    list.push(['CmdOrCtrl+' + String(i + 1), 'shortcut-set-active-frame-by-index', i])
+    return list
+  }, simpleWebContentEvents)
+
+  simpleWebContentEvents.forEach((shortcutEventName) =>
+    electronLocalshortcut.register(shortcutEventName[0], () => {
+      BrowserWindow.getFocusedWindow().webContents.send(shortcutEventName[1], shortcutEventName[2])
+    }))
+
+  electronLocalshortcut.register('CmdOrCtrl+Shift+J', () => {
+    BrowserWindow.getFocusedWindow().toggleDevTools()
+  })
+}

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -103,6 +103,9 @@ const AppActions = {
   },
 
   setActiveFrame: function (frameProps) {
+    if (!frameProps) {
+      return
+    }
     AppDispatcher.dispatch({
       actionType: AppConstants.APP_SET_ACTIVE_FRAME,
       frameProps: frameProps

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -42,6 +42,13 @@ class Main extends ImmutableComponent {
 
     ipc.on('shortcut-close-frame', () =>
       AppActions.closeFrame())
+
+    const self = this
+    ipc.on('shortcut-set-active-frame-by-index', (e, i) =>
+      AppActions.setActiveFrame(FrameStateUtil.getFrameByIndex(self.props.browser, i)))
+
+    ipc.on('shortcut-set-active-frame-to-last', () =>
+      AppActions.setActiveFrame(self.props.browser.getIn(['frames', self.props.browser.get('frames').size - 1])))
   }
 
   get activeFrame () {


### PR DESCRIPTION
This adds CmdOrCtrl+1 to CmdOrCtrl+8 for selecting
one of the first 8 tabs and CmdOrCtrl+9 for selecting
the last tab.  It also pulls out the shortcuts code into
its own file.

@diracdeltas please review.
