### PR TITLE
Add autocomplete entries for about pages

### DIFF
--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -141,6 +141,7 @@ permissionExternal=open an external application
 tabsSuggestionTitle=Tabs
 bookmarksSuggestionTitle=Bookmarks
 historySuggestionTitle=History
+aboutPagesSuggestionTitle=Brave Pages
 searchSuggestionTitle=Search
 topSiteSuggestionTitle=Top Site
 flashTitle=Flash Object Blocked

--- a/app/locale.js
+++ b/app/locale.js
@@ -157,6 +157,7 @@ var rendererIdentifiers = function () {
     'tabsSuggestionTitle',
     'bookmarksSuggestionTitle',
     'historySuggestionTitle',
+    'aboutPagesSuggestionTitle',
     'searchSuggestionTitle',
     'topSiteSuggestionTitle'
   ]

--- a/js/components/urlBarSuggestions.js
+++ b/js/components/urlBarSuggestions.js
@@ -10,7 +10,7 @@ const ImmutableComponent = require('./immutableComponent')
 
 const config = require('../constants/config.js')
 const top500 = require('./../data/top500.js')
-const {isSourceAboutUrl, isUrl} = require('../lib/appUrlUtil')
+const {aboutUrls, isIntermediateAboutPage, isSourceAboutUrl, isUrl} = require('../lib/appUrlUtil')
 const Immutable = require('immutable')
 const debounce = require('../lib/debounce.js')
 const settings = require('../constants/settings')
@@ -93,6 +93,7 @@ class UrlBarSuggestions extends ImmutableComponent {
 
     const bookmarkSuggestions = suggestions.filter((s) => s.type === suggestionTypes.BOOKMARK)
     const historySuggestions = suggestions.filter((s) => s.type === suggestionTypes.HISTORY)
+    const aboutPagesSuggestions = suggestions.filter((s) => s.type === suggestionTypes.ABOUT_PAGES)
     const tabSuggestions = suggestions.filter((s) => s.type === suggestionTypes.TAB)
     const searchSuggestions = suggestions.filter((s) => s.type === suggestionTypes.SEARCH)
     const topSiteSuggestions = suggestions.filter((s) => s.type === suggestionTypes.TOP_SITE)
@@ -144,6 +145,7 @@ class UrlBarSuggestions extends ImmutableComponent {
     }
     addToItems(bookmarkSuggestions, 'bookmarksTitle', locale.translation('bookmarksSuggestionTitle'), 'fa-star-o')
     addToItems(historySuggestions, 'historyTitle', locale.translation('historySuggestionTitle'), 'fa-clock-o')
+    addToItems(aboutPagesSuggestions, 'aboutPagesTitle', locale.translation('aboutPagesSuggestionTitle'), null)
     addToItems(tabSuggestions, 'tabsTitle', locale.translation('tabsSuggestionTitle'), 'fa-external-link')
     addToItems(searchSuggestions, 'searchTitle', locale.translation('searchSuggestionTitle'), 'fa-search')
     addToItems(topSiteSuggestions, 'topSiteTitle', locale.translation('topSiteSuggestionTitle'), 'fa-link')
@@ -290,6 +292,13 @@ class UrlBarSuggestions extends ImmutableComponent {
         }
       }))
     }
+
+    // about pages
+    suggestions = suggestions.concat(mapListToElements({
+      data: aboutUrls.keySeq().filter((x) => !isIntermediateAboutPage(x)),
+      maxResults: config.urlBarSuggestions.maxAboutPages,
+      type: suggestionTypes.ABOUT_PAGES,
+      clickHandler: navigateClickHandler((x) => x)}))
 
     // opened frames
     if (getSetting(settings.OPENED_TAB_SUGGESTIONS)) {

--- a/js/constants/config.js
+++ b/js/constants/config.js
@@ -26,6 +26,7 @@ module.exports = {
     maxOpenedFrames: 2,
     maxBookmarkSites: 2,
     maxHistorySites: 2,
+    maxAboutPages: 2,
     maxSearch: 3,
     maxTopSites: 5
   },

--- a/js/constants/suggestionTypes.js
+++ b/js/constants/suggestionTypes.js
@@ -6,6 +6,7 @@ const suggestionTypes = {
   TAB: 'tabSuggestion',
   BOOKMARK: 'bookmarkSuggestion',
   HISTORY: 'historySuggestion',
+  ABOUT_PAGES: 'aboutPagesSuggestion',
   SEARCH: 'searchSuggestion',
   TOP_SITE: 'topSiteSuggestion'
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fix #2252