### PR TITLE
Add backspace and shift-backspace for back/forward

### DIFF
--- a/app/content/webviewPreload.js
+++ b/app/content/webviewPreload.js
@@ -210,11 +210,32 @@ document.addEventListener('contextmenu', (e) => {
   e.preventDefault()
 }, false)
 
+var shiftDown = false
 document.onkeydown = (e) => {
   switch (e.keyCode) {
     case KeyCodes.ESC:
       e.preventDefault()
       ipc.send(messages.STOP_LOAD)
+      break
+    case KeyCodes.BACKSPACE:
+      const msg = shiftDown ? messages.GO_FORWARD : messages.GO_BACK
+      const elem = document.activeElement
+      if (elem.contentEditable !== 'true' &&
+          elem.nodeName !== 'INPUT' &&
+          elem.nodeName !== 'TEXTAREA') {
+        // TODO: find other node types where this shortcut should be disabled
+        ipc.send(msg)
+      }
+      break
+    case KeyCodes.SHIFT:
+      shiftDown = true
+      break
+  }
+}
+document.onkeyup = (e) => {
+  switch (e.keyCode) {
+    case KeyCodes.SHIFT:
+      shiftDown = false
       break
   }
 }

--- a/app/index.js
+++ b/app/index.js
@@ -134,6 +134,12 @@ app.on('ready', function () {
     ipcMain.on(messages.STOP_LOAD, () => {
       BrowserWindow.getFocusedWindow().webContents.send(messages.STOP_LOAD)
     })
+    ipcMain.on(messages.GO_BACK, () => {
+      BrowserWindow.getFocusedWindow().webContents.send(messages.GO_BACK)
+    })
+    ipcMain.on(messages.GO_FORWARD, () => {
+      BrowserWindow.getFocusedWindow().webContents.send(messages.GO_FORWARD)
+    })
 
     // Load HTTPS Everywhere browser "extension"
     HttpsEverywhere.init()

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -35,6 +35,14 @@ class Main extends ImmutableComponent {
     ipc.on(messages.STOP_LOAD, () => {
       electron.remote.getCurrentWebContents().send(messages.SHORTCUT_ACTIVE_FRAME_STOP)
     })
+    ipc.on(messages.GO_BACK, () => {
+      console.log('going back')
+      electron.remote.getCurrentWebContents().send(messages.SHORTCUT_ACTIVE_FRAME_BACK)
+    })
+    ipc.on(messages.GO_FORWARD, () => {
+      console.log('going forward')
+      electron.remote.getCurrentWebContents().send(messages.SHORTCUT_ACTIVE_FRAME_FORWARD)
+    })
     ipc.on(messages.CONTEXT_MENU_OPENED, (e, nodeProps) => {
       contextMenus.onMainContextMenu(nodeProps)
     })

--- a/js/constants/keyCodes.js
+++ b/js/constants/keyCodes.js
@@ -6,7 +6,9 @@ const KeyCodes = {
   ENTER: 13,
   ESC: 27,
   UP: 38,
-  DOWN: 40
+  DOWN: 40,
+  SHIFT: 16,
+  BACKSPACE: 8
 }
 
 module.exports = KeyCodes

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -55,6 +55,8 @@ const messages = {
   APP_STATE_CHANGE: _,
   APP_ACTION: _,
   STOP_LOAD: _,
+  GO_FORWARD: _,
+  GO_BACK: _,
   // Session restore
   REQUEST_WINDOW_STATE: _,
   RESPONSE_WINDOW_STATE: _,


### PR DESCRIPTION
This is somewhat flakey; pages can prevent us from triggering
the backspace listener. Not sure if it's worth merging now given
the complaints about page/local shortcuts overriding system
shortcuts on OS X.

Fix #192 