### PR TITLE
Contextual search selection ellipse

### DIFF
--- a/app/extensions/brave/locales/de-DE/menu.properties
+++ b/app/extensions/brave/locales/de-DE/menu.properties
@@ -87,6 +87,7 @@ editFolder=Edit Folder...
 editBookmark=Edit Bookmark...
 deleteFolder=Delete Folder
 deleteBookmark=Delete Bookmark
+stop=Stop
 reloadTab=Reload
 unpinTab=Unpin
 pinTab=Pin

--- a/app/extensions/brave/locales/en-US/menu.properties
+++ b/app/extensions/brave/locales/en-US/menu.properties
@@ -87,6 +87,7 @@ editFolder=Edit Folder...
 editBookmark=Edit Bookmark...
 deleteFolder=Delete Folder
 deleteBookmark=Delete Bookmark
+stop=Stop
 reloadTab=Reload
 unpinTab=Unpin
 pinTab=Pin

--- a/app/extensions/brave/locales/es/menu.properties
+++ b/app/extensions/brave/locales/es/menu.properties
@@ -87,6 +87,7 @@ editFolder=Editar carpeta...
 editBookmark=Editar marcador...
 deleteFolder=Eliminar carpeta
 deleteBookmark=Eliminar marcador
+stop=Detener
 reloadTab=Recargar
 unpinTab=Desanclar
 pinTab=Anclar

--- a/app/extensions/brave/locales/fr-FR/menu.properties
+++ b/app/extensions/brave/locales/fr-FR/menu.properties
@@ -87,6 +87,7 @@ editFolder=Éditer le dossier…
 editBookmark=Éditer le signet…
 deleteFolder=Supprimer le dossier
 deleteBookmark=Supprimer le signet
+stop=Interrompre
 reloadTab=Actualiser
 unpinTab=Relâcher
 pinTab=Épingler

--- a/app/extensions/brave/locales/id-ID/menu.properties
+++ b/app/extensions/brave/locales/id-ID/menu.properties
@@ -87,6 +87,7 @@ editFolder=Ubah Folder...
 editBookmark=Ubah Markah...
 deleteFolder=Hapus Arsip
 deleteBookmark=Hapus Markah
+stop=Berhenti
 reloadTab=Muat Ulang
 unpinTab=Lepas Sematan
 pinTab=Sematkan

--- a/app/extensions/brave/locales/nl-NL/menu.properties
+++ b/app/extensions/brave/locales/nl-NL/menu.properties
@@ -87,6 +87,7 @@ editFolder=Edit Folder...
 editBookmark=Edit Bookmark...
 deleteFolder=Delete Folder
 deleteBookmark=Delete Bookmark
+stop=Stop
 reloadTab=Reload
 unpinTab=Unpin
 pinTab=Pin

--- a/app/extensions/brave/locales/pt-BR/menu.properties
+++ b/app/extensions/brave/locales/pt-BR/menu.properties
@@ -87,6 +87,7 @@ editFolder=Editar Pasta...
 editBookmark=Editar Favorito...
 deleteFolder=Deletar Pasta
 deleteBookmark=Deletar Favorito
+stop=Parar
 reloadTab=Recarregar
 unpinTab=Desafixar
 pinTab=Fixar

--- a/app/extensions/brave/locales/sl/menu.properties
+++ b/app/extensions/brave/locales/sl/menu.properties
@@ -87,6 +87,7 @@ editFolder=Uredi mapo ...
 editBookmark=Uredi zaznamek ...
 deleteFolder=Izbriši mapo
 deleteBookmark=Izbriši zaznamek
+stop=Prekini
 reloadTab=Ponovno naloži
 unpinTab=Odpni
 pinTab=Pripni

--- a/app/extensions/brave/locales/tr-TR/menu.properties
+++ b/app/extensions/brave/locales/tr-TR/menu.properties
@@ -87,6 +87,7 @@ editFolder=Klasörü Düzenle...
 editBookmark=Yerimini Düzenle...
 deleteFolder=Klasörü Sil
 deleteBookmark=Yerimini Sil
+stop=Durdur
 reloadTab=Yenile
 unpinTab=Sabitleme
 pinTab=Sabitle

--- a/app/extensions/brave/locales/uk/menu.properties
+++ b/app/extensions/brave/locales/uk/menu.properties
@@ -87,6 +87,7 @@ editFolder=Змінити теку...
 editBookmark=Змінити закладку...
 deleteFolder=Видалити теку
 deleteBookmark=Видалити закладку
+stop=Зупинити
 reloadTab=Перезавантажити
 unpinTab=Відкріпити
 pinTab=Прикріпити

--- a/app/locale.js
+++ b/app/locale.js
@@ -81,6 +81,7 @@ var rendererIdentifiers = function () {
     'zoomIn',
     'zoomOut',
     'toolbars',
+    'stop',
     'reloadPage',
     'reloadTab',
     'cleanReload',

--- a/app/menu.js
+++ b/app/menu.js
@@ -291,6 +291,12 @@ const init = (settingsState, args) => {
         },
         CommonMenu.separatorMenuItem,
         {
+          label: locale.translation('stop'),
+          accelerator: 'CmdOrCtrl+.',
+          click: function (item, focusedWindow) {
+            CommonMenu.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_ACTIVE_FRAME_STOP])
+          }
+        }, {
           label: locale.translation('reloadPage'),
           accelerator: 'CmdOrCtrl+R',
           click: function (item, focusedWindow) {

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -649,7 +649,7 @@ const copyEmailAddressMenuItem = (location) => {
 }
 
 const searchSelectionMenuItem = (location) => {
-  var searchText = textUtils.ellipse(location, 3)
+  var searchText = textUtils.ellipse(location)
   return {
     label: locale.translation('openSearch').replace(/{{\s*selectedVariable\s*}}/, searchText),
     click: (item, focusedWindow) => {

--- a/js/lib/text.js
+++ b/js/lib/text.js
@@ -2,12 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Add ... characters and limit length of a string to a specific size
-module.exports.ellipse = (text, length) => {
-  var tokens = text.split(/\s+/)
-  if (tokens.length > length) {
-    return tokens.slice(0, length).join(' ') + '...'
+// Add an ellipse (...) character and limit length of a string to a specific size.
+// By testing against one length and slicing at a lower threshold, we prevent against unnecesary and early use of ellipses.
+//
+// If we just test and slice against one length, for example > 20 [...] text.slice(0, 20):
+//   [20] countersurveillances        countersurveillances
+//   [21] photolithographically       photolithographicall...
+//
+// If we test one length, and slice at a lower threshhold, for example > 25 [...] text.slice(0, 20)
+//   [25] immunoelectrophoretically   immunoelectrophoretically
+//   [26] zusammengehörigkeitsgefühl  zusammengehörigkeits...
+
+module.exports.ellipse = (text) => {
+  if (text.length > 25) {
+    return text.slice(0, 20) + '...'
   } else {
-    return tokens.join(' ')
+    return text
   }
 }


### PR DESCRIPTION
When invoking the contextual menu on selected text, truncate the "Search for" menu item for text longer than 25 characters at the 20th character and add an ellipse.

For example:
[25] immunoelectrophoretically   immunoelectrophoretically
[26] zusammengehörigkeitsgefühl  zusammengehörigkeits...

Closes #2240 