### PR TITLE
Make 'Passwords Manager...' translatable

### DIFF
--- a/app/extensions/brave/locales/en-US/menu.properties
+++ b/app/extensions/brave/locales/en-US/menu.properties
@@ -117,6 +117,7 @@ quit=Quit
 quitApp=Quit Brave
 inspectElement=Inspect Element
 downloadsManager=Downloads Manager...
+passwordsManager=Passwords Manager...
 zoom=Zoom
 new=New
 learnSpelling=Learn Spelling

--- a/js/commonMenu.js
+++ b/js/commonMenu.js
@@ -210,7 +210,7 @@ module.exports.downloadsMenuItem = () => {
 
 module.exports.passwordsMenuItem = () => {
   return {
-    label: 'Passwords manager...',
+    label: locale.translation('passwordsManager'),
     click: (item, focusedWindow) => {
       if (BrowserWindow.getAllWindows().length === 0) {
         appActions.newWindow(Immutable.fromJS({


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fixes #2596