### PR TITLE
Add line-height at .tabTitle

### DIFF
--- a/less/tabs.less
+++ b/less/tabs.less
@@ -55,6 +55,7 @@
     font-size: 12px;
     overflow: hidden;
     text-overflow: ellipsis;
+    line-height: 16px;
     white-space: nowrap;
     vertical-align: middle;
     width: calc(~'100% - 40px');


### PR DESCRIPTION
It's minor change.
Improve visibility when using japanese.
### before
![](https://pbs.twimg.com/media/CamKs5fUUAAOgG2.png:large)
![](https://pbs.twimg.com/media/CamKs64UcAAM87L.png:large)

### after
![](https://pbs.twimg.com/media/CamKs2EVIAAZWH9.png:large)
![](https://pbs.twimg.com/media/CamKs4MUUAACt9w.png:large)