### PR TITLE
Fix #1848 (URL tooltips for bookmarks)

### DIFF
--- a/js/components/bookmarksToolbar.js
+++ b/js/components/bookmarksToolbar.js
@@ -151,6 +151,7 @@ class BookmarkToolbarButton extends ImmutableComponent {
         isDragging: this.isDragging
       })}
       draggable
+      title={this.props.frameProps.get('location')}
       ref={(node) => { this.bookmarkNode = node }}
       onClick={this.onClick}
       onDragStart={this.onDragStart}


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Adds a tooltip that shows the bookmark's URL.

Fixes #1848 (URL tooltip for items on bookmarks toolbar).