### PR TITLE
Fix search selection menu item length

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -649,7 +649,7 @@ const copyEmailAddressMenuItem = (location) => {
 }
 
 const searchSelectionMenuItem = (location) => {
-  var searchText = textUtils.ellipse(location, 3)
+  var searchText = textUtils.ellipse(location)
   return {
     label: locale.translation('openSearch').replace(/{{\s*selectedVariable\s*}}/, searchText),
     click: (item, focusedWindow) => {

--- a/js/lib/text.js
+++ b/js/lib/text.js
@@ -2,12 +2,21 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-// Add ... characters and limit length of a string to a specific size
-module.exports.ellipse = (text, length) => {
-  var tokens = text.split(/\s+/)
-  if (tokens.length > length) {
-    return tokens.slice(0, length).join(' ') + '...'
+// Add an ellipse (...) character and limit length of a string to a specific size.
+// By testing against one length and slicing at a lower threshold, we prevent against unnecesary and early use of ellipses.
+//
+// If we just test and slice against one length, for example > 20 [...] text.slice(0, 20):
+//   [20] countersurveillances        countersurveillances
+//   [21] photolithographically       photolithographicall...
+//
+// If we test one length, and slice at a lower threshhold, for example > 25 [...] text.slice(0, 20)
+//   [25] immunoelectrophoretically   immunoelectrophoretically
+//   [26] zusammengehörigkeitsgefühl  zusammengehörigkeits...
+
+module.exports.ellipse = (text) => {
+  if (text.length > 25) {
+    return text.slice(0, 20) + '...'
   } else {
-    return tokens.join(' ')
+    return text
   }
 }


### PR DESCRIPTION
- [x] Submitted a ticket for my issue if one did not already exist.
- [x] Used GitHub auto-closing keywords in the commit message.

**Existing approach:** truncate text in menu item to three “words”, with any additional words replaced by an ellipsis.

**Improved approach:** When invoking the contextual menu on selected text, truncate the “Search for” menu item for text longer than 25 characters at the 20th character and add an ellipse.

**For example:**
<tt>[25] immunoelectrophoretically &emsp; immunoelectrophoretically</tt>
<tt>[26] zusammengehörigkeitsgefühl &emsp;zusammengehörigkeits...</tt>

This also has the added benefit of not limiting selections with shorter “words”, for example, if we were counting “words”:
<tt>[25] a b c d e f g h i j k l m &emsp; a b c...</tt>

Counting characters:
<tt>[25] a b c d e f g h i j k l m &emsp; a b c d e f g h i j ...</tt>

Closes #2240