### PR TITLE
Prevent two-finger swipe forard/back when scrolling on viewport

### DIFF
--- a/app/extensions/brave/content/scripts/inputHandler.js
+++ b/app/extensions/brave/content/scripts/inputHandler.js
@@ -156,3 +156,17 @@ document.addEventListener('keydown', (e /*: Event*/) => {
       break
   }
 })
+
+chrome.ipc.on('check-swipe-back', (e) => {
+  if (document.scrollingElement.scrollLeft === 0) {
+    chrome.ipc.sendToHost('can-swipe-back')
+  }
+})
+
+chrome.ipc.on('check-swipe-forward', (e) => {
+  const scrollEle = document.scrollingElement
+  if (scrollEle.scrollLeft === 0 ||
+    scrollEle.scrollLeft === (scrollEle.scrollWidth - scrollEle.clientWidth)) {
+    chrome.ipc.sendToHost('can-swipe-forward')
+  }
+})

--- a/js/actions/webviewActions.js
+++ b/js/actions/webviewActions.js
@@ -4,6 +4,8 @@
 
 'use strict'
 
+const messages = require('../constants/messages.js')
+
 const getWebview = () =>
   document.querySelector('.frameWrapper.isActive webview')
 
@@ -48,6 +50,21 @@ const webviewActions = {
     const webview = getWebview()
     if (webview) {
       webview.showDefinitionForSelection()
+    }
+  },
+
+  /**
+   * Check two-finger gesture swipe back/forward ability
+   * @param {bool} back - true for back, false for forward
+   */
+  checkSwipe: function (back) {
+    const webview = getWebview()
+    if (webview) {
+      if (back) {
+        webview.send(messages.CHECK_SWIPE_BACK)
+      } else {
+        webview.send(messages.CHECK_SWIPE_FORWARD)
+      }
     }
   }
 }

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -505,6 +505,12 @@ class Frame extends ImmutableComponent {
         case messages.GO_FORWARD:
           method = () => this.webview.goForward()
           break
+        case messages.CAN_SWIPE_BACK:
+          remote.getCurrentWindow().webContents.send(messages.CAN_SWIPE_BACK)
+          break
+        case messages.CAN_SWIPE_FORWARD:
+          remote.getCurrentWindow().webContents.send(messages.CAN_SWIPE_FORWARD)
+          break
         case messages.NEW_FRAME:
           method = (frameOpts, openInForeground) => {
             windowActions.newFrame(frameOpts, openInForeground)

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -74,6 +74,10 @@ const messages = {
   SET_RESOURCE_ENABLED: _,
   GO_BACK: _,
   GO_FORWARD: _,
+  CAN_SWIPE_BACK: _,
+  CAN_SWIPE_FORWARD: _,
+  CHECK_SWIPE_BACK: _,
+  CHECK_SWIPE_FORWARD: _,
   // Password manager
   GET_PASSWORDS: _, /** @arg {string} formOrigin, @arg {string} action */
   GOT_PASSWORD: _, /** @arg {string} username, @arg {string} password, @arg {string} origin, @arg {string} action, @arg {boolean} isUnique */


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

fix #2577 