### PR TITLE
Configure crash handling

### DIFF
--- a/app/appConfig.js
+++ b/app/appConfig.js
@@ -5,6 +5,7 @@
 // UPDATE_HOST should be set to the host name for the auto-updater server
 var updateHost = process.env.UPDATE_HOST || 'https://brave-laptop-updates.global.ssl.fastly.net'
 var winUpdateHost = process.env.WIN_UPDATE_HOST || 'https://brave-download.global.ssl.fastly.net'
+var crashURL = process.env.CRASH_URL || 'https://laptop-updates.brave.com/1/crashes'
 
 module.exports = {
   adblock: {
@@ -18,6 +19,9 @@ module.exports = {
     version: 1,
     msBetweenRechecks: 1000 * 60 * 60 * 24, // 1 day
     enabled: true
+  },
+  crashes: {
+    crashSubmitUrl: crashURL
   },
   updates: {
     // Check for front end updates every hour

--- a/app/crash-herald.js
+++ b/app/crash-herald.js
@@ -1,0 +1,17 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const config = require('./appConfig')
+const crashReporter = require('electron').crashReporter
+
+exports.init = () => {
+  const options = {
+    productName: 'Brave Developers',
+    companyName: 'Brave.com',
+    submitURL: config.crashes.crashSubmitUrl,
+    autoSubmit: true,
+    ignoreSystemCrashHandler: true
+  }
+  crashReporter.start(options)
+}

--- a/app/index.js
+++ b/app/index.js
@@ -23,9 +23,7 @@ const messages = require('../js/constants/messages')
 const AppActions = require('../js/actions/appActions')
 const SessionStore = require('./sessionStore')
 const AppStore = require('../js/stores/appStore')
-
-// Report crashes
-electron.crashReporter.start()
+const CrashHerald = require('./crash-herald.js')
 
 app.on('window-all-closed', function () {
   // On OS X it is common for applications and their menu bar
@@ -115,6 +113,9 @@ app.on('ready', function () {
     ipcMain.on(messages.UPDATE_REQUESTED, () => {
       Updater.update()
     })
+
+    // Setup the crash handling
+    CrashHerald.init()
 
     // this only works on prod
     if (process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test') {

--- a/app/menu.js
+++ b/app/menu.js
@@ -35,6 +35,13 @@ const init = () => {
             process.emit(messages.CHECK_FOR_UPDATE)
           }
         },
+// Note: we are keeping this here for testing. Calling process.crash() from the inspector does not create a crash report.
+//        {
+//          label: 'Crash!!!!!',
+//          click: function (item, focusedWindow) {
+//            process.crash()
+//          }
+//        },
         {
           label: 'New Tab',
           accelerator: 'CmdOrCtrl+T',


### PR DESCRIPTION
- Initialize crash handling
- Send crash reports to Heroku bypassing Fastly
