### PR TITLE
Add rulesets.sqlite build script for mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ app/gen
 # HTTPS Everywhere files
 rulesets.json
 httpse.json
+httpse.sqlite

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "nsp": "^2.2.0",
     "pre-commit": "^1.1.2",
     "spectron": "^0.36.0",
+    "sqlite3": "^3.1.1",
     "standard": "^5.4.1",
     "style-loader": "^0.13.0",
     "webdriverio": "^4.0.3",


### PR DESCRIPTION
For performance, sqlite is probably better on mobile than JSON. This converts
httpse.json to httpse.sqlite for mobile HTTPS Everywhere. 

CC @garvankeeley @SergeyZhukovsky - the resulting file from this script is up at https://s3.amazonaws.com/https-everywhere-data/5.1.3/httpse.sqlite

Auditors: @bbondy 