### PR TITLE
Redesign preferences sidebar

### DIFF
--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -10,6 +10,7 @@ hintsTitle=Helpful hints...
 hint0=The Bravery menu allows you turn HTTPS Everywhere on or off. HTTPS Everywhere automatically rewrites your HTTP traffic to HTTPS for supported sites to keep you more secure.
 hint1=Brave will always auto-update for you, but you can check for an update on demand in the menu.
 hint2=The File menu allows you to create a New Session Tab.  Session tabs are like any other tab but they run in a different user profile.  This allows you to login to the same sites multiple times with the same browser.
+prefAsideTitle=Browser Settings
 sendUsFeedback=Send us feedback...
 loveToHear=We'd love to hear from you.
 startsWith=Brave starts with

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -317,9 +317,26 @@ class TopBarButton extends ImmutableComponent {
   }
 }
 
+class HelpfulHints extends ImmutableComponent {
+  render () {
+    return <div className='helpfulHints'>
+      <span className='hintsTitleContainer'>
+        <span data-l10n-id='hintsTitle' />
+        <span className='hintsRefresh fa fa-refresh'
+          onClick={this.props.refreshHint} />
+      </span>
+      <div data-l10n-id={`hint${this.props.hintNumber}`} />
+      <div className='helpfulHintsBottom'>
+        <a data-l10n-id='sendUsFeedback' href={appConfig.contactUrl} />
+      </div>
+    </div>
+  }
+}
+
 class TopBar extends ImmutableComponent {
   render () {
-    return <div className='preferencesTopBar'>
+    return <div className='prefAside'>
+      <div className='prefAsideHeading'>Browser Settings</div>
       <TopBarButton icon='fa-list-alt'
         dataL10nId='general'
         onClick={this.props.changeTab.bind(null, preferenceTabs.GENERAL)}
@@ -356,23 +373,7 @@ class TopBar extends ImmutableComponent {
         className='notImplemented'
         selected={this.props.preferenceTab === preferenceTabs.BRAVERY}
       />
-    </div>
-  }
-}
-
-class HelpfulHints extends ImmutableComponent {
-  render () {
-    return <div className='helpfulHints'>
-      <span className='hintsTitleContainer'>
-        <span data-l10n-id='hintsTitle' />
-        <span className='hintsRefresh fa fa-refresh'
-          onClick={this.props.refreshHint} />
-      </span>
-      <div data-l10n-id={`hint${this.props.hintNumber}`} />
-      <div className='helpfulHintsBottom'>
-        <a data-l10n-id='sendUsFeedback' href={appConfig.contactUrl} />
-        <div className='loveToHear' data-l10n-id='loveToHear' />
-      </div>
+      <HelpfulHints hintNumber={this.props.hintNumber} refreshHint={this.props.refreshHint} />
     </div>
   }
 }
@@ -460,13 +461,14 @@ class AboutPreferences extends React.Component {
         break
     }
     return <div>
-      <TopBar preferenceTab={this.state.preferenceTab}
-        changeTab={this.changeTab.bind(this)} />
+      <TopBar preferenceTab={this.state.preferenceTab} hintNumber={this.state.hintNumber}
+        changeTab={this.changeTab.bind(this)}
+        refreshHint={this.refreshHint.bind(this)}
+        getNextHintNumber={this.getNextHintNumber.bind(this)} />
       <div className='prefBody'>
         <div className='prefTabContainer'>
           {tab}
         </div>
-        <HelpfulHints hintNumber={this.state.hintNumber} refreshHint={this.refreshHint.bind(this)} />
       </div>
     </div>
   }

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -336,7 +336,7 @@ class HelpfulHints extends ImmutableComponent {
 class TopBar extends ImmutableComponent {
   render () {
     return <div className='prefAside'>
-      <div className='prefAsideHeading'>Browser Settings</div>
+      <div data-l10n-id='prefAsideTitle' />
       <TopBarButton icon='fa-list-alt'
         dataL10nId='general'
         onClick={this.props.changeTab.bind(null, preferenceTabs.GENERAL)}

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -1,9 +1,5 @@
 @import "./common.less";
 
-@prefTopBg: #999;
-@prefTopBgButtonSelected: #656565;
-@prefTopBgButtonHover: #444;
-
 .prefTabContainer {
   flex-grow: 1;
   padding: 60px 30px 30px 30px;
@@ -11,14 +7,24 @@
 
 .preferencesTopBar {
   background-color: @prefTopBg;
+  position: fixed;
+  min-width: @sideBarWidth;
+  width: 15%;
+  max-width: @sideBarWidth;
+  height: 100%;
+  z-index: 100;
   >div {
-    display: inline-block;
+    display: block;
+    width: 100%;
     &:hover {
       .topBarButton.fa {
         background-color: @prefTopBgButtonHover;
       }
     }
-
+    .topBarButton.fa {
+      display: block;
+      width: 100%;
+    }
     &.selected {
       .topBarButton.fa {
         background-color: @prefTopBgButtonSelected;
@@ -35,6 +41,7 @@
 }
 
 .topBarButton.fa {
+  box-sizing: border-box;
   color: white;
   cursor: default;
   display: inline-block;
@@ -42,17 +49,24 @@
   padding: 20px;
   position: relative;
   width: 40px;
-  text-align: center;
+  cursor: pointer;
 }
 
 .helpfulHints {
-  background-color: #f5f5f5;
-  color: #999;
+  background-color: #999;
+  color: white;
   cursor: default;
   flex-grow: 0;
   height: 100%;
   padding: 30px 0;
-  width: 200px;
+  min-width: @sideBarWidth;
+  width: 15%;
+  max-width: @sideBarWidth;
+  position: fixed;
+  z-index: 110;
+  bottom: 0;
+  left: 0;
+  height: 240px;
 
   .hintsTitleContainer {
     -webkit-user-select: none;
@@ -60,9 +74,12 @@
     font-size: inherit;
     font-weight: normal;
     margin: 10px;
+    * {
+      color: white;
+    }
   }
   > div {
-    color: @braveOrange;
+    color: white;
     font-size: smaller;
     margin: 10px;
   }
@@ -70,49 +87,57 @@
     position: absolute;
     bottom: 0;
     a {
-      color: @braveOrange;
+      color: white;
     }
     .loveToHear {
       color: initial;
       font-size: smaller;
       margin-top: 5px;
       margin-bottom: 30px;
+      color: white;
     }
   }
   .hintsRefresh {
     margin-left: 15px;
     font-size: smaller;
+    &:before {
+      cursor: pointer;
+    }
   }
 }
 
 .prefBody {
   display: flex;
   height: 100%;
+  margin-left: @sideBarWidth;
 }
-
-@markerSize: 6px;
 
 .tabMarkerContainer {
   position: relative;
 
   .tabMarker {
-    border-left: @markerSize solid transparent;
-    border-right: @markerSize solid transparent;
-    border-top: @markerSize solid @prefTopBg;
+    border-left: @carotRadius solid transparent;
+    border-right: @carotRadius solid transparent;
+    border-top: @carotRadius solid @prefTopBg;
     height: 0;
-    left: ~"calc(50% - 6px)";
+    left: ~"calc(97%)";
+    transform: rotateZ(-90deg);
     position: absolute;
+    z-index: 400;
     width: 0;
+    top: -34px;
   }
 }
 
 .tabMarkerText {
+  display: inline-block;
   color: white;
-  font-size: 10px;
-  left: 0;
-  position: absolute;
-  margin-top: 3px;
-  right: 0;
+  font-size: 0.7em;
+  margin-left: 15px;
+
+  &:before {
+    display: inline-block;
+  }
 }
 
 a {

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -5,20 +5,25 @@
   padding: 60px 30px 30px 30px;
 }
 
-.preferencesTopBar {
-  background-color: @prefTopBg;
+.prefAside {
+  background-color: @gray;
+  box-shadow: @insetShadow;
   position: fixed;
-  min-width: @sideBarWidth;
-  width: 15%;
-  max-width: @sideBarWidth;
+  width: @sideBarWidth;
   height: 100%;
   z-index: 100;
   >div {
     display: block;
     width: 100%;
+    &.prefAsideHeading {
+      margin: 20px auto;
+      text-align: center;
+      color: @white60;
+      font-size: 0.9em;
+    }
     &:hover {
       .topBarButton.fa {
-        background-color: @prefTopBgButtonHover;
+        background-color: @darkGray;
       }
     }
     .topBarButton.fa {
@@ -27,10 +32,10 @@
     }
     &.selected {
       .topBarButton.fa {
-        background-color: @prefTopBgButtonSelected;
+        background-color: @mediumGray;
       }
       .tabMarker {
-        border-top-color: @prefTopBgButtonSelected;
+        border-top-color: @mediumGray;
       }
     }
 
@@ -46,27 +51,22 @@
   cursor: default;
   display: inline-block;
   font-size: 22px;
-  padding: 20px;
+  padding: 12px;
   position: relative;
   width: 40px;
   cursor: pointer;
+
+  &:before {
+    vertical-align: middle;
+  }
+
 }
 
 .helpfulHints {
-  background-color: #999;
-  color: white;
+  color: @white60;
   cursor: default;
-  flex-grow: 0;
-  height: 100%;
   padding: 30px 0;
-  min-width: @sideBarWidth;
-  width: 15%;
-  max-width: @sideBarWidth;
-  position: fixed;
-  z-index: 110;
-  bottom: 0;
-  left: 0;
-  height: 240px;
+  margin-top: 20px;
 
   .hintsTitleContainer {
     -webkit-user-select: none;
@@ -75,11 +75,11 @@
     font-weight: normal;
     margin: 10px;
     * {
-      color: white;
+      color: @white60;
     }
   }
   > div {
-    color: white;
+    color: @white60;
     font-size: smaller;
     margin: 10px;
   }
@@ -87,14 +87,14 @@
     position: absolute;
     bottom: 0;
     a {
-      color: white;
+      color: @white60;
     }
     .loveToHear {
       color: initial;
       font-size: smaller;
       margin-top: 5px;
       margin-bottom: 30px;
-      color: white;
+      color: @white60;
     }
   }
   .hintsRefresh {
@@ -118,14 +118,14 @@
   .tabMarker {
     border-left: @carotRadius solid transparent;
     border-right: @carotRadius solid transparent;
-    border-top: @carotRadius solid @prefTopBg;
+    border-top: @carotRadius solid @gray;
     height: 0;
-    left: ~"calc(97%)";
+    left: ~"calc(100% - 6px)";
     transform: rotateZ(-90deg);
     position: absolute;
     z-index: 400;
     width: 0;
-    top: -34px;
+    top: -27px;
   }
 }
 

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -12,14 +12,18 @@
   width: @sideBarWidth;
   height: 100%;
   z-index: 100;
+
   >div {
     display: block;
     width: 100%;
-    &.prefAsideHeading {
+
+    &:first-of-type {
+      box-sizing: border-box;
       margin: 20px auto;
-      text-align: center;
+      padding-left: 20px;
       color: @white60;
       font-size: 0.9em;
+      font-weight: 300;
     }
     &:hover {
       .topBarButton.fa {

--- a/less/variables.less
+++ b/less/variables.less
@@ -51,3 +51,10 @@
 @navbarButtonWidth: 35px;
 @navbarBraveButtonWidth: 23px;
 @navbarLeftMarginDarwin: 70px;
+
+@prefTopBg: #999;
+@prefTopBgButtonSelected: #656565;
+@prefTopBgButtonHover: #444;
+
+@carotRadius: 8px;
+@sideBarWidth: 200px;

--- a/less/variables.less
+++ b/less/variables.less
@@ -52,9 +52,15 @@
 @navbarBraveButtonWidth: 23px;
 @navbarLeftMarginDarwin: 70px;
 
-@prefTopBg: #999;
-@prefTopBgButtonSelected: #656565;
-@prefTopBgButtonHover: #444;
-
 @carotRadius: 8px;
 @sideBarWidth: 200px;
+
+@gray: rgb(153, 153, 153);
+@mediumGray: rgb(101, 101, 101);
+@darkGray: rgb(68, 68, 68);
+
+@gray30: rgba(116, 116, 130, 0.3);
+@black25: rgba(0, 0, 0, 0.25);
+@white60: rgba(255, 255, 255, 0.6);
+
+@insetShadow: inset -5px 0 15px @black25;


### PR DESCRIPTION
• Restyled `.preferencesTopBar` (`TopBar`) to be a sidebar to reflect latest mockups, and renamed it to `.prefAside`

• Moved `HelpfulHints` out of `.prefBody` (`AboutPreferences`) and into `.prefAside` (`TopBar`)

• Added new variables: `@carotRadius`, `@sideBarWidth`, `@gray`, `@mediumGray`, `@darkGray`, `@gray30`, `@black25`, `@white60`, `@insetShadow` 

Two tests related to locating `.notificationBar` are currently failing, but it seems unrelated to the changes: 
![screen shot 2016-05-19 at 12 34 47 pm](https://cloud.githubusercontent.com/assets/1307594/15407574/7335517c-1dc0-11e6-8932-abacbf541524.png)

