### PR TITLE
.editorconfig: override trim_trailing_whitespace for *.properties as well

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,5 +12,5 @@ end_of_line = lf
 charset = utf-8
 insert_final_newline = true
 
-[*.md]
+[*.{md,properties}]
 trim_trailing_whitespace = false


### PR DESCRIPTION
ref https://github.com/brave/browser-laptop/pull/1443#issuecomment-214965704