### PR TITLE
Fix "retry the URL" button width

### DIFF
--- a/js/about/errorPage.js
+++ b/js/about/errorPage.js
@@ -45,8 +45,8 @@ class ErrorPage extends React.Component {
         <span className='errorText'>{this.state.message}</span>
       </div>
       <div className='buttons'>
-        {this.showBackButton() ? <Button l10nId='back' className='wideButton' onClick={this.reloadPrevious.bind(this)} /> : null}
-        {this.state.url ? <Button l10nId='errorReload' l10nArgs={{url: this.state.url}} className='wideButton' onClick={this.reload.bind(this)} /> : null}
+        {this.showBackButton() ? <Button l10nId='back' className='actionButton' onClick={this.reloadPrevious.bind(this)} /> : null}
+        {this.state.url ? <Button l10nId='errorReload' l10nArgs={{url: this.state.url}} className='actionButton' onClick={this.reload.bind(this)} /> : null}
       </div>
     </div>
   }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

addresses #2155 

This fixes the width of the retry button into this, which is the current one.
![](https://cloud.githubusercontent.com/assets/3362943/16118496/4ee7db10-3412-11e6-8905-5638a4138d1a.jpg)

Also would anyone please tell me the case where ``showBackButton()`` would be fired, which is ``this.state.previousLocation !== this.state.url``? I need an example to style the back button, since currently the same className is attached to the two buttons.