### PR TITLE
Send updater query parameters based on calendar date

### DIFF
--- a/app/dates.js
+++ b/app/dates.js
@@ -1,0 +1,5 @@
+const moment = require('moment')
+
+exports.todayYMD = () => {
+  return moment().format('YYYY-MM-DD')
+}

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -13,6 +13,7 @@ const LocalShortcuts = require('../../app/localShortcuts')
 const AppActions = require('../actions/appActions')
 const firstDefinedValue = require('../lib/functional').firstDefinedValue
 const Serializer = require('../dispatcher/serializer')
+const dates = require('../../app/dates')
 
 let appState
 
@@ -240,6 +241,8 @@ const handleAppAction = (action) => {
       break
     case AppConstants.APP_UPDATE_LAST_CHECK:
       appState = appState.setIn(['updates', 'lastCheckTimestamp'], (new Date()).getTime())
+      appState = appState.setIn(['updates', 'lastCheckYMD'], dates.todayYMD())
+      appState = appState.setIn(['updates', 'firstCheckMade'], true)
       appStore.emitChange()
       break
     case AppConstants.APP_SET_UPDATE_STATUS:

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "font-awesome": "^4.5.0",
     "font-awesome-webpack": "0.0.4",
     "immutable": "^3.7.5",
+    "moment": "^2.11.1",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
     "sqlite3": "^3.1.0",


### PR DESCRIPTION
  * Compare calendar dates when sending daily flag instead of 86400 seconds
  * Send first=true if first update request
  * Use moment.js for date handling