### PR TITLE
usernameElement should blur and hide context menu upon submit

### DIFF
--- a/app/extensions/brave/content/scripts/passwordManager.js
+++ b/app/extensions/brave/content/scripts/passwordManager.js
@@ -74,11 +74,6 @@ if (chrome.contentSettings.passwordManager == 'allow') {
             }, usernameElem.value || '')
         }
       })
-      usernameElem.addEventListener('blur', (e) => {
-        e.preventDefault()
-        e.stopPropagation()
-        chrome.ipc.send('hide-context-menu')
-      })
     }
 
     // Whenever a form is submitted, offer to save it in the password manager
@@ -86,6 +81,7 @@ if (chrome.contentSettings.passwordManager == 'allow') {
     form.addEventListener('submit', (e) => {
       if (usernameElem) {
         usernameElem.blur()
+        chrome.ipc.send('hide-context-menu')
       }
       onFormSubmit(form, formOrigin)
     })

--- a/app/extensions/brave/content/scripts/passwordManager.js
+++ b/app/extensions/brave/content/scripts/passwordManager.js
@@ -74,11 +74,19 @@ if (chrome.contentSettings.passwordManager == 'allow') {
             }, usernameElem.value || '')
         }
       })
+      usernameElem.addEventListener('blur', (e) => {
+        e.preventDefault()
+        e.stopPropagation()
+        chrome.ipc.send('hide-context-menu')
+      })
     }
 
     // Whenever a form is submitted, offer to save it in the password manager
     // if the credentials have changed.
     form.addEventListener('submit', (e) => {
+      if (usernameElem) {
+        usernameElem.blur()
+      }
       onFormSubmit(form, formOrigin)
     })
     Array.from(form.querySelectorAll('button')).forEach((button) => {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Ran `git rebase -i` to squash commits if needed.

fix #2532