### PR TITLE
Don’t pass settings into NavigationBar, etc

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -355,7 +355,6 @@ class Main extends ImmutableComponent {
     const activeFrame = FrameStateUtil.getActiveFrame(this.props.windowState)
 
     this.frames = {}
-    const settingsState = this.props.appState.get('settings') || new Immutable.Map()
     const nonPinnedFrames = this.props.windowState.get('frames').filter((frame) => !frame.get('pinnedLocation'))
     const tabsPerPage = getSetting(settings.TABS_PER_TAB_PAGE)
     const showBookmarksToolbar = getSetting(settings.SHOW_BOOKMARKS_TOOLBAR)
@@ -403,7 +402,6 @@ class Main extends ImmutableComponent {
             activeFrame={activeFrame}
             mouseInTitlebar={this.props.windowState.getIn(['ui', 'mouseInTitlebar'])}
             searchSuggestions={activeFrame && activeFrame.getIn(['navbar', 'urlbar', 'searchSuggestions'])}
-            settings={settingsState}
             searchDetail={this.props.windowState.get('searchDetail')}
           />
           {
@@ -491,7 +489,9 @@ class Main extends ImmutableComponent {
               onCloseFrame={this.onCloseFrame}
               frame={frame}
               key={frame.get('key')}
-              settings={frame.get('location') === 'about:preferences' ? settingsState || new Immutable.Map() : null}
+              settings={frame.get('location') === 'about:preferences'
+                ? this.props.appState.get('settings') || new Immutable.Map()
+                : null}
               bookmarks={frame.get('location') === 'about:bookmarks'
                 ? this.props.appState.get('sites')
                     .filter((site) => site.get('tags')

--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -125,7 +125,6 @@ class NavigationBar extends ImmutableComponent {
         frames={this.props.frames}
         loading={this.loading}
         titleMode={this.titleMode}
-        settings={this.props.settings}
         urlbar={this.props.navbar.get('urlbar')}
         />
       {

--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -283,7 +283,6 @@ class UrlBar extends ImmutableComponent {
           ? <UrlBarSuggestions
             ref={(node) => { this.urlBarSuggestions = node }}
             suggestions={this.props.urlbar.get('suggestions')}
-            settings={this.props.settings}
             sites={this.props.sites}
             frames={this.props.frames}
             searchDetail={this.searchDetail}


### PR DESCRIPTION
It’s unused there - no need to access it outside of about:preferences