### PR TITLE
fix conflict with react-stickynode

### DIFF
--- a/less/about/bookmarks.less
+++ b/less/about/bookmarks.less
@@ -22,17 +22,13 @@
       }
     }
 
-    >.bookmarkFolderList {
-      border-right: 1px solid @chromeBorderColor;
-      padding-top: 10px;
-
-      .listItem {
-        height: 1rem;
-      }
-    }
-
     .bookmarkFolderList {
       min-width: 220px;
+
+      .listItem {
+        border-right: 1px solid @chromeBorderColor;
+        height: 1rem;
+      }
 
       .bookmarkFolderIcon {
         margin-right: 5px;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

addresses #2077.

This fixes styling of ``.bookmarkFolderList`` under ``.sticky-inner-wrapper`` which was introduced with react-stickynode, Now .listItem should be aligned well (#2078).

@bbondy, would you please audit this one? 