### PR TITLE
add cmd+shift+][ shortcuts for tab navigation to match chrome, safari…

### DIFF
--- a/app/localShortcuts.js
+++ b/app/localShortcuts.js
@@ -16,6 +16,8 @@ module.exports.init = () => {
     ['Escape', 'shortcut-stop'],
     ['Ctrl+Tab', 'shortcut-next-tab'],
     ['Ctrl+Shift+Tab', 'shortcut-prev-tab'],
+    ['CmdOrCtrl+Shift+]', 'shortcut-next-tab'],
+    ['CmdOrCtrl+Shift+[', 'shortcut-prev-tab'],
     ['CmdOrCtrl+R', 'shortcut-reload'],
     ['CmdOrCtrl+=', 'shortcut-zoom-in'],
     ['CmdOrCtrl+-', 'shortcut-zoom-out'],


### PR DESCRIPTION
These shortcuts work for every browser on the mac, but not sure if windows has an equivalent ctrl+shift+][ ? 
@bradleyrichter please review
