### PR TITLE
Add downloadInProgressUnknownTotal to download.properties

### DIFF
--- a/app/extensions/brave/locales/en-US/downloads.properties
+++ b/app/extensions/brave/locales/en-US/downloads.properties
@@ -5,6 +5,7 @@ downloadInterrupted=Interrupted
 downloadCancelled=Cancelled
 downloadCompleted=Completed
 downloadInProgress=Downloading: {{downloadPercent}}
+downloadInProgressUnknownTotal=Downloading…
 downloadPaused=Paused: {{downloadPercent}}
 
 downloadPause.title=Pause Download


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Had originally submitted a different pull request that also added localizations
but was told it wasn't necessary.

Fix #2351