### PR TITLE
Support for anchor links on about:pages

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -32,7 +32,8 @@ let generateBraveManifest = () => {
           '<all_urls>'
         ],
         include_globs: [
-          getAppUrl('about-*.html')
+          getAppUrl('about-*.html'),
+          getAppUrl('about-*.html') + '#*'
         ],
         exclude_globs: [
           getAppUrl('about-blank.html')

--- a/app/extensions/brave/js/about.js
+++ b/app/extensions/brave/js/about.js
@@ -1,5 +1,5 @@
 (function () {
-  var queryString = window.location.href.split('?')[1]
+  var queryString = window.location.search
   var devServerPort = queryString && queryString.match(/devServerPort=([^&]*)/)[1]
 
   let aboutEntryPage = 'gen/aboutPages.entry.js'

--- a/js/about/entry.js
+++ b/js/about/entry.js
@@ -1,9 +1,9 @@
 const ReactDOM = require('react-dom')
-const { getSourceAboutUrl } = require('../lib/appUrlUtil')
+const { getSourceAboutUrl, getBaseUrl } = require('../lib/appUrlUtil')
 
 let element
 
-switch (getSourceAboutUrl(window.location.href)) {
+switch (getBaseUrl(getSourceAboutUrl(window.location.href))) {
   case 'about:newtab':
     element = require('./newtab')
     break

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -99,15 +99,8 @@ class SettingCheckbox extends ImmutableComponent {
 }
 
 class GeneralTab extends ImmutableComponent {
-  constructor () {
-    super()
-    this.state = {
-      languageCodes: window.languageCodes
-    }
-  }
-
   render () {
-    var languageOptions = this.state.languageCodes.map(function (lc) {
+    var languageOptions = this.props.languageCodes.map(function (lc) {
       return (
         <option data-l10n-id={lc} value={lc} />
       )
@@ -437,9 +430,11 @@ class TopBar extends ImmutableComponent {
 class AboutPreferences extends React.Component {
   constructor () {
     super()
+    let hash = window.location.hash ? window.location.hash.slice(1) : ''
     this.state = {
-      preferenceTab: preferenceTabs.GENERAL,
+      preferenceTab: hash.toUpperCase() in preferenceTabs ? hash : preferenceTabs.GENERAL,
       hintNumber: this.getNextHintNumber(),
+      languageCodes: window.languageCodes ? Immutable.fromJS(window.languageCodes) : Immutable.Map(),
       settings: window.initSettings ? Immutable.fromJS(window.initSettings) : Immutable.Map(),
       siteSettings: window.initSiteSettings ? Immutable.fromJS(window.initSiteSettings) : Immutable.Map(),
       braveryDefaults: window.initBraveryDefaults ? Immutable.fromJS(window.initBraveryDefaults) : Immutable.Map()
@@ -500,9 +495,10 @@ class AboutPreferences extends React.Component {
     const settings = this.state.settings
     const siteSettings = this.state.siteSettings
     const braveryDefaults = this.state.braveryDefaults
+    const languageCodes = this.state.languageCodes
     switch (this.state.preferenceTab) {
       case preferenceTabs.GENERAL:
-        tab = <GeneralTab settings={settings} onChangeSetting={this.onChangeSetting} />
+        tab = <GeneralTab settings={settings} onChangeSetting={this.onChangeSetting} languageCodes={languageCodes} />
         break
       case preferenceTabs.SEARCH:
         tab = <SearchTab settings={settings} onChangeSetting={this.onChangeSetting} />

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -24,7 +24,7 @@ const settings = require('../constants/settings')
 const adInfo = require('../data/adInfo.js')
 const FindBar = require('./findbar.js')
 const consoleStrings = require('../constants/console')
-const { aboutUrls, isSourceAboutUrl, isTargetAboutUrl, getTargetAboutUrl } = require('../lib/appUrlUtil')
+const { aboutUrls, isSourceAboutUrl, isTargetAboutUrl, getTargetAboutUrl, getBaseUrl } = require('../lib/appUrlUtil')
 const { isFrameError } = require('../lib/errorUtil')
 
 class Frame extends ImmutableComponent {
@@ -37,14 +37,14 @@ class Frame extends ImmutableComponent {
   }
 
   isAboutPage () {
-    return aboutUrls.get(this.props.frame.get('location'))
+    return aboutUrls.get(getBaseUrl(this.props.frame.get('location')))
   }
 
   updateAboutDetails () {
-    let location = this.props.frame.get('location')
+    let location = getBaseUrl(this.props.frame.get('location'))
     if (location === 'about:preferences') {
-      this.webview.send(messages.SETTINGS_UPDATED, this.props.settings.toJS())
-      this.webview.send(messages.SITE_SETTINGS_UPDATED, this.props.allSiteSettings.toJS())
+      this.webview.send(messages.SETTINGS_UPDATED, this.props.settings ? this.props.settings.toJS() : null)
+      this.webview.send(messages.SITE_SETTINGS_UPDATED, this.props.allSiteSettings ? this.props.allSiteSettings.toJS() : null)
       this.webview.send(messages.BRAVERY_DEFAULTS_UPDATED, this.props.braveryDefaults)
     } else if (location === 'about:bookmarks') {
       this.webview.send(messages.BOOKMARKS_UPDATED, {
@@ -87,7 +87,7 @@ class Frame extends ImmutableComponent {
         // allow force loading of new frames
         this.props.frame.get('unloaded') === true &&
         // don't lazy load about pages
-        !aboutUrls.get(this.props.frame.get('src')) &&
+        !aboutUrls.get(getBaseUrl(this.props.frame.get('src'))) &&
         // pinned tabs don't serialize their state so the icon is lost for lazy loading
         !this.props.frame.get('pinnedLocation')) {
       return

--- a/js/lib/appUrlUtil.js
+++ b/js/lib/appUrlUtil.js
@@ -60,7 +60,7 @@ module.exports.aboutUrls = new Immutable.Map({
 })
 
 module.exports.isIntermediateAboutPage = (location) =>
-  ['about:safebrowsing', 'about:error', 'about:certerror'].includes(location)
+  ['about:safebrowsing', 'about:error', 'about:certerror'].includes(getBaseUrl(location))
 
 // Map of target URLs mapped to source about: URLs
 const aboutUrlsReverse = new Immutable.Map(module.exports.aboutUrls.reduce((obj, v, k) => {
@@ -74,7 +74,9 @@ const aboutUrlsReverse = new Immutable.Map(module.exports.aboutUrls.reduce((obj,
  * about:blank -> http://localhost:8000/about-blank/index.html
  */
 module.exports.getTargetAboutUrl = function (input) {
-  return module.exports.aboutUrls.get(input)
+  const hash = getHash(input)
+  const url = module.exports.aboutUrls.get(getBaseUrl(input))
+  return hash ? [url, hash].join('#') : url
 }
 
 /**
@@ -83,7 +85,9 @@ module.exports.getTargetAboutUrl = function (input) {
  * http://localhost:8000/about-blank.html -> about:blank
  */
 module.exports.getSourceAboutUrl = function (input) {
-  return aboutUrlsReverse.get(input)
+  const hash = getHash(input)
+  const url = aboutUrlsReverse.get(getBaseUrl(input))
+  return hash ? [url, hash].join('#') : url
 }
 
 /**
@@ -91,7 +95,7 @@ module.exports.getSourceAboutUrl = function (input) {
  * Example: isSourceAboutUrl('about:blank') -> true
  */
 module.exports.isSourceAboutUrl = function (input) {
-  return !!module.exports.getTargetAboutUrl(input)
+  return !!module.exports.getTargetAboutUrl(getBaseUrl(input))
 }
 
 /**
@@ -99,7 +103,7 @@ module.exports.isSourceAboutUrl = function (input) {
  * Example: isTargetAboutUrl('http://localhost:8000/about-blank/index.html') -> true
  */
 module.exports.isTargetAboutUrl = function (input) {
-  return !!module.exports.getSourceAboutUrl(input)
+  return !!module.exports.getSourceAboutUrl(getBaseUrl(input))
 }
 
 /**
@@ -109,4 +113,19 @@ module.exports.isTargetAboutUrl = function (input) {
 module.exports.isUrl = function (input) {
   input = input.trim()
   return UrlUtil.isURL(input) && !input.includes(' ')
+}
+
+/**
+ * Gets base url from an about: url or its target mapping.
+ */
+function getBaseUrl (input) {
+  return (typeof input === 'string') ? input.split('#')[0] : ''
+}
+module.exports.getBaseUrl = getBaseUrl
+
+/**
+ * Gets hash part of a url
+ */
+function getHash (input) {
+  return (typeof input === 'string') ? input.split('#')[1] : ''
 }


### PR DESCRIPTION
This is needed to link directly to specific tabs in about:preferences,
like about:preferences#privacy in the Bravery panel (#1951).

Auditors: @bbondy 