### PR TITLE
fix: fixes #1186 failed win build due to required platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,8 +94,6 @@
     "co-mocha": "^1.1.2",
     "css-loader": "^0.23.0",
     "electron-builder": "^2.3.1",
-    "electron-installer-debian": "^0.2.0",
-    "electron-installer-redhat": "^0.2.0",
     "electron-installer-squirrel-windows": "^1.2.2",
     "electron-packager": "brave/electron-packager",
     "electron-rebuild": "^1.1.1",
@@ -121,6 +119,10 @@
     "webpack-dev-server": "^1.14.0",
     "webpack-notifier": "^1.2.1",
     "xml2js": "^0.4.15"
+  },
+  "optionalDependencies": {
+    "electron-installer-debian": "^0.2.0",
+    "electron-installer-redhat": "^0.2.0"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
The added modules in the commits below supposedly require platforms through their `package.json`. Hence `npm install` fails on windows currently. Making it those dependencies [optional](https://docs.npmjs.com/files/package.json#optionaldependencies) should fix the issue above.

5735e6d0180db463f737869cb679cc2394e94c83, 724f7b59afede1b998bf2652b397e1d8ce35577f, 3b302ef295c8d6529613856242a75d25b39637a3