### PR TITLE
Consistently unpack the needed selectors under test

### DIFF
--- a/test/app/sessionStoreTest.js
+++ b/test/app/sessionStoreTest.js
@@ -1,7 +1,7 @@
 /* global describe, it, before, after */
 
 const Brave = require('../lib/brave')
-const selectors = require('../lib/selectors')
+const {navigator, urlInput, navigatorBookmarked, navigatorNotBookmarked} = require('../lib/selectors')
 const siteTags = require('../../js/constants/siteTags')
 
 describe('sessionStore', function () {
@@ -9,7 +9,7 @@ describe('sessionStore', function () {
     yield client
       .waitUntilWindowLoaded()
       .waitForVisible('#window')
-      .waitForVisible(selectors.urlInput)
+      .waitForVisible(urlInput)
     Brave.addCommands()
   }
 
@@ -21,16 +21,16 @@ describe('sessionStore', function () {
       yield Brave.startApp()
       yield setup(Brave.app.client)
       yield Brave.app.client.loadUrl(page1Url)
-      yield Brave.app.client.waitForExist(selectors.navigatorNotBookmarked)
+      yield Brave.app.client.waitForExist(navigatorNotBookmarked)
       yield Brave.app.client.addSite({
         location: page1Url,
         title: 'some page'
       }, siteTags.BOOKMARK)
       yield Brave.app.client
-        .moveToObject(selectors.navigator)
-        .waitForExist(selectors.navigatorBookmarked)
+        .moveToObject(navigator)
+        .waitForExist(navigatorBookmarked)
         .waitUntil(function () {
-          return this.getValue(selectors.urlInput).then((val) => val === page1Url)
+          return this.getValue(urlInput).then((val) => val === page1Url)
         })
       yield Brave.stopApp()
       yield Brave.startApp(false)
@@ -44,14 +44,14 @@ describe('sessionStore', function () {
     it('windowState by preserving open page', function *() {
       const page1Url = Brave.server.url('page1.html')
       yield Brave.app.client
-        .moveToObject(selectors.urlInput)
+        .moveToObject(urlInput)
         .waitUntil(function () {
-          return this.getValue(selectors.urlInput).then((val) => val === page1Url)
+          return this.getValue(urlInput).then((val) => val === page1Url)
         })
     })
 
     it('appstate by preserving a bookmark', function *() {
-      yield Brave.app.client.waitForExist(selectors.navigatorBookmarked)
+      yield Brave.app.client.waitForExist(navigatorBookmarked)
     })
   })
 })

--- a/test/components/windowTest.js
+++ b/test/components/windowTest.js
@@ -1,7 +1,7 @@
 /* global describe, it, before */
 
 const Brave = require('../lib/brave')
-const Selectors = require('../lib/selectors')
+const {activeWebview} = require('../lib/selectors')
 
 describe('application window', function () {
   describe('application launch', function () {
@@ -10,7 +10,7 @@ describe('application window', function () {
     it('opens a window and loads the UI', function *() {
       yield this.app.client
         .waitUntilWindowLoaded()
-        .waitForVisible(Selectors.activeWebview)
+        .waitForVisible(activeWebview)
         .getWindowCount().should.eventually.equal(2) // main window and webview
         .isWindowMinimized().should.eventually.be.false
         .isWindowDevToolsOpened().should.eventually.be.false
@@ -39,7 +39,7 @@ describe('application window', function () {
               return count === 4 // two windows with two views each
             })
           })
-          .waitForVisible(Selectors.activeWebview)
+          .waitForVisible(activeWebview)
       })
 
       it('offsets from the focused window', function *() {
@@ -71,7 +71,7 @@ describe('application window', function () {
             })
           })
           .waitUntilWindowLoaded()
-          .waitForVisible(Selectors.activeWebview)
+          .waitForVisible(activeWebview)
       })
 
       it('offsets from the focused window', function *() {
@@ -103,7 +103,7 @@ describe('application window', function () {
             })
           })
           .waitUntilWindowLoaded()
-          .waitForVisible(Selectors.activeWebview)
+          .waitForVisible(activeWebview)
       })
 
       it('is maximized', function *() {
@@ -131,7 +131,7 @@ describe('application window', function () {
 
         yield this.app.client
           .waitUntilWindowLoaded()
-          .waitForVisible(Selectors.activeWebview)
+          .waitForVisible(activeWebview)
           .windowByIndex(1)
           .url(Brave.server.url('window_open.html'))
           .execute(function (page1) {
@@ -182,7 +182,7 @@ describe('application window', function () {
         this.page1 = Brave.server.url('page1.html')
 
         yield this.app.client
-          .waitForVisible(Selectors.activeWebview)
+          .waitForVisible(activeWebview)
           .windowByIndex(1)
           .url(Brave.server.url('window_open.html'))
           .execute(function (page1) {
@@ -203,7 +203,7 @@ describe('application window', function () {
         yield this.app.client
           .windowParentByUrl(this.page1)
           .waitUntilWindowLoaded()
-          .waitForVisible(Selectors.activeWebview)
+          .waitForVisible(activeWebview)
       })
 
       it('has a min width of 480 and height of 300', function *() {
@@ -226,7 +226,7 @@ describe('application window', function () {
         yield this.app.client
           .windowByIndex(0)
           .waitUntilWindowLoaded()
-          .waitForVisible(Selectors.activeWebview)
+          .waitForVisible(activeWebview)
           .windowByIndex(1)
           .url(Brave.server.url('window_open.html'))
           .execute(function (page1) {
@@ -263,7 +263,7 @@ describe('application window', function () {
 
           yield this.app.client
             .waitUntilWindowLoaded()
-            .waitForVisible(Selectors.activeWebview)
+            .waitForVisible(activeWebview)
             .windowByIndex(1)
             .url(this.window_open_page)
             .execute(function (page1) {
@@ -354,7 +354,7 @@ describe('application window', function () {
 
           yield this.app.client
             .waitUntilWindowLoaded()
-            .waitForVisible(Selectors.activeWebview)
+            .waitForVisible(activeWebview)
             .windowByIndex(1)
             .url(this.window_open_page)
             .execute(function (page1) {
@@ -477,7 +477,7 @@ describe('application window', function () {
 
       yield this.app.client
         .waitUntilWindowLoaded()
-        .waitForVisible(Selectors.activeWebview)
+        .waitForVisible(activeWebview)
         .windowByIndex(1)
         .url(this.window_open_page)
         .execute(function (page1) {
@@ -513,7 +513,7 @@ describe('application window', function () {
         yield this.app.client
           .windowByIndex(0)
           .waitUntilWindowLoaded()
-          .waitForVisible(Selectors.activeWebview)
+          .waitForVisible(activeWebview)
           .windowByIndex(1)
           .url(Brave.server.url('window_open.html'))
           .execute(function (page1) {
@@ -554,7 +554,7 @@ describe('application window', function () {
 
         yield this.app.client
           .waitUntilWindowLoaded()
-          .waitForVisible(Selectors.activeWebview)
+          .waitForVisible(activeWebview)
           .windowByIndex(1)
           .url(this.click_with_target_page)
           .waitForVisible('#name')
@@ -613,7 +613,7 @@ describe('application window', function () {
 
         yield this.app.client
           .waitUntilWindowLoaded()
-          .waitForVisible(Selectors.activeWebview)
+          .waitForVisible(activeWebview)
           .windowByIndex(1)
           .url(this.click_with_target_page)
           .waitForVisible('#none')
@@ -648,7 +648,7 @@ describe('application window', function () {
 
         yield this.app.client
           .waitUntilWindowLoaded()
-          .waitForVisible(Selectors.activeWebview)
+          .waitForVisible(activeWebview)
           .windowByIndex(1)
           .url(this.click_with_target_page)
           .waitForVisible('#_self')
@@ -683,7 +683,7 @@ describe('application window', function () {
 
         yield this.app.client
           .waitUntilWindowLoaded()
-          .waitForVisible(Selectors.activeWebview)
+          .waitForVisible(activeWebview)
           .windowByIndex(1)
           .url(this.click_with_target_page)
           .frame('parent')
@@ -719,7 +719,7 @@ describe('application window', function () {
 
         yield this.app.client
           .waitUntilWindowLoaded()
-          .waitForVisible(Selectors.activeWebview)
+          .waitForVisible(activeWebview)
           .windowByIndex(1)
           .url(this.click_with_target_page)
           .frame('parent')


### PR DESCRIPTION
This was the practice elsewhere, and is more explicit & DRY