### PR TITLE
Download bar now accounts for the size of the buttons

### DIFF
--- a/js/components/downloadsBar.js
+++ b/js/components/downloadsBar.js
@@ -116,7 +116,8 @@ class DownloadsBar extends ImmutableComponent {
     const downloadItemWidth = Number.parseInt(window.getComputedStyle(document.querySelector(':root')).getPropertyValue('--download-item-width'), 10)
     const downloadItemMargin = Number.parseInt(window.getComputedStyle(document.querySelector(':root')).getPropertyValue('--download-item-margin'), 10)
     const downloadBarPadding = Number.parseInt(window.getComputedStyle(document.querySelector(':root')).getPropertyValue('--download-bar-padding'), 10)
-    const numItems = Math.floor((this.props.windowWidth - downloadBarPadding * 2) / (downloadItemWidth + downloadItemMargin))
+    const downloadBarButtons = Number.parseInt(window.getComputedStyle(document.querySelector(':root')).getPropertyValue('--download-bar-buttons'), 10)
+    const numItems = Math.floor((this.props.windowWidth - (downloadBarPadding * 2) - downloadBarButtons) / (downloadItemWidth + downloadItemMargin))
     return <div className='downloadsBar'
       onContextMenu={contextMenus.onDownloadsToolbarContextMenu.bind(null, undefined, undefined)}>
       <div className='downloadItems'>

--- a/less/downloadBar.less
+++ b/less/downloadBar.less
@@ -8,6 +8,7 @@
   --download-item-width: 200px;
   --download-item-margin: 10px;
   --download-bar-padding: 20px;
+  --download-bar-buttons: 22px;
 }
 
 .downloadsBar {


### PR DESCRIPTION
(right now, the only button is a single "x" icon)
Fixes https://github.com/brave/browser-laptop/issues/2322

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.