### PR TITLE
add a warning for back/forward repost

### DIFF
--- a/app/extensions/brave/locales/en-US/errorMessages.properties
+++ b/app/extensions/brave/locales/en-US/errorMessages.properties
@@ -1,3 +1,6 @@
+cacheMiss=Confirm Form Resubmission<br> \
+This webpage requires data that you entered earlier in order to be properly displayed. You can send this data again, but by doing so you will repeat any action this page previously performed. \
+Please go back to the previous url and try again.
 connectionReset=A connection was reset (corresponding to a TCP RST).
 connectionRefused=A connection attempt was refused.
 connectionAborted=A connection timed out as a result of not receiving an ACK for data sent. This can include a FIN packet that did not get ACK'd.

--- a/js/about/errorPage.js
+++ b/js/about/errorPage.js
@@ -33,8 +33,8 @@ class ErrorPage extends React.Component {
     })
   }
 
-  showBackButton () {
-    this.state.previousLocation && this.state.previousLocation !== this.state.url
+  get showBackButton () {
+    return this.state.previousLocation && this.state.previousLocation !== this.state.url
   }
 
   render () {
@@ -42,10 +42,10 @@ class ErrorPage extends React.Component {
       <div className='errorTitle'>
         <span className='errorText' data-l10n-id={this.state.title}></span>
         <span className='errorUrl'>{this.state.url}</span>
-        <span className='errorText'>{this.state.message}</span>
+        <span className='errorText' data-l10n-id={this.state.message}></span>
       </div>
       <div className='buttons'>
-        {this.showBackButton() ? <Button l10nId='back' className='actionButton' onClick={this.reloadPrevious.bind(this)} /> : null}
+        {this.showBackButton ? <Button l10nId='back' className='actionButton' onClick={this.reloadPrevious.bind(this)} /> : null}
         {this.state.url ? <Button l10nId='errorReload' l10nArgs={{url: this.state.url}} className='actionButton' onClick={this.reload.bind(this)} /> : null}
       </div>
     </div>

--- a/js/lib/errorUtil.js
+++ b/js/lib/errorUtil.js
@@ -13,8 +13,8 @@ module.exports.isFrameError = function (errorCode) {
   if (errorCode === 501 || (errorCode >= 200 && errorCode <= 299)) {
     return false
   }
-  // ignore cache errors
-  if (errorCode >= 400 && errorCode <= 499) {
+  // ignore cache errors except cache miss (form repost)
+  if (errorCode > 400 && errorCode <= 499) {
     return false
   }
 
@@ -46,6 +46,8 @@ module.exports.l10nErrorText = function (errorCode) {
       title = 'ftpError'
     } else if (errorCode >= 800 && errorCode <= 899) {
       title = 'dnsError'
+    } else if (errorCode === 400) {
+      title = 'cacheError'
     } else {
       title = 'unknownError'
     }
@@ -363,6 +365,7 @@ module.exports.errorMap = {
   // Request is throttled because of a Backoff header.
   // See: crbug.com/486891.,
   369: 'temporaryBackoff',
+  400: 'cacheMiss',
   // The server's response was insecure (e.g. there was a cert error).
   501: 'insecureResponse',
   // DNS error codes.

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -248,6 +248,7 @@ const doAction = (action) => {
       windowState = windowState.mergeIn(['frames', FrameStateUtil.getFramePropsIndex(windowState.get('frames'), action.frameProps)], {
         aboutDetails: Object.assign({
           title: action.errorDetails.title || l10nErrorText(action.errorDetails.errorCode),
+          message: action.errorDetails.message,
           previousLocation,
           frameKey
         }, action.errorDetails)


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

fixes #2267
Also fixes missing back button for all errors

cc @bbondy 