### PR TITLE
Only set etag and last check date if download succeeds

### DIFF
--- a/app/dataFile.js
+++ b/app/dataFile.js
@@ -34,14 +34,12 @@ function downloadSingleFile (resourceName, url, version, force, resolve, reject)
     headers
   }).on('response', function (response) {
     // console.log('response...', resourceName)
-    AppActions.setResourceLastCheck(resourceName, version, new Date().getTime())
     if (response.statusCode !== 200) {
       // console.log(resourceName, 'status code: ', response.statusCode)
       reject('Got HTTP status code ' + response.statusCode)
       return
     }
     const etag = response.headers['etag']
-    AppActions.setResourceETag(resourceName, etag)
 
     // console.log('setting dwonloadPath...', resourceName)
     req.pipe(fs.createWriteStream(downloadPath(url)).on('close', function () {
@@ -51,6 +49,8 @@ function downloadSingleFile (resourceName, url, version, force, resolve, reject)
           reject('could not rename downloaded file')
         } else {
           // console.log('resolving for download:', resourceName)
+          AppActions.setResourceETag(resourceName, etag)
+          AppActions.setResourceLastCheck(resourceName, version, new Date().getTime())
           resolve()
         }
       })


### PR DESCRIPTION
Related to #967, if the resource file download doesn't resolve, the browser
should at least redownload when it restarts.

Auditors: @bbondy 