### PR TITLE
Update install instruction for Debian

### DIFF
--- a/docs/linuxInstall.md
+++ b/docs/linuxInstall.md
@@ -6,7 +6,7 @@ Signed packages are on their way, but in the meantime you can use the following.
 
 ```
 wget -O brave.deb https://laptop-updates.brave.com/latest/dev/debian64
-sudo dpkg -i ./brave.deb
+sudo apt install -y gdebi && sudo gdebi brave.deb
 ```
 
 ## Ubuntu AMD64:


### PR DESCRIPTION
dpkg -i shouldn't be used as there is a good chance of missing dependencies and it can't handle that. So instead gdebi should be used. Also there is no need for "./" in front of name of the package as the command will be issued in same directory where wget downloaded it (assuming user doesn't close and reopen terminal between commands in which case ./ still wouldn't be sane as it is used to detect executable and not a path). This issues is probably the same for other Debian based distributions (such as Ubuntu and Mint) so feel free to edit them too (I don't use them so I can't comment 100% on it).