### PR TITLE
Hide downloads bar when in downloads tab.

### DIFF
--- a/js/commonMenu.js
+++ b/js/commonMenu.js
@@ -201,6 +201,7 @@ module.exports.downloadsMenuItem = () => {
           location: 'about:downloads'
         }))
       } else {
+        module.exports.sendToFocusedWindow(focusedWindow, [messages.HIDE_DOWNLOADS_TOOLBAR])
         module.exports.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_NEW_FRAME, 'about:downloads', { singleFrame: true }])
       }
     }

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -283,6 +283,10 @@ class Main extends ImmutableComponent {
       windowActions.setDownloadsToolbarVisible(true)
     })
 
+    ipc.on(messages.HIDE_DOWNLOADS_TOOLBAR, () => {
+      windowActions.setDownloadsToolbarVisible(false)
+    })
+
     const self = this
     ipc.on(messages.SHORTCUT_SET_ACTIVE_FRAME_BY_INDEX, (e, i) =>
       windowActions.setActiveFrame(FrameStateUtil.getFrameByDisplayIndex(self.props.windowState, i)))

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -49,6 +49,7 @@ const messages = {
   SHOW_FLASH_INSTALLED_MESSAGE: _,
   // Downloads
   SHOW_DOWNLOADS_TOOLBAR: _, /** Ensures the downloads toolbar is visible */
+  HIDE_DOWNLOADS_TOOLBAR: _, /** Hides the downloads toolbar */
   DOWNLOAD_ACTION: _, /** @arg {string} downloadId, @arg {string} action such as 'resume', 'pause', or 'cancel' */
   // Updates
   UPDATE_REQUESTED: _,


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fix #2012