### PR TITLE
Fix margin and padding in .buttonCommon

### DIFF
--- a/less/button.less
+++ b/less/button.less
@@ -9,10 +9,8 @@
   font-size: inherit;
   height: 22px;
   line-height: 22px;
-  margin-right: 0px;
-  margin-top: 5px;
-  padding-left: 20px;
-  padding-right: 20px;
+  margin: 5px 0px 0px 0px;
+  padding: 0px 20px;
 }
 
 span.browserButton {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

addresses #2149 

![](https://cloud.githubusercontent.com/assets/3362943/16119724/b2563232-3417-11e6-8a27-e2afd400c0ef.jpg)

However I'm just wondering if this would break a button somewhere. Please let me know if the padding specification should remain as it is.