### PR TITLE
Don't show an option to pin about:blank and about:newtab

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -27,7 +27,7 @@ const locale = require('../js/l10n')
 const getSetting = require('./settings').getSetting
 const settings = require('./constants/settings')
 const textUtils = require('./lib/text')
-const {isUrl} = require('./lib/appUrlUtil')
+const {isIntermediateAboutPage, isUrl} = require('./lib/appUrlUtil')
 
 const isDarwin = process.platform === 'darwin'
 
@@ -358,14 +358,15 @@ function tabTemplateInit (frameProps) {
 
   if (!frameProps.get('isPrivate')) {
     const isPinned = frameProps.get('pinnedLocation')
-
-    items.push({
-      label: locale.translation(isPinned ? 'unpinTab' : 'pinTab'),
-      click: (item) => {
-        // Handle converting the current tab window into a pinned site
-        windowActions.setPinned(frameProps, !isPinned)
-      }
-    })
+    var location = frameProps.get('location');
+    if (!(location === 'about:blank' || location == 'about:newtab' || isIntermediateAboutPage(location)))
+      items.push({
+        label: locale.translation(isPinned ? 'unpinTab' : 'pinTab'),
+        click: (item) => {
+          // Handle converting the current tab window into a pinned site
+          windowActions.setPinned(frameProps, !isPinned)
+        }
+      })
   }
 
   // items.push({


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fix #2253