### PR TITLE
don't show loading spinner for 'about:' urls, prevents brief flicker …

### DIFF
--- a/docs/windowActions.md
+++ b/docs/windowActions.md
@@ -110,13 +110,15 @@ Sets a frame as pinned
 
 
 
-### onWebviewLoadStart(frameProps) 
+### onWebviewLoadStart(frameProps, indicateLoading) 
 
 Dispatches a message to the store to indicate that the webview is loading.
 
 **Parameters**
 
 **frameProps**: `Object`, The frame properties for the webview in question.
+
+**indicateLoading**: `boolean`, should a loading spinner be shown
 
 
 

--- a/js/actions/windowActions.js
+++ b/js/actions/windowActions.js
@@ -164,11 +164,13 @@ const WindowActions = {
    * Dispatches a message to the store to indicate that the webview is loading.
    *
    * @param {Object} frameProps - The frame properties for the webview in question.
+   * @param {boolean} indicateLoading - should a loading spinner be shown
    */
-  onWebviewLoadStart: function (frameProps) {
+  onWebviewLoadStart: function (frameProps, indicateLoading = true) {
     WindowDispatcher.dispatch({
       actionType: WindowConstants.WINDOW_WEBVIEW_LOAD_START,
-      frameProps
+      frameProps,
+      indicateLoading
     })
   },
 

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -163,12 +163,13 @@ class Frame extends ImmutableComponent {
     this.webview.addEventListener('load-commit', (event) => {
       if (event.isMainFrame) {
         // TODO: These 3 events should be combined into one
-        WindowActions.onWebviewLoadStart(
-          this.props.frame)
+        const protocol = urlParse(event.url).protocol
+        const indicateLoading = protocol !== 'about:'
+        WindowActions.onWebviewLoadStart(this.props.frame, indicateLoading)
         const key = this.props.frame.get('key')
         WindowActions.setLocation(event.url, key)
         WindowActions.setSecurityState({
-          secure: urlParse(event.url).protocol === 'https:'
+          secure: protocol === 'https:'
           // TODO: Set extended validation once Electron exposes this
         })
       }

--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -111,7 +111,8 @@ class Tab extends ImmutableComponent {
 
   get loading () {
     return this.props.frameProps &&
-    this.props.frameProps.get('loading')
+    this.props.frameProps.get('loading') &&
+    !this.props.frameProps.get('location').startsWith('about:')
   }
 
   onMouseLeave () {

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -173,7 +173,7 @@ const doAction = (action) => {
       break
     case WindowConstants.WINDOW_WEBVIEW_LOAD_START:
       windowState = windowState.mergeIn(['frames', FrameStateUtil.getFramePropsIndex(windowState.get('frames'), action.frameProps)], {
-        loading: true,
+        loading: action.indicateLoading,
         startLoadTime: new Date().getTime(),
         endLoadTime: null
       })


### PR DESCRIPTION
…on new tab creation mentioned in https://github.com/brave/browser-laptop/issues/481