### PR TITLE
Added bookmark toolbar signals show/hide test.

### DIFF
--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -71,7 +71,10 @@ const messages = {
   NEW_FRAME: _,
   // HTTPS
   CERT_DETAILS_UPDATED: _, /** @arg {Object} security state of the active frame */
-  CERT_ERROR_ACCEPTED: _ /** @arg {string} url where a cert error was accepted */
+  CERT_ERROR_ACCEPTED: _, /** @arg {string} url where a cert error was accepted */
+  SHOW_BOOKMARKS_TOOLBAR: _,
+  HIDE_BOOKMARKS_TOOLBAR: _
+
 }
 
 module.exports = mapValuesByKeys(messages)

--- a/test/components/bookmarksToolbarTest.js
+++ b/test/components/bookmarksToolbarTest.js
@@ -1,0 +1,34 @@
+/* global describe, it, before */
+
+const Brave = require('../lib/brave')
+const messages = require('../../js/constants/messages')
+const {urlInput} = require('../lib/selectors')
+
+describe('bookmarksToolbar', function () {
+  function * setup (client) {
+    yield client
+      .waitUntilWindowLoaded()
+      .waitForVisible('#window')
+      .waitForVisible(urlInput)
+  }
+
+  describe('toolbar signal', function () {
+    Brave.beforeAll(this)
+    before(function *() {
+      yield setup(this.app.client)
+    })
+
+    it.skip('should open toolbar when signaled', function *() {
+      yield this.app.client
+        .ipcSend(messages.SHOW_BOOKMARKS_TOOLBAR)
+        .waitForExist('.bookmarksToolbar')
+    })
+
+    it.skip('should close toolbar when signaled', function *() {
+      yield this.app.client
+        .ipcSend(messages.SHOW_BOOKMARKS_TOOLBAR)
+        .ipcSend(messages.HIDE_BOOKMARKS_TOOLBAR)
+        .isExisting('.bookmarksToolbar').should.eventually.be.false
+    })
+  })
+})


### PR DESCRIPTION
I assume when the bookmarks toolbar is opened from the render window we want to kick the call back to the main window to do the work. These tests should work when we are able to communicate the messages to the main window. [Skipped for now so we don't break the build.]