### PR TITLE
Block 3rd party cookies and refer(r)er(r)

### DIFF
--- a/js/commonMenu.js
+++ b/js/commonMenu.js
@@ -162,8 +162,8 @@ module.exports.buildBraveryMenu = function (settings, init) {
       {
         type: 'checkbox',
         label: 'Block 3rd party cookies (coming soon)',
-        enabled: false,
-        checked: false
+        checked: true,
+        enabled: false
       }, {
         type: 'checkbox',
         label: 'Block Popups',


### PR DESCRIPTION
Note that the cookies/referer still appear in network devtools with a "provisional headers" warning. however, running wireshark on slashdot.org shows that cookies/referer to slashdot are sent and cookies/referer to other origins are not.

TODO: add pref to turn this off/on

Auditors: @bbondy 