### PR TITLE
Add better URL detection

### DIFF
--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -12,7 +12,8 @@ const cx = require('../lib/classSet.js')
 const ipc = global.require('electron').ipcRenderer
 
 const UrlBarSuggestions = require('./urlBarSuggestions.js')
-const UrlUtil = require('./../../node_modules/urlutil.js/dist/node-urlutil.js')
+
+import {isUrl} from '../lib/appUrlUtil.js'
 
 class UrlBar extends ImmutableComponent {
   constructor () {
@@ -92,8 +93,7 @@ class UrlBar extends ImmutableComponent {
           if (this.suggestionsShown && selectedIndex > 0) {
             // load the selected suggestion
             this.refs.urlBarSuggestions.clickSelected()
-          } else if (this.props.searchSuggestions &&
-                     (!UrlUtil.isURL(location) || location.includes(' '))) {
+          } else if (this.props.searchSuggestions && !isUrl(location)) {
             // do search.
             AppActions.loadUrl(this.props.searchDetail.get('searchURL').replace('{searchTerms}', location))
           } else {

--- a/js/components/urlBarSuggestions.js
+++ b/js/components/urlBarSuggestions.js
@@ -7,11 +7,10 @@ const ReactDOM = require('react-dom')
 
 const AppActions = require('../actions/appActions')
 const ImmutableComponent = require('./immutableComponent')
-const UrlUtil = require('./../../node_modules/urlutil.js/dist/node-urlutil.js')
 
 import Config from '../constants/config.js'
 import top500 from './../data/top500.js'
-import {isSourceAboutUrl} from '../lib/appUrlUtil.js'
+import {isSourceAboutUrl, isUrl} from '../lib/appUrlUtil.js'
 import Immutable from 'immutable'
 import debounce from '../lib/debounce.js'
 import {getSiteIconClass} from '../lib/siteUtil.js'
@@ -207,7 +206,7 @@ class UrlBarSuggestions extends ImmutableComponent {
     }
 
     let urlLocation = this.props.urlLocation
-    if (!UrlUtil.isURL(urlLocation) && urlLocation.length > 0) {
+    if (!isUrl(urlLocation) && urlLocation.length > 0) {
       let xhr = new window.XMLHttpRequest({mozSystem: true})
       xhr.open('GET', this.props.searchDetail.get('autocompleteURL')
         .replace('{searchTerms}', urlLocation), true)

--- a/js/lib/appUrlUtil.js
+++ b/js/lib/appUrlUtil.js
@@ -3,6 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const Immutable = require('immutable')
+const UrlUtil = require('./../../node_modules/urlutil.js/dist/node-urlutil.js')
 
 /**
  * Determines the path of a relative URL from the hosted app
@@ -75,4 +76,12 @@ export function isTargetAboutUrl (input) {
  */
 export function isPrivilegedUrl (input) {
   return isSourceAboutUrl(input)
+}
+
+/**
+ * Determines whether a string is a valid URL. Based on node-urlutil.js.
+ * @param {string} input
+ */
+export function isUrl (input) {
+  return (UrlUtil.isURL(input) && !input.includes(' '))
 }


### PR DESCRIPTION
node-urlutil thinks that spaces are valid in URLs, so multi-word searches were
not working before.

Auditors: @bbondy
