### PR TITLE
Add nsp security check

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,3 @@
+{
+  "exceptions": ["https://nodesecurity.io/advisories/77"]
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "description": "Brave laptop and desktop browser",
   "main": "./app/index.js",
   "scripts": {
+    "checks": "npm run check-security",
+    "check-security": "nsp check",
     "start": "node ./tools/start.js --debug=5858 -enable-logging --v=0 --enable-dcheck",
     "start-brk": "node ./tools/start.js --debug-brk=5858 -enable-logging --v=0 --enable-dcheck",
     "watch-all": "npm run watch & npm run watch-test",
@@ -94,6 +96,8 @@
     "node-libs-browser": "^0.5.3",
     "node-static": "^0.7.7",
     "node-uuid": "^1.4.7",
+    "npm": "3.4.1",
+    "nsp": "^2.2.0",
     "pre-commit": "^1.1.2",
     "spectron": "^0.36.0",
     "standard": "^5.4.1",
@@ -102,7 +106,6 @@
     "webpack": "^1.12.9",
     "webpack-dev-server": "^1.14.0",
     "webpack-notifier": "^1.2.1",
-    "npm": "3.4.1",
     "xml2js": "^0.4.15"
   },
   "standard": {


### PR DESCRIPTION
- "checks" script (to run all checks assuming others might be added in
the future)
- "check-security" script runs nsp
- nsp exception for [advisory 77](https://nodesecurity.io/advisories/77), because [request](/request/request) is [currently blocking](https://github.com/request/request/issues/2020)
updating to hawk 4.1.1 and the affected modules shouldn't impact
overall security for the end user