### PR TITLE
Replace modal dialogs with notification bars

### DIFF
--- a/app/extensions/brave/about-passwords.html
+++ b/app/extensions/brave/about-passwords.html
@@ -14,7 +14,12 @@
         window.initPasswords = e.detail
         window.removeEventListener('password-details-updated', initPasswordsListener)
       }
+      function initPasswordsSiteListener (e) {
+        window.initDisabledSites = e.detail
+        window.removeEventListener('password-site-details-updated', initPasswordsSiteListener)
+      }
       window.addEventListener('password-details-updated', initPasswordsListener)
+      window.addEventListener('password-site-details-updated', initPasswordsSiteListener)
       window.addEventListener('load', function () {
         var po = document.createElement('script'); po.async = true;
         po.src = 'gen/aboutPages.entry.js';

--- a/app/extensions/brave/brave-about.js
+++ b/app/extensions/brave/brave-about.js
@@ -34,6 +34,12 @@
     })
     window.dispatchEvent(event)
   })
+  ipcRenderer.on('password-site-details-updated', (e, details) => {
+    const event = new window.CustomEvent('password-site-details-updated', {
+      detail: details
+    })
+    window.dispatchEvent(event)
+  })
   ipcRenderer.on('decrypted-password', (e, details) => {
     const event = new window.CustomEvent('decrypted-password', {
       detail: details
@@ -70,6 +76,9 @@
   })
   window.addEventListener('delete-password', (e) => {
     ipcRenderer.send('delete-password', e.detail)
+  })
+  window.addEventListener('delete-password-site', (e) => {
+    ipcRenderer.send('delete-password-site', e.detail)
   })
   window.addEventListener('clear-passwords', (e) => {
     ipcRenderer.send('clear-passwords')

--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -107,6 +107,7 @@ nameField=Title:
 locationField=Location:
 parentFolderField=Folder:
 save=Save
+rememberDecision=Remember this decision
 bookmarksToolbar=Bookmarks Toolbar
 otherBookmarks=Other Bookmarks
 urlbar.placeholder=Enter a URL or search term

--- a/app/extensions/brave/locales/en-US/passwords.properties
+++ b/app/extensions/brave/locales/en-US/passwords.properties
@@ -1,4 +1,6 @@
-passwordsTitle=Manage Passwords
+passwordsTitle=Password Settings
+savedPasswords=Saved passwords:
+passwordSites=Never save passwords on these sites:
 showPassword=Show
 hidePassword=Hide
 deletePassword=Delete
@@ -6,5 +8,6 @@ passwordsSite=Site
 passwordsUsername=Username
 passwordsPassword=Password
 passwordsActions=Actions
-clearPasswords=Delete all passwords
+passwordDisableInstructions=To enable/disable password saving, go to Preferences > Security.
+clearPasswords=Delete all saved passwords
 confirmClearPasswords=Are you sure you want to delete all passwords? This cannot be undone.

--- a/app/filtering.js
+++ b/app/filtering.js
@@ -45,9 +45,9 @@ const downloadMap = {}
 const registeredSessions = {}
 
 /**
- * Maps notification messages to their callback
+ * Maps permission notification bar messages to their callback
  */
-const notificationCallbacks = {}
+const permissionCallbacks = {}
 
 module.exports.registerBeforeSendHeadersFilteringCB = (filteringFn) => {
   beforeSendHeadersFilteringFns.push(filteringFn)
@@ -254,17 +254,20 @@ function registerPermissionHandler (session) {
       return
     }
     const message = `Allow ${host} to ${permissions[permission].action}?`
-    if (message in notificationCallbacks) {
+    if (message in permissionCallbacks) {
       // This notification is already shown
       return
     }
 
     appActions.showMessageBox({
       buttons: ['Deny', 'Allow'],
+      options: {
+        persist: true
+      },
       message
     })
-    notificationCallbacks[message] = (buttonIndex, persist) => {
-      let result = !!(buttonIndex)
+    permissionCallbacks[message] = (buttonIndex, persist) => {
+      const result = !!(buttonIndex)
       cb(result)
       if (persist) {
         // remember site setting for this host over http(s)
@@ -403,9 +406,9 @@ module.exports.init = () => {
     }
   })
   ipcMain.on(messages.NOTIFICATION_RESPONSE, (e, message, buttonIndex, persist) => {
-    if (notificationCallbacks[message]) {
-      notificationCallbacks[message](buttonIndex, persist)
-      delete notificationCallbacks[message]
+    if (permissionCallbacks[message]) {
+      permissionCallbacks[message](buttonIndex, persist)
+      delete permissionCallbacks[message]
     }
     appActions.hideMessageBox(message)
   })

--- a/app/filtering.js
+++ b/app/filtering.js
@@ -254,18 +254,17 @@ function registerPermissionHandler (session) {
       return
     }
     const message = `Allow ${host} to ${permissions[permission].action}?`
-    if (message in permissionCallbacks) {
-      // This notification is already shown
-      return
+    if (!(message in permissionCallbacks)) {
+      // This notification is not shown yet
+      appActions.showMessageBox({
+        buttons: ['Deny', 'Allow'],
+        options: {
+          persist: true
+        },
+        message
+      })
     }
 
-    appActions.showMessageBox({
-      buttons: ['Deny', 'Allow'],
-      options: {
-        persist: true
-      },
-      message
-    })
     permissionCallbacks[message] = (buttonIndex, persist) => {
       const result = !!(buttonIndex)
       cb(result)

--- a/app/filtering.js
+++ b/app/filtering.js
@@ -17,6 +17,7 @@ const urlParse = require('url').parse
 const getBaseDomain = require('../js/lib/baseDomain').getBaseDomain
 const getSetting = require('../js/settings').getSetting
 const appUrlUtil = require('../js/lib/appUrlUtil')
+const siteSettings = require('../js/state/siteSettings')
 const settings = require('../js/constants/settings')
 const ipcMain = electron.ipcMain
 const dialog = electron.dialog
@@ -42,6 +43,11 @@ const downloadMap = {}
  * Maps partition name to the session object
  */
 const registeredSessions = {}
+
+/**
+ * Maps notification messages to their callback
+ */
+const notificationCallbacks = {}
 
 module.exports.registerBeforeSendHeadersFilteringCB = (filteringFn) => {
   beforeSendHeadersFilteringFns.push(filteringFn)
@@ -198,32 +204,25 @@ function registerPermissionHandler (session) {
   // TODO: Localize strings
   let permissions = {
     media: {
-      action: 'use your camera and/or microphone',
-      hosts: {}
+      action: 'use your camera and/or microphone'
     },
     geolocation: {
-      action: 'see your location',
-      hosts: {}
+      action: 'see your location'
     },
     notifications: {
-      action: 'show you notifications',
-      hosts: {}
+      action: 'show you notifications'
     },
     midiSysex: {
-      action: 'use web MIDI',
-      hosts: {}
+      action: 'use web MIDI'
     },
     pointerLock: {
-      action: 'disable your mouse cursor',
-      hosts: {}
+      action: 'disable your mouse cursor'
     },
     fullscreen: {
-      action: 'be fullscreen',
-      hosts: {}
+      action: 'use fullscreen mode'
     },
     openExternal: {
-      action: 'open an external application',
-      hosts: {}
+      action: 'open an external application'
     }
   }
   session.setPermissionRequestHandler((webContents, permission, cb) => {
@@ -233,36 +232,43 @@ function registerPermissionHandler (session) {
       cb(true)
       return
     }
-    const host = urlParse(url).host
+
     if (!permissions[permission]) {
       console.log('WARNING: got unregistered permission request', permission)
       cb(false)
       return
     }
-    let isAllowed = permissions[permission].hosts[host]
-    if (isAllowed !== undefined) {
-      cb(isAllowed)
-    } else {
-      // TODO: Add option to remember decision between restarts.
-      let result = dialog.showMessageBox({
-        type: 'question',
-        message: host + ' is requesting permission to ' + permissions[permission].action,
-        buttons: ['Deny', 'Allow'],
-        defaultId: 0,
-        cancelId: 0
-      })
-      let isTemp = dialog.showMessageBox({
-        type: 'question',
-        title: 'Remember this decision?',
-        message: 'Would you like to remember this decision on ' + host + ' until Brave closes?',
-        buttons: ['Yes', 'No'],
-        defaultId: 0,
-        cancelId: 0
-      })
-      result = !!(result)
+
+    // Check whether there is a persistent site setting for this host
+    const settings = siteSettings.getSiteSettingsForURL(AppStore.getState().get('siteSettings'), url)
+    if (settings) {
+      const isAllowed = settings.get(permission + 'Permission')
+      if (isAllowed !== undefined) {
+        cb(isAllowed)
+        return
+      }
+    }
+
+    const host = urlParse(url).host
+    if (!host) {
+      return
+    }
+    const message = `Allow ${host} to ${permissions[permission].action}?`
+    if (message in notificationCallbacks) {
+      // This notification is already shown
+      return
+    }
+
+    appActions.showMessageBox({
+      buttons: ['Deny', 'Allow'],
+      message
+    })
+    notificationCallbacks[message] = (buttonIndex, persist) => {
+      let result = !!(buttonIndex)
       cb(result)
-      if (!isTemp) {
-        permissions[permission].hosts[host] = result
+      if (persist) {
+        // remember site setting for this host over http(s)
+        appActions.changeSiteSetting('https?://' + host, permission + 'Permission', result)
       }
     }
   })
@@ -395,6 +401,13 @@ module.exports.init = () => {
         updateDownloadState(downloadId, item, downloadStates.IN_PROGRESS)
         break
     }
+  })
+  ipcMain.on(messages.NOTIFICATION_RESPONSE, (e, message, buttonIndex, persist) => {
+    if (notificationCallbacks[message]) {
+      notificationCallbacks[message](buttonIndex, persist)
+      delete notificationCallbacks[message]
+    }
+    appActions.hideMessageBox(message)
   })
 }
 

--- a/app/index.js
+++ b/app/index.js
@@ -508,20 +508,18 @@ app.on('ready', () => {
         ? `Would you like Brave to remember the password for ${username} on ${origin}?`
         : `Would you like Brave to remember your password on ${origin}?`
 
-      if (message in passwordCallbacks) {
-        // Notification already shown
-        return
+      if (!(message in passwordCallbacks)) {
+        // Notification not shown already
+        appActions.showMessageBox({
+          buttons: ['Yes', 'No', 'Never for this site'],
+          options: {
+            persist: false,
+            advancedText: '[Password settings]',
+            advancedLink: 'about:passwords'
+          },
+          message
+        })
       }
-
-      appActions.showMessageBox({
-        buttons: ['Yes', 'No', 'Never for this site'],
-        options: {
-          persist: false,
-          advancedText: '[Password settings]',
-          advancedLink: 'about:passwords'
-        },
-        message
-      })
 
       passwordCallbacks[message] = (buttonIndex) => {
         if (buttonIndex === 1) {

--- a/app/index.js
+++ b/app/index.js
@@ -375,6 +375,9 @@ app.on('ready', () => {
     ipcMain.on(messages.DELETE_PASSWORD, (e, password) => {
       appActions.deletePassword(password)
     })
+    ipcMain.on(messages.DELETE_PASSWORD_SITE, (e, origin) => {
+      appActions.changeSiteSetting(origin, 'savePasswords', undefined)
+    })
     ipcMain.on(messages.CLEAR_PASSWORDS, () => {
       appActions.clearPasswords()
     })

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -219,6 +219,8 @@ module.exports.loadAppState = () => {
           return
         }
       }
+      // Don't show notifications from the last session
+      data.notifications = []
       // We used to store a huge list of IDs but we didn't use them.
       // Get rid of them here.
       delete data.windows
@@ -281,6 +283,7 @@ module.exports.defaultAppState = () => {
     sites: [],
     visits: [],
     settings: {},
-    passwords: []
+    passwords: [],
+    notifications: []
   }
 }

--- a/docs/appActions.md
+++ b/docs/appActions.md
@@ -231,6 +231,26 @@ Change a hostPattern's config
 
 
 
+### showMessageBox(detail) 
+
+Shows a message box in the notification bar
+
+**Parameters**
+
+**detail**: `Object`, Shows a message box in the notification bar
+
+
+
+### hideMessageBox(message) 
+
+Hides a message box in the notification bar
+
+**Parameters**
+
+**message**: `string`, Hides a message box in the notification bar
+
+
+
 
 * * *
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -32,7 +32,14 @@ AppStore
   }],
   siteSettings: {
     [hostPattern]: {
-      zoomLevel: number
+      zoomLevel: number,
+      mediaPermission: boolean,
+      geolocationPermission: boolean,
+      notificationsPermission: boolean,
+      midiSysexPermission: boolean,
+      pointerLockPermission: boolean,
+      fullscreenPermission: boolean,
+      openExternalPermission: boolean
     }
   },
   visits: [{
@@ -91,7 +98,6 @@ AppStore
   },
   notifications: [{
     message: string,
-    id: string,
     buttons: Array<string>
   }], // the notifications for the frame. not preserved across restart.
   settings: [{

--- a/docs/state.md
+++ b/docs/state.md
@@ -89,6 +89,11 @@ AppStore
     verbose: boolean, // Whether to show update UI for checking, downloading, and errors
     lastCheckTimestamp: boolean
   },
+  notifications: [{
+    message: string,
+    id: string,
+    buttons: Array<string>
+  }], // the notifications for the frame. not preserved across restart.
   settings: [{
     // See defaults in js/constants/appConfig.js
     'general.startup-mode': string, // One of: lastTime, homePage, newTabPage

--- a/docs/state.md
+++ b/docs/state.md
@@ -39,7 +39,8 @@ AppStore
       midiSysexPermission: boolean,
       pointerLockPermission: boolean,
       fullscreenPermission: boolean,
-      openExternalPermission: boolean
+      openExternalPermission: boolean,
+      savePasswords: boolean // Only false for now
     }
   },
   visits: [{
@@ -98,7 +99,12 @@ AppStore
   },
   notifications: [{
     message: string,
-    buttons: Array<string>
+    buttons: Array<string>,
+    options: {
+      persist: boolean, // whether to show a 'Remember this decision' checkbox
+      advancedText: string, // more info text
+      advancedLink: string, // more info link URL
+    }
   }], // the notifications for the frame. not preserved across restart.
   settings: [{
     // See defaults in js/constants/appConfig.js

--- a/js/about/aboutActions.js
+++ b/js/about/aboutActions.js
@@ -122,6 +122,13 @@ const AboutActions = {
     window.dispatchEvent(event)
   },
 
+  deletePasswordSite: function (origin) {
+    const event = new window.CustomEvent(messages.DELETE_PASSWORD_SITE, {
+      detail: origin
+    })
+    window.dispatchEvent(event)
+  },
+
   clearPasswords: function () {
     const event = new window.CustomEvent(messages.CLEAR_PASSWORDS)
     window.dispatchEvent(event)

--- a/js/about/passwords.js
+++ b/js/about/passwords.js
@@ -10,6 +10,27 @@ const aboutActions = require('./aboutActions')
 require('../../less/about/passwords.less')
 require('../../node_modules/font-awesome/css/font-awesome.css')
 
+class SiteItem extends React.Component {
+  onDelete () {
+    aboutActions.deletePasswordSite(this.props.site)
+  }
+
+  render () {
+    return <tr className='passwordItem'>
+      <td className='passwordOrigin'>{this.props.site}</td>
+      <td className='passwordActions'>
+        <span className='passwordAction fa fa-times' title='Remove site'
+          onClick={this.onDelete.bind(this)}>
+        </span>
+      </td>
+    </tr>
+  }
+}
+
+SiteItem.propTypes = {
+  site: React.PropTypes.string
+}
+
 class PasswordItem extends React.Component {
   constructor () {
     super()
@@ -139,12 +160,20 @@ class AboutPasswords extends React.Component {
   constructor () {
     super()
     this.state = {
-      passwordDetails: window.initPasswords ? Immutable.fromJS(window.initPasswords) : new Immutable.List()
+      passwordDetails: window.initPasswords ? Immutable.fromJS(window.initPasswords) : new Immutable.List(),
+      disabledSiteDetails: window.initDisabledSites ? Immutable.fromJS(window.initDisabledSites) : new Immutable.Map()
     }
     window.addEventListener(messages.PASSWORD_DETAILS_UPDATED, (e) => {
       if (e.detail) {
         this.setState({
           passwordDetails: Immutable.fromJS(e.detail)
+        })
+      }
+    })
+    window.addEventListener(messages.PASSWORD_SITE_DETAILS_UPDATED, (e) => {
+      if (e.detail) {
+        this.setState({
+          disabledSiteDetails: Immutable.fromJS(e.detail)
         })
       }
     })
@@ -161,7 +190,9 @@ class AboutPasswords extends React.Component {
   render () {
     let counter = 0
     return <div className='passwordsPage'>
-      <h2 data-l10n-id='passwordsTitle'></h2>
+      <h1 data-l10n-id='passwordsTitle'></h1>
+      <div className='passwordInstructions' data-l10n-id='passwordDisableInstructions'></div>
+      <h2 data-l10n-id='savedPasswords'></h2>
       <div className='passwordsPageContent'>
         <table className='passwordsList'>
           <thead>
@@ -182,10 +213,23 @@ class AboutPasswords extends React.Component {
           }
           </tbody>
         </table>
+        <div className='passwordsPageFooter'>
+          <span data-l10n-id='clearPasswords'
+            onClick={this.onClear.bind(this)}></span>
+        </div>
       </div>
-      <div className='passwordsPageFooter'>
-        <span data-l10n-id='clearPasswords'
-          onClick={this.onClear.bind(this)}></span>
+      <h2 data-l10n-id='passwordSites'></h2>
+      <div className='passwordsPageContent'>
+        <table className='passwordsList'>
+          <tbody>
+          {
+            this.state.disabledSiteDetails
+              ? this.state.disabledSiteDetails.map((item, site) =>
+                <SiteItem site={site}/>)
+              : null
+          }
+          </tbody>
+        </table>
       </div>
     </div>
   }

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -269,6 +269,17 @@ const appActions = {
       key,
       value
     })
+  },
+
+  /**
+   * Shows a message box in the notification bar
+   * @param {{id: string, message: string, buttons: Array.<string>}} detail
+   */
+  showMessageBox: function (detail) {
+    AppDispatcher.dispatch({
+      actionType: AppConstants.APP_SHOW_MESSAGE_BOX,
+      detail
+    })
   }
 }
 

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -273,12 +273,23 @@ const appActions = {
 
   /**
    * Shows a message box in the notification bar
-   * @param {{id: string, message: string, buttons: Array.<string>}} detail
+   * @param {{message: string, buttons: Array.<string>}} detail
    */
   showMessageBox: function (detail) {
     AppDispatcher.dispatch({
       actionType: AppConstants.APP_SHOW_MESSAGE_BOX,
       detail
+    })
+  },
+
+  /**
+   * Hides a message box in the notification bar
+   * @param {string} message
+   */
+  hideMessageBox: function (message) {
+    AppDispatcher.dispatch({
+      actionType: AppConstants.APP_HIDE_MESSAGE_BOX,
+      message
     })
   }
 }

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -273,7 +273,7 @@ const appActions = {
 
   /**
    * Shows a message box in the notification bar
-   * @param {{message: string, buttons: Array.<string>}} detail
+   * @param {{message: string, buttons: Array.<string>, options: Object}} detail
    */
   showMessageBox: function (detail) {
     AppDispatcher.dispatch({

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -226,9 +226,16 @@ class Frame extends ImmutableComponent {
       this.webview.send(messages.DOWNLOADS_UPDATED, {
         downloads: this.props.downloads.toJS()
       })
-    } else if (this.props.frame.get('location') === 'about:passwords' &&
-               prevProps.passwords !== this.props.passwords) {
-      this.webview.send(messages.PASSWORD_DETAILS_UPDATED, this.props.passwords.toJS())
+    } else if (this.props.frame.get('location') === 'about:passwords') {
+      if (prevProps.passwords !== this.props.passwords) {
+        this.webview.send(messages.PASSWORD_DETAILS_UPDATED, this.props.passwords.toJS())
+      }
+      if (prevProps.siteSettings !== this.props.siteSettings) {
+        if (this.props.siteSettings) {
+          this.webview.send(messages.PASSWORD_SITE_DETAILS_UPDATED,
+                            this.props.siteSettings.filter((setting) => setting.get('savePasswords') === false).toJS())
+        }
+      }
     }
   }
 
@@ -365,6 +372,8 @@ class Frame extends ImmutableComponent {
         })
       } else if (this.props.frame.get('location') === 'about:passwords') {
         this.webview.send(messages.PASSWORD_DETAILS_UPDATED, this.props.passwords.toJS())
+        this.webview.send(messages.PASSWORD_SITE_DETAILS_UPDATED,
+                          this.props.siteSettings.filter((setting) => setting.get('savePasswords') === false).toJS())
       }
 
       const parsedUrl = urlParse(this.props.frame.get('location'))

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -21,6 +21,7 @@ const Frame = require('./frame')
 const TabPages = require('./tabPages')
 const TabsToolbar = require('./tabsToolbar')
 const UpdateBar = require('./updateBar')
+const NotificationBar = require('./notificationBar')
 const DownloadsBar = require('./downloadsBar')
 const Button = require('./button')
 const SiteInfo = require('./siteInfo')
@@ -469,6 +470,8 @@ class Main extends ImmutableComponent {
               onClick={this.onBraveMenu.bind(this)} />
           </div>
         </div>
+        <UpdateBar updates={this.props.appState.get('updates')} />
+        <NotificationBar notifications={this.props.appState.get('notifications')} />
         {
           showBookmarksToolbar
           ? <BookmarksToolbar
@@ -509,7 +512,6 @@ class Main extends ImmutableComponent {
           activeFrame={activeFrame}
           onMenu={this.onHamburgerMenu.bind(this)}
         />
-        <UpdateBar updates={this.props.appState.get('updates')} />
       </div>
       <div className='mainContainer'>
         <div className='tabContainer'

--- a/js/components/notificationBar.js
+++ b/js/components/notificationBar.js
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const React = require('react')
+const ImmutableComponent = require('./immutableComponent')
+
+const Button = require('./button')
+
+class NotificationItem extends ImmutableComponent {
+  clickHandler (buttonIndex, e) {
+    console.log('got click of index', buttonIndex, this.props.detail.id)
+  }
+
+  render () {
+    let i = 0
+    return <div className='notificationItem'>
+      <span className='notificationMessage'>this.props.detail.message</span>
+      {
+        this.props.detail.buttons.map((button) => {
+          <Button disabled={false}
+            label={button}
+            className='notificationButton'
+            onClick={this.clickHandler.bind(i++, this)}/>
+        })
+      }
+    </div>
+  }
+}
+
+class NotificationBar extends ImmutableComponent {
+  render () {
+    if (!this.props.notifications || !this.props.notifications.size) {
+      return null
+    }
+
+    return <div className='notificationBar'>
+    {
+      this.props.notifications.map((notificationDetail) => {
+        <NotificationItem detail={notificationDetail} />
+      })
+    }
+    </div>
+  }
+}
+
+module.exports = NotificationBar

--- a/js/components/notificationBar.js
+++ b/js/components/notificationBar.js
@@ -10,15 +10,32 @@ const messages = require('../constants/messages')
 
 class NotificationItem extends ImmutableComponent {
   clickHandler (buttonIndex, e) {
-    ipc.send(messages.NOTIFICATION_RESPONSE, this.props.detail.get('message'), buttonIndex, this.checkbox.checked)
+    ipc.send(messages.NOTIFICATION_RESPONSE, this.props.detail.get('message'),
+             buttonIndex, this.checkbox ? this.checkbox.checked : false)
+  }
+
+  openAdvanced () {
+    ipc.emit(messages.SHORTCUT_NEW_FRAME, {}, this.props.detail.get('options').get('advancedLink'))
   }
 
   render () {
     let i = 0
+    const options = this.props.detail.get('options')
     return <div className='notificationItem'>
       <span className='notificationMessage'>{this.props.detail.get('message')}</span>
+      <span className='notificationAdvanced'>
+        {
+          options.get('advancedText') && options.get('advancedLink')
+            ? <span onClick={this.openAdvanced.bind(this)}>{options.get('advancedText')}</span>
+            : null
+        }
+      </span>
       <span className='notificationOptions'>
-        <label><input type='checkbox' ref={(node) => { this.checkbox = node }}/>{'Remember this decision'}</label>
+        {
+          options.get('persist')
+            ? <label><input type='checkbox' ref={(node) => { this.checkbox = node }}/>{'Remember this decision'}</label>
+            : null
+        }
         {
           this.props.detail.get('buttons').map((button) =>
             <button

--- a/js/components/notificationBar.js
+++ b/js/components/notificationBar.js
@@ -5,25 +5,29 @@
 const React = require('react')
 const ImmutableComponent = require('./immutableComponent')
 
-const Button = require('./button')
+const ipc = require('electron').ipcRenderer
+const messages = require('../constants/messages')
 
 class NotificationItem extends ImmutableComponent {
   clickHandler (buttonIndex, e) {
-    console.log('got click of index', buttonIndex, this.props.detail.id)
+    ipc.send(messages.NOTIFICATION_RESPONSE, this.props.detail.get('message'), buttonIndex, this.checkbox.checked)
   }
 
   render () {
     let i = 0
     return <div className='notificationItem'>
-      <span className='notificationMessage'>this.props.detail.message</span>
-      {
-        this.props.detail.buttons.map((button) => {
-          <Button disabled={false}
-            label={button}
-            className='notificationButton'
-            onClick={this.clickHandler.bind(i++, this)}/>
-        })
-      }
+      <span className='notificationMessage'>{this.props.detail.get('message')}</span>
+      <span className='notificationOptions'>
+        <label><input type='checkbox' ref={(node) => { this.checkbox = node }}/>{'Remember this decision'}</label>
+        {
+          this.props.detail.get('buttons').map((button) =>
+            <button
+              type='button'
+              className='notificationButton'
+              onClick={this.clickHandler.bind(this, i++)}>{button}</button>
+          )
+        }
+      </span>
     </div>
   }
 }
@@ -36,9 +40,9 @@ class NotificationBar extends ImmutableComponent {
 
     return <div className='notificationBar'>
     {
-      this.props.notifications.map((notificationDetail) => {
+      this.props.notifications.map((notificationDetail) =>
         <NotificationItem detail={notificationDetail} />
-      })
+      )
     }
     </div>
   }

--- a/js/components/notificationBar.js
+++ b/js/components/notificationBar.js
@@ -33,7 +33,7 @@ class NotificationItem extends ImmutableComponent {
       <span className='notificationOptions'>
         {
           options.get('persist')
-            ? <label><input type='checkbox' ref={(node) => { this.checkbox = node }}/>{'Remember this decision'}</label>
+            ? <span><input type='checkbox' ref={(node) => { this.checkbox = node }}/><label data-l10n-id='rememberDecision'/></span>
             : null
         }
         {

--- a/js/constants/appConstants.js
+++ b/js/constants/appConstants.js
@@ -26,7 +26,8 @@ const AppConstants = {
   APP_SET_UPDATE_STATUS: _,
   APP_CHANGE_SETTING: _,
   APP_CHANGE_SITE_SETTING: _,
-  APP_SHOW_MESSAGE_BOX: _ /** @param {Object} detail */
+  APP_SHOW_MESSAGE_BOX: _, /** @param {Object} detail */
+  APP_HIDE_MESSAGE_BOX: _ /** @param {string} message */
 }
 
 module.exports = mapValuesByKeys(AppConstants)

--- a/js/constants/appConstants.js
+++ b/js/constants/appConstants.js
@@ -25,7 +25,8 @@ const AppConstants = {
   APP_UPDATE_LAST_CHECK: _,
   APP_SET_UPDATE_STATUS: _,
   APP_CHANGE_SETTING: _,
-  APP_CHANGE_SITE_SETTING: _
+  APP_CHANGE_SITE_SETTING: _,
+  APP_SHOW_MESSAGE_BOX: _ /** @param {Object} detail */
 }
 
 module.exports = mapValuesByKeys(AppConstants)

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -42,7 +42,7 @@ const messages = {
   CERT_ERROR: _, /** @arg {Object} details of certificate error */
   LOGIN_REQUIRED: _, /** @arg {Object} details of the login required request */
   LOGIN_RESPONSE: _,
-  NOTIFICATION_RESPONSE: _, /** @arg {string} id, @arg {number} buttonId */
+  NOTIFICATION_RESPONSE: _, /** @arg {string} message, @arg {number} buttonId, @arg {boolean} persist */
   // Downloads
   SHOW_DOWNLOADS_TOOLBAR: _, /** Ensures the downloads toolbar is visible */
   DOWNLOAD_ACTION: _, /** @arg {string} downloadId, @arg {string} action such as 'resume', 'pause', or 'cancel' */

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -42,6 +42,7 @@ const messages = {
   CERT_ERROR: _, /** @arg {Object} details of certificate error */
   LOGIN_REQUIRED: _, /** @arg {Object} details of the login required request */
   LOGIN_RESPONSE: _,
+  NOTIFICATION_RESPONSE: _, /** @arg {string} id, @arg {number} buttonId */
   // Downloads
   SHOW_DOWNLOADS_TOOLBAR: _, /** Ensures the downloads toolbar is visible */
   DOWNLOAD_ACTION: _, /** @arg {string} downloadId, @arg {string} action such as 'resume', 'pause', or 'cancel' */

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -77,9 +77,11 @@ const messages = {
   SHOW_USERNAME_LIST: _, /** @arg {string} formOrigin, @arg {string} action, @arg {Object} boundingRect, @arg {string} usernameValue */
   FILL_PASSWORD: _, /** @arg {string} username, @arg {string} password, @arg {string} origin, @arg {string} action */
   PASSWORD_DETAILS_UPDATED: _, /** @arg {Object} passwords app state */
+  PASSWORD_SITE_DETAILS_UPDATED: _, /** @arg {Object} passwords app state */
   DECRYPT_PASSWORD: _, /** @arg {string} encrypted pw, @arg {string} iv, @arg {string} authTag, @arg {number} id */
   DECRYPTED_PASSWORD: _, /** @arg {number} decrypted pw, @arg {number} id */
   DELETE_PASSWORD: _, /** @arg {Object} password */
+  DELETE_PASSWORD_SITE: _, /** @arg {string} site */
   CLEAR_PASSWORDS: _,
   // Init
   INITIALIZE_WINDOW: _,

--- a/js/entry.js
+++ b/js/entry.js
@@ -15,6 +15,7 @@ require('../less/dialogs.less')
 require('../less/updateBar.less')
 require('../less/downloadBar.less')
 require('../less/bookmarksToolbar.less')
+require('../less/notificationBar.less')
 require('../node_modules/font-awesome/css/font-awesome.css')
 
 const React = require('react')

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -400,6 +400,11 @@ const handleAppAction = (action) => {
       let notifications = appState.get('notifications')
       appState = appState.set('notifications', notifications.push(Immutable.fromJS(action.detail)))
       break
+    case AppConstants.APP_HIDE_MESSAGE_BOX:
+      appState = appState.set('notifications', appState.get('notifications').filterNot((notification) => {
+        return notification.get('message') === action.message
+      }))
+      break
     default:
   }
 

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -396,6 +396,10 @@ const handleAppAction = (action) => {
       appState = appState.set('siteSettings',
         siteSettings.mergeSiteSetting(appState.get('siteSettings'), action.hostPattern, action.key, action.value))
       break
+    case AppConstants.APP_SHOW_MESSAGE_BOX:
+      let notifications = appState.get('notifications')
+      appState = appState.set('notifications', notifications.push(Immutable.fromJS(action.detail)))
+      break
     default:
   }
 

--- a/less/about/passwords.less
+++ b/less/about/passwords.less
@@ -5,13 +5,20 @@
 
   .passwordsPageContent {
     border-top: 1px solid @chromeBorderColor;
-    display: flex;
 
     .passwordsList {
       padding-top: 10px;
       overflow: hidden;
     }
   }
+}
+
+.passwordInstructions {
+  border-top: 1px solid @chromeBorderColor;
+  padding-top: 10px;
+  padding-bottom: 20px;
+  font-size: 18px;
+  color: grey;
 }
 
 th {
@@ -56,6 +63,7 @@ td:not(.passwordActions) {
 
 .passwordsPageFooter {
   padding: 10px;
+  margin-bottom: 20px;
   span {
     color: grey;
     cursor: pointer;

--- a/less/notificationBar.less
+++ b/less/notificationBar.less
@@ -38,7 +38,7 @@
 
   label {
     font-size: 15px;
-    padding: 0 10px;
+    padding: 0 10px 0 0;
     color: #666;
   }
   input[type="checkbox"] {

--- a/less/notificationBar.less
+++ b/less/notificationBar.less
@@ -1,0 +1,38 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@import "variables.less";
+
+.notificationBar {
+  background-color: #fff;
+  border-bottom: 1px solid #888;
+  padding: 8px 20px;
+
+  >div {
+    display: flex;
+  }
+
+  .notificationMessage {
+    color: #000;
+    font-size: 15px;
+    padding-left: 10px;
+    margin: auto 0;
+  }
+
+  .notificationSecondaryButton {
+    background-color: #eee;
+  }
+
+  .notificationButton {
+    padding: 0px 25px;
+    float: right;
+    font-size: 14px;
+    width: auto;
+    margin: auto 5px;
+  }
+
+  .notificationSpacer {
+    flex-grow: 1;
+  }
+}

--- a/less/notificationBar.less
+++ b/less/notificationBar.less
@@ -4,14 +4,12 @@
 
 @import "variables.less";
 
-.notificationBar {
-  background-color: #fff;
+.notificationItem {
+  background-color: #ffefc0;
   border-bottom: 1px solid #888;
-  padding: 8px 20px;
-
-  >div {
-    display: flex;
-  }
+  display: inline-block;
+  width: 100%;
+  padding: 6px;
 
   .notificationMessage {
     color: #000;
@@ -25,14 +23,28 @@
   }
 
   .notificationButton {
-    padding: 0px 25px;
-    float: right;
-    font-size: 14px;
+    padding: 2px 15px;
     width: auto;
-    margin: auto 5px;
+    margin-right: 10px;
+  }
+
+  .notificationOptions {
+    float: right;
   }
 
   .notificationSpacer {
     flex-grow: 1;
+  }
+
+  label {
+    font-size: 15px;
+    padding: 0 10px;
+    color: #666;
+  }
+  input[type="checkbox"] {
+    margin: 0 3px;
+  }
+  button {
+    font-size: 13px;
   }
 }

--- a/less/notificationBar.less
+++ b/less/notificationBar.less
@@ -47,4 +47,12 @@
   button {
     font-size: 13px;
   }
+
+  .notificationAdvanced {
+    color: grey;
+    cursor: pointer;
+    text-decoration: underline;
+    font-size: 13px;
+    margin: 5px;
+  }
 }


### PR DESCRIPTION
* replaces the modal dialogs for password saving / permission requests with a notification bar at the top of the browser. I decided that notification bars should *not* be per-frame, since they refer to top-level app state.
* add site-specific settings for permissions
* adds "never save password on this site" option

Fix #1049, fix #1206, fix #923, fix #1201 

Auditors: @bbondy 