### PR TITLE
don't reuse guestInstanceId when reloading webview

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -74,7 +74,7 @@ class Frame extends ImmutableComponent {
   }
 
   shouldCreateWebview () {
-    return !this.webview || this.webview.isCrashed() || this.webview.allowRunningInsecureContent !== this.allowRunningInsecureContent()
+    return !this.webview || this.webview.allowRunningInsecureContent !== this.allowRunningInsecureContent()
   }
 
   allowRunningInsecureContent () {
@@ -98,7 +98,12 @@ class Frame extends ImmutableComponent {
     // Create the webview dynamically because React doesn't whitelist all
     // of the attributes we need
     let webviewAdded = false
+    let guestInstanceId = null
     if (this.shouldCreateWebview()) {
+      // only set the guestInstanceId if this is a new frame
+      if (this.webview == null) {
+        guestInstanceId = this.props.frame.get('guestInstanceId')
+      }
       while (this.webviewContainer.firstChild) {
         this.webviewContainer.removeChild(this.webviewContainer.firstChild)
       }
@@ -120,7 +125,7 @@ class Frame extends ImmutableComponent {
       ipc.send(messages.INITIALIZE_PARTITION, partition)
       this.webview.setAttribute('partition', partition)
     }
-    if (this.props.frame.get('guestInstanceId')) {
+    if (guestInstanceId) {
       this.webview.setAttribute('data-guest-instance-id', this.props.frame.get('guestInstanceId'))
     }
 
@@ -452,6 +457,7 @@ class Frame extends ImmutableComponent {
         url: this.props.frame.get('location')
       })
       windowActions.loadUrl(this.props.frame, 'about:error')
+      this.webview = false
     })
     this.webview.addEventListener('did-fail-load', (e) => {
       if (e.isMainFrame && isFrameError(e.errorCode)) {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

fixes #1161

@bbondy 