### PR TITLE
Drop use of defunct frame prop from Main.onCloseFrame

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -288,7 +288,7 @@ class Main extends ImmutableComponent {
   }
 
   onCloseFrame (activeFrameProps) {
-    windowActions.closeFrame(this.props.windowState.get('frames'), this.props.frame)
+    windowActions.closeFrame(this.props.windowState.get('frames'), activeFrameProps)
   }
 
   onDragOver (e) {


### PR DESCRIPTION
There is no frame passed in by the caller of Main, instead use the
props passed in as an argument.