### PR TITLE
Transition between title mode and address entry in URL bar. Closes #1192

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -8,6 +8,16 @@
 
 @import "variables.less";
 
+// Fade In animation for URL bar transitions
+@keyframes fadeIn {
+  from {
+    opacity: 0
+  }
+  to {
+    opacity: 1
+  }
+}
+
 // On MacOS we need to keep a padding left to avoid overlapping
 // with the window buttons to close/maximize/minimize the window.
 .platform--darwin .navigatorWrapper .backforward {
@@ -207,7 +217,18 @@
     }
   }
 
+  &:not(.titleMode) {
+    .urlbarForm, .browserButton {
+      animation: fadeIn .6s;
+      opacity: 0;
+      animation-fill-mode: forwards;
+    }
+  }
+
   &.titleMode {
+    &:extend(#navigator:not(.titleMode).urlbarForm);
+    animation: fadeIn 1.2s;
+
     input {
       display: none;
     }


### PR DESCRIPTION
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.

**Worth notes**:

* I had to use `keyframes` instead of opacity because `titleBar` is a child of `urlbarForm`, and setting `urlbarForm` to zero has lead its entire children to inherit the property.
* The animation duration was arbitrary and after testing for a while I must have given way more or way less animation time than it needed.

I think @bradleyrichter would also like to take a look on it, so I did a GIF:

![brave-urlbar](https://cloud.githubusercontent.com/assets/4672033/17012588/fd9fe5b6-4eee-11e6-8f64-b2fea82c923a.gif)

