### PR TITLE
Make permission message translatable

### DIFF
--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -140,6 +140,7 @@ permissionDisableCursor=disable your mouse cursor
 permissionFullscreen=use fullscreen mode
 permissionExternal=open an external application
 permissionProtocolRegistration=register a protocol handler
+permissionMessage=Allow {{host}} to {{permission}}?
 tabsSuggestionTitle=Tabs
 bookmarksSuggestionTitle=Bookmarks
 historySuggestionTitle=History

--- a/app/filtering.js
+++ b/app/filtering.js
@@ -316,7 +316,7 @@ function registerPermissionHandler (session, partition) {
     if (!host) {
       return
     }
-    const message = `Allow ${host} to ${permissions[permission].action}?`
+    const message = locale.translation('permissionMessage').replace(/{{\s*host\s*}}/, host).replace(/{{\s*permission\s*}}/, permissions[permission].action)
 
     // If this is a duplicate, clear the previous callback and use the new one
     if (permissionCallbacks[message]) {

--- a/app/locale.js
+++ b/app/locale.js
@@ -160,6 +160,7 @@ var rendererIdentifiers = function () {
     'permissionFullscreen',
     'permissionExternal',
     'permissionProtocolRegistration',
+    'permissionMessage',
     'tabsSuggestionTitle',
     'bookmarksSuggestionTitle',
     'historySuggestionTitle',


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fixes #2540