### PR TITLE
Added 'quitApp' locale identifier

### DIFF
--- a/app/extensions/brave/locales/en-US/menu.properties
+++ b/app/extensions/brave/locales/en-US/menu.properties
@@ -108,6 +108,7 @@ copyImageAddress=Copy image address
 viewPageSource=View Page Source
 addToReadingList=Add to reading list
 quit=Quit
+quitApp=Quit Brave
 about=About
 inspectElement=Inspect Element
 downloadsManager=Downloads Manager...

--- a/app/locale.js
+++ b/app/locale.js
@@ -18,6 +18,7 @@ var rendererIdentifiers = function () {
     'passwordCopied',
     'about',
     'quit',
+    'quitApp',
     'addToReadingList',
     'viewPageSource',
     'copyImageAddress',

--- a/js/commonMenu.js
+++ b/js/commonMenu.js
@@ -62,7 +62,7 @@ module.exports.sendToFocusedWindow = (focusedWindow, message) => {
 
 module.exports.quitMenuItem = () => {
   return {
-    label: locale.translation('quit') + ' ' + appConfig.name,
+    label: locale.translation('quitApp'),
     accelerator: 'CmdOrCtrl+Q',
     click: app.quit
   }


### PR DESCRIPTION
 * Allow languages to configure entire quit message instead of automatically inserting product name

Issue: #1659