### PR TITLE
Add Ctrl+PageDown/Up for next/previous tab like Chrome and Firefox

### DIFF
--- a/app/localShortcuts.js
+++ b/app/localShortcuts.js
@@ -17,8 +17,8 @@ module.exports.register = (win) => {
     ['CmdOrCtrl+Shift+[', messages.SHORTCUT_PREV_TAB],
     ['CmdOrCtrl+Alt+Right', messages.SHORTCUT_NEXT_TAB],
     ['CmdOrCtrl+Alt+Left', messages.SHORTCUT_PREV_TAB],
-    ['CmdOrCtrl+Alt+Right', messages.SHORTCUT_NEXT_TAB],
-    ['CmdOrCtrl+Alt+Left', messages.SHORTCUT_PREV_TAB],
+    ['Ctrl+PageDown', messages.SHORTCUT_NEXT_TAB],
+    ['Ctrl+PageUp', messages.SHORTCUT_PREV_TAB],
     ['CmdOrCtrl+9', messages.SHORTCUT_SET_ACTIVE_FRAME_TO_LAST]
   ]
 


### PR DESCRIPTION
Remove duplicate shortcut. Fix #737