### PR TITLE
Fix #1871 (panel alignment on about:preferences)

### DIFF
--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -31,7 +31,8 @@
       }
     }
     .topBarButton.fa {
-      display: block;
+      display: flex;
+      align-items: center;
       width: 100%;
     }
     &.selected {
@@ -61,7 +62,9 @@
   cursor: pointer;
 
   &:before {
-    vertical-align: middle;
+    display: flex;
+    justify-content: center;
+    width: 20px;
   }
 
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

This fix aligns .topbarButton and .tabMarkerText in .prefAside on about:preferences.