### PR TITLE
Fix #2682: Make getBaseDomain use LRU cache

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -196,7 +196,7 @@ function registerForBeforeSendHeaders (session) {
           requestHeaders['Cookie'] = undefined
         }
         if (requestHeaders['Referer'] &&
-            !refererExceptions.includes(parsedUrl.hostname) && !refererExceptions.includes(getBaseDomain(parsedUrl.hostname))) {
+            !refererExceptions.includes(parsedUrl.hostname)) {
           requestHeaders['Referer'] = undefined
         }
       }

--- a/app/filtering.js
+++ b/app/filtering.js
@@ -196,7 +196,7 @@ function registerForBeforeSendHeaders (session) {
           requestHeaders['Cookie'] = undefined
         }
         if (requestHeaders['Referer'] &&
-            !refererExceptions.includes(parsedUrl.hostname)) {
+            !refererExceptions.includes(parsedUrl.hostname) && !refererExceptions.includes(getBaseDomain(parsedUrl.hostname))) {
           requestHeaders['Referer'] = undefined
         }
       }

--- a/js/lib/baseDomain.js
+++ b/js/lib/baseDomain.js
@@ -54,8 +54,7 @@ module.exports.getBaseDomain = function (hostname) {
     tld--
   }
 
-  baseDomain = curDomain
-  cachedBaseDomain.put(baseDomain)
+  cachedBaseDomain.put(curDomain)
 
-  return baseDomain
+  return curDomain
 }

--- a/js/lib/baseDomain.js
+++ b/js/lib/baseDomain.js
@@ -5,14 +5,24 @@
 const punycode = require('punycode')
 const publicSuffixes = require('./psl')
 
+const LRUCache = require('lru_cache/core').LRUCache
+
+let cachedBaseDomain = new LRUCache(50)
+
 /**
  * Returns base domain for specified host based on Public Suffix List.
  * @param {string} hostname The name of the host to get the base domain for
  */
+
 module.exports.getBaseDomain = function (hostname) {
   // decode punycode if exists
   if (hostname.indexOf('xn--') >= 0) {
     hostname = punycode.toUnicode(hostname)
+  }
+
+  let baseDomain = cachedBaseDomain.get(hostname)
+  if (baseDomain) {
+    return baseDomain
   }
 
   // search through PSL
@@ -44,5 +54,8 @@ module.exports.getBaseDomain = function (hostname) {
     tld--
   }
 
-  return curDomain
+  baseDomain = curDomain
+  cachedBaseDomain.put(baseDomain)
+
+  return baseDomain
 }


### PR DESCRIPTION
- [x ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.

Should the refererExceptions array also be updated to include the base domains that keep popping up? (E.g. facebook.com, naver.net, etc.)

