### PR TITLE
Key binding to quit Brave

### DIFF
--- a/js/commonMenu.js
+++ b/js/commonMenu.js
@@ -63,7 +63,7 @@ module.exports.sendToFocusedWindow = (focusedWindow, message) => {
 module.exports.quitMenuItem = () => {
   return {
     label: locale.translation('quit') + ' ' + appConfig.name,
-    accelerator: 'Command+Q',
+    accelerator: 'CmdOrCtrl+Q',
     click: app.quit
   }
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

This fix enables the key binding to quit Brave.

cf. https://github.com/electron/electron/blob/master/docs/api/accelerator.md#platform-notice