### PR TITLE
Add font-awesome folder icon for folders on bookmarks toolbar and menus

### DIFF
--- a/js/components/bookmarksToolbar.js
+++ b/js/components/bookmarksToolbar.js
@@ -160,6 +160,11 @@ class BookmarkToolbarButton extends ImmutableComponent {
       onDragOver={this.onDragOver}
       onContextMenu={this.onContextMenu}>
       {
+        this.isFolder
+        ? <span className='bookmarkFavicon bookmarkFolder fa fa-folder-o' style={iconStyle} />
+        : null
+      }
+      {
         !this.isFolder && showFavicon ? <span className='bookmarkFavicon' style={iconStyle}></span> : null
       }
       <span className='bookmarkText'>

--- a/js/components/contextMenu.js
+++ b/js/components/contextMenu.js
@@ -16,6 +16,9 @@ class ContextMenuItem extends ImmutableComponent {
   get hasSubmenu () {
     return this.submenu && this.submenu.size > 0
   }
+  get isBookmarksToolbarSubmenu () {
+    return this.hasSubmenu && this.props.contextMenuItem.get('bookmark')
+  }
   onClick (clickAction, shouldHide, e) {
     e.stopPropagation()
     if (clickAction) {
@@ -155,6 +158,11 @@ class ContextMenuItem extends ImmutableComponent {
             [faIcon]: !!faIcon
           })}
             style={iconStyle}></span>
+          : null
+      }
+      {
+        this.isBookmarksToolbarSubmenu
+          ? <span className='submenuIndicator contextMenuIcon bookmarkIcon fa fa-folder-o' style={iconStyle} />
           : null
       }
       <span className='contextMenuItemText'

--- a/less/bookmarksToolbar.less
+++ b/less/bookmarksToolbar.less
@@ -78,6 +78,9 @@
       text-overflow: ellipsis;
       overflow: hidden;
     }
+    .bookmarkFolder {
+      font-size: @bookmarksIconSize;
+    }
     .bookmarkFolderChevron {
       color: #676767;
       margin-left: 4px;

--- a/less/contextMenu.less
+++ b/less/contextMenu.less
@@ -27,6 +27,11 @@
   -webkit-user-select: none;
   &.reverseExpand {
     flex-direction: row-reverse;
+    .fa {
+      font-size: 0;
+      width: 0;
+      margin: 0;
+    }
   }
 
   .contextMenuSingle {
@@ -133,5 +138,9 @@
       float: right;
       margin: auto 0 auto 5px;
     }
+  }
+
+  .fa {
+    font-size: @bookmarksIconSize;
   }
 }

--- a/less/variables.less
+++ b/less/variables.less
@@ -46,6 +46,7 @@
 @tabPagesHeight: 12px;
 @bookmarksToolbarHeight: 23px;
 @bookmarksToolbarWithFaviconsHeight: 28px;
+@bookmarksIconSize: 16px;
 
 @navbarButtonSpacing: 4px;
 @navbarButtonWidth: 35px;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fix #1469 

Image 1:
![](https://cloud.githubusercontent.com/assets/3362943/15540466/772d249c-22c2-11e6-96f6-ffc82ab029fd.jpg)

Please make sure that ``@bookmarksIconSize: 16px;`` is based on ``const iconSize = 16`` [(here)](https://github.com/luixxiul/browser-laptop/blob/b2c4775606a2384bdff7d80ddb7f58343c27f33b/js/components/bookmarksToolbar.js#L126).

I like the white icon better than ``fa-folder``, which is a black icon.
http://fontawesome.io/icon/folder/