### PR TITLE
Fix text overflow in buttons

### DIFF
--- a/less/button.less
+++ b/less/button.less
@@ -61,17 +61,12 @@ span.browserButton {
   &.secondaryButton,
   &.subtleButton {
     .buttonCommon;
-  }
-
-  &.actionButton,
-  &.wideButton,
-  &.subtleButton {
     width: auto;
+    height: auto;
   }
 
-  &.menuButton,
-  &.wideButton {
-    height: auto;
+  &.primaryButton {
+    background-color: @braveOrange;
   }
 
   &.actionButton,
@@ -79,8 +74,10 @@ span.browserButton {
     background-color: #4099FF;
   }
 
-  &.primaryButton {
-    background-color: @braveOrange;
+  &.wideButton {
+    display: block;
+    margin-right: 0px;
+    margin-left: 0px;
   }
 
   &.secondaryButton {
@@ -90,11 +87,5 @@ span.browserButton {
   &.subtleButton {
     background-color: #ccc;
     font-size: 14px;
-  }
-
-  &.wideButton {
-    display: block;
-    margin-right: 0px;
-    margin-left: 0px;
   }
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

addresses #2149
This fixes the overflow of text in buttons, which sometimes happens due to l10n.
![](https://cloud.githubusercontent.com/assets/3362943/16042560/4dc292a4-3276-11e6-9539-cb9772e5c557.jpg)