### PR TITLE
about:preferences now has "autohide menu" option

### DIFF
--- a/app/extensions/brave/locales/en-US/menu.properties
+++ b/app/extensions/brave/locales/en-US/menu.properties
@@ -120,4 +120,4 @@ zoom=Zoom
 new=New
 learnSpelling=Learn Spelling
 ignoreSpelling=Ignore Spelling
-autoHideMenuBar=Hide the menu bar
+autoHideMenuBar=Hide Menu Bar

--- a/app/extensions/brave/locales/en-US/menu.properties
+++ b/app/extensions/brave/locales/en-US/menu.properties
@@ -120,3 +120,4 @@ zoom=Zoom
 new=New
 learnSpelling=Learn Spelling
 ignoreSpelling=Ignore Spelling
+autoHideMenuBar=Hide the menu bar

--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -71,3 +71,5 @@ fullscreenPermission=Fullscreen access
 openExternalPermission=Open external applications
 alwaysAllow=Always allow
 alwaysDeny=Always deny
+appearanceSettings=Appearance settings
+autoHideMenuBar=Hide the menu bar by default

--- a/app/locale.js
+++ b/app/locale.js
@@ -135,7 +135,8 @@ var rendererIdentifiers = function () {
     'learnSpelling',
     'ignoreSpelling',
     // Other identifiers
-    'urlCopied'
+    'urlCopied',
+    'autoHideMenuBar'
   ]
 }
 

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -13,6 +13,7 @@ const messages = require('../constants/messages')
 const settings = require('../constants/settings')
 const aboutActions = require('./aboutActions')
 const getSetting = require('../settings').getSetting
+const isDarwin = process.platform === 'darwin'
 
 // TODO: Determine this from the l20n file automatically
 const hintCount = 3
@@ -131,7 +132,9 @@ class GeneralTab extends ImmutableComponent {
       </SettingsList>
       <SettingsList dataL10nId='appearanceSettings'>
         <SettingCheckbox dataL10nId='showHomeButton' prefKey={settings.SHOW_HOME_BUTTON} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
-        <SettingCheckbox dataL10nId='autoHideMenuBar' prefKey={settings.AUTO_HIDE_MENU_BAR} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
+        {
+          isDarwin ? null : <SettingCheckbox dataL10nId='autoHideMenuBar' prefKey={settings.AUTO_HIDE_MENU_BAR} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
+        }
       </SettingsList>
     </SettingsList>
   }

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -124,14 +124,14 @@ class GeneralTab extends ImmutableComponent {
             value={getSetting(settings.HOMEPAGE, this.props.settings)}
             onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.HOMEPAGE)} />
         </SettingItem>
-        <SettingCheckbox dataL10nId='showHomeButton' prefKey={settings.SHOW_HOME_BUTTON} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
       </SettingsList>
       <SettingsList dataL10nId='bookmarkToolbarSettings'>
         <SettingCheckbox dataL10nId='bookmarkToolbar' prefKey={settings.SHOW_BOOKMARKS_TOOLBAR} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
         <SettingCheckbox dataL10nId='bookmarkToolbarShowFavicon' prefKey={settings.SHOW_BOOKMARKS_TOOLBAR_FAVICON} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
       </SettingsList>
       <SettingsList dataL10nId='appearanceSettings'>
-        <SettingCheckbox dataL10nId='autoHideMenuBar' prefKey={settings.AUTO_HIDE_MENU_BAR} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting}/>
+        <SettingCheckbox dataL10nId='showHomeButton' prefKey={settings.SHOW_HOME_BUTTON} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
+        <SettingCheckbox dataL10nId='autoHideMenuBar' prefKey={settings.AUTO_HIDE_MENU_BAR} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
       </SettingsList>
     </SettingsList>
   }

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -130,6 +130,9 @@ class GeneralTab extends ImmutableComponent {
         <SettingCheckbox dataL10nId='bookmarkToolbar' prefKey={settings.SHOW_BOOKMARKS_TOOLBAR} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
         <SettingCheckbox dataL10nId='bookmarkToolbarShowFavicon' prefKey={settings.SHOW_BOOKMARKS_TOOLBAR_FAVICON} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
       </SettingsList>
+      <SettingsList dataL10nId='appearanceSettings'>
+        <SettingCheckbox dataL10nId='autoHideMenuBar' prefKey={settings.AUTO_HIDE_MENU_BAR} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting}/>
+      </SettingsList>
     </SettingsList>
   }
 }

--- a/js/commonMenu.js
+++ b/js/commonMenu.js
@@ -290,6 +290,18 @@ module.exports.bookmarksToolbarMenuItem = () => {
   }
 }
 
+module.exports.autoHideMenuBarMenuItem = () => {
+  const autoHideMenuBar = getSetting(settings.AUTO_HIDE_MENU_BAR)
+  return {
+    label: locale.translation('autoHideMenuBar'),
+    type: 'checkbox',
+    checked: autoHideMenuBar,
+    click: (item, focusedWindow) => {
+      appActions.changeSetting(settings.AUTO_HIDE_MENU_BAR, !autoHideMenuBar)
+    }
+  }
+}
+
 module.exports.aboutBraveMenuItem = () => {
   return {
     label: locale.translation('about') + ' ' + appConfig.name,

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -76,6 +76,7 @@ module.exports = {
     'general.homepage': 'https://www.brave.com',
     'general.show-home-button': false,
     'general.useragent.value': null, // Set at runtime
+    'general.autohide-menubar': false,
     'search.default-search-engine': 'content/search/google.xml',
     'tabs.switch-to-new-tabs': false,
     'tabs.paint-tabs': true,

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -8,7 +8,7 @@ const winUpdateHost = process.env.BRAVE_WIN_UPDATE_HOST || 'https://brave-downlo
 const crashURL = process.env.BRAVE_CRASH_URL || 'https://laptop-updates.brave.com/1/crashes'
 
 // Windows specific configuration settings.
-const autoHideMenuBar = process.platform === 'win32' ? false : true;
+const autoHideMenuBar = process.platform !== 'win32'
 
 module.exports = {
   name: 'Brave',

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -76,7 +76,7 @@ module.exports = {
     'general.homepage': 'https://www.brave.com',
     'general.show-home-button': false,
     'general.useragent.value': null, // Set at runtime
-    'general.autohide-menubar': false,
+    'general.autohide-menubar': true,
     'search.default-search-engine': 'content/search/google.xml',
     'tabs.switch-to-new-tabs': false,
     'tabs.paint-tabs': true,

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -7,6 +7,9 @@ const updateHost = process.env.BRAVE_UPDATE_HOST || 'https://brave-laptop-update
 const winUpdateHost = process.env.BRAVE_WIN_UPDATE_HOST || 'https://brave-download.global.ssl.fastly.net'
 const crashURL = process.env.BRAVE_CRASH_URL || 'https://laptop-updates.brave.com/1/crashes'
 
+// Windows specific configuration settings.
+const autoHideMenuBar = process.platform === 'win32' ? false : true;
+
 module.exports = {
   name: 'Brave',
   contactUrl: 'mailto:support+laptop@brave.com',
@@ -76,7 +79,7 @@ module.exports = {
     'general.homepage': 'https://www.brave.com',
     'general.show-home-button': false,
     'general.useragent.value': null, // Set at runtime
-    'general.autohide-menubar': true,
+    'general.autohide-menubar': autoHideMenuBar,
     'search.default-search-engine': 'content/search/google.xml',
     'tabs.switch-to-new-tabs': false,
     'tabs.paint-tabs': true,

--- a/js/constants/settings.js
+++ b/js/constants/settings.js
@@ -9,6 +9,7 @@ const settings = {
   SHOW_HOME_BUTTON: 'general.show-home-button',
   USERAGENT: 'general.useragent.value',
   DEFAULT_DOWNLOAD_SAVE_PATH: 'general.downloads.default-save-path',
+  AUTO_HIDE_MENU_BAR: 'general.autohide-menubar',
   // Search tab
   DEFAULT_SEARCH_ENGINE: 'search.default-search-engine',
   // Tabs tab

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -26,6 +26,7 @@ const ipc = global.require('electron').ipcRenderer
 const locale = require('../js/l10n')
 const getSetting = require('./settings').getSetting
 const settings = require('./constants/settings')
+const isDarwin = process.platform === 'darwin'
 
 /**
  * Obtains an add bookmark menu item
@@ -78,15 +79,21 @@ function inputTemplateInit (e) {
 }
 
 function tabsToolbarTemplateInit (activeFrame, closestDestinationDetail, isParent) {
-  return [
+  const menu = [
     CommonMenu.bookmarksMenuItem(),
     CommonMenu.bookmarksToolbarMenuItem(),
-    CommonMenu.separatorMenuItem,
-    CommonMenu.autoHideMenuBarMenuItem(),
-    CommonMenu.separatorMenuItem,
-    addBookmarkMenuItem('addBookmark', siteUtil.getDetailFromFrame(activeFrame, siteTags.BOOKMARK), closestDestinationDetail, isParent),
-    addFolderMenuItem(closestDestinationDetail, isParent)
+    CommonMenu.separatorMenuItem
   ]
+
+  if (!isDarwin) {
+    menu.push(CommonMenu.autoHideMenuBarMenuItem(),
+      CommonMenu.separatorMenuItem)
+  }
+
+  menu.push(addBookmarkMenuItem('addBookmark', siteUtil.getDetailFromFrame(activeFrame, siteTags.BOOKMARK), closestDestinationDetail, isParent),
+    addFolderMenuItem(closestDestinationDetail, isParent))
+
+  return menu
 }
 
 function downloadsToolbarTemplateInit (downloadId, downloadItem) {

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -82,6 +82,8 @@ function tabsToolbarTemplateInit (activeFrame, closestDestinationDetail, isParen
     CommonMenu.bookmarksMenuItem(),
     CommonMenu.bookmarksToolbarMenuItem(),
     CommonMenu.separatorMenuItem,
+    CommonMenu.autoHideMenuBarMenuItem(),
+    CommonMenu.separatorMenuItem,
     addBookmarkMenuItem('addBookmark', siteUtil.getDetailFromFrame(activeFrame, siteTags.BOOKMARK), closestDestinationDetail, isParent),
     addFolderMenuItem(closestDestinationDetail, isParent)
   ]

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -109,6 +109,8 @@ const createWindow = (browserOpts, defaults) => {
   browserOpts.width = browserOpts.width < minWidth ? minWidth : browserOpts.width
   browserOpts.height = browserOpts.height < minHeight ? minHeight : browserOpts.height
 
+  const autoHideMenuBarSetting = getSetting(settings.AUTO_HIDE_MENU_BAR)
+
   let mainWindow = new BrowserWindow(Object.assign({
     // smaller min size for "modal" windows
     minWidth,
@@ -117,7 +119,7 @@ const createWindow = (browserOpts, defaults) => {
     // frame: false,
     // A frame but no title bar and windows buttons in titlebar 10.10 OSX and up only?
     titleBarStyle: 'hidden-inset',
-    autoHideMenuBar: true,
+    autoHideMenuBar: autoHideMenuBarSetting,
     title: appConfig.name,
     webPreferences: defaults.webPreferences
   }, browserOpts))

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -244,6 +244,18 @@ const filterOutNonRecents = debounce(() => {
   emitChanges()
 }, 60 * 1000)
 
+function handleChangeSettingAction (settingKey, settingValue) {
+  switch (settingKey) {
+    case settings.AUTO_HIDE_MENU_BAR:
+      BrowserWindow.getAllWindows().forEach(function (wnd) {
+        wnd.setAutoHideMenuBar(settingValue)
+        wnd.setMenuBarVisibility(!settingValue)
+      })
+      break
+    default:
+  }
+}
+
 const handleAppAction = (action) => {
   switch (action.actionType) {
     case AppConstants.APP_SET_STATE:
@@ -393,6 +405,7 @@ const handleAppAction = (action) => {
       break
     case AppConstants.APP_CHANGE_SETTING:
       appState = appState.setIn(['settings', action.key], action.value)
+      handleChangeSettingAction(action.key, action.value)
       break
     case AppConstants.APP_CHANGE_SITE_SETTING:
       let propertyName = action.temporary ? 'temporarySiteSettings' : 'siteSettings'

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -26,6 +26,7 @@ const EventEmitter = require('events').EventEmitter
 const Immutable = require('immutable')
 const diff = require('immutablediff')
 const debounce = require('../lib/debounce.js')
+const isDarwin = process.platform === 'darwin'
 
 // Only used internally
 const CHANGE_EVENT = 'app-state-change'
@@ -109,7 +110,7 @@ const createWindow = (browserOpts, defaults) => {
   browserOpts.width = browserOpts.width < minWidth ? minWidth : browserOpts.width
   browserOpts.height = browserOpts.height < minHeight ? minHeight : browserOpts.height
 
-  const autoHideMenuBarSetting = getSetting(settings.AUTO_HIDE_MENU_BAR)
+  const autoHideMenuBarSetting = isDarwin || getSetting(settings.AUTO_HIDE_MENU_BAR)
 
   let mainWindow = new BrowserWindow(Object.assign({
     // smaller min size for "modal" windows


### PR DESCRIPTION
Updates to resolve https://github.com/brave/browser-laptop/issues/1524

- Home button and this new setting pulled into an "Appearance settings" area of the general tab.
- Change takes effect immediately

~~What is missing (will address in future PR):~~
- ~~context menu item in the bookmarks toolbar~~
- ~~default this new option to "false", but only for Windows users~~
