### PR TITLE
Add downloadInProgressUnknownTotal to download.properties

### DIFF
--- a/app/extensions/brave/content/scripts/blockCanvasFingerprinting.js
+++ b/app/extensions/brave/content/scripts/blockCanvasFingerprinting.js
@@ -78,7 +78,6 @@ if (chrome.contentSettings.canvasFingerprinting == 'block') {
 
     // Block the read from occuring; send info to background page instead
     chrome.ipc.sendToHost('got-canvas-fingerprinting', msg)
-    throw 'access denied'
   }
 
   /**

--- a/app/extensions/brave/locales/bn-BD/downloads.properties
+++ b/app/extensions/brave/locales/bn-BD/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=বাধাগ্রস্থ হয়েছে
 downloadCancelled=বাতিল হয়েছে
 downloadCompleted=সম্পূর্ণ হয়েছে
 downloadInProgress={{downloadPercent}} ডাউনলোডিং
+downloadInProgressUnknownTotal=ডাউনলোডিং…
 downloadPaused={{downloadPercent}} থেমে আছে
 
 downloadPause.title=ডাউনলোড থামিয়ে রাখুন

--- a/app/extensions/brave/locales/bn-IN/downloads.properties
+++ b/app/extensions/brave/locales/bn-IN/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=বাধাপ্রাপ্ত
 downloadCancelled=বাতিল করা হয়েছে
 downloadCompleted=সম্পূর্ণ
 downloadInProgress=ডাউনলোড হচ্ছে: {{downloadPercent}}
+downloadInProgressUnknownTotal=ডাউনলোড হচ্ছে…
 downloadPaused=থামানো হয়েছে: {{downloadPercent}}
 
 downloadPause.title=ডাউনলোড থামান

--- a/app/extensions/brave/locales/cs/downloads.properties
+++ b/app/extensions/brave/locales/cs/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=Přerušeno
 downloadCancelled=Zrušeno
 downloadCompleted=Dokončeno
 downloadInProgress=Stahování: {{downloadPercent}}
+downloadInProgressUnknownTotal=Stahování…
 downloadPaused=Pozastaveno: {{downloadPercent}}
 
 downloadPause.title=Pozastavit stahování

--- a/app/extensions/brave/locales/de-DE/downloads.properties
+++ b/app/extensions/brave/locales/de-DE/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=Interrupted
 downloadCancelled=Cancelled
 downloadCompleted=Completed
 downloadInProgress=Downloading: {{downloadPercent}}
+downloadInProgressUnknownTotal=Downloading…
 downloadPaused=Paused: {{downloadPercent}}
 
 downloadPause.title=Pause Download

--- a/app/extensions/brave/locales/en-US/downloads.properties
+++ b/app/extensions/brave/locales/en-US/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=Interrupted
 downloadCancelled=Cancelled
 downloadCompleted=Completed
 downloadInProgress=Downloading: {{downloadPercent}}
+downloadInProgressUnknownTotal=Downloading…
 downloadPaused=Paused: {{downloadPercent}}
 
 downloadPause.title=Pause Download

--- a/app/extensions/brave/locales/es/downloads.properties
+++ b/app/extensions/brave/locales/es/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=Interrumpido
 downloadCancelled=Cancelado
 downloadCompleted=Terminado
 downloadInProgress=Descargando: {{downloadPercent}}
+downloadInProgressUnknownTotal=Descargando…
 downloadPaused=Pausado: {{downloadPercent}}
 
 downloadPause.title=Pausar la descarga

--- a/app/extensions/brave/locales/fr-FR/downloads.properties
+++ b/app/extensions/brave/locales/fr-FR/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=Interrompu
 downloadCancelled=Annulé
 downloadCompleted=Terminé
 downloadInProgress=Téléchargement : {{downloadPercent}}
+downloadInProgressUnknownTotal=Téléchargement…
 downloadPaused=Pause : {{downloadPercent}}
 
 downloadPause.title=Mettre en pause

--- a/app/extensions/brave/locales/hi-IN/downloads.properties
+++ b/app/extensions/brave/locales/hi-IN/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=बाधित
 downloadCancelled=रद्द
 downloadCompleted=पूरा कर लिया है
 downloadInProgress=डाउनलोड हो रहा है:{{डाउनलोड प्रतिशत्}}
+downloadInProgressUnknownTotal=डाउनलोड हो रहा है…
 downloadPaused=रोका गया {{डाउनलोड प्रतिशत्}}
 
 downloadPause.title=डाउनलोड रोकें

--- a/app/extensions/brave/locales/id-ID/downloads.properties
+++ b/app/extensions/brave/locales/id-ID/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=Menyela
 downloadCancelled=Dibatalkan
 downloadCompleted=Lengkap
 downloadInProgress=Mengunduh: {{downloadPercent}}
+downloadInProgressUnknownTotal=Mengunduh…
 downloadPaused=Jeda: {{downloadPercent}}
 
 downloadPause.title=Jeda Unduhan

--- a/app/extensions/brave/locales/ja-JP/downloads.properties
+++ b/app/extensions/brave/locales/ja-JP/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=中断しました
 downloadCancelled=キャンセルしました
 downloadCompleted=完了しました
 downloadInProgress=ダウンロード中 {{downloadPercent}}完了
+downloadInProgressUnknownTotal=ダウンロード中 …
 downloadPaused=中断しました {{downloadPercent}}完了
 
 downloadPause.title=ダウンロードを中断

--- a/app/extensions/brave/locales/nl-NL/downloads.properties
+++ b/app/extensions/brave/locales/nl-NL/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=Interrupted
 downloadCancelled=Cancelled
 downloadCompleted=Completed
 downloadInProgress=Downloading: {{downloadPercent}}
+downloadInProgressUnknownTotal=Downloading…
 downloadPaused=Paused: {{downloadPercent}}
 
 downloadPause.title=Pause Download

--- a/app/extensions/brave/locales/pt-BR/downloads.properties
+++ b/app/extensions/brave/locales/pt-BR/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=Interrompido
 downloadCancelled=Cancelado
 downloadCompleted=Concluído
 downloadInProgress=Baixando: {{downloadPercent}}
+downloadInProgressUnknownTotal=Baixando…
 downloadPaused=Pausado: {{downloadPercent}}
 
 downloadPause.title=Pausar Download

--- a/app/extensions/brave/locales/sl/downloads.properties
+++ b/app/extensions/brave/locales/sl/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=Prekinjeno
 downloadCancelled=Preklicano
 downloadCompleted=Dokončano
 downloadInProgress=Prenašanje: {{downloadPercent}}
+downloadInProgressUnknownTotal=Prenašanje…
 downloadPaused=Prekinjeno: {{downloadPercent}}
 
 downloadPause.title=Prekini prenos

--- a/app/extensions/brave/locales/ta/downloads.properties
+++ b/app/extensions/brave/locales/ta/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=குறுக்கிட்டது
 downloadCancelled=நீக்கப்பட்டது
 downloadCompleted=முடிந்தது
 downloadInProgress=பதிவிறக்குகிறது: {{downloadPercent}}
+downloadInProgressUnknownTotal=பதிவிறக்குகிறது…
 downloadPaused=இடைநிறுத்தப்பட்டது: {{downloadPercent}}
 
 downloadPause.title=பதிவிறக்கத்தை இடைநிறுத்து

--- a/app/extensions/brave/locales/te/downloads.properties
+++ b/app/extensions/brave/locales/te/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=Interrupted
 downloadCancelled=Cancelled
 downloadCompleted=Completed
 downloadInProgress=Downloading: {{downloadPercent}}
+downloadInProgressUnknownTotal=Downloading…
 downloadPaused=Paused: {{downloadPercent}}
 
 downloadPause.title=Pause Download

--- a/app/extensions/brave/locales/tr-TR/downloads.properties
+++ b/app/extensions/brave/locales/tr-TR/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=Yarıda kesilmiş
 downloadCancelled=İptal edilmiş
 downloadCompleted=Tamamlanmış
 downloadInProgress=İndiriliyor: {{downloadPercent}}
+downloadInProgressUnknownTotal=İndiriliyor…
 downloadPaused=Durduruldu: {{downloadPercent}}
 
 downloadPause.title=Duraklat

--- a/app/extensions/brave/locales/uk/downloads.properties
+++ b/app/extensions/brave/locales/uk/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=Перервано
 downloadCancelled=Скасовано
 downloadCompleted=Завершено
 downloadInProgress=Завантаження: {{downloadPercent}}
+downloadInProgressUnknownTotal=Завантаження…
 downloadPaused=Призупинено: {{downloadPercent}}
 
 downloadPause.title=Призупинити завантаження

--- a/docs/windowActions.md
+++ b/docs/windowActions.md
@@ -6,7 +6,7 @@
 
 * * *
 
-### setState(windowState) 
+### setState(windowState)
 
 Dispatches an event to the main process to replace the window state
 
@@ -16,7 +16,7 @@ Dispatches an event to the main process to replace the window state
 
 
 
-### loadUrl(frame, location) 
+### loadUrl(frame, location)
 
 Dispatches a message to the store to load a new URL.
 Both the frame's src and location properties will be updated accordingly.
@@ -36,7 +36,7 @@ but the location should. For user entered new URLs, both should be updated.
 
 
 
-### setNavigated(location, key, isNavigatedInPage) 
+### setNavigated(location, key, isNavigatedInPage)
 
 Dispatches a message to the store to let it know a page has been navigated.
 
@@ -50,7 +50,7 @@ Dispatches a message to the store to let it know a page has been navigated.
 
 
 
-### setSecurityState(frameProps, securityState) 
+### setSecurityState(frameProps, securityState)
 
 Dispatches a message to set the security state.
 
@@ -63,7 +63,7 @@ Dispatches a message to set the security state.
 
 
 
-### setFrameTabId(frameProps, tabId) 
+### setFrameTabId(frameProps, tabId)
 
 Dispatches a message to set the frame tab id
 
@@ -75,7 +75,7 @@ Dispatches a message to set the frame tab id
 
 
 
-### setFrameError(frameProps, errorDetails) 
+### setFrameError(frameProps, errorDetails)
 
 Dispatches a message to set the frame error state
 
@@ -88,7 +88,7 @@ Dispatches a message to set the frame error state
 
 
 
-### setLoginRequiredDetail(frameProps, detail) 
+### setLoginRequiredDetail(frameProps, detail)
 
 Dispatches a message to set the login required detail.
 
@@ -100,7 +100,7 @@ Dispatches a message to set the login required detail.
 
 
 
-### setNavBarUserInput(location) 
+### setNavBarUserInput(location)
 
 Dispatches a message to the store to set the user entered text for the URL bar.
 Unlike setLocation and loadUrl, this does not modify the state of src and location.
@@ -111,10 +111,10 @@ Unlike setLocation and loadUrl, this does not modify the state of src and locati
 
 
 
-### setFrameTitle(frameProps, title) 
+### setFrameTitle(frameProps, title)
 
 Dispatches a message to the store to set the current frame's title.
-This should be called in response to the webview encountering a <title> tag.
+This should be called in response to the webview encountering a `<title>` tag.
 
 **Parameters**
 
@@ -124,7 +124,7 @@ This should be called in response to the webview encountering a <title> tag.
 
 
 
-### setFindbarShown(frameProps, shown) 
+### setFindbarShown(frameProps, shown)
 
 Shows/hides the find-in-page bar.
 
@@ -136,7 +136,7 @@ Shows/hides the find-in-page bar.
 
 
 
-### setFindbarSelected(frameProps, selected) 
+### setFindbarSelected(frameProps, selected)
 
 Highlight text in the findbar
 
@@ -148,7 +148,7 @@ Highlight text in the findbar
 
 
 
-### setPinned(frameProps, isPinned) 
+### setPinned(frameProps, isPinned)
 
 Sets a frame as pinned
 
@@ -160,7 +160,7 @@ Sets a frame as pinned
 
 
 
-### onWebviewLoadStart(frameProps, location) 
+### onWebviewLoadStart(frameProps, location)
 
 Dispatches a message to the store to indicate that the webview is loading.
 
@@ -172,7 +172,7 @@ Dispatches a message to the store to indicate that the webview is loading.
 
 
 
-### onWebviewLoadEnd(frameProps) 
+### onWebviewLoadEnd(frameProps)
 
 Dispatches a message to the store to indicate that the webview is done loading.
 
@@ -182,7 +182,7 @@ Dispatches a message to the store to indicate that the webview is done loading.
 
 
 
-### setFullScreen(frameProps, isFullScreen, showFullScreenWarning) 
+### setFullScreen(frameProps, isFullScreen, showFullScreenWarning)
 
 Dispatches a message to the store to indicate that the webview entered full screen mode.
 
@@ -196,7 +196,7 @@ Dispatches a message to the store to indicate that the webview entered full scre
 
 
 
-### setNavBarFocused(focused) 
+### setNavBarFocused(focused)
 
 Dispatches a message to the store to indicate if the navigation bar is focused.
 
@@ -206,7 +206,7 @@ Dispatches a message to the store to indicate if the navigation bar is focused.
 
 
 
-### newFrame(frameOpts, openInForeground) 
+### newFrame(frameOpts, openInForeground)
 
 Dispatches a message to the store to create a new frame
 
@@ -219,7 +219,7 @@ Dispatches a message to the store to create a new frame
 
 
 
-### cloneFrame(frameProps) 
+### cloneFrame(frameProps)
 
 Dispatches a message to the store to create a new frame similar to the passed arg.
 
@@ -229,7 +229,7 @@ Dispatches a message to the store to create a new frame similar to the passed ar
 
 
 
-### closeFrame(frames, frameProps) 
+### closeFrame(frames, frameProps)
 
 Dispatches a message to close a frame
 
@@ -241,14 +241,14 @@ Dispatches a message to close a frame
 
 
 
-### undoClosedFrame() 
+### undoClosedFrame()
 
 Dispatches a message to the store to undo a closed frame
 The new frame is expected to appear at the index it was last closed at
 
 
 
-### setActiveFrame(frameProps) 
+### setActiveFrame(frameProps)
 
 Dispatches a message to the store to set a new frame as the active frame.
 
@@ -258,7 +258,7 @@ Dispatches a message to the store to set a new frame as the active frame.
 
 
 
-### setFocusedFrame(frameProps) 
+### setFocusedFrame(frameProps)
 
 Dispatches a message to the store when the frame is active and the window is focused
 
@@ -268,7 +268,7 @@ Dispatches a message to the store when the frame is active and the window is foc
 
 
 
-### setPreviewFrame(frameProps) 
+### setPreviewFrame(frameProps)
 
 Dispatches a message to the store to set a preview frame.
 This is done when hovering over a tab.
@@ -279,7 +279,7 @@ This is done when hovering over a tab.
 
 
 
-### setTabPageIndex(index) 
+### setTabPageIndex(index)
 
 Dispatches a message to the store to set the tab page index.
 
@@ -289,7 +289,7 @@ Dispatches a message to the store to set the tab page index.
 
 
 
-### setTabPageIndexByFrame(frameProps) 
+### setTabPageIndexByFrame(frameProps)
 
 Dispatches a message to the store to set the tab page index.
 
@@ -299,7 +299,7 @@ Dispatches a message to the store to set the tab page index.
 
 
 
-### updateBackForwardState(frameProps, canGoBack, canGoForward) 
+### updateBackForwardState(frameProps, canGoBack, canGoForward)
 
 Dispatches a message to the store to update the back-forward information.
 
@@ -313,7 +313,7 @@ Dispatches a message to the store to update the back-forward information.
 
 
 
-### setIsBeingDraggedOverDetail(dragType, dragOverKey, dragDetail) 
+### setIsBeingDraggedOverDetail(dragType, dragOverKey, dragDetail)
 
 Dispatches a message to the store to indicate that something is dragging over this item.
 
@@ -327,7 +327,7 @@ Dispatches a message to the store to indicate that something is dragging over th
 
 
 
-### moveTab(sourceFrameProps, destinationFrameProps, prepend) 
+### moveTab(sourceFrameProps, destinationFrameProps, prepend)
 
 Dispatches a message to the store to indicate that the specified frame should move locations.
 
@@ -341,7 +341,7 @@ Dispatches a message to the store to indicate that the specified frame should mo
 
 
 
-### setUrlBarSuggestions(suggestionList, selectedIndex) 
+### setUrlBarSuggestions(suggestionList, selectedIndex)
 
 Sets the URL bar suggestions and selected index.
 
@@ -353,7 +353,7 @@ Sets the URL bar suggestions and selected index.
 
 
 
-### setUrlBarAutocompleteEnabled(enabled) 
+### setUrlBarAutocompleteEnabled(enabled)
 
 Enables or disables the urlbar autocomplete.
 Autocomplete is defined to be the action of inserting text into the urlbar itself
@@ -367,7 +367,7 @@ This is sometimes only temporarily disabled, e.g. a user is pressing backspace.
 
 
 
-### setUrlBarSuggestionSearchResults(searchResults) 
+### setUrlBarSuggestionSearchResults(searchResults)
 
 Sets the URL bar suggestion search results.
 This is typically from a service like Duck Duck Go auto complete for the portion of text that the user typed in.
@@ -379,7 +379,7 @@ Note: This should eventually be refactored outside of the component doing XHR an
 
 
 
-### setUrlBarSelected(isSelected) 
+### setUrlBarSelected(isSelected)
 
 Marks the URL bar text as selected or not
 
@@ -389,7 +389,7 @@ Marks the URL bar text as selected or not
 
 
 
-### setUrlBarActive(isActive) 
+### setUrlBarActive(isActive)
 
 Marks the URL bar as active or not.
 If the URL bar is active that means it's in a position that it should be displaying
@@ -402,7 +402,7 @@ are no autocomplete results.
 
 
 
-### setActiveFrameShortcut(frameProps, activeShortcut, activeShortcutDetails) 
+### setActiveFrameShortcut(frameProps, activeShortcut, activeShortcutDetails)
 
 Dispatches a message to the store to indicate that the pending frame shortcut info should be updated.
 
@@ -417,7 +417,7 @@ set from an IPC call.
 
 
 
-### setSearchDetail(searchDetail) 
+### setSearchDetail(searchDetail)
 
 Dispatches a message to set the search engine details.
 
@@ -427,7 +427,7 @@ Dispatches a message to set the search engine details.
 
 
 
-### setFindDetail(frameProps, findDetail) 
+### setFindDetail(frameProps, findDetail)
 
 Dispatches a message to set the find-in-page details.
 
@@ -439,7 +439,7 @@ Dispatches a message to set the find-in-page details.
 
 
 
-### setBookmarkDetail(currentDetail, originalDetail, destinationDetail) 
+### setBookmarkDetail(currentDetail, originalDetail, destinationDetail)
 
 Dispatches a message to set add/edit bookmark details
 If set, also indicates that add/edit is shown
@@ -454,7 +454,7 @@ If set, also indicates that add/edit is shown
 
 
 
-### setContextMenuDetail(detail) 
+### setContextMenuDetail(detail)
 
 Dispatches a message to set context menu detail.
 If set, also indicates that the context menu is shown.
@@ -465,7 +465,7 @@ If set, also indicates that the context menu is shown.
 
 
 
-### setPopupWindowDetail(detail) 
+### setPopupWindowDetail(detail)
 
 Dispatches a message to set popup window detail.
 If set, also indicates that the popup window is shown.
@@ -476,7 +476,7 @@ If set, also indicates that the popup window is shown.
 
 
 
-### setAudioMuted(frameProps, muted) 
+### setAudioMuted(frameProps, muted)
 
 Dispatches a message to indicate that the frame should be muted
 
@@ -488,7 +488,7 @@ Dispatches a message to indicate that the frame should be muted
 
 
 
-### muteAllAudio(framePropsList, muted) 
+### muteAllAudio(framePropsList, muted)
 
 Dispatches a mute/unmute call to all frames in a provided list (used by TabList).
 
@@ -500,7 +500,7 @@ Dispatches a mute/unmute call to all frames in a provided list (used by TabList)
 
 
 
-### muteAllAudioExcept(frameToSkip) 
+### muteAllAudioExcept(frameToSkip)
 
 Dispatches a mute call to all frames except the one provided.
 The provided frame will have its audio unmuted.
@@ -511,7 +511,7 @@ The provided frame will have its audio unmuted.
 
 
 
-### setAudioPlaybackActive(frameProps, audioPlaybackActive) 
+### setAudioPlaybackActive(frameProps, audioPlaybackActive)
 
 Dispatches a message to indicate that audio is playing
 
@@ -523,7 +523,7 @@ Dispatches a message to indicate that audio is playing
 
 
 
-### setThemeColor(frameProps, themeColor, computedThemeColor) 
+### setThemeColor(frameProps, themeColor, computedThemeColor)
 
 Dispatches a message to indicate that the theme color has changed for a page
 
@@ -538,7 +538,7 @@ Dispatches a message to indicate that the theme color has changed for a page
 
 
 
-### setFavicon(frameProps, favicon) 
+### setFavicon(frameProps, favicon)
 
 Dispatches a message to indicate that the favicon has changed
 
@@ -550,7 +550,7 @@ Dispatches a message to indicate that the favicon has changed
 
 
 
-### setMaximizeState(isMaximized) 
+### setMaximizeState(isMaximized)
 
 Sets the maximize state of the window
 
@@ -560,7 +560,7 @@ Sets the maximize state of the window
 
 
 
-### savePosition(position) 
+### savePosition(position)
 
 Saves the position of the window in the window state
 
@@ -570,7 +570,7 @@ Saves the position of the window in the window state
 
 
 
-### setWindowFullScreen(isFullScreen) 
+### setWindowFullScreen(isFullScreen)
 
 Sets the fullscreen state of the window
 
@@ -580,7 +580,7 @@ Sets the fullscreen state of the window
 
 
 
-### setMouseInTitlebar(mouseInTitlebar) 
+### setMouseInTitlebar(mouseInTitlebar)
 
 Dispatches a message to indicate if the mouse is in the titlebar
 
@@ -590,7 +590,7 @@ Dispatches a message to indicate if the mouse is in the titlebar
 
 
 
-### setSiteInfoVisible(isVisible) 
+### setSiteInfoVisible(isVisible)
 
 Dispatches a message to indicate the site info, such as # of blocked ads, should be shown
 
@@ -600,7 +600,7 @@ Dispatches a message to indicate the site info, such as # of blocked ads, should
 
 
 
-### setBraveryPanelDetail(braveryPanelDetail) 
+### setBraveryPanelDetail(braveryPanelDetail)
 
 Dispatches a message to indicate the bravery panel should be shown
 
@@ -611,7 +611,7 @@ Dispatches a message to indicate the bravery panel should be shown
 
 
 
-### setDownloadsToolbarVisible(isVisible) 
+### setDownloadsToolbarVisible(isVisible)
 
 Dispatches a message to indicate if the downloads toolbar is visible
 
@@ -621,7 +621,7 @@ Dispatches a message to indicate if the downloads toolbar is visible
 
 
 
-### setReleaseNotesVisible(isVisible) 
+### setReleaseNotesVisible(isVisible)
 
 Dispatches a message to indicate the release notes should be visible
 
@@ -631,7 +631,7 @@ Dispatches a message to indicate the release notes should be visible
 
 
 
-### setLinkHoverPreview(href, showOnRight) 
+### setLinkHoverPreview(href, showOnRight)
 
 Dispatches a message to indicate the href preview should be shown
 for a hovered link
@@ -644,7 +644,7 @@ for a hovered link
 
 
 
-### setBlockedBy(frameProps, blockType, location) 
+### setBlockedBy(frameProps, blockType, location)
 
 Dispatches a message to indicate the site info, such as # of blocked ads, should be shown
 
@@ -658,7 +658,7 @@ Dispatches a message to indicate the site info, such as # of blocked ads, should
 
 
 
-### setRedirectedBy(frameProps, ruleset, location) 
+### setRedirectedBy(frameProps, ruleset, location)
 
 Similar to setBlockedBy but for httpse redirects
 
@@ -672,7 +672,7 @@ Similar to setBlockedBy but for httpse redirects
 
 
 
-### setNoScript(frameProps, source) 
+### setNoScript(frameProps, source)
 
 Sets which scripts were blocked on a page.
 
@@ -684,7 +684,7 @@ Sets which scripts were blocked on a page.
 
 
 
-### setNoScriptVisible(isVisible) 
+### setNoScriptVisible(isVisible)
 
 Sets whether the noscript icon is visible.
 
@@ -694,7 +694,7 @@ Sets whether the noscript icon is visible.
 
 
 
-### addHistory(frameProps) 
+### addHistory(frameProps)
 
 Adds a history entry
 

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -829,7 +829,7 @@ class Main extends ImmutableComponent {
         </div>
       </div>
       {
-        this.props.windowState.getIn(['ui', 'downloadsToolbar', 'isVisible']) && this.props.appState.get('downloads') && this.props.appState.get('downloads').size > 0 && activeFrame.get('location') !== 'about:downloads'
+        this.props.windowState.getIn(['ui', 'downloadsToolbar', 'isVisible']) && this.props.appState.get('downloads') && this.props.appState.get('downloads').size > 0
         ? <DownloadsBar
           windowWidth={this.props.appState.get('defaultWindowWidth')}
           downloads={this.props.appState.get('downloads')} />

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -829,7 +829,7 @@ class Main extends ImmutableComponent {
         </div>
       </div>
       {
-        this.props.windowState.getIn(['ui', 'downloadsToolbar', 'isVisible']) && this.props.appState.get('downloads') && this.props.appState.get('downloads').size > 0
+        this.props.windowState.getIn(['ui', 'downloadsToolbar', 'isVisible']) && this.props.appState.get('downloads') && this.props.appState.get('downloads').size > 0 && activeFrame.get('location') !== 'about:downloads'
         ? <DownloadsBar
           windowWidth={this.props.appState.get('defaultWindowWidth')}
           downloads={this.props.appState.get('downloads')} />

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -461,7 +461,13 @@ const handleAppAction = (action) => {
       break
     case AppConstants.APP_SHOW_MESSAGE_BOX:
       let notifications = appState.get('notifications')
-      appState = appState.set('notifications', notifications.push(Immutable.fromJS(action.detail)))
+      appState = appState.set('notifications', notifications.filterNot((notification) => {
+        let message = notification.get('message')
+        // action.detail is a regular mutable object only when running tests
+        return action.detail.get
+          ? message === action.detail.get('message')
+          : message === action.detail['message']
+      }).push(Immutable.fromJS(action.detail)))
       break
     case AppConstants.APP_HIDE_MESSAGE_BOX:
       appState = appState.set('notifications', appState.get('notifications').filterNot((notification) => {

--- a/test/components/braveryPanelTest.js
+++ b/test/components/braveryPanelTest.js
@@ -114,7 +114,7 @@ describe('Bravery Panel', function () {
         .waitForVisible(braveryPanel)
         .waitUntil(function () {
           return this.getText(fpStat)
-            .then((stat) => stat === '1')
+            .then((stat) => stat === '3')
         })
         .click(fpSwitch)
     })

--- a/test/components/notificationBarTest.js
+++ b/test/components/notificationBarTest.js
@@ -75,6 +75,18 @@ describe('notificationBar', function () {
       })
   })
 
+  it('does not show the same notification twice', function * () {
+    let notificationUrl = Brave.server.url('double-notification.html')
+    yield this.app.client
+      .tabByIndex(0)
+      .loadUrl(notificationUrl)
+      .windowByUrl(Brave.browserWindowUrl)
+      .waitForExist('.notificationItem:nth-child(2)')
+      .waitUntil(function () {
+        return this.getText('.notificationItem:last-child').then((val) => val.includes('notification'))
+      })
+  })
+
   // https://travis-ci.org/brave/browser-laptop/builds/132700770
   it.skip('shows notification for login form', function * () {
     yield this.app.client

--- a/test/fixtures/double-notification.html
+++ b/test/fixtures/double-notification.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Notification</title>
+</head>
+<body>
+  <div id="result"></div>
+  <script type="text/javascript">
+    var result = document.getElementById('result');
+    navigator.geolocation.getCurrentPosition(position => {
+      result.textContent = 'grant';
+    }, error => {
+      result.textContent = error.message;
+    }, {timeout: 1});
+    navigator.geolocation.getCurrentPosition(position => {
+      result.textContent = 'grant';
+    }, error => {
+      result.textContent = error.message;
+    }, {timeout: 1});
+    Notification.requestPermission(function (permission) {
+        document.title = permission
+    })
+  </script>
+</body>
+</html>

--- a/test/fixtures/fingerprinting.html
+++ b/test/fixtures/fingerprinting.html
@@ -2,6 +2,29 @@
 <head>
 <script>
 function init() {
+  // WebRTC from https://github.com/diafygi/webrtc-ips
+  var RTCPeerConnection = window.webkitRTCPeerConnection;
+  //minimal requirements for data connection
+  var mediaConstraints = {
+      optional: [{RtpDataChannels: true}]
+  };
+  var servers = {iceServers: [{urls: "stun:stun.services.mozilla.com"}]};
+  //construct a new RTCPeerConnection
+  var pc = new RTCPeerConnection(servers, mediaConstraints);
+  //listen for candidate events
+  pc.onicecandidate = function(ice){
+      //skip non-candidate events
+      if(ice.candidate)
+          console.log(ice.candidate.candidate);
+  };
+  //create a bogus data channel
+  pc.createDataChannel("");
+  //create an offer sdp
+  pc.createOffer(function(result){
+      //trigger the stun server request
+      pc.setLocalDescription(result, function(){}, function(){});
+  }, function(){});
+
   // Canvas
   var canvas = document.createElement("canvas");
   canvas.width = 2000;
@@ -11,6 +34,7 @@ function init() {
   ctx.rect(0, 0, 10, 10);
   ctx.rect(2, 2, 6, 6);
   document.getElementById('canvas').innerText = canvas.toDataURL()
+
   // WebGL
   canvas = document.createElement("canvas");
   var gl = canvas.getContext("webgl")
@@ -19,7 +43,7 @@ function init() {
 }
 </script>
 </head>
-<body onload="init()">
+<body onload="setTimeout(init, 100)">
 <div>
 fingerprinting test
 <div id='canvas'></div>


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Copied the text from each locale's downloadInProgress property and
replaced the progress percent with a U+2026 (Horizontal Ellipsis)
character. Note that encoding of ellipsis is not consistent across
property files in the project: some use three dots, some use the
single unicode char, with a prevalence of three dots. Despite that,
I opted for the unicode char as the space is tight in the downloads
popup window. In Wikipedia (https://en.wikipedia.org/wiki/Ellipsis#In_different_languages),
I read that in Japanese the ellipsis is actually six dots, but I saw
that in other properties the localizer had used only three so I stuck
to that. Tested only in U.S. English locale in OS X.

Fix #2351