### PR TITLE
Remove dependency on gnu rm for Windows builds

### DIFF
--- a/tools/buildPackage.js
+++ b/tools/buildPackage.js
@@ -19,24 +19,33 @@ var env = {
   NODE_ENV: 'production'
 }
 
-console.log('Cleaning build target')
+var cmds = ['echo cleaning up target...']
 
 if (isWindows) {
-  var cmds = [
-    'if exist ' + buildDir + ' rmdir /s /q ' + buildDir,
-  ]
-  execute(cmds, env, console.log.bind(null, 'done'))
+  cmds = cmds.concat([
+    '(if exist ' + buildDir + ' rmdir /s /q ' + buildDir + ')',
+    '(if exist dist\*.dmg del /q dist\*.dmg)',
+    '(if exist dist\*.nupkg del /q dist\*.nupkg)',
+    '(if exist dist\*.exe del /q dist\*.exe)',
+    '(if exist dist\*.msi del /q dist\*.msi)',
+    '(if exist dist\RELEASES del /q dist\RELEASES)',
+    '(if exist dist\*.zip del /q dist\*.zip)'
+  ])
 } else {
-  var cmds = [
+  cmds = cmds.concat([
     'rm -rf ' + buildDir,
-    'rm -f dist/*.dmg dist/*.nupkg dist/*.exe dist/*.msi dist/RELEASES dist/*.zip',
-  ]
-  execute(cmds, env, console.log.bind(null, 'done'))
+    'rm -f dist/*.dmg dist/*.nupkg dist/*.exe dist/*.msi dist/RELEASES dist/*.zip'
+  ])
 }
+
+cmds = cmds.concat([
+  'echo done',
+  'echo starting build...'
+])
 
 console.log('Building version ' + VersionInfo.braveVersion + ' in ' + buildDir + ' with Electron ' + VersionInfo.electronVersion)
 
-var cmds = [
+cmds = cmds.concat([
   '"./node_modules/.bin/webpack"',
   'npm run checks',
   'node ./node_modules/electron-packager/cli.js . Brave' +
@@ -55,6 +64,6 @@ var cmds = [
     ' --version-string.ProductName=\"Brave\"' +
     ' --version-string.Copyright=\"Copyright 2016, Brave Inc.\"' +
     ' --version-string.FileDescription=\"Brave\"'
-]
+])
 
 execute(cmds, env, console.log.bind(null, 'done'))

--- a/tools/buildPackage.js
+++ b/tools/buildPackage.js
@@ -19,11 +19,24 @@ var env = {
   NODE_ENV: 'production'
 }
 
+console.log('Cleaning build target')
+
+if (isWindows) {
+  var cmds = [
+    'if exist ' + buildDir + ' rmdir /s /q ' + buildDir,
+  ]
+  execute(cmds, env, console.log.bind(null, 'done'))
+} else {
+  var cmds = [
+    'rm -rf ' + buildDir,
+    'rm -f dist/*.dmg dist/*.nupkg dist/*.exe dist/*.msi dist/RELEASES dist/*.zip',
+  ]
+  execute(cmds, env, console.log.bind(null, 'done'))
+}
+
 console.log('Building version ' + VersionInfo.braveVersion + ' in ' + buildDir + ' with Electron ' + VersionInfo.electronVersion)
 
 var cmds = [
-  'rm -rf ' + buildDir,
-  'rm -f dist/*.dmg dist/*.nupkg dist/*.exe dist/*.msi dist/RELEASES dist/*.zip',
   '"./node_modules/.bin/webpack"',
   'npm run checks',
   'node ./node_modules/electron-packager/cli.js . Brave' +


### PR DESCRIPTION
Windows doesn't have the gnu coreutils (including rm) by default, as such this script (which powers 'npm run build-package') cannot run successfully without the user first installing GnuWin or a similar tool bundle and wiring up the PATH environment variable to point to the location of the rm command.

This change removes the dependency on rm and uses Windows' own rmdir instead.

It also checks to see if any deletions are necessary by prefacing with 'if exist', and it eliminates all of the dist/* deletions, as they seemed unnecessary. (Perhaps they're required for other workflows I haven't got to yet, but on my Windows 10 machine, I never saw a dist folder created by the build.