### PR TITLE
'Open in new tab' shouldn't focus newly opened tab

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -86,7 +86,7 @@ class Main extends ImmutableComponent {
         location: url || Config.defaultUrl,
         isPrivate: !!options.isPrivate,
         isPartitioned: !!options.isPartitioned
-      })
+      }, options.openInForeground)
 
       // Focus URL bar when adding tab via shortcut
       electron.remote.getCurrentWebContents().send(messages.SHORTCUT_FOCUS_URL)

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -170,7 +170,7 @@ function mainTemplateInit (nodeProps) {
             // TODO: open this in the next tab instead of last tab
             // TODO: If the tab is private, this should probably be private.
             // Depends on #139
-            focusedWindow.webContents.send(messages.SHORTCUT_NEW_FRAME, nodeProps.src)
+            focusedWindow.webContents.send(messages.SHORTCUT_NEW_FRAME, nodeProps.src, { openInForeground: false })
           }
         }
       })


### PR DESCRIPTION
Now matches behaviour of cmd/ctrl click.

Fixes https://github.com/brave/browser-laptop/issues/587
