### PR TITLE
fix tab loading spinner width; prevent tab title jump after loading f…

### DIFF
--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -142,7 +142,11 @@ class Tab extends ImmutableComponent {
 
   render () {
     // Style based on theme-color
-    let iconStyle = {}
+    const iconSize = 16
+    let iconStyle = {
+      minWidth: iconSize,
+      width: iconSize
+    }
     const activeTabStyle = {}
     const backgroundColor = this.props.frameProps.get('themeColor') || this.props.frameProps.get('computedThemeColor')
     if (this.props.isActive && backgroundColor) {
@@ -155,13 +159,11 @@ class Tab extends ImmutableComponent {
     }
 
     if (!this.loading) {
-      iconStyle = {
+      iconStyle = Object.assign(iconStyle, {
         backgroundImage: `url(${getFavicon(this.props.frameProps)})`,
-        backgroundSize: 16,
-        width: 16,
-        minWidth: 16,
-        height: 16
-      }
+        backgroundSize: iconSize,
+        height: iconSize
+      })
     }
 
     let playIcon = null

--- a/less/tabs.less
+++ b/less/tabs.less
@@ -67,6 +67,7 @@
     font-size: 12px;
     margin-left: 4px;
     margin-right: 4px;
+    text-align: center;
   }
 
   .privateIcon {


### PR DESCRIPTION
…avicon - https://github.com/brave/browser-laptop/issues/536

Set width for loading spinner as well as favicon. Untested for window.devicePixelRatio > 1

