### PR TITLE
Drag and drop should not be allowed to pin a tab for about:blank and about:newtab tabs

### DIFF
--- a/js/components/pinnedTabs.js
+++ b/js/components/pinnedTabs.js
@@ -25,6 +25,10 @@ class PinnedTabs extends ImmutableComponent {
   onDrop (e) {
     const clientX = e.clientX
     const sourceDragData = dndData.getDragData(e.dataTransfer, dragTypes.TAB)
+    const location = sourceDragData.get('location')
+    if (location === 'about:blank' || location === 'about:newtab' || isIntermediateAboutPage(location)) {
+      return
+    }
 
     // This must be executed async because the state change that this causes
     // will cause the onDragEnd to never run
@@ -36,10 +40,7 @@ class PinnedTabs extends ImmutableComponent {
         const droppedOnFrameProps = this.props.frames.find((frame) => frame.get('key') === droppedOnTab.props.frameProps.get('key'))
         windowActions.moveTab(sourceDragData, droppedOnFrameProps, isLeftSide)
         if (!sourceDragData.get('pinnedLocation')) {
-          const location = sourceDragData.get('location')
-          if (!(location === 'about:blank' || location === 'about:newtab' || isIntermediateAboutPage(location))) {
-            windowActions.setPinned(sourceDragData, true)
-          }
+          windowActions.setPinned(sourceDragData, true)
         } else {
           appActions.moveSite(siteUtil.getDetailFromFrame(sourceDragData, siteTags.PINNED),
             siteUtil.getDetailFromFrame(droppedOnFrameProps, siteTags.PINNED),

--- a/js/components/pinnedTabs.js
+++ b/js/components/pinnedTabs.js
@@ -13,6 +13,7 @@ const dragTypes = require('../constants/dragTypes')
 const siteUtil = require('../state/siteUtil')
 const dnd = require('../dnd')
 const dndData = require('../dndData')
+const {isIntermediateAboutPage} = require('../lib/appUrlUtil')
 
 class PinnedTabs extends ImmutableComponent {
   constructor () {
@@ -35,7 +36,10 @@ class PinnedTabs extends ImmutableComponent {
         const droppedOnFrameProps = this.props.frames.find((frame) => frame.get('key') === droppedOnTab.props.frameProps.get('key'))
         windowActions.moveTab(sourceDragData, droppedOnFrameProps, isLeftSide)
         if (!sourceDragData.get('pinnedLocation')) {
-          windowActions.setPinned(sourceDragData, true)
+          const location = sourceDragData.get('location')
+          if (!(location === 'about:blank' || location === 'about:newtab' || isIntermediateAboutPage(location))) {
+            windowActions.setPinned(sourceDragData, true)
+          }
         } else {
           appActions.moveSite(siteUtil.getDetailFromFrame(sourceDragData, siteTags.PINNED),
             siteUtil.getDetailFromFrame(droppedOnFrameProps, siteTags.PINNED),

--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -10,6 +10,7 @@ const windowActions = require('../actions/windowActions')
 const dragTypes = require('../constants/dragTypes')
 const cx = require('../lib/classSet.js')
 const {getTextColorForBackground} = require('../lib/color')
+const {isIntermediateAboutPage} = require('../lib/appUrlUtil')
 
 const contextMenus = require('../contextMenus')
 const dnd = require('../dnd')
@@ -22,6 +23,15 @@ class Tab extends ImmutableComponent {
   get draggingOverData () {
     if (!this.props.draggingOverData ||
         this.props.draggingOverData.get('dragOverKey') !== this.props.frameProps.get('key')) {
+      return
+    }
+
+    const sourceDragData = dnd.getInProcessDragData()
+    const location = sourceDragData.get('location')
+    const key = this.props.draggingOverData.get('dragOverKey')
+    const draggingOverFrame = this.props.frames.get(key)
+    if ((location === 'about:blank' || location === 'about:newtab' || isIntermediateAboutPage(location)) &&
+        (draggingOverFrame && draggingOverFrame.get('pinnedLocation'))) {
       return
     }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

fix #2395