### PR TITLE
Preference page sidebar overflow

### DIFF
--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -11,6 +11,7 @@
   position: fixed;
   width: @sideBarWidth;
   height: 100%;
+  overflow-y: auto;
 
   >div {
     display: block;
@@ -73,6 +74,7 @@
   cursor: default;
   padding: 30px 0;
   margin-top: 20px;
+  position: relative;
 
   .hintsTitleContainer {
     -webkit-user-select: none;


### PR DESCRIPTION
<img width="998" alt="sidebar" src="https://cloud.githubusercontent.com/assets/5427715/16413366/1b7484b8-3d4f-11e6-9b59-0143dcf47b31.png">

The "send us feedback" link is absolutely positioned but its parent isn't relative. On decreasing the window height the link overlaps upper text (**red background added only to make it visible for screenshot**).  I've also added `overflow-y: auto` to sidebar wrapper.