### PR TITLE
Wait long enough always for saving when no windows

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -155,12 +155,12 @@ app.on('ready', function () {
       return
     }
 
+    e.preventDefault()
     if (BrowserWindow.getAllWindows().length === 0) {
       saveIfAllCollected()
       return
     }
 
-    e.preventDefault()
     perWindowState.length = 0
     BrowserWindow.getAllWindows().forEach(win => win.webContents.send(messages.REQUEST_WINDOW_STATE))
   })


### PR DESCRIPTION
This was from a refactoring needed for saving periodically.  After the
data saves it will call quit again and it will exit out, so we should
preent default when therea re no windows too.

Auditors: @aekeus