### PR TITLE
Update for hide/show menu bar in context menu

### DIFF
--- a/app/extensions/brave/locales/en-US/menu.properties
+++ b/app/extensions/brave/locales/en-US/menu.properties
@@ -122,4 +122,4 @@ zoom=Zoom
 new=New
 learnSpelling=Learn Spelling
 ignoreSpelling=Ignore Spelling
-autoHideMenuBar=Hide Menu Bar
+autoHideMenuBar=Menu Bar

--- a/js/commonMenu.js
+++ b/js/commonMenu.js
@@ -295,7 +295,7 @@ module.exports.autoHideMenuBarMenuItem = () => {
   return {
     label: locale.translation('autoHideMenuBar'),
     type: 'checkbox',
-    checked: autoHideMenuBar,
+    checked: !autoHideMenuBar,
     click: (item, focusedWindow) => {
       appActions.changeSetting(settings.AUTO_HIDE_MENU_BAR, !autoHideMenuBar)
     }


### PR DESCRIPTION
Fix for https://github.com/brave/browser-laptop/issues/1699

Fixes for the context menu which appears when right clicking bookmarks toolbar
- Removes the check mark
- If menu is visible, it will show "Hide Menu Bar"
- If menu is hidden, it will show "Show Menu Bar"

The preferences screen and underlying setting for this were not changed