### PR TITLE
Fix dev app init for Windows

### DIFF
--- a/app/index-create-script.js
+++ b/app/index-create-script.js
@@ -10,8 +10,7 @@ const createScript = function (scriptPath) {
     document.body.appendChild(script)
   })
 }
+createScript('http://localhost:{port}/built/app.entry.js')
 createScript('http://localhost:{port}/webpack-dev-server.js').catch(function () {
   document.querySelector('#setupError').style.display = 'block'
-}).then(function () {
-  createScript('http://localhost:{port}/built/app.entry.js')
 })


### PR DESCRIPTION
Having it load entry.js only after the other script is loading is
causing problems in init on slow machines (or my Windows VM).

The devserver doesn't need to be included first, it's just for live
realoading.

Auditors: @diracdeltas