### PR TITLE
show urlbar when hovering tabs & loadtime hidden for about pages

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -259,7 +259,7 @@ class Main extends ImmutableComponent {
   }
 
   checkForTitleMode (pageY) {
-    const navigator = document.querySelector('#navigator')
+    const navigator = document.querySelector('.top')
     // Uncaught TypeError: Cannot read property 'getBoundingClientRect' of null
     if (!navigator) {
       return

--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -201,11 +201,7 @@ class UrlBar extends ImmutableComponent {
 
     if (startLoadTime && endLoadTime) {
       const loadMilliseconds = endLoadTime - startLoadTime
-      if (loadMilliseconds > 1000) {
-        loadTime = (loadMilliseconds / 1000).toFixed(2) + 's'
-      } else {
-        loadTime = loadMilliseconds + 'ms'
-      }
+      loadTime = (loadMilliseconds / 1000).toFixed(2) + 's'
     }
     return loadTime
   }
@@ -287,7 +283,7 @@ class UrlBar extends ImmutableComponent {
         }
       <legend/>
         {
-          this.props.titleMode
+          this.props.titleMode || this.aboutPage
           ? null
           : <span className='loadTime'>{this.loadTime}</span>
         }


### PR DESCRIPTION
show urlbar when mouse is over tabbar, for easier navigation of nav
resolves #1486

hide loadtime for about: pages
always show loadtime in seconds for consistency
fixes #1503