### PR TITLE
Hide scrollbar in tab toolbar

### DIFF
--- a/less/tabs.less
+++ b/less/tabs.less
@@ -21,7 +21,7 @@
   display: flex;
   flex: 1;
   z-index: @zindexTabs;
-  overflow-x: auto;
+  overflow-x: hidden;
   overflow-y: hidden;
   &.allowDragging {
     -webkit-app-region: drag;


### PR DESCRIPTION
Changed `overflow-x` to `hidden` for `.tabStripContainer` to prevent a scrollbar from appearing over the tabs when they fill the tab bar.

Fixes #2599