### PR TITLE
navigator z-index smaller to close Bravery menu

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -191,7 +191,7 @@
   position: relative;
   -webkit-user-select: none;
 
-  z-index: 99999;
+  z-index: 312;
 
   form {
     -webkit-app-region: drag;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fix #1910

cf. https://github.com/brave/browser-laptop/blob/2dd92a9eb3b42053ceaafc32a63e1d3508e8c039/less/dialogs.less#L13

I think the z-index values should be handled in ``variables.less`` to avoid a case like this.
Here I created a proposal: https://github.com/luixxiul/browser-laptop/commit/03379fca46c87c8ad9b541806029b30c694ea2bc. If it is OK I will send another PR after this one or add the commit to this PR.

There is one value remaining here: https://github.com/brave/browser-laptop/blob/747d4f3f6e8faf1b04ac7de744d07082a7f46544/app/extensions/1password/data/ui/fillStyle.css#L22 cc:@bridiver 