### PR TITLE
don't show loading spinner for 'about:' urls, prevents brief flicker …

### DIFF
--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -111,7 +111,8 @@ class Tab extends ImmutableComponent {
 
   get loading () {
     return this.props.frameProps &&
-    this.props.frameProps.get('loading')
+    this.props.frameProps.get('loading') &&
+    !this.props.frameProps.get('location').startsWith('about:')
   }
 
   onMouseLeave () {


### PR DESCRIPTION
…on new tab creation, from #481 