### PR TITLE
subtree property should be set in MutationObserverInit

### DIFF
--- a/app/extensions/brave/content/scripts/passwordManager.js
+++ b/app/extensions/brave/content/scripts/passwordManager.js
@@ -272,7 +272,8 @@ if (chrome.contentSettings.passwordManager == 'allow') {
         })
       })
       observer.observe(document.documentElement, {
-        childList: true
+        childList: true,
+        subtree: true
       })
     }, 1000)
   }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

fix #2509