### PR TITLE
change timing of onMouseEnter and onMouseLeave

### DIFF
--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -162,7 +162,9 @@ class Tab extends ImmutableComponent {
         isDragging: this.isDragging,
         isPinned: this.isPinned,
         partOfFullPageSet: this.props.partOfFullPageSet
-      })}>
+      })}
+      onMouseEnter={this.props.previewTabs ? this.onMouseEnter.bind(this) : null}
+      onMouseLeave={this.props.previewTabs ? this.onMouseLeave.bind(this) : null}>
       <div className={cx({
         tab: true,
         isPinned: this.isPinned,
@@ -173,8 +175,6 @@ class Tab extends ImmutableComponent {
         ref={(node) => { this.tab = node }}
         draggable
         title={this.props.frameProps.get('title')}
-        onMouseEnter={this.props.previewTabs ? this.onMouseEnter.bind(this) : null}
-        onMouseLeave={this.props.previewTabs ? this.onMouseLeave.bind(this) : null}
         onDragStart={this.onDragStart.bind(this)}
         onDragEnd={this.onDragEnd.bind(this)}
         onDragOver={this.onDragOver.bind(this)}


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

fix #2062
