### PR TITLE
Remove 'chrome-extension://*' prefix from URL bar

### DIFF
--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -15,8 +15,11 @@ const ipc = global.require('electron').ipcRenderer
 const UrlBarSuggestions = require('./urlBarSuggestions.js')
 const messages = require('../constants/messages')
 const dragTypes = require('../constants/dragTypes')
+const { getSetting } = require('../settings')
+const settings = require('../constants/settings')
 const contextMenus = require('../contextMenus')
 const dndData = require('../dndData')
+const appStoreRenderer = require('../stores/appStoreRenderer')
 
 const { isUrl, isIntermediateAboutPage } = require('../lib/appUrlUtil')
 
@@ -265,10 +268,16 @@ class UrlBar extends ImmutableComponent {
       }
     }
 
-    const location = this.props.urlbar.get('location')
+    let location = this.props.urlbar.get('location')
     const history = this.props.activeFrameProps.get('history')
     if (isIntermediateAboutPage(location) && history.size > 0) {
       return history.last()
+    }
+
+    // We can extend the conditions if there are more chrome-extension to
+    // truncate
+    if (getSetting(settings.PDFJS_ENABLED) && location.startsWith(appStoreRenderer.state.get('pdfjsOrigin'))) {
+      location = location.replace(/^chrome-extension:\/\/.+\/(\w+:\/\/.+)/, '$1')
     }
 
     return ['about:blank', 'about:newtab'].includes(this.props.urlbar.get('location'))


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Ran `git rebase -i` to squash commits if needed.

fix #2534