### PR TITLE
make inactive pinned tabs the same color as inactive regular tabs

### DIFF
--- a/less/tabs.less
+++ b/less/tabs.less
@@ -50,14 +50,9 @@
   width: 100%;
   align-items: center;
   justify-content: center;
-
-  &:not(.isPinned) {
-   border-radius: @borderRadiusTabs @borderRadiusTabs 0px 0px;
-   border-width: 1px 1px 0;
-   background: #DEDEDE;
-   border: 1px solid @chromeTertiary;
-   border-bottom: 1px;
-  }
+  background: #DEDEDE;
+  border: 1px solid @chromeTertiary;
+  border-bottom: 1px;
 
   .tabTitle {
     -webkit-user-select: none;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

fixes #1894

@bradleyrichter @bbondy 