### PR TITLE
Integrate NSP security checks into build scripts

### DIFF
--- a/build-darwin.js
+++ b/build-darwin.js
@@ -15,6 +15,7 @@ var cmds = [
   'rm -rf Brave-darwin-x64',
   'NODE_ENV=production ./node_modules/.bin/webpack',
   'rm -f dist/Brave.dmg',
+  'npm run checks',
   './node_modules/electron-packager/cli.js . Brave --overwrite --ignore="electron-download|electron-rebuild|electron-packager|electron-builder|electron-prebuilt|electron-rebuild|babel$|babel-(?!polyfill|regenerator-runtime)" --platform=darwin --arch=x64 --version=' + electronVersion + ' --icon=res/app.icns --app-version=' + version + ' --build-version=' + electronVersion + ' --protocol="http" --protocol-name="HTTP Handler" --protocol="https" --protocol-name="HTTPS Handler"'
 ]
 

--- a/build-win64.js
+++ b/build-win64.js
@@ -14,6 +14,7 @@ console.log('Building version ' + version + ' in Brave-win32-x64 with Electron '
 var cmds = [
   'rm -rf Brave-win32-x64',
   'set NODE_ENV=production&&"./node_modules/.bin/webpack"',
+  'npm run checks',
   'node node_modules/electron-packager/cli.js . Brave --ignore=\"electron-packager|electron-builder|electron-prebuilt|electron-rebuild|win64-dist|babel$|babel-(?!polyfill|regenerator-runtime)\" --platform=win32 --arch=x64 --version=' + electronVersion + ' --icon=res/app.ico --asar=true --app-version=' + version + ' --version-string.CompanyName=\"Brave Inc.\" --version-string.ProductName=\"Brave\" --version-string.Copyright=\"Copyright 2016, Brave Inc.\" --version-string.FileDescription=\"Brave\"'
 ]
 


### PR DESCRIPTION
@bbondy @yan this adds the NSP security checks into both the OSx and win64 build scripts. Tested build on both platforms.