### PR TITLE
Add print to context menu. Fix #1270

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -760,6 +760,12 @@ function mainTemplateInit (nodeProps, frame) {
           click: function (item, focusedWindow) {
             focusedWindow.webContents.send(messages.SHORTCUT_ACTIVE_FRAME_SHOW_FINDBAR)
           }
+        }, {
+          label: locale.translation('print'),
+          accelerator: 'CmdOrCtrl+P',
+          click: function (item, focusedWindow) {
+            focusedWindow.webContents.send(messages.SHORTCUT_ACTIVE_FRAME_PRINT)
+          }
         }
         // CommonMenu.separatorMenuItem
         // TODO: bravery menu goes here


### PR DESCRIPTION
- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Ran `git rebase -i` to squash commits if needed.
- [ ]  Make sure context menu items in the URL bar work
- [x]  Make sure context menu items on content work with no selected text.
- [ ]  Make sure context menu items on content work with selected text.
- [ ]  Make sure context menu items on content work inside an editable control (input, textarea, or contenteditable).

When using Chrome you can also print when a text is selected, but I opted to avoid this in concordance with *Bookmark Page* behavior inside the context menu, which is hidden when a text is selected.