### PR TITLE
only set the partition when a new webview is added

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -132,15 +132,16 @@ class Frame extends ImmutableComponent {
     this.webview.setAttribute('data-frame-key', this.props.frame.get('key'))
     this.webview.setAttribute('useragent', getSetting(settings.USERAGENT) || '')
 
-    let partition
-    if (this.props.frame.get('isPrivate')) {
-      partition = 'default'
-    } else if (this.props.frame.get('partitionNumber')) {
-      partition = `persist:partition-${this.props.frame.get('partitionNumber')}`
-    } else {
-      partition = 'persist:default'
-    }
-    if (partition) {
+    if (webviewAdded) {
+      let partition
+      if (this.props.frame.get('isPrivate')) {
+        partition = 'default'
+      } else if (this.props.frame.get('partitionNumber')) {
+        partition = `persist:partition-${this.props.frame.get('partitionNumber')}`
+      } else {
+        partition = 'persist:default'
+      }
+
       ipc.send(messages.INITIALIZE_PARTITION, partition)
       this.webview.setAttribute('partition', partition)
     }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

possible fix for #2085
to be verified by @bbondy because the updater won't run unless signed