### PR TITLE
align .switchcontrol better

### DIFF
--- a/js/components/switchControl.js
+++ b/js/components/switchControl.js
@@ -59,14 +59,14 @@ class SwitchControl extends ImmutableComponent {
       {
         this.props.rightl10nId && this.props.topl10nId
         ? <div className='switchControlText'><div className='switchControlRightText'><div className='switchSpacer'>&nbsp;</div><span className='switchControlRightText' data-l10n-id={this.props.rightl10nId} /></div></div>
-        : <span className='switchControlRight'>
-          {this.props.rightl10nId
+        : <div className='switchControlRight'>
+          {this.props.rightl10nId && !this.props.infoUrl
           ? <span className='switchControlRightText' data-l10n-id={this.props.rightl10nId} />
           : null}
-          {this.props.infoUrl
-          ? <span className='fa fa-question-circle info' onClick={this.onInfoClick} />
+          {this.props.rightl10nId && this.props.infoUrl
+          ? <div className='switchControlRightText'><span data-l10n-id={this.props.rightl10nId} /><span className='fa fa-question-circle info' onClick={this.onInfoClick} /></div>
           : null}
-        </span>
+        </div>
       }
     </div>
   }

--- a/less/forms.less
+++ b/less/forms.less
@@ -184,7 +184,7 @@
         display: inline;
         cursor: pointer;
         padding-left: 2px;
-        font-size: 16px;
+        font-size: 15px;
       }
 
       hr {

--- a/less/switchControls.less
+++ b/less/switchControls.less
@@ -44,16 +44,16 @@
     margin: auto 5px auto 0;
   }
 
-  .switchControlRight {
-    display: flex;
-
-    .switchControlRightText {
-      margin: auto 0 auto 5px;
-    }
+  .switchControlRightText {
+    margin: auto 0 auto 5px;
   }
 
   .switchControlTopText {
     margin: 0 auto 5px auto;
+  }
+
+  .switchControlRight {
+    display: flex;
   }
 
   .switchMiddle {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Ran `git rebase -i` to squash commits if needed.

addresses #1951

Basically you'll get this one:
![](https://cloud.githubusercontent.com/assets/3362943/15631532/ac90620e-25a9-11e6-9225-fcf683bacfec.jpg)

On a small screen you'll get this one:
![](https://cloud.githubusercontent.com/assets/3362943/15631524/64502678-25a9-11e6-827b-c223c5f68643.jpg)

``.info`` should be small as this, in order to align the text and the button without using ``flex``.

This also fixes margin between the switch and "Up" in the .braveryPanelHeader