### PR TITLE
File name tooltip for items on download bar, downloadArrow on items

### DIFF
--- a/js/components/downloadsBar.js
+++ b/js/components/downloadsBar.js
@@ -93,7 +93,8 @@ class DownloadItem extends ImmutableComponent {
       }
       <div className='downloadInfo'>
         <span>
-          <div className='downloadFilename'>
+          <div className='downloadFilename'
+            title={this.props.download.get('filename')}>
             {
               this.props.download.get('filename')
             }

--- a/less/downloadBar.less
+++ b/less/downloadBar.less
@@ -87,7 +87,7 @@
           white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
-          padding-right: 5px;
+          width: 150px;
         }
 
         .downloadArrow {
@@ -96,7 +96,8 @@
         }
 
         >span {
-          width: 100%;
+          width: 150px;
+          margin-right: 12px;
         }
       }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Inspired with #1848

Placement of .downloadArrow on items is also improved.

From
![](https://cloud.githubusercontent.com/assets/3362943/15816973/92100930-2c10-11e6-856e-edb6f1cca7a2.jpg)
To
![](https://cloud.githubusercontent.com/assets/3362943/15816972/920a225e-2c10-11e6-8809-8db03ff55bee.jpg)

margin-right of the down arrow icon becomes the same.