### PR TITLE
Show history on long click over back button

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -165,6 +165,8 @@ class Frame extends ImmutableComponent {
       while (this.webviewContainer.firstChild) {
         this.webviewContainer.removeChild(this.webviewContainer.firstChild)
       }
+      // the webview tag is where the user's page is rendered (runs in its own process)
+      // @see http://electron.atom.io/docs/api/web-view-tag/
       this.webview = document.createElement('webview')
 
       let partition = FrameStateUtil.getPartition(this.props.frame)
@@ -752,6 +754,31 @@ class Frame extends ImmutableComponent {
 
   goBack () {
     this.webview.goBack()
+  }
+
+  showBackHistory (rect) {
+    const webContent = this.webview.getWebContents()
+    const currentIndex = webContent.getCurrentEntryIndex()
+    const historyCount = webContent.getEntryCount()
+
+    let history = {
+      count: historyCount,
+      currentIndex: currentIndex,
+      entries: []
+    }
+
+    for (let index = 0; index < historyCount; index++) {
+      history.entries.push({
+        index: index,
+        url: webContent.getURLAtIndex(index)
+      })
+    }
+
+    contextMenus.onBackButtonHistoryMenu(this, history, rect)
+  }
+
+  goToIndex (index) {
+    this.webview.goToIndex(index)
   }
 
   goForward () {

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -995,6 +995,27 @@ function onMoreBookmarksMenu (activeFrame, allBookmarkItems, overflowItems, e) {
   }))
 }
 
+function onBackButtonHistoryMenu (activeFrame, history, rect) {
+  const menuTemplate = []
+
+  if (activeFrame && history) {
+    for (let index = (history.currentIndex - 1); index > -1; index--) {
+      menuTemplate.push({
+        label: history.entries[index].url,
+        click: (item, focusedWindow) => {
+          activeFrame.goToIndex(index)
+        }
+      })
+    }
+  }
+
+  windowActions.setContextMenuDetail(Immutable.fromJS({
+    left: rect.left,
+    top: rect.bottom,
+    template: menuTemplate
+  }))
+}
+
 module.exports = {
   onHamburgerMenu,
   onMainContextMenu,
@@ -1006,5 +1027,6 @@ module.exports = {
   onBookmarkContextMenu,
   onShowBookmarkFolderMenu,
   onShowUsernameMenu,
-  onMoreBookmarksMenu
+  onMoreBookmarksMenu,
+  onBackButtonHistoryMenu
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Shows context menu when click-and-hold over back button. Works great, except it'll continue to propagate the click (opening this PR while I figure that part out- help is appreciated)

Will fix https://github.com/brave/browser-laptop/issues/1622 (although, it doesn't match the wireframe yet)