### PR TITLE
don't load tabs until the become active or previewed

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -26,7 +26,7 @@ const adInfo = require('../data/adInfo.js')
 const FindBar = require('./findbar.js')
 const consoleStrings = require('../constants/console')
 
-const { isSourceAboutUrl, getTargetAboutUrl } = require('../lib/appUrlUtil')
+const { isSourceAboutUrl, getTargetAboutUrl, aboutUrls } = require('../lib/appUrlUtil')
 
 class Frame extends ImmutableComponent {
   constructor () {
@@ -39,6 +39,10 @@ class Frame extends ImmutableComponent {
   }
 
   updateWebview () {
+    if (!this.webview && !this.props.isActive && !this.props.isPreview && !aboutUrls.get(this.props.frame.get('src'))) {
+      return
+    }
+
     let src = this.props.frame.get('src')
     let location = this.props.frame.get('location')
     const hack = siteHacks[urlParse(location).hostname]


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fixes #1794 #470 