### PR TITLE
Fix #1776 (Audio indicator on/off button)

### DIFF
--- a/less/tabs.less
+++ b/less/tabs.less
@@ -96,6 +96,7 @@
   .audioPlaybackActive {
     margin: auto 4px auto 0;
     color: @audioColor;
+    width: 20px;
   }
 
   .thumbnail {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fix the width of the audio indicator.