### PR TITLE
changed titleBarStyle to hidden-inset

### DIFF
--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -115,7 +115,7 @@ const createWindow = (browserOpts, defaults) => {
     // Neither a frame nor a titlebar
     // frame: false,
     // A frame but no title bar and windows buttons in titlebar 10.10 OSX and up only?
-    titleBarStyle: 'hidden',
+    titleBarStyle: 'hidden-inset',
     autoHideMenuBar: true,
     title: appConfig.name,
     webPreferences: defaults.webPreferences


### PR DESCRIPTION
**Before:**
<img width="264" alt="screen shot 2016-04-07 at 11 40 58 am" src="https://cloud.githubusercontent.com/assets/2644648/14357175/a99d5df8-fcb5-11e5-9777-3d9b221d97fa.png">
**After:**
<img width="195" alt="screen shot 2016-04-07 at 11 40 47 am" src="https://cloud.githubusercontent.com/assets/2644648/14357174/a9996cc0-fcb5-11e5-9fd6-26153caf1e75.png">

It was always bothering me that the traffic light wasn't centered. Changing `titleBarStyle` to `'hidden-inset'` did the trick.

**Full screen before:**
<img width="1440" alt="screen shot 2016-04-07 at 11 44 39 am" src="https://cloud.githubusercontent.com/assets/2644648/14357302/2ff70eda-fcb6-11e5-8ef4-6dc010e431c3.png">
** Full screen after:**
<img width="1440" alt="screen shot 2016-04-07 at 11 44 57 am" src="https://cloud.githubusercontent.com/assets/2644648/14357317/3c6c4ef0-fcb6-11e5-921a-079ea4360f7a.png">

I'm not sure if I did this pull request correctly. If I didn't, I'm happy to modify :) 