### PR TITLE
make cert error safety button go back to previous page

### DIFF
--- a/app/content/scripts/aboutPreload.js
+++ b/app/content/scripts/aboutPreload.js
@@ -29,6 +29,9 @@
   window.addEventListener('cert-error-accepted', (e) => {
     ipcRenderer.send('cert-error-accepted', e.detail.url)
   })
+  window.addEventListener('cert-error-rejected', (e) => {
+    ipcRenderer.send('cert-error-rejected', e.detail.previousLocation, e.detail.frameKey)
+  })
   window.addEventListener('new-frame', (e) => {
     ipcRenderer.sendToHost('new-frame', e.detail.frameOpts, e.detail.openInForeground)
   })

--- a/app/index.js
+++ b/app/index.js
@@ -184,6 +184,10 @@ app.on('ready', function () {
       BrowserWindow.getFocusedWindow().webContents.send(messages.SHORTCUT_ACTIVE_FRAME_LOAD_URL, url)
     })
 
+    ipcMain.on(messages.CERT_ERROR_REJECTED, (event, previousLocation, frameKey) => {
+      BrowserWindow.getFocusedWindow().webContents.send(messages.CERT_ERROR_REJECTED, previousLocation, frameKey)
+    })
+
     AppStore.addChangeListener(() => {
       Menu.init(AppStore.getState().get('settings'))
     })

--- a/js/about/aboutActions.js
+++ b/js/about/aboutActions.js
@@ -51,6 +51,16 @@ const AboutActions = {
   },
 
   /**
+   * Reject a certificate error.
+   *
+   * @param {Object} detail
+   */
+  rejectCertError: function (detail) {
+    const event = new window.CustomEvent(messages.CERT_ERROR_REJECTED, {detail})
+    window.dispatchEvent(event)
+  },
+
+  /**
    * Opens a context menu
    */
   contextMenu: function (nodeProps, contextMenuType, e) {

--- a/js/about/certerror.js
+++ b/js/about/certerror.js
@@ -31,7 +31,10 @@ class CertErrorPage extends React.Component {
   }
 
   onSafety () {
-    window.location.href = 'about:newtab'
+    aboutActions.rejectCertError({
+      previousLocation: this.state.certDetails.get('previousLocation'),
+      frameKey: this.state.certDetails.get('frameKey')
+    })
   }
 
   onAdvanced () {

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -149,6 +149,10 @@ class Main extends ImmutableComponent {
       })
     })
 
+    ipc.on(messages.CERT_ERROR_REJECTED, (e, previousLocation, frameKey) => {
+      windowActions.loadUrl(FrameStateUtil.getFrameByKey(self.props.windowState, frameKey), previousLocation)
+    })
+
     this.loadOpenSearch()
 
     window.addEventListener('mousemove', (e) => {

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -76,6 +76,7 @@ const messages = {
   // HTTPS
   CERT_DETAILS_UPDATED: _, /** @arg {Object} security state of the active frame */
   CERT_ERROR_ACCEPTED: _, /** @arg {string} url where a cert error was accepted */
+  CERT_ERROR_REJECTED: _, /** @arg {string} url where a cert error was rejected */
   // Bookmarks
   IMPORT_BOOKMARKS: _
 }


### PR DESCRIPTION
This is a hopefully-temporary workaround for <webview>.goBack
not working on about: pages.

Fix #899

Auditors: @bbondy