### PR TITLE
Fixed #200: add "engines" field to package.json to indicate node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,5 +120,9 @@
   },
   "pre-commit": [
     "lint"
-  ]
+  ],
+  "engineStrict": true,
+  "engines": {
+    "node": ">= 5.0.0"
+  }
 }


### PR DESCRIPTION
Noted, this field can't avoid user to install it with wrong version of node, so it just indicates what version of node we should use.

reference: http://www.marcusoft.net/2015/03/packagejson-and-engines-and-enginestrict.html