### PR TITLE
Properly handle middle mouse button click on context menus

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -454,6 +454,13 @@ class Main extends ImmutableComponent {
     while (node) {
       if (node.classList &&
           (node.classList.contains('popupWindow') || node.classList.contains('contextMenu'))) {
+
+        // Middle click (on context menu) needs to fire the click event.
+        // We need to prevent the default "Auto-Scrolling" behavior.
+        if (node.classList.contains('contextMenu') && e.button === 1) {
+          e.preventDefault()
+        }
+
         return
       }
       node = node.parentNode


### PR DESCRIPTION
This PR fixes https://github.com/brave/browser-laptop/issues/1724

However, I'd like get other folks feedback before anyone would consider this for a merge. It does work, but I feel like a bad person. Here's the executive summary:
* If you have bookmarks toolbar enabled and you have a folder with items inside, you cannot open those sub-items by doing a middle click (CTRL + click works fine, though)
* Middle click is never handled for ContextMenu object (js/components/contextMenu.js)
 * ContextMenu control derives from ImmutableComponent which derives from React.Component
 * onClick properly handles left clicks
 * onContextMenu properly handles right clicks
 * since onClick was not being triggered for middle clicks, I created a new handler for onMouseDown

Is this a bug w/ React or is that expected? I'm not sure. Here's a link to the relevant mouse event documentation, which is sparse:
https://facebook.github.io/react/docs/events.html#mouse-events

I'm also curious if this happens on any other platform, other than Windows 10. Windows responds fine when doing a middle click on the bookmarks toolbar (BTB), just not the context menus that are created by clicking a folder contained inside the BTB.