### PR TITLE
update navbar input for app initiated navigations

### DIFF
--- a/docs/windowActions.md
+++ b/docs/windowActions.md
@@ -40,7 +40,7 @@ but the location should. For user entered new URLs, both should be updated.
 
 Dispatches a message to the store to set the current navigated location.
 This differs from the above in that it will not change the webview's (iframe's) src.
-This should be used for inter-page navigation but not user initiated loads.
+This should be used for renderer initiated navigation but not user initiated loads.
 
 **Parameters**
 

--- a/js/actions/windowActions.js
+++ b/js/actions/windowActions.js
@@ -96,7 +96,7 @@ const WindowActions = {
   /**
    * Dispatches a message to the store to set the current navigated location.
    * This differs from the above in that it will not change the webview's (iframe's) src.
-   * This should be used for inter-page navigation but not user initiated loads.
+   * This should be used for renderer initiated navigation but not user initiated loads.
    *
    * @param {string} location - The URL of the page to load
    * @param {number} key - The frame key to modify, it is checked against the active frame and if

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -129,7 +129,7 @@ const doAction = (action) => {
           audioPlaybackActive: false,
           icon: undefined,
           // We want theme colors reset here instead of in WINDOW_SET_LOCATION
-          // because inter page navigation would make the tab color
+          // because intra-page navigation would make the tab color
           // blink otherwise.  The theme color will be reset eventually
           // once the page loads anyway though for the case of navigation change
           // without src change.
@@ -137,6 +137,9 @@ const doAction = (action) => {
           computedThemeColor: undefined,
           title: ''
         })
+        // force a navbar update in case this was called from an app
+        // initiated navigation (bookmarks, etc...)
+        updateNavBarInput(action.location, frameStatePath(action.key))
       }
       break
     case WindowConstants.WINDOW_SET_LOCATION:
@@ -152,7 +155,10 @@ const doAction = (action) => {
         title: locationChanged ? '' : lastTitle,
         location: action.location
       })
-      updateNavBarInput(action.location, frameStatePath(key))
+      // include the url fragment when updating navbar input
+      if (action.location !== lastLocation) {
+        updateNavBarInput(action.location, frameStatePath(key))
+      }
       break
     case WindowConstants.WINDOW_SET_NAVBAR_INPUT:
       updateNavBarInput(action.location)

--- a/test/app/sesionStoreTest.js
+++ b/test/app/sesionStoreTest.js
@@ -29,6 +29,9 @@ describe('sessionStore', function () {
       yield Brave.app.client
         .moveToObject(selectors.urlInput)
         .waitForExist(selectors.navigatorBookmarked)
+        .waitUntil(function () {
+          return this.getValue(selectors.urlInput).then(val => val === page1Url)
+        })
       yield Brave.stopApp()
       yield Brave.startApp(false)
       yield setup(Brave.app.client)


### PR DESCRIPTION
this breaks a pinned tab test, but the test appears to be broken to me. This diff demonstrates the issue:

```
diff --git a/test/components/pinnedTabTest.js b/test/components/pinnedTabTest.js
index baa1d0c..9e0800a 100644
--- a/test/components/pinnedTabTest.js
+++ b/test/components/pinnedTabTest.js
@@ -151,9 +151,10 @@ describe('pinnedTabs', function () {
     it('navigate within the same origin', function *() {
       const page2Url = Brave.server.url('page2.html')
       yield loadUrl(this.app.client, page2Url)
-      yield this.app.client.waitUntil(function () {
-        return this.getAttribute('webview[data-frame-key="2"]', 'src').then(src => src === page2Url)
-      })
+      yield this.app.client
+        .waitUntil(function () {
+          return this.getAttribute('webview[data-frame-key="2"]', 'src').then(src => src === page2Url)
+        })
         .waitUntil(function () {
           return this.elements(pinnedTabsTabs).then((res) => res.value.length === 1)
         })
@@ -164,13 +165,16 @@ describe('pinnedTabs', function () {
     it('navigating to a different origin opens a new tab', function *() {
       const page2Url = Brave.server.url('page2.html').replace('localhost', '127.0.0.1')
       yield loadUrl(this.app.client, page2Url)
-      this.app.client.waitForExist('webview[data-frame-key="3"]')
+      this.app.client.waitForExist('webview[data-frame-key="3"]')
         .waitUntil(function () {
           return this.elements(pinnedTabsTabs).then((res) => res.value.length === 1)
-        })
+        })
         .waitUntil(function () {
           return this.elements(tabsTabs).then((res) => res.value.length === 2)
         })
+        .waitUntil(function () {
+          return this.getAttribute('webview[data-frame-key="3"]', 'src').then(src => src === page2Url)
+        })
     })
   }) 
```