### PR TITLE
Add ‘stop’ menu bar item

### DIFF
--- a/app/extensions/brave/locales/en-US/menu.properties
+++ b/app/extensions/brave/locales/en-US/menu.properties
@@ -87,6 +87,7 @@ editFolder=Edit Folder...
 editBookmark=Edit Bookmark...
 deleteFolder=Delete Folder
 deleteBookmark=Delete Bookmark
+stop=Stop
 reloadTab=Reload
 unpinTab=Unpin
 pinTab=Pin

--- a/app/locale.js
+++ b/app/locale.js
@@ -81,6 +81,7 @@ var rendererIdentifiers = function () {
     'zoomIn',
     'zoomOut',
     'toolbars',
+    'stop',
     'reloadPage',
     'reloadTab',
     'cleanReload',

--- a/app/menu.js
+++ b/app/menu.js
@@ -291,6 +291,12 @@ const init = (settingsState, args) => {
         },
         CommonMenu.separatorMenuItem,
         {
+          label: locale.translation('stop'),
+          accelerator: 'CmdOrCtrl+.',
+          click: function (item, focusedWindow) {
+            CommonMenu.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_ACTIVE_FRAME_STOP])
+          }
+        }, {
           label: locale.translation('reloadPage'),
           accelerator: 'CmdOrCtrl+R',
           click: function (item, focusedWindow) {


### PR DESCRIPTION
- [x] Submitted a ticket for my issue if one did not already exist.
- [x] Used GitHub auto-closing keywords in the commit message.
- [ ] Ran `git rebase -i` to squash commits if needed.

This adds a 'stop' menu bar item to the 'view' menu.
The keyboard shortcut is set to command or control + period.

Closes #2234 