### PR TITLE
Add 'Esc' shortcut to stop loading for Linux and Windows

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -292,7 +292,7 @@ const init = (settingsState, args) => {
         CommonMenu.separatorMenuItem,
         {
           label: locale.translation('stop'),
-          accelerator: 'CmdOrCtrl+.',
+          accelerator: isDarwin ? 'Cmd+.' : 'Esc',
           click: function (item, focusedWindow) {
             CommonMenu.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_ACTIVE_FRAME_STOP])
           }


### PR DESCRIPTION
- [x] Submitted a ticket for my issue if one did not already exist.

Web browsers on Windows and Linux tend to use the `Escape` key to stop page loading.