### PR TITLE
"new tab" on tab should open tab right after it

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -182,12 +182,14 @@ class Main extends ImmutableComponent {
           return
         }
       }
+      const activeFrame = FrameStateUtil.getActiveFrame(self.props.windowState)
 
       let openInForeground = getSetting(settings.SWITCH_TO_NEW_TABS) === true || options.openInForeground
       windowActions.newFrame({
         location: url || config.defaultUrl,
         isPrivate: !!options.isPrivate,
-        isPartitioned: !!options.isPartitioned
+        isPartitioned: !!options.isPartitioned,
+        parentFrameKey: activeFrame.get('key')
       }, openInForeground)
     })
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

fix #2521