### PR TITLE
Fix extension ID for PDFJS

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -132,7 +132,6 @@ let generateBraveManifest = () => {
 }
 
 let defaultExtensions = {
-  PDFJS: 'oemmndcbldboiebfnladdacbdfmadadm',
   OnePassword: 'aomjjhallfgjeglblehebfpbcfeobpgk',
   Dashlane: 'fdjamakpfbbddfjaooikfcpapjohcfmg',
   LastPass: 'hdokiejnpimakedhajhdlcegeplioahd'
@@ -181,10 +180,10 @@ module.exports.init = () => {
     installExtension(config.braveExtensionId, getExtensionsPath('brave'), {manifest_location: 'component', manifest: generateBraveManifest()})
 
     if (getSetting(settings.PDFJS_ENABLED)) {
-      installExtension(defaultExtensions.PDFJS, getExtensionsPath('pdfjs'))
-      enableExtension(defaultExtensions.PDFJS)
+      installExtension(config.PDFJSExtensionId, getExtensionsPath('pdfjs'))
+      enableExtension(config.PDFJSExtensionId)
     } else {
-      disableExtension(defaultExtensions.PDFJS)
+      disableExtension(config.PDFJSExtensionId)
     }
 
     if (getSetting(settings.ONE_PASSWORD_ENABLED)) {

--- a/app/extensions/pdfjs/content/build/pdf.js
+++ b/app/extensions/pdfjs/content/build/pdf.js
@@ -28,8 +28,8 @@ factory((root.pdfjsDistBuildPdf = {}));
   // Use strict in our context only - users might not want it
   'use strict';
 
-var pdfjsVersion = '1.5.338';
-var pdfjsBuild = '5779432';
+var pdfjsVersion = '1.5.339';
+var pdfjsBuild = '3e89444';
 
   var pdfjsFilePath =
     typeof document !== 'undefined' && document.currentScript ?

--- a/app/extensions/pdfjs/content/build/pdf.worker.js
+++ b/app/extensions/pdfjs/content/build/pdf.worker.js
@@ -28,8 +28,8 @@ factory((root.pdfjsDistBuildPdfWorker = {}));
   // Use strict in our context only - users might not want it
   'use strict';
 
-var pdfjsVersion = '1.5.338';
-var pdfjsBuild = '5779432';
+var pdfjsVersion = '1.5.339';
+var pdfjsBuild = '3e89444';
 
   var pdfjsFilePath =
     typeof document !== 'undefined' && document.currentScript ?

--- a/app/extensions/pdfjs/extension-router.js
+++ b/app/extensions/pdfjs/extension-router.js
@@ -20,6 +20,9 @@ limitations under the License.
 (function ExtensionRouterClosure() {
   var VIEWER_URL = chrome.extension.getURL('content/web/viewer.html');
   var CRX_BASE_URL = chrome.extension.getURL('/');
+  if (chrome.ipc && chrome.ipc.send) {
+    chrome.ipc.send('got-pdfjs-url', CRX_BASE_URL)
+  }
 
   var schemes = [
     'http',

--- a/app/extensions/pdfjs/manifest.json
+++ b/app/extensions/pdfjs/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "PDF Viewer",
-  "version": "1.5.338",
+  "version": "1.5.339",
   "description": "Uses HTML5 to display PDF files directly in the browser.",
   "icons": {
     "128": "icon128.png",

--- a/app/index.js
+++ b/app/index.js
@@ -512,6 +512,10 @@ app.on('ready', () => {
       }
     })
 
+    ipcMain.on(messages.GOT_PDFJS_URL, (e, origin) => {
+      appActions.setPDFJSOrigin(origin)
+    })
+
     ipcMain.on(messages.SHOW_USERNAME_LIST, (e, origin, action, boundingRect, value) => {
       const passwords = AppStore.getState().get('passwords')
       if (!passwords || passwords.size === 0) {

--- a/docs/state.md
+++ b/docs/state.md
@@ -338,5 +338,6 @@ WindowStore
   },
   flashInitialized: boolean, // Whether flash was initialized successfully. Cleared on shutdown.
   cleanedOnShutdown: boolean, // whether app data was successfully cleared on shutdown
+  pdfjsOrigin: string // Origin of the PDFJS extension
 }
 ```

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -323,6 +323,18 @@ const appActions = {
       actionType: AppConstants.APP_SET_DICTIONARY,
       locale
     })
+  },
+
+  /**
+   * Sets PDFJS origin
+   * @param {string} origin - The origin of the PDFJS extension. Ends in
+   *   a slash.
+   */
+  setPDFJSOrigin: function (origin) {
+    AppDispatcher.dispatch({
+      actionType: AppConstants.APP_SET_PDFJS_ORIGIN,
+      origin
+    })
   }
 }
 

--- a/js/constants/appConstants.js
+++ b/js/constants/appConstants.js
@@ -30,7 +30,8 @@ const AppConstants = {
   APP_SHOW_MESSAGE_BOX: _, /** @param {Object} detail */
   APP_HIDE_MESSAGE_BOX: _, /** @param {string} message */
   APP_ADD_WORD: _, /** @param {string} word, @param {boolean} learn */
-  APP_SET_DICTIONARY: _ /** @param {string} locale */
+  APP_SET_DICTIONARY: _, /** @param {string} locale */
+  APP_SET_PDFJS_ORIGIN: _ /** @param {string} origin */
 }
 
 module.exports = mapValuesByKeys(AppConstants)

--- a/js/constants/config.js
+++ b/js/constants/config.js
@@ -40,5 +40,6 @@ module.exports = {
     authUrl: (userId) => `${vaultHost}/v1/users/${userId}`,
     replacementUrl: adHost
   },
-  braveExtensionId: 'mnojpmjdmbbfmejpflffifhffcmidifd'
+  braveExtensionId: 'mnojpmjdmbbfmejpflffifhffcmidifd',
+  PDFJSExtensionId: 'ckglimbbooghmggmkikhbolcfmgniemo'
 }

--- a/js/constants/config.js
+++ b/js/constants/config.js
@@ -41,5 +41,5 @@ module.exports = {
     replacementUrl: adHost
   },
   braveExtensionId: 'mnojpmjdmbbfmejpflffifhffcmidifd',
-  PDFJSExtensionId: 'ckglimbbooghmggmkikhbolcfmgniemo'
+  PDFJSExtensionId: 'oemmndcbldboiebfnladdacbdfmadadm'
 }

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -74,6 +74,7 @@ const messages = {
   SET_RESOURCE_ENABLED: _,
   GO_BACK: _,
   GO_FORWARD: _,
+  GOT_PDFJS_URL: _, /** @arg {string} origin - of PDFJS extension */
   // Password manager
   GET_PASSWORDS: _, /** @arg {string} formOrigin, @arg {string} action */
   GOT_PASSWORD: _, /** @arg {string} username, @arg {string} password, @arg {string} origin, @arg {string} action, @arg {boolean} isUnique */

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -488,6 +488,9 @@ const handleAppAction = (action) => {
     case AppConstants.APP_SET_DICTIONARY:
       appState = appState.setIn(['dictionary', 'locale'], action.locale)
       break
+    case AppConstants.APP_SET_PDFJS_ORIGIN:
+      appState = appState.set('pdfjsOrigin', action.origin)
+      break
     default:
   }
 

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -36,7 +36,7 @@ let windowState = Immutable.fromJS({
 let lastEmittedState
 
 const CHANGE_EVENT = 'change'
-const PDFJS_ORIGIN = 'chrome-extension://adnmjfhcejodgpaljdmlmjoclihpcfka/'
+const PDFJS_ORIGIN = `chrome-extension://${config.PDFJSExtensionId}/`
 
 const frameStatePath = (key) =>
   ['frames', FrameStateUtil.findIndexForFrameKey(windowState.get('frames'), key)]

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -36,7 +36,7 @@ let windowState = Immutable.fromJS({
 let lastEmittedState
 
 const CHANGE_EVENT = 'change'
-const PDFJS_ORIGIN = `chrome-extension://${config.PDFJSExtensionId}/`
+let PDFJS_ORIGIN = null
 
 const frameStatePath = (key) =>
   ['frames', FrameStateUtil.findIndexForFrameKey(windowState.get('frames'), key)]
@@ -55,7 +55,9 @@ const updateNavBarInput = (loc, frameStatePath = activeFrameStatePath()) => {
  * @param {string=} loc - Original URL
  */
 const setPDFLocation = (loc) => {
-  if (loc && UrlUtil.isFileType(loc, 'pdf') && !loc.startsWith(PDFJS_ORIGIN)) {
+  PDFJS_ORIGIN = PDFJS_ORIGIN || require('./appStoreRenderer').state.get('pdfjsOrigin')
+  if (loc && PDFJS_ORIGIN &&
+      UrlUtil.isFileType(loc, 'pdf') && !loc.startsWith(PDFJS_ORIGIN)) {
     return PDFJS_ORIGIN + loc
   }
   return loc


### PR DESCRIPTION
This was failing to load for me I think because the PDFJS_ORIGIN ID was different from the one installed. It's unclear to me if the new one that I have that is in use by my instance will be the same for everyone.  This works concistently for me though and keeps the 2 IDs in sync

Auditors: @bridiver, @diracdeltas 