### PR TITLE
Add a way to view TLS certificates when error

### DIFF
--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -25,6 +25,7 @@ certErrorText=This site cannot be loaded due to a certificate error:
 certErrorAdvanced=Advanced settings
 certErrorSafety=Back to safety
 certErrorButtonText=Ignore certificate error (dangerous!)
+certErrorShowCertificate=Show Certificate
 safebrowsingError=Dangerous Site Blocked
 safebrowsingErrorText=For your safety, Brave has blocked this site because it is distributing malware or stealing login credentials.
 safebrowsingErrorAdvanced=Advanced

--- a/app/index.js
+++ b/app/index.js
@@ -55,6 +55,7 @@ let lastWindowClosed = false
 
 // Domains to accept bad certs for. TODO: Save the accepted cert fingerprints.
 let acceptCertDomains = {}
+let errorCerts = {}
 // URLs to callback for auth.
 let authCallbacks = {}
 // Don't show the keytar prompt more than once per 24 hours
@@ -206,6 +207,15 @@ app.on('ready', () => {
       e.preventDefault()
       cb(true)
       return
+    }
+
+    errorCerts[url] = {
+      subjectName: cert.subjectName,
+      issuerName: cert.issuerName,
+      serialNumber: cert.serialNumber,
+      validStart: cert.validStart,
+      validExpiry: cert.validExpiry,
+      fingerprint: cert.fingerprint
     }
 
     // Tell the page to show an unlocked icon. Note this is sent to the main
@@ -443,6 +453,19 @@ app.on('ready', () => {
       if (acceptCertDomains[host]) {
         event.sender.send(messages.SET_SECURITY_STATE, frameKey, {
           secure: false
+        })
+      }
+    })
+
+    ipcMain.on(messages.GET_CERT_ERROR_DETAIL, (event, url) => {
+      if (errorCerts[url]) {
+        event.sender.send(messages.SET_CERT_ERROR_DETAIL, {
+          subjectName: errorCerts[url].subjectName,
+          issuerName: errorCerts[url].issuerName,
+          serialNumber: errorCerts[url].serialNumber,
+          validStart: errorCerts[url].validStart,
+          validExpiry: errorCerts[url].validExpiry,
+          fingerprint: errorCerts[url].fingerprint
         })
       }
     })

--- a/js/about/aboutActions.js
+++ b/js/about/aboutActions.js
@@ -66,6 +66,15 @@ const AboutActions = {
   },
 
   /**
+   * Get certificate detail when error.
+   *
+   * @param {string} url - The URL with the cert error
+   */
+  getCertErrorDetail: function (url) {
+    ipc.send(messages.GET_CERT_ERROR_DETAIL, url)
+  },
+
+  /**
    * Opens a context menu
    */
   contextMenu: function (nodeProps, contextMenuType, e) {

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -120,6 +120,8 @@ const messages = {
   // HTTPS
   CERT_ERROR_ACCEPTED: _, /** @arg {string} url where a cert error was accepted */
   CHECK_CERT_ERROR_ACCEPTED: _, /** @arg {string} url to check cert error, @arg {number} key of frame */
+  GET_CERT_ERROR_DETAIL: _,
+  SET_CERT_ERROR_DETAIL: _,
   SET_SECURITY_STATE: _, /** @arg {number} key of frame, @arg {Object} security state */
   HTTPSE_RULE_APPLIED: _, /** @arg {string} name of ruleset file, @arg {Object} details of rewritten request */
   // Bookmarks


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fix #1057 

Problems needs to be solved:
~~~- [ ] `[52870:0709/161617:ERROR:browser_plugin_guest.cc(419)] Attempting to require callback on nonexistent surface` keeps emerging when click `Show Certificate`
<img width="257" alt="screen shot 2016-07-09 at 16 42 07" src="https://cloud.githubusercontent.com/assets/11330831/16707020/75a32432-45f4-11e6-8425-96f5c442e4de.png">~~~

~~~- [ ] Waiting for [`UMD` problem](https://github.com/digitalbazaar/forge/issues/198) of [node-forge](https://github.com/digitalbazaar/forge) to be [fixed](https://github.com/digitalbazaar/forge/pull/357) then we can use this library to parse certificate info~~~

- [x] Waiting for brave/electron#25 being merged
- [x] Waiting for brave/electron#27 being merged