### PR TITLE
flow type checking

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,10 +1,9 @@
 [ignore]
-.*/node_modules/.*
 .*/app/extensions/brave/gen/.*
+.*/test/.*/*.json
+.*/node_modules/fbjs/lib/.*
 .*/build/Release/.*
 .*/public/built/.*
-.*/dist/.*
-.*/win64-dist/.*
 
 [libs]
 decls

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,10 @@
+[ignore]
+.*/node_modules/.*
+.*/app/extensions/brave/gen/.*
+.*/build/Release/.*
+.*/public/built/.*
+.*/dist/.*
+.*/win64-dist/.*
+
+[libs]
+decls

--- a/app/extensions/brave/brave-default.js
+++ b/app/extensions/brave/brave-default.js
@@ -1,10 +1,11 @@
+// @flow weak
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 // inject missing DOM Level 3 KeyEvent
 // https://www.w3.org/TR/2001/WD-DOM-Level-3-Events-20010410/DOM3-Events.html#events-Events-KeyEvent
-if (typeof this.KeyEvent === 'undefined') {
-  this.KeyEvent = {
+if (typeof KeyEvent === 'undefined') {
+  KeyEvent = {
     DOM_VK_CANCEL: 3,
     DOM_VK_HELP: 6,
     DOM_VK_BACK_SPACE: 8,
@@ -223,13 +224,10 @@ if (typeof this.KeyEvent === 'undefined') {
             node.removeChild(node.firstChild)
           }
           var iframe = document.createElement('iframe')
-          iframe.style.padding = 0
-          iframe.style.border = 0
-          iframe.style.margin = 0
-          iframe.style.width = adSize[0] + 'px'
-          iframe.style.height = adSize[1] + 'px'
-          iframe.srcdoc = src
-          iframe.sandbox = sandbox
+          iframe.setAttribute('sandbox', sandbox)
+          iframe.setAttribute('srcdoc', src)
+          iframe.setAttribute('style',
+                              'padding: 0; border: 0; margin: 0; width: ' + adSize[0] + 'px; ' + 'height: ' + adSize[1] + 'px;')
           node.appendChild(iframe)
           ensureNodeVisible(node)
           if (node.parentNode) {
@@ -600,29 +598,29 @@ if (typeof this.KeyEvent === 'undefined') {
     }, 0)
   }, false)
 
-  document.onkeydown = (e) => {
+  document.addEventListener('keydown', (e) => {
     switch (e.keyCode) {
-      case this.KeyEvent.DOM_VK_ESCAPE:
+      case KeyEvent.DOM_VK_ESCAPE:
         e.preventDefault()
         ipcRenderer.sendToHost('stop-load')
         break
-      case this.KeyEvent.DOM_VK_BACK_SPACE:
+      case KeyEvent.DOM_VK_BACK_SPACE:
         if (!isEditable(document.activeElement)) {
           e.shiftKey ? window.history.forward() : window.history.back()
         }
         break
-      case this.KeyEvent.DOM_VK_LEFT:
+      case KeyEvent.DOM_VK_LEFT:
         if (e.metaKey && !isEditable(document.activeElement) && isPlatformOSX()) {
           window.history.back()
         }
         break
-      case this.KeyEvent.DOM_VK_RIGHT:
+      case KeyEvent.DOM_VK_RIGHT:
         if (e.metaKey && !isEditable(document.activeElement) && isPlatformOSX()) {
           window.history.forward()
         }
         break
     }
-  }
+  })
 
   // shamelessly taken from https://developer.mozilla.org/en-US/docs/Web/Events/mouseenter
   function delegate (event, selector) {

--- a/app/index.js
+++ b/app/index.js
@@ -1,3 +1,4 @@
+// @flow
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/decls/globals.js
+++ b/decls/globals.js
@@ -8,3 +8,10 @@ declare class IpcRenderer {
     sendToHost(msg: string, ...args: any): void;
 }
 declare var KeyEvent: any;
+declare module electron {
+  declare var BrowserWindow: any;
+  declare var ipcMain: any;
+  declare var dialog: any;
+  declare var clipboard: any;
+  declare var app: any;
+}

--- a/decls/globals.js
+++ b/decls/globals.js
@@ -1,0 +1,10 @@
+declare var chrome: Chrome;
+declare class Chrome {
+  ipc: IpcRenderer;
+}
+declare class IpcRenderer {
+    on(msg: string, cb: (...args: any) => any): void;
+    send(msg: string, ...args: any): void;
+    sendToHost(msg: string, ...args: any): void;
+}
+declare var KeyEvent: any;

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "vagrant-halt-linux": "VAGRANT_CWD=./test/vms/vagrant/ubuntu-14.04 vagrant halt",
     "vagrant-destroy-linux": "VAGRANT_CWD=./test/vms/vagrant/ubuntu-14.04 vagrant destroy",
     "vagrant-ssh-linux": "VAGRANT_CWD=./test/vms/vagrant/ubuntu-14.04 vagrant ssh",
-    "vagrant-rsync-linux": "VAGRANT_CWD=./test/vms/vagrant/ubuntu-14.04 vagrant rsync-auto"
+    "vagrant-rsync-linux": "VAGRANT_CWD=./test/vms/vagrant/ubuntu-14.04 vagrant rsync-auto",
+    "flow": "flow; test $? -eq 0 -o $? -eq 2"
   },
   "repository": "brave/browser-laptop",
   "author": {
@@ -100,6 +101,7 @@
     "electron-packager": "brave/electron-packager",
     "electron-rebuild": "^1.1.1",
     "empty-port": "0.0.2",
+    "flow-bin": "^0.22.1",
     "gulp": "^3.9.0",
     "jsdox": "^0.4.9",
     "jsonfile": "^2.2.3",
@@ -138,7 +140,8 @@
       "doc/**",
       "public/**",
       "app/ext/**",
-      "app/gen/**"
+      "app/gen/**",
+      "decls/**"
     ]
   },
   "pre-commit": [


### PR DESCRIPTION
This adds Flow type checking to `app/extensions/brave/brave-default.js` to see if it could have prevented #1305. Note that the Flow type checker will not throw errors when it does not have enough context/annotations to infer types. This means that annotated code will often cause more errors than unannotated code.

Conclusion: #1305 could have probably been prevented with Flow though it would have been a lot of manual work to annotate all types being sent across the IPC boundary. I caught some other potential bugs while working on making `npm run-script flow` pass, so that was good.