### PR TITLE
Fork the bookmarks manager hotkey

### DIFF
--- a/js/commonMenu.js
+++ b/js/commonMenu.js
@@ -18,6 +18,7 @@ const cookieblock = AppConfig.resourceNames.COOKIEBLOCK
 const settings = require('./constants/settings')
 const getSetting = require('./settings').getSetting
 const issuesUrl = 'https://github.com/brave/browser-laptop/issues'
+const isDarwin = process.platform === 'darwin'
 
 let electron
 try {
@@ -151,7 +152,7 @@ module.exports.preferencesMenuItem = {
 
 module.exports.bookmarksMenuItem = {
   label: 'Bookmarks manager...',
-  accelerator: process.platform === 'win32' ? 'Shift+Alt+B' : 'CmdOrCtrl+Alt+B',
+  accelerator: isDarwin ? 'CmdOrCtrl+Alt+B' : 'Ctrl+Shift+O',
   click: (item, focusedWindow) => {
     module.exports.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_NEW_FRAME, 'about:bookmarks', { singleFrame: true }])
   }

--- a/js/commonMenu.js
+++ b/js/commonMenu.js
@@ -151,7 +151,7 @@ module.exports.preferencesMenuItem = {
 
 module.exports.bookmarksMenuItem = {
   label: 'Bookmarks manager...',
-  accelerator: 'CmdOrCtrl+Alt+b',
+  accelerator: process.platform === 'win32' ? 'Shift+Alt+B' : 'CmdOrCtrl+Alt+B',
   click: (item, focusedWindow) => {
     module.exports.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_NEW_FRAME, 'about:bookmarks', { singleFrame: true }])
   }


### PR DESCRIPTION
This is a potential fix for #926. Use Shift+Alt+B to open the bookmarks manager on windows since Ctrl+Alt+B seems to be often hijacked.

As far as I can tell the only other way to fix this to make it work universally is to add a hotkey for `ctrl+alt+b` to `localShortcuts.js` to open a new window pointing at `about:bookmarks`. I have a working copy of that if that is preferred.