### PR TITLE
Bookmarks Toolbar - shows in prefs and icons also show

### DIFF
--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -38,3 +38,6 @@ selectedLanguage=Language
 en-US=English (U.S.)
 nl-NL=Dutch (Netherlands)
 pt-BR=Portuguese (Brazil)
+bookmarkToolbarSettings=Bookmarks Toolbar settings
+bookmarkToolbar=Show Bookmarks Toolbar
+bookmarkToolbarShowFavicon=Show favicon for items in Bookmarks Toolbar

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -79,27 +79,33 @@ class SettingCheckbox extends ImmutableComponent {
 class GeneralTab extends ImmutableComponent {
   render () {
     return <SettingsList>
-      <SettingItem dataL10nId='startsWith'>
-        <select value={getSetting(settings.STARTUP_MODE, this.props.settings)}
-          onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.STARTUP_MODE)} >
-          <option data-l10n-id='startsWithOptionLastTime' value='lastTime'/>
-          <option data-l10n-id='startsWithOptionHomePage' value='homePage'/>
-          <option data-l10n-id='startsWithOptionNewTabPage' value='newTabPage'/>
-        </select>
-      </SettingItem>
-      <SettingItem dataL10nId='myHomepage'>
-        <input data-l10n-id='homepageInput'
-          value={getSetting(settings.HOMEPAGE, this.props.settings)}
-          onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.HOMEPAGE)} />
-      </SettingItem>
-      <SettingItem dataL10nId='selectedLanguage'>
-        <select value={getSetting(settings.LANGUAGE, this.props.settings)}
-          onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.LANGUAGE)} >
-          <option data-l10n-id='en-US' value='en-US'/>
-          <option data-l10n-id='nl-NL' value='nl-NL'/>
-          <option data-l10n-id='pt-BR' value='pt-BR'/>
-        </select>
-      </SettingItem>
+      <SettingsList>
+        <SettingItem dataL10nId='startsWith'>
+          <select value={getSetting(settings.STARTUP_MODE, this.props.settings)}
+            onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.STARTUP_MODE)} >
+            <option data-l10n-id='startsWithOptionLastTime' value='lastTime'/>
+            <option data-l10n-id='startsWithOptionHomePage' value='homePage'/>
+            <option data-l10n-id='startsWithOptionNewTabPage' value='newTabPage'/>
+          </select>
+        </SettingItem>
+        <SettingItem dataL10nId='myHomepage'>
+          <input data-l10n-id='homepageInput'
+            value={getSetting(settings.HOMEPAGE, this.props.settings)}
+            onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.HOMEPAGE)} />
+        </SettingItem>
+        <SettingItem dataL10nId='selectedLanguage'>
+          <select value={getSetting(settings.LANGUAGE, this.props.settings)}
+            onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.LANGUAGE)} >
+            <option data-l10n-id='en-US' value='en-US'/>
+            <option data-l10n-id='nl-NL' value='nl-NL'/>
+            <option data-l10n-id='pt-BR' value='pt-BR'/>
+          </select>
+        </SettingItem>
+      </SettingsList>
+      <SettingsList dataL10nId='bookmarkToolbarSettings'>
+        <SettingCheckbox dataL10nId='bookmarkToolbar' prefKey={settings.SHOW_BOOKMARKS_TOOLBAR} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting}/>
+        <SettingCheckbox dataL10nId='bookmarkToolbarShowFavicon' prefKey={settings.SHOW_BOOKMARKS_TOOLBAR_FAVICON} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting}/>
+      </SettingsList>
     </SettingsList>
   }
 }

--- a/js/components/bookmarksToolbar.js
+++ b/js/components/bookmarksToolbar.js
@@ -126,6 +126,8 @@ class BookmarkToolbarButton extends ImmutableComponent {
           backgroundSize: iconSize,
           height: iconSize
         })
+      } else {
+        showFavicon = false
       }
     }
 
@@ -255,12 +257,15 @@ class BookmarksToolbar extends ImmutableComponent {
     contextMenus.onTabsToolbarContextMenu(this.props.activeFrame, closest && closest.props.bookmark || undefined, closest.isDroppedOn, e)
   }
   render () {
+    let showFavicon = getSetting(settings.SHOW_BOOKMARKS_TOOLBAR_FAVICON) === true
     this.bookmarkRefs = []
     return <div
-      className={cx({
-        bookmarksToolbar: true,
-        allowDragging: this.props.shouldAllowWindowDrag
-      })}
+      className={
+        cx({
+          bookmarksToolbar: true,
+          allowDragging: this.props.shouldAllowWindowDrag
+        }) + (showFavicon ? ' showFavicons' : '')
+      }
       onDrop={this.onDrop.bind(this)}
       onDragEnter={this.onDragEnter.bind(this)}
       onDragOver={this.onDragOver.bind(this)}

--- a/js/components/bookmarksToolbar.js
+++ b/js/components/bookmarksToolbar.js
@@ -16,6 +16,8 @@ const Button = require('../components/button')
 const cx = require('../lib/classSet.js')
 const dnd = require('../dnd')
 const dndData = require('../dndData')
+const settings = require('../constants/settings')
+const getSetting = require('../settings').getSetting
 
 // TODO: Obtain from the less file
 const bookmarkMaxWidth = 100
@@ -108,6 +110,25 @@ class BookmarkToolbarButton extends ImmutableComponent {
   }
 
   render () {
+    let showFavicon = getSetting(settings.SHOW_BOOKMARKS_TOOLBAR_FAVICON) === true
+    const iconSize = 16
+    let iconStyle = {
+      minWidth: iconSize,
+      width: iconSize
+    }
+
+    if (showFavicon) {
+      let icon = this.props.bookmark.get('favicon')
+
+      if (icon) {
+        iconStyle = Object.assign(iconStyle, {
+          backgroundImage: `url(${icon})`,
+          backgroundSize: iconSize,
+          height: iconSize
+        })
+      }
+    }
+
     return <span
       className={cx({
         bookmarkToolbarButton: true,
@@ -124,6 +145,9 @@ class BookmarkToolbarButton extends ImmutableComponent {
       onDragLeave={this.onDragLeave.bind(this)}
       onDragOver={this.onDragOver.bind(this)}
       onContextMenu={contextMenus.onBookmarkContextMenu.bind(this, this.props.bookmark, this.props.activeFrame)}>
+      {
+        !this.isFolder && showFavicon ? <span className="bookmarkFavicon" style={iconStyle}></span> : null
+      }
       <span>
       {
         this.props.bookmark.get('customTitle') || this.props.bookmark.get('title') || this.props.bookmark.get('location')

--- a/js/components/contextMenu.js
+++ b/js/components/contextMenu.js
@@ -9,6 +9,8 @@ const windowActions = require('../actions/windowActions')
 const config = require('../constants/config')
 const siteSettings = require('../state/siteSettings')
 const cx = require('../lib/classSet.js')
+const settings = require('../constants/settings')
+const getSetting = require('../settings').getSetting
 
 export default class ContextMenuItem extends ImmutableComponent {
   get submenu () {
@@ -92,6 +94,27 @@ export default class ContextMenuItem extends ImmutableComponent {
     return ''
   }
   render () {
+    let showFavicon = getSetting(settings.SHOW_BOOKMARKS_TOOLBAR_FAVICON) === true
+    const iconSize = 16
+    let iconStyle = {
+      minWidth: iconSize,
+      width: iconSize
+    }
+
+    if (showFavicon) {
+      let icon = this.props.contextMenuItem.get('favicon')
+
+      if (icon) {
+        iconStyle = Object.assign(iconStyle, {
+          backgroundImage: `url(${icon})`,
+          backgroundSize: iconSize,
+          height: iconSize
+        })
+      } else {
+        showFavicon = false
+      }
+    }
+
     if (this.props.contextMenuItem.get('type') === 'separator') {
       return <div className='contextMenuItem contextMenuSeparator' role='listitem'>
         <hr/>
@@ -127,6 +150,9 @@ export default class ContextMenuItem extends ImmutableComponent {
         this.props.contextMenuItem.get('checked')
         ? <span className='fa fa-check contextMenuCheckIndicator'/>
         : null
+      }
+      {
+        !this.hasSubmenu && showFavicon ? <span className="bookmarkFavicon" style={iconStyle}></span> : null
       }
       <span className='contextMenuItemText'
         data-l10n-id={this.props.contextMenuItem.get('l10nLabelId')}>{this.props.contextMenuItem.get('label')}</span>

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -81,6 +81,7 @@ module.exports = {
     'privacy.autocomplete.history-size': 500,
     'privacy.block-canvas-fingerprinting': false,
     'bookmarks.toolbar.show': false,
+    'bookmarks.toolbar.showFavicon': false,
     'privacy.do-not-track': false,
     'security.passwords.manager-enabled': true,
     'security.passwords.one-password-enabled': false

--- a/js/constants/settings.js
+++ b/js/constants/settings.js
@@ -26,6 +26,7 @@ const settings = {
   ONE_PASSWORD_ENABLED: 'security.passwords.one-password-enabled',
   // Other settings
   SHOW_BOOKMARKS_TOOLBAR: 'bookmarks.toolbar.show',
+  SHOW_BOOKMARKS_TOOLBAR_FAVICON: 'bookmarks.toolbar.showFavicon',
   LANGUAGE: 'general.language'
 }
 

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -246,6 +246,7 @@ function bookmarkItemsInit (allBookmarkItems, items, activeFrame) {
       bookmark: site,
       draggable: true,
       label: site.get('customTitle') || site.get('title') || site.get('location'),
+      favicon: site.get('favicon'),
       contextMenu: function (e) {
         onBookmarkContextMenu(site, activeFrame, e)
       },

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -108,6 +108,9 @@ module.exports.addSite = function (sites, siteDetail, tag, originalSiteDetail) {
   if (siteDetail.get('partitionNumber') || oldSite && oldSite.get('partitionNumber')) {
     site = site.set('partitionNumber', Number(siteDetail.get('partitionNumber') || oldSite.get('partitionNumber')))
   }
+  if (siteDetail.get('favicon') || oldSite && oldSite.get('favicon')) {
+    site = site.set('favicon', siteDetail.get('favicon') || oldSite.get('favicon'))
+  }
 
   if (index === -1) {
     return sites.push(site)
@@ -195,7 +198,7 @@ module.exports.moveSite = function (sites, sourceDetail, destinationDetail, prep
 }
 
 /**
- * Detemrines the icon class to use for the site
+ * Determines the icon class to use for the site
  *
  * @param site The site in question
  * @return the class of the fontawesome icon to use
@@ -220,7 +223,8 @@ module.exports.getDetailFromFrame = function (frame, tag) {
     location,
     title: frame.get('title'),
     partitionNumber: frame.get('partitionNumber'),
-    tags: tag ? [tag] : []
+    tags: tag ? [tag] : [],
+    favicon: frame.get('icon')
   })
 }
 

--- a/less/bookmarksToolbar.less
+++ b/less/bookmarksToolbar.less
@@ -12,14 +12,13 @@
   display: flex;
   flex: 1;
   padding: 3px 10px;
-  height: 30px;
+  height: 23px;
   &.allowDragging {
     -webkit-app-region: drag;
     >* {
       -webkit-app-region: no-drag;
     }
   }
-
   .bookmarkToolbarButton {
     border-radius: @borderRadius;
     color: black;
@@ -75,4 +74,7 @@
     width: auto;
     -webkit-user-select: none;
   }
+}
+.showFavicons {
+  height: 30px;
 }

--- a/less/bookmarksToolbar.less
+++ b/less/bookmarksToolbar.less
@@ -12,7 +12,7 @@
   display: flex;
   flex: 1;
   padding: 3px 10px;
-  height: 23px;
+  height: 30px;
   &.allowDragging {
     -webkit-app-region: drag;
     >* {
@@ -35,6 +35,8 @@
     max-width: 100px;
     box-sizing: border-box;
     -webkit-user-select: none;
+    align-items: center;
+    display: flex;
     &:hover {
       background: lighten(@tabsBackground, 5%);
     }
@@ -50,6 +52,12 @@
     }
     &.isDragging {
       opacity: 0.2;
+    }
+    .bookmarkFavicon {
+      background-position: center;
+      background-repeat: no-repeat;
+      display: inline-block;
+      margin-right: 4px;
     }
     .bookmarkFolderChevron {
       color: #676767;

--- a/less/contextMenu.less
+++ b/less/contextMenu.less
@@ -35,6 +35,10 @@
       position: relative;
     }
   }
+
+  .bookmarkFavicon {
+    margin-right: 8px;
+  }
 }
 
 .contextMenuItem {
@@ -49,6 +53,7 @@
   box-sizing: border-box;
   max-width: 300px;
   display: flex;
+  align-items: center;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;


### PR DESCRIPTION
Part 1 of a fix for https://github.com/brave/browser-laptop/issues/1114

Added configuration for toggling Bookmarks Toolbar / favicon. Favicon now shows in Bookmarks Toolbar (not in folders though- those use the ContextMenu object).

Here's a pic which shows the preferences along with how the icons look in the menu. Ones that receive a 404 unfortunately don't have a default icon.

![bookmarks_toolbar](https://cloud.githubusercontent.com/assets/4733304/14763233/826f1b36-0944-11e6-9377-039800138801.png)
