### PR TITLE
Add support for alt+arrow key navigation

### DIFF
--- a/app/localShortcuts.js
+++ b/app/localShortcuts.js
@@ -20,9 +20,7 @@ module.exports.register = (win) => {
     ['CmdOrCtrl+Alt+Left', messages.SHORTCUT_PREV_TAB],
     ['Ctrl+PageDown', messages.SHORTCUT_NEXT_TAB],
     ['Ctrl+PageUp', messages.SHORTCUT_PREV_TAB],
-    ['CmdOrCtrl+9', messages.SHORTCUT_SET_ACTIVE_FRAME_TO_LAST],
-    ['Alt+Left', messages.SHORTCUT_ACTIVE_FRAME_BACK],
-    ['Alt+Right', messages.SHORTCUT_ACTIVE_FRAME_FORWARD]
+    ['CmdOrCtrl+9', messages.SHORTCUT_SET_ACTIVE_FRAME_TO_LAST]
   ]
 
   if (!isDarwin) {
@@ -30,7 +28,9 @@ module.exports.register = (win) => {
       ['F5', messages.SHORTCUT_ACTIVE_FRAME_RELOAD],
       ['Ctrl+F5', messages.SHORTCUT_ACTIVE_FRAME_CLEAN_RELOAD],
       ['F12', messages.SHORTCUT_ACTIVE_FRAME_TOGGLE_DEV_TOOLS],
-      ['Alt+D', messages.SHORTCUT_FOCUS_URL, false])
+      ['Alt+D', messages.SHORTCUT_FOCUS_URL, false],
+      ['Alt+Left', messages.SHORTCUT_ACTIVE_FRAME_BACK],
+      ['Alt+Right', messages.SHORTCUT_ACTIVE_FRAME_FORWARD])
   }
 
   // Tab ordering shortcuts

--- a/app/localShortcuts.js
+++ b/app/localShortcuts.js
@@ -20,7 +20,9 @@ module.exports.register = (win) => {
     ['CmdOrCtrl+Alt+Left', messages.SHORTCUT_PREV_TAB],
     ['Ctrl+PageDown', messages.SHORTCUT_NEXT_TAB],
     ['Ctrl+PageUp', messages.SHORTCUT_PREV_TAB],
-    ['CmdOrCtrl+9', messages.SHORTCUT_SET_ACTIVE_FRAME_TO_LAST]
+    ['CmdOrCtrl+9', messages.SHORTCUT_SET_ACTIVE_FRAME_TO_LAST],
+    ['Alt+Left', messages.SHORTCUT_ACTIVE_FRAME_BACK],
+    ['Alt+Right', messages.SHORTCUT_ACTIVE_FRAME_FORWARD]
   ]
 
   if (!isDarwin) {


### PR DESCRIPTION
Even more hotkeys, woo.

Looks like most other browsers support `alt+left/right` to navigate. This PR adds support for that.