### PR TITLE
replace eyeball icon for private tab

### DIFF
--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -183,7 +183,7 @@ class Tab extends ImmutableComponent {
         style={activeTabStyle}>
         {
           this.props.frameProps.get('isPrivate')
-          ? <div className='privateIcon fa fa-eye' />
+          ? <div className='privateIcon fa fa-user-secret' />
           : null
         }
         {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Ran `git rebase -i` to squash commits if needed.

partially addresses #547

This PR is intended to submit a temp fix until sunglasses icon will become available in a future release of Font Awesome.