### PR TITLE
Temporarily whitelist domains needed for fb login to work

### DIFF
--- a/app/trackingProtection.js
+++ b/app/trackingProtection.js
@@ -17,7 +17,7 @@ let cachedFirstPartyCount = 0
 let cachedFirstParty = {}
 
 // Temporary whitelist until we find a better solution
-const whitelistHosts = ['connect.facebook.net']
+const whitelistHosts = ['connect.facebook.net', 'connect.facebook.com', 'staticxx.facebook.com', 'www.facebook.com']
 
 const startTrackingProtection = (wnd) => {
   Filtering.registerBeforeSendHeadersFilteringCB((details) => {


### PR DESCRIPTION
this temporarily fixes the broken sites reported in https://github.com/brave/browser-laptop/issues/780 but i want to get others' thoughts on whether it's too tracking-permissive before merging.