### PR TITLE
Fix for https://github.com/brave/browser-laptop/issues/1407

### DIFF
--- a/app/extensions/brave/locales/en-US/menu.properties
+++ b/app/extensions/brave/locales/en-US/menu.properties
@@ -16,6 +16,7 @@ redo=Redo
 cut=Cut
 copy=Copy
 paste=Paste
+pasteAndGo=Paste and Go
 pasteWithoutFormatting=Paste without formatting
 delete=Delete
 selectAll=Select All

--- a/app/extensions/brave/locales/en-US/menu.properties
+++ b/app/extensions/brave/locales/en-US/menu.properties
@@ -17,6 +17,7 @@ cut=Cut
 copy=Copy
 paste=Paste
 pasteAndGo=Paste and Go
+pasteAndSearch=Paste and Search
 pasteWithoutFormatting=Paste without formatting
 delete=Delete
 selectAll=Select All

--- a/app/locale.js
+++ b/app/locale.js
@@ -64,6 +64,7 @@ var rendererIdentifiers = function () {
     'copy',
     'paste',
     'pasteAndGo',
+    'pasteAndSearch',
     'pasteWithoutFormatting',
     'delete',
     'selectAll',

--- a/app/locale.js
+++ b/app/locale.js
@@ -63,6 +63,7 @@ var rendererIdentifiers = function () {
     'cut',
     'copy',
     'paste',
+    'pasteAndGo',
     'pasteWithoutFormatting',
     'delete',
     'selectAll',

--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -252,7 +252,7 @@ class UrlBar extends ImmutableComponent {
   }
 
   onContextMenu (e) {
-    contextMenus.onUrlBarContextMenu(e)
+    contextMenus.onUrlBarContextMenu(this.props.activeFrameProps, e)
   }
 
   render () {

--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -252,7 +252,7 @@ class UrlBar extends ImmutableComponent {
   }
 
   onContextMenu (e) {
-    contextMenus.onUrlBarContextMenu(this.props.activeFrameProps, e)
+    contextMenus.onUrlBarContextMenu(this.searchDetail, this.props.activeFrameProps, e)
   }
 
   render () {

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -26,6 +26,7 @@ const ipc = global.require('electron').ipcRenderer
 const locale = require('../js/l10n')
 const getSetting = require('./settings').getSetting
 const settings = require('./constants/settings')
+const {isUrl} = require('./lib/appUrlUtil')
 
 /**
  * Obtains an add bookmark menu item
@@ -70,11 +71,28 @@ function tabPageTemplateInit (framePropsList) {
   }]
 }
 
-function inputTemplateInit (e) {
+function urlBarTemplateInit (activeFrame, e) {
   const hasSelection = e.target.selectionStart !== undefined &&
       e.target.selectionEnd !== undefined &&
       e.target.selectionStart !== e.target.selectionEnd
-  return getEditableItems(hasSelection)
+  const items = getEditableItems(hasSelection)
+  const clipboardText = clipboard.readText()
+  const hasClipboard = clipboardText && clipboardText.length > 0
+  const isLocationUrl = hasClipboard && isUrl(clipboardText)
+
+  if (isLocationUrl) {
+    items.push({
+      label: locale.translation('pasteAndGo'),
+      enabled: hasClipboard,
+      click: (item, focusedWindow) => {
+        windowActions.loadUrl(activeFrame, clipboardText)
+      }
+    })
+  } else {
+    // TODO: paste and search
+  }
+
+  return items
 }
 
 function tabsToolbarTemplateInit (activeFrame, closestDestinationDetail, isParent) {
@@ -428,25 +446,26 @@ function getMisspelledSuggestions (selection, isMisspelled, suggestions) {
 
 function getEditableItems (selection) {
   const hasSelection = selection.length > 0
+  const hasClipboard = clipboard.readText().length > 0
   const items = []
-  if (hasSelection) {
-    items.push({
-      label: locale.translation('cut'),
-      enabled: hasSelection,
-      accelerator: 'CmdOrCtrl+X',
-      role: 'cut'
-    }, {
-      label: locale.translation('copy'),
-      enabled: hasSelection,
-      accelerator: 'CmdOrCtrl+C',
-      role: 'copy'
-    })
-  }
+
   items.push({
+    label: locale.translation('cut'),
+    enabled: hasSelection,
+    accelerator: 'CmdOrCtrl+X',
+    role: 'cut'
+  }, {
+    label: locale.translation('copy'),
+    enabled: hasSelection,
+    accelerator: 'CmdOrCtrl+C',
+    role: 'copy'
+  }, {
     label: locale.translation('paste'),
     accelerator: 'CmdOrCtrl+V',
+    enabled: hasClipboard,
     role: 'paste'
   })
+
   return items
 }
 
@@ -819,9 +838,9 @@ function onTabPageContextMenu (framePropsList, e) {
   tabPageMenu.popup(remote.getCurrentWindow())
 }
 
-function onUrlBarContextMenu (e) {
+function onUrlBarContextMenu (activeFrame, e) {
   e.stopPropagation()
-  const inputMenu = Menu.buildFromTemplate(inputTemplateInit(e))
+  const inputMenu = Menu.buildFromTemplate(urlBarTemplateInit(activeFrame, e))
   inputMenu.popup(remote.getCurrentWindow())
 }
 

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -71,7 +71,7 @@ function tabPageTemplateInit (framePropsList) {
   }]
 }
 
-function urlBarTemplateInit (activeFrame, e) {
+function urlBarTemplateInit (searchDetail, activeFrame, e) {
   const hasSelection = e.target.selectionStart !== undefined &&
       e.target.selectionEnd !== undefined &&
       e.target.selectionStart !== e.target.selectionEnd
@@ -89,7 +89,15 @@ function urlBarTemplateInit (activeFrame, e) {
       }
     })
   } else {
-    // TODO: paste and search
+    let searchUrl = searchDetail.get('searchURL').replace('{searchTerms}', encodeURIComponent(clipboardText))
+
+    items.push({
+      label: locale.translation('pasteAndSearch'),
+      enabled: hasClipboard,
+      click: (item, focusedWindow) => {
+        windowActions.loadUrl(activeFrame, searchUrl)
+      }
+    })
   }
 
   return items
@@ -838,9 +846,9 @@ function onTabPageContextMenu (framePropsList, e) {
   tabPageMenu.popup(remote.getCurrentWindow())
 }
 
-function onUrlBarContextMenu (activeFrame, e) {
+function onUrlBarContextMenu (searchDetail, activeFrame, e) {
   e.stopPropagation()
-  const inputMenu = Menu.buildFromTemplate(urlBarTemplateInit(activeFrame, e))
+  const inputMenu = Menu.buildFromTemplate(urlBarTemplateInit(searchDetail, activeFrame, e))
   inputMenu.popup(remote.getCurrentWindow())
 }
 


### PR DESCRIPTION
- added "Paste and Go" option for urls
- added "Paste and Search" option for non-urls
- empty clipboard shows disabled "Paste and Search", similar to other browsers
- urlBar now has different context menu than text input
- similar to Chrome, cut/copy/paste always visible in context menu... but disabled if no action can be taken