### PR TITLE
Restyled the retry button on about:error

### DIFF
--- a/app/extensions/brave/locales/en-US/error.properties
+++ b/app/extensions/brave/locales/en-US/error.properties
@@ -1,4 +1,4 @@
-errorReload=Retry {{url}}
+errorReload=Retry the URL
 unexpectedError=An unexpected error has occurred
 networkError=A network error has occurred
 httpError=An HTTP error has occurred

--- a/js/about/certerror.js
+++ b/js/about/certerror.js
@@ -51,7 +51,7 @@ class CertErrorPage extends React.Component {
         <span className='errorText'>{this.state.error || ''}</span>
       </div>
       <div className='buttons'>
-        <Button l10nId='certErrorSafety' className='wideButton' onClick={this.onSafety.bind(this)} />
+        <Button l10nId='certErrorSafety' className='actionButton' onClick={this.onSafety.bind(this)} />
         {this.state.url ? (this.state.advanced
                   ? <Button l10nId='certErrorButtonText' className='subtleButton' onClick={this.onAccept.bind(this)} />
                   : <Button l10nId='certErrorAdvanced' className='subtleButton' onClick={this.onAdvanced.bind(this)} />) : null}

--- a/js/components/noScriptInfo.js
+++ b/js/components/noScriptInfo.js
@@ -51,7 +51,7 @@ class NoScriptInfo extends ImmutableComponent {
         <div className='truncate' data-l10n-args={JSON.stringify(l10nArgs)}
           data-l10n-id={this.numberBlocked === 1 ? 'scriptBlocked' : 'scriptsBlocked'} />
         <div>
-          <Button l10nId='allowScriptsOnce' className='wideButton'
+          <Button l10nId='allowScriptsOnce' className='actionButton'
             onClick={this.onAllowOnce.bind(this)} />
         </div>
         <div>

--- a/less/about/error.less
+++ b/less/about/error.less
@@ -33,7 +33,7 @@
 }
 
 .errorText {
-  color: @chromeSecondary;
+  color: @errorTextColor;
   display: block;
 }
 

--- a/less/button.less
+++ b/less/button.less
@@ -4,6 +4,17 @@
 
 @import "variables.less";
 
+.buttonCommon {
+  color: #fff;
+  font-size: inherit;
+  height: 22px;
+  line-height: 22px;
+  margin-right: 0px;
+  margin-top: 5px;
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
 span.browserButton {
   cursor: default;
   display: inline-block;
@@ -34,51 +45,56 @@ span.browserButton {
     height: 18px;
     font-size: 12px;
   }
-}
 
-span.browserButton.newFrameButton {
-  font-family: helvetica;
-  font-weight: 100;
-  font-size: 26px;
-  line-height: 17px;
-  width: 16px;
-  vertical-align: middle;
-}
+  &.newFrameButton {
+    font-family: helvetica;
+    font-weight: 100;
+    font-size: 26px;
+    line-height: 17px;
+    width: 16px;
+    vertical-align: middle;
+  }
 
-span.browserButton.menuButton {
-  height: auto;
-}
+  &.primaryButton,
+  &.actionButton,
+  &.wideButton,
+  &.secondaryButton,
+  &.subtleButton {
+    .buttonCommon;
+  }
 
-.buttonCommon {
-  color: #fff;
-  font-size: inherit;
-  height: 22px;
-  line-height: 22px;
-  margin-right: 0px;
-  margin-top: 5px;
-  padding-left: 20px;
-  padding-right: 20px;
-}
+  &.actionButton,
+  &.wideButton,
+  &.subtleButton {
+    width: auto;
+  }
 
-span.browserButton.primaryButton {
-  background-color: @braveOrange;
-  .buttonCommon;
-}
+  &.menuButton,
+  &.wideButton {
+    height: auto;
+  }
 
-span.browserButton.wideButton {
-  background-color: #4099FF;
-  width: auto;
-  .buttonCommon;
-}
+  &.actionButton,
+  &.wideButton {
+    background-color: #4099FF;
+  }
 
-span.browserButton.secondaryButton {
-  background-color: #eee;
-  .buttonCommon;
-}
+  &.primaryButton {
+    background-color: @braveOrange;
+  }
 
-span.browserButton.subtleButton {
-  width: auto;
-  font-size: 14px;
-  background-color: #ccc;
-  .buttonCommon;
+  &.secondaryButton {
+    background-color: #eee;
+  }
+
+  &.subtleButton {
+    background-color: #ccc;
+    font-size: 14px;
+  }
+
+  &.wideButton {
+    display: block;
+    margin-right: 0px;
+    margin-left: 0px;
+  }
 }

--- a/less/variables.less
+++ b/less/variables.less
@@ -25,6 +25,7 @@
 @toolbarBackground: #eee;
 @toolbarBorderColor: #ccc;
 @menuSelectionColor: #2F7AFB;
+@errorTextColor: #999;
 
 @navigatorHeight: 48px;
 @defaultSpacing: 12px;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fixes #2147

Also refactored button.less, adding a class "actionButton" to replace the class of allowScriptsOnce button with it, which was introduced with #1564.

Image:
![](https://cloud.githubusercontent.com/assets/3362943/15941083/ad623a68-2eb9-11e6-82f8-a5c932783601.jpg)
