### PR TITLE
Fixed issue w/ overflow on hamburger menu; it was causing scrollbars …

### DIFF
--- a/less/contextMenu.less
+++ b/less/contextMenu.less
@@ -18,7 +18,6 @@
   // and bookmarks overflow menu reaching down too low.
   @usedUpChrome: @navbarHeight + @bookmarksToolbarWithFaviconsHeight;
   max-height: calc(~'100% - @{usedUpChrome}');
-  overflow: auto;
   padding: 0px 0px;
   position: absolute;
   z-index: 350;

--- a/less/contextMenu.less
+++ b/less/contextMenu.less
@@ -16,8 +16,11 @@
   }
   // This is a reasonable max height and also solves problems for bookmarks menu
   // and bookmarks overflow menu reaching down too low.
+  height: 100%;
+  width: 100%;
   @usedUpChrome: @navbarHeight + @bookmarksToolbarWithFaviconsHeight;
   max-height: calc(~'100% - @{usedUpChrome}');
+  overflow: auto;
   padding: 0px 0px;
   position: absolute;
   z-index: 350;


### PR DESCRIPTION
Possibly only an issue on Windows? Caused by this commit:
https://github.com/brave/browser-laptop/commit/b3759626137c673be083b0bf26692dd258b59186#diff-368c5017488bea1c7d085fe1054d0684R21

Here's what the issue looks like before this patch:
![hamburger](https://cloud.githubusercontent.com/assets/4733304/14910970/c92d6418-0da6-11e6-9749-1b8cb2ef4b03.png)

And here's a screencap w/ the dev tools open showing how the submenus have overflow:
![2016-05-01](https://cloud.githubusercontent.com/assets/4733304/14940787/03ff9c3a-0f39-11e6-8546-65814b78a740.png)
