### PR TITLE
When the active tab is closed, removeFrame will now properly pick a new active tab (ignoring pinned tabs).

### DIFF
--- a/test/unit/frameStateUtilTest.js
+++ b/test/unit/frameStateUtilTest.js
@@ -3,6 +3,8 @@ const frameStateUtil = require('../../js/state/frameStateUtil')
 const Immutable = require('immutable')
 const assert = require('assert')
 
+/*global beforeEach */
+
 const defaultWindowStore = Immutable.fromJS({
   activeFrameKey: null,
   frames: [],
@@ -87,6 +89,101 @@ describe('frameStateUtil', function () {
 
       result = frameStateUtil.find(this.windowState, {audioMuted: true})
       assert.equal(null, result)
+    })
+  })
+
+  describe('removeFrame', function () {
+    let frames, closedFrames, frameProps, activeFrameKey
+
+    beforeEach(function () {
+      frames = Immutable.fromJS([
+        { key: 2 },
+        { key: 3 },
+        { key: 4, pinnedLocation: 'https://www.facebook.com/' },
+        { key: 5, pinnedLocation: 'https://twitter.com/' }
+      ])
+      closedFrames = Immutable.fromJS([{ key: 1 }])
+      frameProps = Immutable.fromJS({ key: 2 })
+      activeFrameKey = 2
+    })
+
+    it('removed frame is added to `closedFrames`', function () {
+      const result = frameStateUtil.removeFrame(frames, closedFrames, frameProps, activeFrameKey)
+      const inClosedFrames = result.closedFrames.find((frame) => frame.get('key') === frameProps.get('key'))
+      assert.equal(false, inClosedFrames === undefined)
+    })
+
+    it('sets isFullScreen=false for the removed frame', function () {
+      frameProps = Immutable.fromJS({ key: 2, isFullScreen: true })
+      const result = frameStateUtil.removeFrame(frames, closedFrames, frameProps, activeFrameKey)
+      const inClosedFrames = result.closedFrames.find((frame) => frame.get('key') === frameProps.get('key'))
+      assert.equal(false, inClosedFrames.get('isFullScreen'))
+    })
+
+    it('removed frame is NOT added to `closedFrames` if private', function () {
+      frames = Immutable.fromJS([{ key: 2 }])
+      frameProps = Immutable.fromJS({ isPrivate: true, key: 2 })
+      const result = frameStateUtil.removeFrame(frames, closedFrames, frameProps, activeFrameKey)
+      const inClosedFrames = result.closedFrames.find((frame) => frame.get('key') === frameProps.get('key'))
+      assert.equal(true, inClosedFrames === undefined)
+    })
+
+    it('removes the frame from `frames`', function () {
+      const result = frameStateUtil.removeFrame(frames, closedFrames, frameProps, activeFrameKey)
+      const inFrames = result.frames.find((frame) => frame.get('key') === frameProps.get('key'))
+      assert.equal(true, inFrames === undefined)
+    })
+
+    describe('does not change `activeFrameKey`', function () {
+      it('if frame removed is not active', function () {
+        activeFrameKey = 3
+        const result = frameStateUtil.removeFrame(frames, closedFrames, frameProps, activeFrameKey)
+        assert.equal(activeFrameKey, result.activeFrameKey)
+      })
+
+      it('if there are no frames left', function () {
+        frames = Immutable.fromJS([{ key: 2 }])
+        const result = frameStateUtil.removeFrame(frames, closedFrames, frameProps, activeFrameKey)
+        assert.equal(activeFrameKey, result.activeFrameKey)
+      })
+    })
+
+    describe('when active frame is removed', function () {
+      it('returns the next *non-pinned* active frame key', function () {
+        const result = frameStateUtil.removeFrame(frames, closedFrames, frameProps, activeFrameKey)
+        assert.equal(3, result.activeFrameKey)
+      })
+
+      it('returns the previous *non-pinned* frame key (if none found for next)', function () {
+        frameProps = Immutable.fromJS({
+          isFullScreen: false,
+          isPrivate: false,
+          key: 3
+        })
+        activeFrameKey = 3
+        const result = frameStateUtil.removeFrame(frames, closedFrames, frameProps, activeFrameKey)
+        assert.equal(2, result.activeFrameKey)
+      })
+
+      describe('when only pinned tabs remaining', function () {
+        it('defaults to next index if there are tabs to right', function () {
+          frames = Immutable.fromJS([
+            { key: 2 },
+            { pinnedLocation: 'https://www.facebook.com/', key: 4 }
+          ])
+          const result = frameStateUtil.removeFrame(frames, closedFrames, frameProps, activeFrameKey)
+          assert.equal(4, result.activeFrameKey)
+        })
+
+        it('defaults to previous if no tabs to right', function () {
+          frames = Immutable.fromJS([
+            { pinnedLocation: 'https://www.facebook.com/', key: 6 },
+            { key: 2 }
+          ])
+          const result = frameStateUtil.removeFrame(frames, closedFrames, frameProps, activeFrameKey)
+          assert.equal(6, result.activeFrameKey)
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
When the active tab is closed, removeFrame will now properly pick a new active tab (ignoring pinned tabs). If no tabs are found, it'll default to the old behavior (which will pick a pinned tab).

Fixes https://github.com/brave/browser-laptop/issues/2333

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.