### PR TITLE
Context menu for non-text links

### DIFF
--- a/app/content/webviewPreload.js
+++ b/app/content/webviewPreload.js
@@ -197,9 +197,21 @@ function isPlatformOSX () {
 
 document.addEventListener('contextmenu', (e) => {
   var name = e.target.nodeName.toUpperCase()
+
+  var href
+  var maybeLink = e.target
+  while (maybeLink.parentNode) {
+    if (maybeLink.nodeName.toUpperCase() === 'A') {
+      href = maybeLink.href
+      break
+    }
+    maybeLink = maybeLink.parentNode
+  }
+
   var nodeProps = {
     name: name,
-    src: name === 'A' ? e.target.href : e.target.src,
+    href: href,
+    src: e.target.src,
     isContentEditable: e.target.isContentEditable,
     hasSelection: hasSelection(e.target)
   }

--- a/app/content/webviewPreload.js
+++ b/app/content/webviewPreload.js
@@ -156,11 +156,14 @@ ipc.on(messages.SET_AD_DIV_CANDIDATES, function (e, adDivCandidates, placeholder
 })
 
 function hasSelection (node) {
-  if (node && /password|search|tel|text|url/.test(node.type) &&
-      node.selectionStart !== undefined &&
-      node.selectionEnd !== undefined &&
-      node.selectionStart !== node.selectionEnd) {
-    return true
+  try {
+    if (node && node.selectionStart !== undefined &&
+        node.selectionEnd !== undefined &&
+        node.selectionStart !== node.selectionEnd) {
+      return true
+    }
+  } catch (e) {
+    return false
   }
 
   var selection = window.getSelection()

--- a/app/content/webviewPreload.js
+++ b/app/content/webviewPreload.js
@@ -156,7 +156,8 @@ ipc.on(messages.SET_AD_DIV_CANDIDATES, function (e, adDivCandidates, placeholder
 })
 
 function hasSelection (node) {
-  if (node && node.selectionStart !== undefined &&
+  if (node && /password|search|tel|text|url/.test(node.type) &&
+      node.selectionStart !== undefined &&
       node.selectionEnd !== undefined &&
       node.selectionStart !== node.selectionEnd) {
     return true

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -161,76 +161,74 @@ function hamburgerTemplateInit (settings) {
 function mainTemplateInit (nodeProps) {
   const template = []
   const nodeName = nodeProps.name
-  switch (nodeName) {
-    case 'A':
-      template.push({
-        label: 'Open in new tab',
-        click: (item, focusedWindow) => {
-          if (focusedWindow && nodeProps.src) {
-            // TODO: open this in the next tab instead of last tab
-            // TODO: If the tab is private, this should probably be private.
-            // Depends on #139
-            focusedWindow.webContents.send(messages.SHORTCUT_NEW_FRAME, nodeProps.src)
-          }
+
+  if (nodeProps.href) {
+    template.push({
+      label: 'Open in new tab',
+      click: (item, focusedWindow) => {
+        if (focusedWindow) {
+          // TODO: open this in the next tab instead of last tab
+          // TODO: If the tab is private, this should probably be private.
+          // Depends on #139
+          focusedWindow.webContents.send(messages.SHORTCUT_NEW_FRAME, nodeProps.href)
         }
-      })
-      template.push({
-        label: 'Open in new private tab',
-        click: (item, focusedWindow) => {
-          if (focusedWindow && nodeProps.src) {
-            // TODO: open this in the next tab instead of last tab
-            focusedWindow.webContents.send(messages.SHORTCUT_NEW_FRAME, nodeProps.src, { isPrivate: true })
-          }
+      }
+    })
+    template.push({
+      label: 'Open in new private tab',
+      click: (item, focusedWindow) => {
+        if (focusedWindow) {
+          // TODO: open this in the next tab instead of last tab
+          focusedWindow.webContents.send(messages.SHORTCUT_NEW_FRAME, nodeProps.href, { isPrivate: true })
         }
-      })
-      template.push({
-        label: 'Open in new session tab',
-        click: (item, focusedWindow) => {
-          if (focusedWindow && nodeProps.src) {
-            // TODO: open this in the next tab instead of last tab
-            focusedWindow.webContents.send(messages.SHORTCUT_NEW_FRAME, nodeProps.src, { isPartitioned: true })
-          }
+      }
+    })
+    template.push({
+      label: 'Open in new session tab',
+      click: (item, focusedWindow) => {
+        if (focusedWindow) {
+          // TODO: open this in the next tab instead of last tab
+          focusedWindow.webContents.send(messages.SHORTCUT_NEW_FRAME, nodeProps.href, { isPartitioned: true })
         }
-      })
-      template.push({
-        label: 'Copy link address',
-        click: (item, focusedWindow) => {
-          if (focusedWindow && nodeProps.src) {
-            Clipboard.writeText(nodeProps.src)
-          }
+      }
+    })
+    template.push({
+      label: 'Copy link address',
+      click: (item, focusedWindow) => {
+        if (focusedWindow) {
+          Clipboard.writeText(nodeProps.href)
         }
-      })
-      break
-    case 'IMG':
-      template.push({
-        label: 'Save image...',
-        click: (item, focusedWindow) => {
-          if (focusedWindow && nodeProps.src) {
-            focusedWindow.webContents.downloadURL(nodeProps.src)
-          }
-        }
-      })
-      template.push({
-        label: 'Open image in new tab',
-        click: (item, focusedWindow) => {
-          if (focusedWindow && nodeProps.src) {
-            // TODO: open this in the next tab instead of last tab
-            focusedWindow.webContents.send(messages.SHORTCUT_NEW_FRAME, nodeProps.src)
-          }
-        }
-      })
-      template.push({
-        label: 'Copy image address',
-        click: (item, focusedWindow) => {
-          if (focusedWindow && nodeProps.src) {
-            Clipboard.writeText(nodeProps.src)
-          }
-        }
-      })
-      break
+      }
+    })
+    template.push(CommonMenu.separatorMenuItem)
   }
 
-  if (template.length > 0) {
+  if (nodeName === 'IMG') {
+    template.push({
+      label: 'Save image...',
+      click: (item, focusedWindow) => {
+        if (focusedWindow && nodeProps.src) {
+          focusedWindow.webContents.downloadURL(nodeProps.src)
+        }
+      }
+    })
+    template.push({
+      label: 'Open image in new tab',
+      click: (item, focusedWindow) => {
+        if (focusedWindow && nodeProps.src) {
+          // TODO: open this in the next tab instead of last tab
+          focusedWindow.webContents.send(messages.SHORTCUT_NEW_FRAME, nodeProps.src)
+        }
+      }
+    })
+    template.push({
+      label: 'Copy image address',
+      click: (item, focusedWindow) => {
+        if (focusedWindow && nodeProps.src) {
+          Clipboard.writeText(nodeProps.src)
+        }
+      }
+    })
     template.push(CommonMenu.separatorMenuItem)
   }
 


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/248

- Check parentNodes to see if the Link context menu items should be shown. 
- Allow showing both link and image menu items (for image-links)
- Show context menu for non-text input types


