### PR TITLE
Handle mousewheel zoom

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -27,6 +27,7 @@ class Frame extends ImmutableComponent {
   constructor () {
     super()
     this.previousLocation = 'about:newtab'
+    this.mouseWheelZoomCount = 0
   }
 
   updateWebview () {
@@ -403,6 +404,9 @@ class Frame extends ImmutableComponent {
     if (this.props.frame.get('audioMuted')) {
       this.webview.setAudioMuted(true)
     }
+
+    // Handle zoom using Ctrl/Cmd and the mouse wheel.
+    this.webview.addEventListener('mousewheel', this.onMouseWheel.bind(this))
   }
 
   insertAds (currentLocation) {
@@ -430,6 +434,20 @@ class Frame extends ImmutableComponent {
   onFindHide () {
     windowActions.setFindbarShown(this.props.frame, false)
     this.onClearMatch()
+  }
+
+  onMouseWheel (e) {
+    if (e.ctrlKey || (e.metaKey && process.platform === 'darwin')) {
+      // Do not change the zoom level on each WheelEvent.
+      if (this.mouseWheelZoomCount++ === 15) {
+        this.mouseWheelZoomCount = 0
+        if (e.deltaY >= 0) {
+          windowActions.zoomIn(this.props.frame)
+        } else {
+          windowActions.zoomOut(this.props.frame)
+        }
+      }
+    }
   }
 
   onFind (searchString, caseSensitivity, forward) {


### PR DESCRIPTION
Aloha,

Should fix issue #1110. However, I did not found (because of no experience with Electron and React at all) why the current `zoomLevel` is not saved to the `WindowStore`. 