### PR TITLE
Fix an occasional navigationBarTest failure

### DIFF
--- a/test/components/navigationBarTest.js
+++ b/test/components/navigationBarTest.js
@@ -127,6 +127,8 @@ describe('urlbar', function () {
         // Navigate to a page with a title first to ensure it gets reset
         yield this.app.client
           .loadUrl(this.page)
+          .moveToObject(navigator)
+          .waitForValue(urlInput)
           .waitUntil(function () {
             return this.getValue(urlInput).then((val) => val === page)
           })


### PR DESCRIPTION
By applying some setup that is present e.g. on line 102 of this file,
to reveal the urlInput.