### PR TITLE
in titlemode, only show bookmark for bookmarked pages

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -51,7 +51,7 @@
       background: @chromePrimary;
       color: @chromeText;
       font-size: 15px;
-      max-width: calc(~'100% - 16px'); // space for icon
+      max-width: 100%;
       overflow-x: hidden;
       text-overflow: ellipsis;
       margin-top: 5px;
@@ -64,7 +64,11 @@
       */
     }
     .startButtons {
-      visibility: hidden;
+      display: none;
+    }
+
+    .endButtons {
+      position: absolute;
     }
 
     .urlbarIcon {
@@ -84,6 +88,10 @@
     .bookmark-button {
       transform: scale(0.6);
       opacity: 0.6;
+
+      &:not(.remove-bookmark-button) {
+        display: none;
+      }
     }
   }
 


### PR DESCRIPTION
And `position: absolute` the star to page title doesn't jump when bookmarking with ctrl D

![screen shot 2016-02-20 at 00 46 20](https://cloud.githubusercontent.com/assets/1731922/13177166/7b34cc36-d76b-11e5-940a-f6111b0d6f1d.png)
![screen shot 2016-02-20 at 00 46 31](https://cloud.githubusercontent.com/assets/1731922/13177167/7b379e66-d76b-11e5-812c-df59aa194b8b.png)
