### PR TITLE
Adding correct shortcut (⌃ ⌘ F) for toggleFullScreenView

### DIFF
--- a/app/localShortcuts.js
+++ b/app/localShortcuts.js
@@ -33,11 +33,6 @@ module.exports.register = (win) => {
       ['Alt+D', messages.SHORTCUT_FOCUS_URL, false],
       ['Alt+Left', messages.SHORTCUT_ACTIVE_FRAME_BACK],
       ['Alt+Right', messages.SHORTCUT_ACTIVE_FRAME_FORWARD])
-
-    electronLocalshortcut.register(win, 'F11', (win) => {
-      const focusedWindow = win || BrowserWindow.getFocusedWindow()
-      focusedWindow.setFullScreen(!focusedWindow.isFullScreen())
-    })
   } else {
     // Workaround for #1060
     simpleWebContentEvents.push([

--- a/app/menu.js
+++ b/app/menu.js
@@ -347,7 +347,7 @@ const init = (settingsState, args) => {
         CommonMenu.separatorMenuItem,
         {
           label: locale.translation('toggleFullScreenView'),
-          accelerator: 'Shift+CmdOrCtrl+F',
+          accelerator: isDarwin ? 'Ctrl+Cmd+F' : 'F11',
           click: function (item, focusedWindow) {
             if (focusedWindow) {
               // This doesn't seem to work but also doesn't throw errors...


### PR DESCRIPTION
Closes #2194
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.
