### PR TITLE
Created inspect element option in contextMenu including the correct locations (x&y) for the console

### DIFF
--- a/app/content/scripts/webviewPreload.js
+++ b/app/content/scripts/webviewPreload.js
@@ -449,7 +449,9 @@
         href: href,
         src: e.target.src,
         isContentEditable: e.target.isContentEditable,
-        hasSelection: hasSelection(e.target)
+        hasSelection: hasSelection(e.target),
+        offsetX: e.pageX,
+        offsetY: e.pageY
       }
       ipcRenderer.sendToHost('context-menu-opened', nodeProps)
       e.preventDefault()

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -241,7 +241,7 @@ function tabTemplateInit (frameProps) {
           // Handle converting the current tab window into a pinned site
           windowActions.setPinned(frameProps, false)
           // Handle setting it in app storage for the other windows
-          appActions.removeSite(siteUtil.getDetailFromFrame(frameProps, siteTags.PINNED), siteTags.PINNED)
+          appActions.removeSite(siteUtil.getDetailFromFrame(frameProps), siteTags.PINNED)
         }
       })
     } else {
@@ -251,7 +251,7 @@ function tabTemplateInit (frameProps) {
           // Handle converting the current tab window into a pinned site
           windowActions.setPinned(frameProps, true)
           // Handle setting it in app storage for the other windows
-          appActions.addSite(siteUtil.getDetailFromFrame(frameProps, siteTags.PINNED), siteTags.PINNED)
+          appActions.addSite(siteUtil.getDetailFromFrame(frameProps), siteTags.PINNED)
         }
       })
     }
@@ -488,7 +488,11 @@ function mainTemplateInit (nodeProps, frame) {
         focusedWindow.webContents.send(messages.SHORTCUT_ACTIVE_FRAME_RELOAD)
       }
     }
-  }, {
+  })
+
+  template.push(CommonMenu.separatorMenuItem)
+
+  template.push({
     label: 'View Page Source',
     click: (item, focusedWindow) => {
       if (focusedWindow) {
@@ -501,6 +505,19 @@ function mainTemplateInit (nodeProps, frame) {
       label: 'Add to reading list',
       enabled: false
     })
+
+  template.push(CommonMenu.separatorMenuItem)
+  
+  template.push({
+    label: 'Inspect Element',
+    click: (item, focusedWindow) => {
+      if (focusedWindow) {
+        document.querySelector( 'webview' ).openDevTools();
+        document.querySelector( 'webview' ).inspectElement(nodeProps.offsetX, nodeProps.offsetY);
+        // Used for Brave dev tools: focusedWindow.openDevTools();
+      }
+    }
+  })
   return template
 }
 


### PR DESCRIPTION
Right click inspect element, it will also go to the correct element location in the console...

PS:
This is a new request based on: https://github.com/brave/browser-laptop/pull/1148/files