### PR TITLE
Pre-requisite link 404 corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Laptop and Desktop browser for OS X, Windows and Linux.
 
 ## Installation
 
-Make sure you have all of the pre-requisite compilers/applications [Installed](https://github.com/brave/browser-laptop/docs/prerequisites.md)
+Make sure you have all of the pre-requisite compilers/applications [Installed](https://github.com/brave/browser-laptop/blob/master/docs/prerequisites.md)
 
 1. Shallow clone the git repository from GitHub:
         


### PR DESCRIPTION
There was a 404 error when I navigate to pre-requisites configuration link. Added correct url to the link.