### PR TITLE
Add rudimentary cert warning pages

### DIFF
--- a/app/about-certerror.html
+++ b/app/about-certerror.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; form-action 'none'; referrer no-referrer; script-src 'self'; connect-src 'self'">
+    <meta name="availableLanguages" content="en-US">
+    <meta name="defaultLanguage" content="en-US">
+    <meta name='theme-color' content='#ff5000'>
+    <title data-l10n-id="certError"></title>
+    <script src="gen/aboutPages.entry.js" defer></script>
+    <script src="./ext/l20n.min.js" defer></script>
+    <link rel="localization" href="locales/{locale}/app.l20n">
+ </head>
+ <body>
+    <div id="appContainer"/>
+ </body>
+</html>

--- a/app/content/aboutPreload.js
+++ b/app/content/aboutPreload.js
@@ -10,6 +10,12 @@
     })
     window.dispatchEvent(event)
   })
+  ipcRenderer.on('cert-details-updated', (e, details) => {
+    const event = new window.CustomEvent('cert-details-updated', {
+      detail: details
+    })
+    window.dispatchEvent(event)
+  })
 
   window.addEventListener('change-setting', (e) => {
     ipcRenderer.send('change-setting', e.detail.key, e.detail.value)

--- a/app/index.js
+++ b/app/index.js
@@ -80,9 +80,9 @@ app.on('ready', function () {
     // window webcontents, not the webview webcontents
     BrowserWindow.getAllWindows().map((win) => {
       win.webContents.send(messages.CERT_ERROR, {
-        url: url,
+        url,
         certError: error,
-        cert: cert
+        cert
       })
     })
   })

--- a/app/index.js
+++ b/app/index.js
@@ -75,6 +75,17 @@ const saveIfAllCollected = () => {
 }
 
 app.on('ready', function () {
+  app.on('certificate-error', function (e, webContents, url, error, cert, cb) {
+    // Tell the page to show an unlocked icon. Note this is sent to the main
+    // window webcontents, not the webview webcontents
+    BrowserWindow.getAllWindows().map((win) => {
+      win.webContents.send(messages.CERT_ERROR, {
+        url: url,
+        certError: error,
+        cert: cert
+      })
+    })
+  })
   app.on('window-all-closed', function () {
     // On OS X it is common for applications and their menu bar
     // to stay active until the user quits explicitly with Cmd + Q

--- a/app/locales/en-US/app.l20n
+++ b/app/locales/en-US/app.l20n
@@ -15,6 +15,8 @@
 <settingName "Setting name">
 <settingValue "Setting value">
 <newTab "New Tab">
+<certError "HTTPS Certificate Error">
+<certErrorText "This site cannot be loaded due to a certificate error: ">
 <openTypeInNewTab "Open {{$type}} in a new tab">
 <openTypeInNewPrivateTab "Open {{$type}} in a new private tab">
 <copyLinkLocation "Copy Link Location">

--- a/docs/state.md
+++ b/docs/state.md
@@ -110,6 +110,14 @@ WindowStore
     },
     security: {
       isSecure: boolean, // is using https
+      certDetails: {
+        url: string,
+        certError: string,
+        cert: {
+            data: Uint8Array,
+            issuer: string
+        }
+      }, // the certificate details if any
       isExtendedValidation: boolean, // is using https ev
       activeMixedContent: boolean, // has active mixed content
       passiveMixedContent: boolean, // has passive mixed content

--- a/js/about/aboutActions.js
+++ b/js/about/aboutActions.js
@@ -19,6 +19,15 @@ const AboutActions = {
       }
     })
     window.dispatchEvent(event)
+  },
+
+  /**
+   * Click through a certificate error.
+   *
+   * @param {string} url - The URL with the cert error
+   */
+  acceptCertError: function (url) {
+    // TODO
   }
 }
 module.exports = AboutActions

--- a/js/about/certerror.js
+++ b/js/about/certerror.js
@@ -1,0 +1,29 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const React = require('react')
+const messages = require('../constants/messages')
+
+class CertErrorPage extends React.Component {
+  constructor () {
+    super()
+    this.state = {certDetails: {}}
+    window.addEventListener(messages.CERT_DETAILS_UPDATED, (e) => {
+      if (e.detail.certDetails) {
+        this.setState({
+          certDetails: e.detail.certDetails
+        })
+      }
+    })
+  }
+  render () {
+    return <div>
+      <span data-l10n-id='certErrorText'></span>
+      <span>{this.state.certDetails.url || ''}</span>
+      <div>{this.state.certDetails.error || ''}</div>
+    </div>
+  }
+}
+
+module.exports = <CertErrorPage/>

--- a/js/about/entry.js
+++ b/js/about/entry.js
@@ -12,6 +12,9 @@ switch (getSourceAboutUrl(window.location.href)) {
   case 'about:preferences':
     rootComponent = require('./preferences')
     break
+  case 'about:certerror':
+    rootComponent = require('./certerror')
+    break
 }
 
 if (rootComponent) {

--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -159,6 +159,18 @@ class UrlBar extends ImmutableComponent {
     })
     // escape key handling
     ipc.on(messages.SHORTCUT_ACTIVE_FRAME_STOP, this.onActiveFrameStop.bind(this))
+    ipc.on(messages.CERT_ERROR, (e, details) => {
+      // Sometimes the cert error fires before the active frame location
+      // has been updated, so wait 100ms.
+      window.setTimeout(() => {
+        if (details.url === this.props.activeFrameProps.get('location')) {
+          WindowActions.setSecurityState({
+            certDetails: {url: details.url, error: details.certError}
+          })
+          WindowActions.loadUrl(this.props.activeFrameProps, 'about:certerror')
+        }
+      }, 100)
+    })
   }
 
   componentDidMount () {

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -37,6 +37,7 @@ const messages = {
   // Misc application events
   QUIT_APPLICATION: _,
   UPDATE_APP_MENU: _, /** @arg {Object} args menu args to update */
+  CERT_ERROR: _, /** @arg {Object} details of certificate error */
   // Updates
   UPDATE_REQUESTED: _,
   UPDATE_AVAILABLE: _,
@@ -63,7 +64,9 @@ const messages = {
   BLOCKED_RESOURCE: _,
   // SETTINGS
   SETTINGS_UPDATED: _,
-  CHANGE_SETTING: _
+  CHANGE_SETTING: _,
+  // HTTPS
+  CERT_DETAILS_UPDATED: _ /** @arg {Object} security state of the active frame */
 }
 
 module.exports = mapValuesByKeys(messages)

--- a/js/lib/appUrlUtil.js
+++ b/js/lib/appUrlUtil.js
@@ -26,7 +26,8 @@ export const aboutUrls = new Immutable.Map({
   'about:history': getAppUrl('./about-history.html'),
   'about:newtab': getAppUrl('./about-newtab.html'),
   'about:preferences': getAppUrl('./about-preferences.html'),
-  'about:config': getAppUrl('./about-config.html')
+  'about:config': getAppUrl('./about-config.html'),
+  'about:certerror': getAppUrl('./about-certerror.html')
 })
 
 // Map of target URLs mapped to source about: URLs

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -397,6 +397,10 @@ const doAction = (action) => {
         windowState = windowState.setIn(activeFrameStatePath().concat(['security', 'isSecure']),
                                         action.securityState.secure)
       }
+      if (action.securityState.certDetails) {
+        windowState = windowState.setIn(activeFrameStatePath().concat(['security', 'certDetails']),
+                                        action.securityState.certDetails)
+      }
       break
     case WindowConstants.WINDOW_SET_BLOCKED_BY:
       const blockedByPath = ['frames', FrameStateUtil.getFramePropsIndex(windowState.get('frames'), action.frameProps), action.blockType, 'blocked']


### PR DESCRIPTION
Currently there is no way to click through the warning or inspect the cert. Will add later.

Test sites: https://lenovo.com and pages at https://badssl.com

Auditors: @bbondy