### PR TITLE
Closing Findbar removes text search highlighting from page

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -773,6 +773,7 @@ class Frame extends ImmutableComponent {
 
   onFindHide () {
     windowActions.setFindbarShown(this.props.frame, false)
+    this.onClearMatch()
   }
 
   onUpdateWheelZoom () {


### PR DESCRIPTION
This commit is for #2374.  

I can work on adding more tests to the Findbar actions so something like this doesn't happen again. 