### PR TITLE
Start password saving

### DIFF
--- a/app/content/scripts/webviewPreload.js
+++ b/app/content/scripts/webviewPreload.js
@@ -209,11 +209,12 @@
       // Wait for user to pick the username, then autofill password
       usernameElem.addEventListener('focus', e => {
         let rect = usernameElem.getBoundingClientRect()
+        // TODO: This should update on every keystroke
         ipcRenderer.send('show-username-list', formOrigin, action, {
           bottom: rect.bottom,
           left: rect.left,
           width: rect.width
-        })
+        }, usernameElem.value || '')
       })
       usernameElem.addEventListener('blur', e => {
         // Wait for the background to process the focus event

--- a/app/content/scripts/webviewPreload.js
+++ b/app/content/scripts/webviewPreload.js
@@ -318,8 +318,8 @@
     // what username/password combo to save.
     var oldPassword = null
     var newPassword = null
-    var value1 = passwords[0].value
-    var value2 = passwords[1].value
+    var value1 = passwords[0] ? passwords[0].value : ''
+    var value2 = passwords[1] ? passwords[1].value : ''
     var value3 = passwords[2] ? passwords[2].value : ''
 
     if (passwords.length === 2) {
@@ -358,10 +358,15 @@
    * @return {Array.<Element>|null}
    */
   function getPasswordFields (form, isSubmission) {
-    var oldPassword = form.querySelector('input[autocomplete=current-password i]')
+    var currentPassword = form.querySelector('input[autocomplete=current-password i]')
     var newPassword = form.querySelector('input[autocomplete=new-password i]')
-    if (newPassword || oldPassword) {
-      return [oldPassword, newPassword]
+    if (currentPassword) {
+      if (!newPassword) {
+        // This probably isn't a password change form; ex: twitter login
+        return [currentPassword]
+      } else {
+        return [currentPassword, newPassword]
+      }
     }
     var passwordNodes = Array.from(form.querySelectorAll('input[type=password]:not([autocomplete=off i])'))
     if (isSubmission) {

--- a/app/content/scripts/webviewPreload.js
+++ b/app/content/scripts/webviewPreload.js
@@ -213,6 +213,13 @@
             width: rect.width
           })
         })
+        usernameElem.addEventListener('blur', e => {
+          // Wait for the background to process the focus event
+          // before hiding the context menu
+          window.setTimeout(() => {
+            ipcRenderer.send('hide-context-menu')
+          }, 300)
+        })
       }
 
       // Whenever a form is submitted, offer to save it in the password manager

--- a/app/filtering.js
+++ b/app/filtering.js
@@ -167,6 +167,11 @@ function registerPermissionHandler (session) {
   }
   session.setPermissionRequestHandler((webContents, permission, cb) => {
     let host = urlParse(webContents.getURL()).host
+    if (!permissions[permission]) {
+      console.log('WARNING: got registered permission request', permission)
+      cb(false)
+      return
+    }
     let isAllowed = permissions[permission].hosts[host]
     if (isAllowed !== undefined) {
       cb(isAllowed)

--- a/app/index.js
+++ b/app/index.js
@@ -323,7 +323,7 @@ app.on('ready', function () {
       }
     })
 
-    ipcMain.on(messages.SHOW_USERNAME_LIST, (e, origin, action, boundingRect) => {
+    ipcMain.on(messages.SHOW_USERNAME_LIST, (e, origin, action, boundingRect, value) => {
       masterKey = masterKey || getMasterKey()
       if (!masterKey) {
         console.log('Could not access master password; aborting')
@@ -334,7 +334,10 @@ app.on('ready', function () {
       if (passwords) {
         let usernames = {}
         let results = passwords.filter(password => {
-          return password.get('username') && password.get('origin') === origin && password.get('action') === action
+          return password.get('username') &&
+            password.get('username').includes(value) &&
+            password.get('origin') === origin &&
+            password.get('action') === action
         })
         results.forEach(result => {
           usernames[result.get('username')] = CryptoUtil.decryptVerify(result.get('encryptedPassword'),

--- a/app/index.js
+++ b/app/index.js
@@ -318,7 +318,9 @@ app.on('ready', function () {
     })
 
     ipcMain.on(messages.HIDE_CONTEXT_MENU, () => {
-      BrowserWindow.getFocusedWindow().webContents.send(messages.HIDE_CONTEXT_MENU)
+      if (BrowserWindow.getFocusedWindow()) {
+        BrowserWindow.getFocusedWindow().webContents.send(messages.HIDE_CONTEXT_MENU)
+      }
     })
 
     ipcMain.on(messages.SHOW_USERNAME_LIST, (e, origin, action, boundingRect) => {
@@ -340,7 +342,8 @@ app.on('ready', function () {
                                                                        masterKey,
                                                                        result.get('iv')) || ''
         })
-        if (Object.keys(usernames).length > 0) {
+        if (Object.keys(usernames).length > 0 &&
+            BrowserWindow.getFocusedWindow()) {
           BrowserWindow.getFocusedWindow().webContents.send(messages.SHOW_USERNAME_LIST,
                                                             usernames, origin, action,
                                                             boundingRect)

--- a/app/index.js
+++ b/app/index.js
@@ -33,6 +33,7 @@ const urlParse = require('url').parse
 const debounce = require('../js/lib/debounce.js')
 const CryptoUtil = require('../js/lib/cryptoUtil')
 const keytar = require('keytar')
+const dialog = electron.dialog
 
 let loadAppStatePromise = SessionStore.loadAppState().catch(() => {
   return SessionStore.defaultAppState()
@@ -48,6 +49,24 @@ let lastWindowState
 let acceptCertUrls = {}
 // URLs to callback for auth.
 let authCallbacks = {}
+
+/**
+ * Gets the master key for encrypting login credentials from the OS keyring.
+ */
+const getMasterKey = () => {
+  const appName = 'Brave'
+  const accountName = 'login master key'
+  let masterKey = keytar.getPassword(appName, accountName)
+  if (masterKey === null) {
+    // Either the user denied access or no master key has been created.
+    // We can't tell the difference so try making a new master key.
+    let success = keytar.addPassword(appName, accountName, CryptoUtil.getRandomBytes(32).toString('binary'))
+    if (success) {
+      masterKey = keytar.getPassword(appName, accountName)
+    }
+  }
+  return masterKey
+}
 
 const saveIfAllCollected = () => {
   // If we're shutting down early and can't access the state, it's better
@@ -274,11 +293,10 @@ app.on('ready', function () {
       Updater.updateNowRequested()
     })
 
-    let masterPassword = null
+    let masterKey
     ipcMain.on(messages.GET_PASSWORD, (e, origin, action) => {
-      console.log('got pw request', origin, action)
-      masterPassword = masterPassword || keytar.getPassword('Brave', 'master password')
-      if (masterPassword === null) {
+      masterKey = masterKey || getMasterKey()
+      if (!masterKey) {
         console.log('Could not access master password; aborting')
         return
       }
@@ -293,12 +311,63 @@ app.on('ready', function () {
         if (result) {
           let password = CryptoUtil.decryptVerify(result.get('encryptedPassword'),
                                                   result.get('authTag'),
-                                                  masterPassword,
+                                                  masterKey,
                                                   result.get('iv'))
           e.sender.send(messages.GOT_PASSWORD, result.get('username'),
                         password, origin, action)
         }
       }
+    })
+
+    ipcMain.on(messages.SAVE_PASSWORD, (e, username, password, origin, action) => {
+      if (!password || !origin || !action) {
+        return
+      }
+
+      masterKey = masterKey || getMasterKey()
+      if (!masterKey) {
+        console.log('Could not access master password; aborting')
+        return
+      }
+
+      const passwords = AppStore.getState().get('passwords')
+
+      // If the same password already exists, don't offer to save it
+      let result = passwords.findLast((pw) => {
+        return pw.get('origin') === origin && pw.get('action') === action && (username ? pw.get('username') === username : !pw.get('username'))
+      })
+      if (result && password === CryptoUtil.decryptVerify(result.get('encryptedPassword'),
+                                                          result.get('authTag'),
+                                                          masterKey,
+                                                          result.get('iv'))) {
+        return
+      }
+
+      var message = username
+        ? 'Would you like Brave to save the password for ' + username + ' on ' + origin + '?'
+        : 'Would you like Brave to save this password on ' + origin + '?'
+      dialog.showMessageBox({
+        type: 'question',
+        title: 'Save password?',
+        message: message,
+        buttons: ['Yes', 'No'],
+        defaultId: 1,
+        cancelId: 1
+      }, buttonId => {
+        if (buttonId !== 0) {
+          return
+        }
+        // Save the password
+        const encrypted = CryptoUtil.encryptAuthenticate(password, masterKey)
+        appActions.savePassword({
+          origin,
+          action,
+          username: username || '',
+          encryptedPassword: encrypted.content,
+          authTag: encrypted.tag,
+          iv: encrypted.iv
+        })
+      })
     })
 
     // Setup the crash handling

--- a/app/index.js
+++ b/app/index.js
@@ -272,6 +272,11 @@ app.on('ready', function () {
       Updater.updateNowRequested()
     })
 
+    ipcMain.on(messages.GET_PASSWORD, (e, origin, action) => {
+      console.log('got pw request', origin, action)
+      e.sender.send(messages.GOT_PASSWORD, 'foo', 'bar', origin, action)
+    })
+
     // Setup the crash handling
     CrashHerald.init()
 

--- a/app/index.js
+++ b/app/index.js
@@ -317,6 +317,10 @@ app.on('ready', function () {
       }
     })
 
+    ipcMain.on(messages.HIDE_CONTEXT_MENU, () => {
+      BrowserWindow.getFocusedWindow().webContents.send(messages.HIDE_CONTEXT_MENU)
+    })
+
     ipcMain.on(messages.SHOW_USERNAME_LIST, (e, origin, action, boundingRect) => {
       masterKey = masterKey || getMasterKey()
       if (!masterKey) {

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -140,6 +140,8 @@ module.exports.cleanSessionData = (sessionData) => {
     // restored.  We will be able to keep this once we
     // don't regenerate new frame keys when opening storage.
     delete frame.parentFrameKey
+    // Delete the active shortcut details
+    delete frame.activeShortcutDetails
 
     if (frame.navbar && frame.navbar.urlbar) {
       frame.navbar.urlbar.urlPreview = null

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -210,6 +210,7 @@ module.exports.loadAppState = () => {
         data.perWindowState.forEach(module.exports.cleanSessionData)
       }
       data.settings = data.settings || {}
+      data.passwords = data.passwords || []
       resolve(data)
     })
   })
@@ -222,6 +223,7 @@ module.exports.defaultAppState = () => {
   return {
     sites: [],
     visits: [],
-    settings: {}
+    settings: {},
+    passwords: []
   }
 }

--- a/docs/appActions.md
+++ b/docs/appActions.md
@@ -160,6 +160,16 @@ Sets the update status
 
 
 
+### savePassword(passwordDetail) 
+
+Saves login credentials
+
+**Parameters**
+
+**passwordDetail**: `Object`, login details
+
+
+
 ### changeSetting(key, value) 
 
 Changes an application level setting

--- a/docs/state.md
+++ b/docs/state.md
@@ -22,10 +22,12 @@ AppStore
     endTime: number // datetime.getTime()
   }],
   passwords: [{
-    origin: string,
-    action: string,
+    origin: string, // origin of the form
+    action: string, // URL of the form action
     username: string,
-    password: string // encrypted before saving to disk
+    encryptedPassword: string, // encrypted by master password, binary-encoded
+    authTag: string, // AES-GCM authentication data, binary-encoded
+    iv: string // AES-GCM initialization vector, binary-encoded
   }],
   adblock: {
     etag: string, // last downloaded data file etag

--- a/docs/state.md
+++ b/docs/state.md
@@ -21,6 +21,12 @@ AppStore
     startTime: number, // datetime.getTime()
     endTime: number // datetime.getTime()
   }],
+  passwords: [{
+    origin: string,
+    action: string,
+    username: string,
+    password: string // encrypted before saving to disk
+  }],
   adblock: {
     etag: string, // last downloaded data file etag
     lastCheckVersion: string, // last checked data file version

--- a/docs/state.md
+++ b/docs/state.md
@@ -112,6 +112,7 @@ WindowStore
     guestInstanceId: string, // not persisted
     closedAtIndex: number, // Index the frame was last closed at, cleared unless the frame is inside of closedFrames
     activeShortcut: string, // Set by the application store when the component should react to a shortcut
+    activeShortcutDetails: object, // Additional parameters for the active shortcut action if any
     adblock: {
       blocked: Array<string>
     },

--- a/docs/windowActions.md
+++ b/docs/windowActions.md
@@ -336,7 +336,7 @@ are no autocomplete results.
 
 
 
-### setActiveFrameShortcut(frameProps, activeShortcut) 
+### setActiveFrameShortcut(frameProps, activeShortcut, activeShortcutDetails) 
 
 Dispatches a message to the store to indicate that the pending frame shortcut info should be updated.
 
@@ -346,6 +346,8 @@ Dispatches a message to the store to indicate that the pending frame shortcut in
 
 **activeShortcut**: `string`, The text for the new shortcut. Usually this is null to clear info which was previously
 set from an IPC call.
+
+**activeShortcutDetails**: `string`, Parameters for the shortcut action
 
 
 

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -190,6 +190,17 @@ const appActions = {
   },
 
   /**
+   * Saves login credentials
+   * @param {Object} passwordDetail - login details
+   */
+  savePassword: function (passwordDetail) {
+    AppDispatcher.dispatch({
+      actionType: AppConstants.APP_ADD_PASSWORD,
+      passwordDetail
+    })
+  },
+
+  /**
    * Changes an application level setting
    * @param {string} key - The key name for the setting
    * @param {string} value - The value of the setting

--- a/js/actions/windowActions.js
+++ b/js/actions/windowActions.js
@@ -510,12 +510,14 @@ const windowActions = {
    * @param {Object} frameProps - Properties of the frame in question
    * @param {string} activeShortcut - The text for the new shortcut. Usually this is null to clear info which was previously
    * set from an IPC call.
+   * @param {string} activeShortcutDetails - Parameters for the shortcut action
    */
-  setActiveFrameShortcut: function (frameProps, activeShortcut) {
+  setActiveFrameShortcut: function (frameProps, activeShortcut, activeShortcutDetails) {
     dispatch({
       actionType: WindowConstants.WINDOW_SET_ACTIVE_FRAME_SHORTCUT,
       frameProps,
-      activeShortcut
+      activeShortcut,
+      activeShortcutDetails
     })
   },
 

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -131,6 +131,7 @@ class Frame extends ImmutableComponent {
       this.webview.focus()
     }
     const activeShortcut = this.props.frame.get('activeShortcut')
+    const activeShortcutDetails = this.props.frame.get('activeShortcutDetails')
     switch (activeShortcut) {
       case 'stop':
         this.webview.stop()
@@ -186,9 +187,19 @@ class Frame extends ImmutableComponent {
       case 'show-findbar':
         windowActions.setFindbarShown(this.props.frame, true)
         break
+      case 'fill-password':
+        let currentUrl = urlParse(this.webview.getURL())
+        if (currentUrl &&
+            [currentUrl.protocol, currentUrl.host].join('//') === activeShortcutDetails.get('origin')) {
+          this.webview.send(messages.GOT_PASSWORD,
+                            activeShortcutDetails.get('username'),
+                            activeShortcutDetails.get('password'),
+                            activeShortcutDetails.get('origin'),
+                            activeShortcutDetails.get('action'))
+        }
     }
     if (activeShortcut) {
-      windowActions.setActiveFrameShortcut(this.props.frame, null)
+      windowActions.setActiveFrameShortcut(this.props.frame, null, null)
     }
 
     if (this.props.frame.get('location') === 'about:preferences') {

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -173,6 +173,11 @@ class Main extends ImmutableComponent {
       windowActions.loadUrl(FrameStateUtil.getFrameByKey(self.props.windowState, frameKey), previousLocation)
     })
 
+    ipc.on(messages.SHOW_USERNAME_LIST, (e, usernames, origin, action, boundingRect) => {
+      const activeFrame = FrameStateUtil.getActiveFrame(self.props.windowState)
+      contextMenus.onShowUsernameMenu(usernames, origin, action, boundingRect, activeFrame)
+    })
+
     this.loadOpenSearch()
 
     window.addEventListener('mousemove', (e) => {

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -174,8 +174,7 @@ class Main extends ImmutableComponent {
     })
 
     ipc.on(messages.SHOW_USERNAME_LIST, (e, usernames, origin, action, boundingRect) => {
-      const activeFrame = FrameStateUtil.getActiveFrame(self.props.windowState)
-      contextMenus.onShowUsernameMenu(usernames, origin, action, boundingRect, activeFrame)
+      contextMenus.onShowUsernameMenu(usernames, origin, action, boundingRect)
     })
 
     this.loadOpenSearch()

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -177,6 +177,10 @@ class Main extends ImmutableComponent {
       contextMenus.onShowUsernameMenu(usernames, origin, action, boundingRect)
     })
 
+    ipc.on(messages.HIDE_CONTEXT_MENU, () => {
+      windowActions.setContextMenuDetail()
+    })
+
     this.loadOpenSearch()
 
     window.addEventListener('mousemove', (e) => {

--- a/js/constants/appConstants.js
+++ b/js/constants/appConstants.js
@@ -13,6 +13,8 @@ const AppConstants = {
   APP_SET_STATE: _,
   APP_REMOVE_SITE: _,
   APP_MOVE_SITE: _,
+  APP_ADD_PASSWORD: _, /** @param {Object} passwordDetail */
+  APP_REMOVE_PASSWORD: _, /** @param {Object} passwordDetail */
   APP_SET_DEFAULT_WINDOW_SIZE: _,
   APP_SET_DATA_FILE_ETAG: _,
   APP_SET_DATA_FILE_LAST_CHECK: _,

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -64,7 +64,7 @@ const messages = {
   GET_PASSWORD: _, /** @arg {string} formOrigin, @arg {string} action */
   GOT_PASSWORD: _, /** @arg {string} username, @arg {string} password */
   SAVE_PASSWORD: _, /** @arg {string} username, @arg {string} password, @arg {string} formOrigin, @arg {string} action */
-  SHOW_USERNAME_LIST: _, /** @arg {string} formOrigin, @arg {string} action, @arg {Object} boundingRect */
+  SHOW_USERNAME_LIST: _, /** @arg {string} formOrigin, @arg {string} action, @arg {Object} boundingRect, @arg {string} usernameValue */
   FILL_PASSWORD: _, /** @arg {string} username, @arg {string} password, @arg {string} origin, @arg {string} action */
   // Init
   INITIALIZE_WINDOW: _,

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -59,6 +59,10 @@ const messages = {
   STOP_LOAD: _,
   POST_PAGE_LOAD_RUN: _,
   THEME_COLOR_COMPUTED: _,
+  // Password manager
+  GET_PASSWORD: _, /** @arg {string} formOrigin, @arg {string} action */
+  GOT_PASSWORD: _, /** @arg {string} username, @arg {string} password */
+  SAVE_PASSWORD: _, /** @arg {string} username, @arg {string} password, @arg {string} formOrigin, @arg {string} action */
   // Init
   INITIALIZE_WINDOW: _,
   INITIALIZE_PARTITION: _, /** @arg {string} name of partition */

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -63,6 +63,8 @@ const messages = {
   GET_PASSWORD: _, /** @arg {string} formOrigin, @arg {string} action */
   GOT_PASSWORD: _, /** @arg {string} username, @arg {string} password */
   SAVE_PASSWORD: _, /** @arg {string} username, @arg {string} password, @arg {string} formOrigin, @arg {string} action */
+  SHOW_USERNAME_LIST: _, /** @arg {string} formOrigin, @arg {string} action, @arg {Object} boundingRect */
+  FILL_PASSWORD: _, /** @arg {string} username, @arg {string} password, @arg {string} origin, @arg {string} action */
   // Init
   INITIALIZE_WINDOW: _,
   INITIALIZE_PARTITION: _, /** @arg {string} name of partition */

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -59,6 +59,7 @@ const messages = {
   STOP_LOAD: _,
   POST_PAGE_LOAD_RUN: _,
   THEME_COLOR_COMPUTED: _,
+  HIDE_CONTEXT_MENU: _,
   // Password manager
   GET_PASSWORD: _, /** @arg {string} formOrigin, @arg {string} action */
   GOT_PASSWORD: _, /** @arg {string} username, @arg {string} password */

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -197,6 +197,26 @@ function moreBookmarksTemplateInit (allBookmarkItems, bookmarks, activeFrame) {
   return template
 }
 
+function usernameTemplateInit (usernames, origin, action, activeFrame) {
+  let items = []
+  for (let username in usernames) {
+    let password = usernames[username]
+    items.push({
+      label: username,
+      click: (item, focusedWindow) => {
+        windowActions.setActiveFrameShortcut(activeFrame, messages.FILL_PASSWORD, {
+          username,
+          password,
+          origin,
+          action
+        })
+        windowActions.setContextMenuDetail()
+      }
+    })
+  }
+  return items
+}
+
 function tabTemplateInit (frameProps) {
   const tabKey = frameProps.get('key')
   const items = []
@@ -525,6 +545,22 @@ export function onShowBookmarkFolderMenu (bookmarks, bookmark, activeFrame, e) {
   windowActions.setContextMenuDetail(Immutable.fromJS({
     left: (rectLeft.left | 0) - 2,
     top: (rectBottom.bottom | 0) - 1,
+    template: menuTemplate
+  }))
+}
+
+/**
+ * @param {Object} usernames - map of username to plaintext password
+ * @param {string} origin - origin of the form
+ * @param {string} action - action of the form
+ * @param {Object} boundingRect - bounding rectangle of username input field
+ * @param {Object} activeFrame - active frame
+ */
+export function onShowUsernameMenu (usernames, origin, action, boundingRect, activeFrame) {
+  const menuTemplate = usernameTemplateInit(usernames, origin, action, activeFrame)
+  windowActions.setContextMenuDetail(Immutable.fromJS({
+    left: boundingRect.left,
+    top: boundingRect.bottom + 62,
     template: menuTemplate
   }))
 }

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -197,14 +197,14 @@ function moreBookmarksTemplateInit (allBookmarkItems, bookmarks, activeFrame) {
   return template
 }
 
-function usernameTemplateInit (usernames, origin, action, activeFrame) {
+function usernameTemplateInit (usernames, origin, action) {
   let items = []
   for (let username in usernames) {
     let password = usernames[username]
     items.push({
       label: username,
       click: (item, focusedWindow) => {
-        windowActions.setActiveFrameShortcut(activeFrame, messages.FILL_PASSWORD, {
+        windowActions.setActiveFrameShortcut(null, messages.FILL_PASSWORD, {
           username,
           password,
           origin,
@@ -554,10 +554,9 @@ export function onShowBookmarkFolderMenu (bookmarks, bookmark, activeFrame, e) {
  * @param {string} origin - origin of the form
  * @param {string} action - action of the form
  * @param {Object} boundingRect - bounding rectangle of username input field
- * @param {Object} activeFrame - active frame
  */
-export function onShowUsernameMenu (usernames, origin, action, boundingRect, activeFrame) {
-  const menuTemplate = usernameTemplateInit(usernames, origin, action, activeFrame)
+export function onShowUsernameMenu (usernames, origin, action, boundingRect) {
+  const menuTemplate = usernameTemplateInit(usernames, origin, action)
   windowActions.setContextMenuDetail(Immutable.fromJS({
     left: boundingRect.left,
     top: boundingRect.bottom + 62,

--- a/js/lib/cryptoUtil.js
+++ b/js/lib/cryptoUtil.js
@@ -1,0 +1,48 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const crypto = require('crypto')
+
+const AES_256_GCM = 'aes-256-gcm'
+
+/**
+ * Encrypts and integrity-protects some text using AES GCM 256
+ * @param {string} text - utf8 encoded text to encrypt
+ * @param {string} key - binary encoded secret key, 32 bytes
+ * @param {string} iv - binary encoded IV, 12 bytes
+ * @return {{content: string, tag: string}}
+ */
+module.exports.encryptAuthenticate = function (text, key, iv) {
+  var cipher = crypto.createCipheriv(AES_256_GCM, key, iv)
+  var encrypted = cipher.update(text, 'utf8', 'binary')
+  encrypted += cipher.final('binary')
+  return {
+    content: encrypted,
+    tag: cipher.getAuthTag().toString('binary')
+  }
+}
+
+/**
+ * Decrypts and verifies text using AES GCM 256
+ * @param {string} encrypted - binary string to decrypt
+ * @param {string} authTag - binary-encoded authentication tag
+ * @param {string} key - binary encoded secret key, 32 bytes
+ * @param {string} iv - binary encoded IV, 12 bytes
+ * @return {string|null}
+ */
+module.exports.decryptVerify = function (encrypted, authTag, key, iv) {
+  try {
+    let decipher = crypto.createDecipheriv(AES_256_GCM, key, iv)
+    decipher.setAuthTag(new Buffer(authTag, 'binary'))
+    let decrypted = decipher.update(encrypted, 'binary', 'utf8')
+    decrypted += decipher.final('utf8')
+    return decrypted
+  } catch (e) {
+    // node throws error if authentication fails
+    console.log('got decryption failure', e)
+    return null
+  }
+}

--- a/js/lib/cryptoUtil.js
+++ b/js/lib/cryptoUtil.js
@@ -12,16 +12,17 @@ const AES_256_GCM = 'aes-256-gcm'
  * Encrypts and integrity-protects some text using AES GCM 256
  * @param {string} text - utf8 encoded text to encrypt
  * @param {string} key - binary encoded secret key, 32 bytes
- * @param {string} iv - binary encoded IV, 12 bytes
- * @return {{content: string, tag: string}}
+ * @return {{content: string, tag: string, iv: string}}
  */
-module.exports.encryptAuthenticate = function (text, key, iv) {
+module.exports.encryptAuthenticate = function (text, key) {
+  var iv = module.exports.getRandomBytes(12).toString('binary')
   var cipher = crypto.createCipheriv(AES_256_GCM, key, iv)
   var encrypted = cipher.update(text, 'utf8', 'binary')
   encrypted += cipher.final('binary')
   return {
     content: encrypted,
-    tag: cipher.getAuthTag().toString('binary')
+    tag: cipher.getAuthTag().toString('binary'),
+    iv: iv
   }
 }
 
@@ -45,4 +46,13 @@ module.exports.decryptVerify = function (encrypted, authTag, key, iv) {
     console.log('got decryption failure', e)
     return null
   }
+}
+
+/**
+ * Generates a buffer of N random bytes.
+ * @param {number} size - number of bytes to generate
+ * @return {Buffer}
+ */
+module.exports.getRandomBytes = function (size) {
+  return crypto.randomBytes(size)
 }

--- a/js/lib/cryptoUtil.js
+++ b/js/lib/cryptoUtil.js
@@ -15,8 +15,10 @@ const AES_256_GCM = 'aes-256-gcm'
  * @return {{content: string, tag: string, iv: string}}
  */
 module.exports.encryptAuthenticate = function (text, key) {
-  var iv = module.exports.getRandomBytes(12).toString('binary')
+  var ivBuffer = module.exports.getRandomBytes(12)
+  var iv = ivBuffer.toString('binary')
   var cipher = crypto.createCipheriv(AES_256_GCM, key, iv)
+  cipher.setAAD(ivBuffer)
   var encrypted = cipher.update(text, 'utf8', 'binary')
   encrypted += cipher.final('binary')
   return {
@@ -37,6 +39,7 @@ module.exports.encryptAuthenticate = function (text, key) {
 module.exports.decryptVerify = function (encrypted, authTag, key, iv) {
   try {
     let decipher = crypto.createDecipheriv(AES_256_GCM, key, iv)
+    decipher.setAAD(new Buffer(iv, 'binary'))
     decipher.setAuthTag(new Buffer(authTag, 'binary'))
     let decrypted = decipher.update(encrypted, 'binary', 'utf8')
     decrypted += decipher.final('utf8')

--- a/js/lib/cryptoUtil.js
+++ b/js/lib/cryptoUtil.js
@@ -7,6 +7,8 @@
 const crypto = require('crypto')
 
 const AES_256_GCM = 'aes-256-gcm'
+const DEFAULT_ENCODING = 'binary' // encoding of ciphertexts, iv's, keys, etc.
+const PLAINTEXT_ENCODING = 'utf8' // encoding of encryption input and decryption output
 
 /**
  * Encrypts and integrity-protects some text using AES GCM 256
@@ -15,16 +17,18 @@ const AES_256_GCM = 'aes-256-gcm'
  * @return {{content: string, tag: string, iv: string}}
  */
 module.exports.encryptAuthenticate = function (text, key) {
-  var ivBuffer = module.exports.getRandomBytes(12)
-  var iv = ivBuffer.toString('binary')
-  var cipher = crypto.createCipheriv(AES_256_GCM, key, iv)
-  cipher.setAAD(ivBuffer)
-  var encrypted = cipher.update(text, 'utf8', 'binary')
-  encrypted += cipher.final('binary')
+  var iv = module.exports.getRandomBytes(12)
+  var encrypted = module.exports.encryptAuthenticateInternal(
+    new Buffer(text, PLAINTEXT_ENCODING),
+    new Buffer(key, DEFAULT_ENCODING),
+    iv,
+    iv,
+    DEFAULT_ENCODING
+  )
   return {
-    content: encrypted,
-    tag: cipher.getAuthTag().toString('binary'),
-    iv: iv
+    content: encrypted.ciphertext,
+    tag: encrypted.tag,
+    iv: iv.toString(DEFAULT_ENCODING)
   }
 }
 
@@ -38,12 +42,15 @@ module.exports.encryptAuthenticate = function (text, key) {
  */
 module.exports.decryptVerify = function (encrypted, authTag, key, iv) {
   try {
-    let decipher = crypto.createDecipheriv(AES_256_GCM, key, iv)
-    decipher.setAAD(new Buffer(iv, 'binary'))
-    decipher.setAuthTag(new Buffer(authTag, 'binary'))
-    let decrypted = decipher.update(encrypted, 'binary', 'utf8')
-    decrypted += decipher.final('utf8')
-    return decrypted
+    let ivBuffer = new Buffer(iv, DEFAULT_ENCODING)
+    return module.exports.decryptVerifyInternal(
+      new Buffer(encrypted, DEFAULT_ENCODING),
+      new Buffer(key, DEFAULT_ENCODING),
+      ivBuffer,
+      ivBuffer,
+      new Buffer(authTag, DEFAULT_ENCODING),
+      PLAINTEXT_ENCODING
+    )
   } catch (e) {
     // node throws error if authentication fails
     console.log('got decryption failure', e)
@@ -58,4 +65,48 @@ module.exports.decryptVerify = function (encrypted, authTag, key, iv) {
  */
 module.exports.getRandomBytes = function (size) {
   return crypto.randomBytes(size)
+}
+
+/**
+ * Encrypts and integrity-protects some data using AES GCM 256
+ * @param {Buffer} pdata - plaintext data to encrypt
+ * @param {Buffer} key - secret key
+ * @param {Buffer} iv - initialization vector
+ * @param {Buffer|undefined} adata - additional authenticated data
+ * @param {string} outputEncoding - 'hex', 'binary', or 'base64'
+ * @return {{ciphertext: string, tag: string}}
+ */
+module.exports.encryptAuthenticateInternal = function (pdata, key, iv, adata, outputEncoding) {
+  // Note that Node's GCM implementation only accepts 12 byte IV's
+  var cipher = crypto.createCipheriv(AES_256_GCM, key, iv)
+  if (adata) {
+    cipher.setAAD(adata)
+  }
+  var encrypted = cipher.update(pdata, undefined, outputEncoding)
+  encrypted += cipher.final(outputEncoding)
+  return {
+    ciphertext: encrypted,
+    tag: cipher.getAuthTag().toString(outputEncoding)
+  }
+}
+
+/**
+ * Decrypts and verifies some data using AES GCM 256
+ * @param {Buffer} ciphertext - ciphertext
+ * @param {Buffer} key - secret key
+ * @param {Buffer} iv - initialization vector
+ * @param {Buffer|undefined} adata - additional authenticated data
+ * @param {Buffer} tag - authentication tag
+ * @param {string} outputEncoding - 'binary', 'ascii', 'utf8'
+ * @return {string}
+ */
+module.exports.decryptVerifyInternal = function (ciphertext, key, iv, adata, tag, outputEncoding) {
+  let decipher = crypto.createDecipheriv(AES_256_GCM, key, iv)
+  if (adata) {
+    decipher.setAAD(adata)
+  }
+  decipher.setAuthTag(tag)
+  let decrypted = decipher.update(ciphertext, undefined, outputEncoding)
+  decrypted += decipher.final(outputEncoding)
+  return decrypted
 }

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -287,6 +287,21 @@ const handleAppAction = (action) => {
       const appWindow = BrowserWindow.fromId(action.appWindowId)
       appWindow.close()
       break
+    case AppConstants.APP_ADD_PASSWORD:
+      // If there is already an entry for this exact origin, action, and
+      // username if it exists, update the password instead of creating a new entry
+      let passwords = appState.get('passwords').filterNot((pw) => {
+        return pw.get('origin') === action.passwordDetail.origin &&
+          pw.get('action') === action.passwordDetail.action &&
+          (!pw.get('username') || pw.get('username') === action.passwordDetail.action)
+      })
+      appState = appState.set('passwords', passwords.push(Immutable.fromJS(action.passwordDetail)))
+      break
+    case AppConstants.APP_REMOVE_PASSWORD:
+      appState.set('passwords', appState.get('passwords').filterNot((pw) => {
+        return Immutable.is(pw, Immutable.fromJS(action.passwordDetail))
+      }))
+      break
     case AppConstants.APP_ADD_SITE:
       const oldSiteSize = appState.get('sites').size
       if (action.siteDetail.constructor === Immutable.List) {

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -326,7 +326,10 @@ const doAction = (action) => {
       }
       break
     case WindowConstants.WINDOW_SET_ACTIVE_FRAME_SHORTCUT:
-      windowState = windowState.mergeIn(['frames', FrameStateUtil.getFramePropsIndex(windowState.get('frames'), action.frameProps), 'activeShortcut'], action.activeShortcut)
+      windowState = windowState.mergeIn(['frames', FrameStateUtil.getFramePropsIndex(windowState.get('frames'), action.frameProps)], {
+        activeShortcut: action.activeShortcut,
+        activeShortcutDetails: action.activeShortcutDetails
+      })
       break
     case WindowConstants.WINDOW_SET_SEARCH_DETAIL:
       windowState = windowState.merge({
@@ -507,7 +510,8 @@ frameShortcuts.forEach(shortcut => {
   // Listen for actions on the active frame
   ipc.on(`shortcut-active-frame-${shortcut}`, () => {
     windowState = windowState.mergeIn(activeFrameStatePath(), {
-      activeShortcut: shortcut
+      activeShortcut: shortcut,
+      activeShortcutDetails: null
     })
     emitChanges()
   })
@@ -516,7 +520,8 @@ frameShortcuts.forEach(shortcut => {
     ipc.on(`shortcut-frame-${shortcut}`, (e, i) => {
       const path = ['frames', FrameStateUtil.findIndexForFrameKey(windowState.get('frames'), i)]
       windowState = windowState.mergeIn(path, {
-        activeShortcut: shortcut
+        activeShortcut: shortcut,
+        activeShortcutDetails: null
       })
       emitChanges()
     })

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -326,7 +326,8 @@ const doAction = (action) => {
       }
       break
     case WindowConstants.WINDOW_SET_ACTIVE_FRAME_SHORTCUT:
-      windowState = windowState.mergeIn(['frames', FrameStateUtil.getFramePropsIndex(windowState.get('frames'), action.frameProps)], {
+      const framePath = action.frameProps ? ['frames', FrameStateUtil.getFramePropsIndex(windowState.get('frames'), action.frameProps)] : activeFrameStatePath()
+      windowState = windowState.mergeIn(framePath, {
         activeShortcut: action.activeShortcut,
         activeShortcutDetails: action.activeShortcutDetails
       })

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "immutable": "^3.7.5",
     "immutablediff": "^0.4.2",
     "immutablepatch": "^0.2.2",
+    "keytar": "^3.0.0",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",
     "tracking-protection": "1.0.x",

--- a/test/unit/cryptoUtilTest.js
+++ b/test/unit/cryptoUtilTest.js
@@ -1,0 +1,28 @@
+/* global describe, it */
+const CryptoUtil = require('../../js/lib/cryptoUtil')
+const assert = require('assert')
+
+describe('crypto util test', function () {
+  it('gets random bytes', function () {
+    assert.equal(CryptoUtil.getRandomBytes(256).length, 256)
+  })
+  it('throws if random bytes argument is not a number', function () {
+    assert.throws(
+      () => { CryptoUtil.getRandomBytes('') }
+    )
+  })
+  it('encrypts and decrypts successfully', function () {
+    let message = 'hello world'
+    let key = '3zTvzr3p67VC61jmV54rIYu1545x4TlY'
+    let encrypted = CryptoUtil.encryptAuthenticate(message, key)
+    assert.equal(message, CryptoUtil.decryptVerify(encrypted.content, encrypted.tag, key, encrypted.iv))
+  })
+  it('decryption fails with wrong authentication tag', function () {
+    let message = 'hello world'
+    let tamperedMessage = 'i hate browsers'
+    let key = '3zTvzr3p67VC61jmV54rIYu1545x4TlY'
+    let encrypted = CryptoUtil.encryptAuthenticate(message, key)
+    let wrongEncrypted = CryptoUtil.encryptAuthenticate(tamperedMessage, key)
+    assert.equal(null, CryptoUtil.decryptVerify(encrypted.content, wrongEncrypted.tag, key, encrypted.iv))
+  })
+})

--- a/test/unit/cryptoUtilTest.js
+++ b/test/unit/cryptoUtilTest.js
@@ -25,4 +25,84 @@ describe('crypto util test', function () {
     let wrongEncrypted = CryptoUtil.encryptAuthenticate(tamperedMessage, key)
     assert.equal(null, CryptoUtil.decryptVerify(encrypted.content, wrongEncrypted.tag, key, encrypted.iv))
   })
+  it('decryption fails with wrong IV', function () {
+    let message = 'hello world'
+    let key = '3zTvzr3p67VC61jmV54rIYu1545x4TlY'
+    let encrypted = CryptoUtil.encryptAuthenticate(message, key)
+    assert.equal(null, CryptoUtil.decryptVerify(encrypted.content, encrypted.tag, key,
+                                                CryptoUtil.getRandomBytes(12)))
+  })
+  // Try some test vectors from
+  // http://csrc.nist.gov/groups/ST/toolkit/BCM/documents/proposedmodes/gcm/gcm-revised-spec.pdf
+  it('passes NIST Test Case 13', function () {
+    let K = '0000000000000000000000000000000000000000000000000000000000000000'
+    let P = ''
+    let IV = '000000000000000000000000'
+    let encrypted = CryptoUtil.encryptAuthenticateInternal(
+      new Buffer(P, 'hex'),
+      new Buffer(K, 'hex'),
+      new Buffer(IV, 'hex'),
+      undefined,
+      'hex'
+    )
+    let decrypted = CryptoUtil.decryptVerifyInternal(
+      new Buffer('', 'hex'), new Buffer(K, 'hex'), new Buffer(IV, 'hex'), undefined,
+      new Buffer('530f8afbc74536b9a963b4f1c4cb738b', 'hex'), 'binary'
+    )
+    assert.equal(encrypted.ciphertext, '')
+    assert.equal(encrypted.tag, '530f8afbc74536b9a963b4f1c4cb738b')
+    assert.equal(decrypted, P)
+  })
+  it('passes NIST Test Case 14', function () {
+    let K = '0000000000000000000000000000000000000000000000000000000000000000'
+    let P = '00000000000000000000000000000000'
+    let IV = '000000000000000000000000'
+    let encrypted = CryptoUtil.encryptAuthenticateInternal(
+      new Buffer(P, 'hex'),
+      new Buffer(K, 'hex'),
+      new Buffer(IV, 'hex'),
+      undefined,
+      'hex'
+    )
+    assert.equal(encrypted.ciphertext, 'cea7403d4d606b6e074ec5d3baf39d18')
+    assert.equal(encrypted.tag, 'd0d1c8a799996bf0265b98b5d48ab919')
+  })
+  it('passes NIST Test Case 15', function () {
+    let K = 'feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308'
+    let P = 'd9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b391aafd255'
+    let IV = 'cafebabefacedbaddecaf888'
+    let encrypted = CryptoUtil.encryptAuthenticateInternal(
+      new Buffer(P, 'hex'),
+      new Buffer(K, 'hex'),
+      new Buffer(IV, 'hex'),
+      undefined,
+      'hex'
+    )
+    assert.equal(encrypted.ciphertext, '522dc1f099567d07f47f37a32a84427d' +
+                 '643a8cdcbfe5c0c97598a2bd2555d1aa' +
+                 '8cb08e48590dbb3da7b08b1056828838' +
+                 'c5f61e6393ba7a0abcc9f662898015ad')
+    assert.equal(encrypted.tag, 'b094dac5d93471bdec1a502270e3cc6c')
+  })
+  it('passes NIST Test Case 16', function () {
+    let K = 'feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308'
+    let P = 'd9313225f88406e5a55909c5aff5269a86a7a9531534f7da2e4c303d8a318a721c3c0c95956809532fcf0e2449a6b525b16aedf5aa0de657ba637b39'
+    let IV = 'cafebabefacedbaddecaf888'
+    let A = 'feedfacedeadbeeffeedfacedeadbeefabaddad2'
+    let encrypted = CryptoUtil.encryptAuthenticateInternal(
+      new Buffer(P, 'hex'),
+      new Buffer(K, 'hex'),
+      new Buffer(IV, 'hex'),
+      new Buffer(A, 'hex'),
+      'hex'
+    )
+    let decrypted = CryptoUtil.decryptVerifyInternal(
+      new Buffer('522dc1f099567d07f47f37a32a84427d643a8cdcbfe5c0c97598a2bd2555d1aa8cb08e48590dbb3da7b08b1056828838c5f61e6393ba7a0abcc9f662', 'hex'),
+      new Buffer(K, 'hex'), new Buffer(IV, 'hex'), new Buffer(A, 'hex'),
+      new Buffer('76fc6ece0f4e1768cddf8853bb2d551b', 'hex'), 'binary'
+    )
+    assert.equal(encrypted.ciphertext, '522dc1f099567d07f47f37a32a84427d643a8cdcbfe5c0c97598a2bd2555d1aa8cb08e48590dbb3da7b08b1056828838c5f61e6393ba7a0abcc9f662')
+    assert.equal(encrypted.tag, '76fc6ece0f4e1768cddf8853bb2d551b')
+    assert.equal(P, new Buffer(decrypted, 'binary').toString('hex'))
+  })
 })


### PR DESCRIPTION
This adds basic support for saving username/passwords and autofilling them later. It seems to work for most simple forms like https://trac.torproject.org/projects/tor/login.

follow-ups:
- [ ] replace electron's dialog with our custom dialog (#923)
- [x]  more crypto unit tests
- [ ] add prefs page to view and manage passwords (#1101)
- [x] better multi-account support (detect when a username has been entered and find the corresponding password)

login details are stored in `appState`; the password is encrypted with a key stored in the OS keychain before being written to disk. 

Auditors: @bbondy (aiming for 0.8.2)