### PR TITLE
cosmetic change for .loadtime

### DIFF
--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -300,7 +300,10 @@ class UrlBar extends ImmutableComponent {
         {
           this.props.titleMode || this.aboutPage
           ? null
-          : <span className='loadTime'>{this.loadTime}</span>
+          : <span className={cx({
+            'loadTime': true,
+            'onFocus': this.props.urlbar.get('active')
+            })}>{this.loadTime}</span>
         }
 
         {

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -268,11 +268,18 @@
 
   .loadTime {
     color: @loadTimeColor;
+    background: @navigationBarBackground;
     font-size: 12px;
     right: 10px;
     text-align: right;
     margin: 4px 0 0 0;
     top: 9px;
+    cursor: default;
+    padding-top: 1px;
+
+    &.onFocus {
+        display: none;
+    }
   }
 
   .noScript {
@@ -313,7 +320,7 @@
     cursor: text;
     font-size: @defaultFontSize;
     font-weight: normal;
-    margin: 3px 10px 0 3px;
+    margin: 3px 0 0 3px;
     outline: none;
     text-overflow: ellipsis;
     flex-grow: 1;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

close #2044 

also hide .loadtime if urlbar is active, which is helpful to input a url on a small window.