### PR TITLE
Fix #1848 (bookmark tooltips)

### DIFF
--- a/js/components/bookmarksToolbar.js
+++ b/js/components/bookmarksToolbar.js
@@ -152,6 +152,7 @@ class BookmarkToolbarButton extends ImmutableComponent {
       })}
       draggable
       ref={(node) => { this.bookmarkNode = node }}
+      title={this.isFolder ? '' : this.props.bookmark.get('title') + '\n' + this.props.bookmark.get('location')}
       onClick={this.onClick}
       onDragStart={this.onDragStart}
       onDragEnd={this.onDragEnd}


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Adds a tooltip that shows the bookmark's title and URL.

Fixes #1848 (URL tooltip for items on bookmarks toolbar).