### PR TITLE
tabPages should not show if only pinned tabs open. fixes #647

### DIFF
--- a/js/components/tabPages.js
+++ b/js/components/tabPages.js
@@ -33,10 +33,10 @@ class TabPages extends ImmutableComponent {
     return <div
       className={cx({
         tabPages: true,
-        singlePage: this.tabPageCount === 1
+        singlePage: this.tabPageCount <= 1
       })}>
     {
-      this.tabPageCount !== 1 &&
+      this.tabPageCount > 1 &&
       Array.from(new Array(this.tabPageCount)).map((x, i) =>
         <TabPage
           key={`tabPage-${i}`}

--- a/js/components/tabs.js
+++ b/js/components/tabs.js
@@ -40,6 +40,7 @@ class Tabs extends ImmutableComponent {
 
   render () {
     return <div className='tabs'>
+        <span className='tabContainer'>
         {(() => {
           if (this.props.tabPageIndex > 0) {
             return <span
@@ -47,7 +48,6 @@ class Tabs extends ImmutableComponent {
                 onClick={this.onPrevPage.bind(this)} />
           }
         })()}
-        <span className='tabContainer'>
         {
           this.props.currentFrames
             .filter(frameProps => !frameProps.get('isPinned'))
@@ -62,11 +62,6 @@ class Tabs extends ImmutableComponent {
                   isPrivate={frameProps.get('isPrivate')}
                   partOfFullPageSet={this.props.partOfFullPageSet}/>)
         }
-        { !this.props.partOfFullPageSet && this.props.currentFrames.size !== 0
-        ? <Button label='+'
-          className='navbutton newFrameButton'
-          onClick={WindowActions.newFrame} /> : null }
-        </span>
         {(() => {
           if (this.props.currentFrames.size >= this.props.tabsPerTabPage && this.totalPages > this.props.tabPageIndex + 1) {
             return <span
@@ -74,6 +69,10 @@ class Tabs extends ImmutableComponent {
               onClick={this.onNextPage.bind(this)} />
           }
         })()}
+        <Button label='+'
+          className='navbutton newFrameButton'
+          onClick={WindowActions.newFrame} />
+        </span>
     </div>
   }
 }

--- a/js/components/tabsToolbar.js
+++ b/js/components/tabsToolbar.js
@@ -7,14 +7,10 @@ const ImmutableComponent = require('./immutableComponent')
 const Tabs = require('./tabs')
 const Button = require('./button')
 const PinnedTabs = require('./pinnedTabs')
-const WindowActions = require('../actions/windowActions')
 
 class TabsToolbarButtons extends ImmutableComponent {
   render () {
     return <div className='tabsToolbarButtons'>
-      { this.props.partOfFullPageSet || this.props.noFrames
-          ? <Button label='+'
-              className='navbutton newFrameButton' onClick={WindowActions.newFrame} /> : null }
       <Button iconClass='fa-bars'
         className='navbutton menu-button'
         onClick={this.props.onMenu} />
@@ -49,7 +45,7 @@ class TabsToolbar extends ImmutableComponent {
         startingFrameIndex={startingFrameIndex}
         partOfFullPageSet={currentFrames.size === this.props.tabsPerTabPage}
       />
-      <TabsToolbarButtons partOfFullPageSet={currentFrames.size === this.props.tabsPerTabPage}
+      <TabsToolbarButtons
         noFrames={currentFrames.size === 0}
         onMenu={this.props.onMenu}/>
     </div>

--- a/less/tabs.less
+++ b/less/tabs.less
@@ -252,16 +252,18 @@
   }
 }
 
-.prevTab, .nextTab {
-  display: none !important;
+.prevTab,
+.nextTab {
+  display: none;
   color: #3B3B3B;
   font-size: 19px !important;
   height: 27px;
   line-height: 25px !important;
+  text-align: center;
   vertical-align: top;
   width: 34px;
   &:not([disabled]) {
-    display: inline-block !important;
+    display: block;
     background: @chromeSecondary;
     &:hover {
       background: lighten(#eeeeee, 10%);
@@ -273,19 +275,12 @@
   background: linear-gradient(to right, @chromeControlsBackground2, @tabsBackground);
   border-bottom-left-radius: 0;
   border-top-left-radius: @borderRadius;
-  padding-left: 36px;
-  text-align: left;
-  transform: translateX(13px);
 }
 
 .nextTab {
   background: linear-gradient(to left, #afb0b4, #cccccc);
   border-bottom-right-radius: 0;
   border-top-right-radius: @borderRadius;
-  float: right;
-  padding-right: 36px;
-  text-align: right;
-  transform: translateX(-15px);
 }
 
 .pinnedTabs {


### PR DESCRIPTION
shrinks the tab page next/prev buttons a bit, but more sensible display for the add new tab button