### PR TITLE
Fix to get urlBar context menu working again

### DIFF
--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -251,8 +251,8 @@ class UrlBar extends ImmutableComponent {
     dndData.setupDataTransferBraveData(e.dataTransfer, dragTypes.TAB, this.props.activeFrameProps)
   }
 
-  onContextMenu () {
-    contextMenus.onUrlBarContextMenu()
+  onContextMenu (e) {
+    contextMenus.onUrlBarContextMenu(e)
   }
 
   render () {


### PR DESCRIPTION
Was broke w/ this:
https://github.com/brave/browser-laptop/commit/d5c102e9079fb792ef3e100cf4eb09e912198c1f#diff-bf31d40b9ccd66ab63bd8cf24b30eab0R255

Just needed to propagate event object