### PR TITLE
open view-source in a new tab.

### DIFF
--- a/docs/windowActions.md
+++ b/docs/windowActions.md
@@ -335,11 +335,13 @@ Marks the URL bar as active or not
 
 
 
-### setActiveFrameShortcut(activeShortcut) 
+### setActiveFrameShortcut(frameProps, activeShortcut)
 
 Dispatches a message to the store to indicate that the pending frame shortcut info should be updated.
 
 **Parameters**
+
+**frameProps**: `Object`, Properties of the frame in question
 
 **activeShortcut**: `string`, The text for the new shortcut. Usually this is null to clear info which was previously
 set from an IPC call.

--- a/js/actions/windowActions.js
+++ b/js/actions/windowActions.js
@@ -501,12 +501,14 @@ const WindowActions = {
   /**
    * Dispatches a message to the store to indicate that the pending frame shortcut info should be updated.
    *
+   * @param {Object} frameProps - Properties of the frame in question
    * @param {string} activeShortcut - The text for the new shortcut. Usually this is null to clear info which was previously
    * set from an IPC call.
    */
-  setActiveFrameShortcut: function (activeShortcut) {
+  setActiveFrameShortcut: function (frameProps, activeShortcut) {
     dispatch({
       actionType: WindowConstants.WINDOW_SET_ACTIVE_FRAME_SHORTCUT,
+      frameProps,
       activeShortcut
     })
   },

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -113,10 +113,9 @@ class Frame extends ImmutableComponent {
         }
         break
       case 'view-source':
-        const src = UrlUtil.getViewSourceUrlFromUrl(this.webview.getURL())
-        WindowActions.loadUrl(this.props.frame, src)
+        const location = UrlUtil.getViewSourceUrlFromUrl(this.webview.getURL())
+        WindowActions.newFrame({location}, true)
         // TODO: Make the URL bar show the view-source: prefix
-        WindowActions.setFrameTitle(this.props.frame, src)
         break
       case 'save':
         // TODO: Sometimes this tries to save in a non-existent directory
@@ -130,7 +129,7 @@ class Frame extends ImmutableComponent {
         break
     }
     if (activeShortcut) {
-      WindowActions.setActiveFrameShortcut(null)
+      WindowActions.setActiveFrameShortcut(this.props.frame, null)
     }
 
     if (this.props.frame.get('location') === 'about:preferences') {

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -313,9 +313,7 @@ const doAction = (action) => {
       }
       break
     case WindowConstants.WINDOW_SET_ACTIVE_FRAME_SHORTCUT:
-      windowState = windowState.mergeIn(activeFrameStatePath(), {
-        activeShortcut: action.activeShortcut
-      })
+      windowState = windowState.mergeIn(['frames', FrameStateUtil.getFramePropsIndex(windowState.get('frames'), action.frameProps), 'activeShortcut'], action.activeShortcut)
       break
     case WindowConstants.WINDOW_SET_SEARCH_DETAIL:
       windowState = windowState.merge({

--- a/test/components/frameTest.js
+++ b/test/components/frameTest.js
@@ -2,9 +2,10 @@
 
 const Brave = require('../lib/brave')
 const { activeWebview, findBarInput, findBarMatches, urlInput } = require('../lib/selectors')
+const messages = require('../../js/constants/messages')
 const assert = require('assert')
 
-describe('findbar', function () {
+describe.only('findbar', function () {
   Brave.beforeAll(this)
 
   before(function *() {
@@ -51,6 +52,38 @@ describe('findbar', function () {
       .click('#navigator')
       .click(urlInput)
       .waitForElementFocus(urlInput)
+  })
+})
+
+describe('view source', function () {
+  Brave.beforeAll(this)
+
+  before(function *() {
+    this.url = Brave.server.url('find_in_page.html')
+    // todo: move to selectors
+    this.webview1 = '.frameWrapper:nth-child(1) webview'
+    this.webview2 = '.frameWrapper:nth-child(2) webview'
+
+    yield setup(this.app.client)
+    yield this.app.client
+      .waitUntilWindowLoaded()
+      .waitForVisible(activeWebview)
+      .loadUrl(this.url)
+      .waitForExist('.tab[data-frame-key="1"]')
+      .waitForExist(this.webview1)
+  })
+
+  it('should open in new tab', function *() {
+    yield this.app.client
+      .ipcSend(messages.SHORTCUT_ACTIVE_FRAME_VIEW_SOURCE)
+      .waitForExist(this.webview2)
+  })
+
+  it('open from pinned tab', function *() {
+    yield this.app.client
+      .pinTab(2)
+      .ipcSend(messages.SHORTCUT_ACTIVE_FRAME_VIEW_SOURCE)
+      .waitForExist(this.webview2)
   })
 })
 

--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -120,6 +120,17 @@ var exports = {
       })
     })
 
+    this.app.client.addCommand('pinTab', function (key) {
+      return this.execute(function (key) {
+        var Immutable = require('immutable')
+        var windowActions = require('../js/actions/windowActions')
+        windowActions.dispatchViaIPC()
+        windowActions.setPinned(Immutable.fromJS({
+          key
+        }), true)
+      }, key)
+    })
+
     this.app.client.addCommand('ipcOn', function (message, fn) {
       return this.execute(function (message, fn) {
         return require('electron').remote.getCurrentWindow().webContents.on(message, fn)


### PR DESCRIPTION
- Open view source in new tab. 
- make `setActiveFrameShortcut` accept frameProps; since activeShortcut events were being fired twice in the same frame for new tab actions


fixes #797
fixes #798
fixes #511