### PR TITLE
Get rid of sqlite for HTTPS Everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,5 @@ app/gen
 *.pfx
 
 # HTTPS Everywhere files
-httpse-targets.json
-rulesets.sqlite
+rulesets.json
+httpse.json

--- a/app/dataFile.js
+++ b/app/dataFile.js
@@ -61,45 +61,23 @@ function downloadSingleFile (resourceName, url, version, force, resolve, reject)
 }
 
 module.exports.downloadDataFile = (resourceName, url, version, force) => {
-  if (resourceName === 'httpsEverywhere') {
-    return new Promise((resolve, reject) => {
-      downloadSingleFile(resourceName, url, version, force, () => {
-        var targets = AppConfig[resourceName].targetsUrl.replace('{version}', version)
-        downloadSingleFile(resourceName, targets, version, force, resolve, reject)
-      }, reject)
-    })
-  } else {
-    return new Promise((resolve, reject) => {
-      downloadSingleFile(resourceName, url, version, force, resolve, reject)
-    })
-  }
+  return new Promise((resolve, reject) => {
+    downloadSingleFile(resourceName, url, version, force, resolve, reject)
+  })
 }
 
 module.exports.readDataFile = (resourceName, url) => {
-  if (resourceName === 'httpsEverywhere') {
-    // If https everywhere, just return the path to the files on disk
-    return new Promise((resolve, reject) => {
-      fs.stat(storagePath(url), function (err, stats) {
-        if (err || !stats.isFile()) {
-          reject()
-        } else {
-          resolve(app.getPath('userData'))
-        }
-      })
+  return new Promise((resolve, reject) => {
+    fs.readFile(storagePath(url), function (err, data) {
+      if (err || !data || data.length === 0) {
+        // console.log('rejecting for read for resource:', resourceName)
+        reject()
+      } else {
+        // console.log('resolving for read for resource:', resourceName)
+        resolve(data)
+      }
     })
-  } else {
-    return new Promise((resolve, reject) => {
-      fs.readFile(storagePath(url), function (err, data) {
-        if (err || !data || data.length === 0) {
-          // console.log('rejecting for read for resource:', resourceName)
-          reject()
-        } else {
-          // console.log('resolving for read for resource:', resourceName)
-          resolve(data)
-        }
-      })
-    })
-  }
+  })
 }
 
 module.exports.shouldRedownloadFirst = (resourceName, version) => {

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -33,9 +33,8 @@ module.exports = {
     enabled: true
   },
   httpsEverywhere: {
-    url: 'https://s3.amazonaws.com/https-everywhere-data/{version}/rulesets.sqlite',
-    targetsUrl: 'https://s3.amazonaws.com/https-everywhere-data/{version}/httpse-targets.json',
-    version: '5.1.2', // latest stable release from https://eff.org/https-everywhere
+    url: 'https://s3.amazonaws.com/https-everywhere-data/{version}/httpse.json',
+    version: '5.1.3', // latest stable release from https://eff.org/https-everywhere
     msBetweenRechecks: 1000 * 60 * 60 * 24, // 1 day
     enabled: true
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "clean-session-store": "rm -f ~/Library/Application\\ Support/Brave/session-store-*",
     "clean-adblock-data": "rm -f ~/Library/Application\\ Support/Brave/ABPFilterParserData.dat",
     "clean-tp-data": "rm -f ~/Library/Application\\ Support/Brave/TrackingProtection.dat",
-    "clean-httpse-data": "rm -f ~/Library/Application\\ Support/Brave/httpse-targets.json  ~/Library/Application\\ Support/Brave/rulesets.sqlite*",
+    "clean-httpse-data": "rm -f ~/Library/Application\\ Support/Brave/httpse.json",
     "postinstall": "node ./tools/rebuildNativeModules.js&&webpack",
     "webpack": "webpack",
     "test": "NODE_ENV=test mocha --compilers js:babel-register --recursive $(find test -name '*Test.js')"
@@ -66,7 +66,6 @@
     "immutable": "^3.7.5",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
-    "sqlite3": "^3.1.0",
     "tracking-protection": "1.0.x",
     "url-loader": "^0.5.7"
   },


### PR DESCRIPTION
Fix #673 
Also fixes all SQLITE issues :)

I will open separate issues for iOS/Android to get rid of sqlite. @garvankeeley @SergeyZhukovsky here is a summary of the changes:
* In `https://s3.amazonaws.com/https-everywhere-data/5.1.3/`, there is now a single file `httpse.json` that replaces `rulesets.sqlite` and `httpse-targets.json`.
* `httpse.json` has two fields: `rulesetStrings` and `targets`. 
* `targets` is the same as what used to be `httpse-targets.json` (map of hostname patterns to ruleset IDs).
* `rulesetStrings` is a map of ruleset IDs to the actual ruleset, which can be applied using the same code as before.

Now instead of doing a sqlite query for `ruleset_id` to get the ruleset, you can just get the ruleset by `rulesetStrings[ruleset_id]`.

Auditors: @bbondy 