### PR TITLE
Increase delay to tab previews on hover

### DIFF
--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -102,7 +102,7 @@ class Tab extends ImmutableComponent {
     const previewMode = new Date().getTime() - this.lastPreviewClearTime < 1500
     window.clearTimeout(this.hoverClearTimeout)
     this.hoverTimeout =
-      window.setTimeout(WindowActions.setPreviewFrame.bind(null, this.props.frameProps), previewMode ? 0 : 400)
+      window.setTimeout(WindowActions.setPreviewFrame.bind(null, this.props.frameProps), previewMode ? 50 : 750)
   }
 
   onClickTab (e) {


### PR DESCRIPTION
I personally find the tab previews to be very abrupt which becomes annoying sometimes.
Ideally we should allow the timings to be configurable, and probably we can choose a default that everyone is happy with, via some telemetry or voting.