### PR TITLE
remove box shadow from urlbar inner input

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -152,7 +152,6 @@
     background: @navigationBarBackground;
     border: none;
     box-sizing: border-box;
-    box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
     color: @chromeText;
     cursor: text;
     font-size: @defaultFontSize;


### PR DESCRIPTION
I think I derped a rebase for the urlbar wrapper changes. Removes this top line (right about "search for address"):

![screen shot 2016-02-27 at 19 52 11](https://cloud.githubusercontent.com/assets/1731922/13372074/a4955b4c-dd8b-11e5-993f-946efb5955fa.png)
