### PR TITLE
Show history on long click over back button

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -802,7 +802,7 @@ class Frame extends ImmutableComponent {
         url: url,
         title: title,
         display: title || url,
-        icon: UrlUtil.getDefaultFavicon(url)
+        icon: UrlUtil.getDefaultFaviconUrl(url)
       })
     }
 

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -165,6 +165,8 @@ class Frame extends ImmutableComponent {
       while (this.webviewContainer.firstChild) {
         this.webviewContainer.removeChild(this.webviewContainer.firstChild)
       }
+      // the webview tag is where the user's page is rendered (runs in its own process)
+      // @see http://electron.atom.io/docs/api/web-view-tag/
       this.webview = document.createElement('webview')
 
       let partition = FrameStateUtil.getPartition(this.props.frame)
@@ -778,6 +780,37 @@ class Frame extends ImmutableComponent {
 
   goBack () {
     this.webview.goBack()
+  }
+
+  getHistory () {
+    const webContent = this.webview.getWebContents()
+    const currentIndex = webContent.getCurrentEntryIndex()
+    const historyCount = webContent.getEntryCount()
+
+    let history = {
+      count: historyCount,
+      currentIndex: currentIndex,
+      entries: []
+    }
+
+    for (let index = 0; index < historyCount; index++) {
+      const url = webContent.getURLAtIndex(index)
+      const title = webContent.getTitleAtIndex(index)
+
+      history.entries.push({
+        index: index,
+        url: url,
+        title: title,
+        display: title || url,
+        icon: UrlUtil.getDefaultFavicon(url)
+      })
+    }
+
+    return history
+  }
+
+  goToIndex (index) {
+    this.webview.goToIndex(index)
   }
 
   goForward () {

--- a/js/components/longPressButton.js
+++ b/js/components/longPressButton.js
@@ -1,0 +1,66 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const React = require('react')
+const ImmutableComponent = require('./immutableComponent')
+
+class LongPressButton extends ImmutableComponent {
+  constructor () {
+    super()
+    this.isLocked = false
+    this.onClick = this.onClick.bind(this)
+    this.onMouseDown = this.onMouseDown.bind(this)
+    this.onMouseUp = this.onMouseUp.bind(this)
+    this.onMouseLeave = this.onMouseLeave.bind(this)
+  }
+
+  onMouseDown (e) {
+    if (e.target.attributes.getNamedItem('disabled')) {
+      return
+    }
+
+    const self = this
+    const rect = e.target.getBoundingClientRect()
+    const LONG_PRESS_MILLISECONDS = 300
+
+    this.longPressTimer = setTimeout(function () {
+      self.isLocked = true
+      self.props.onLongPress(rect)
+    }, LONG_PRESS_MILLISECONDS)
+  }
+
+  onMouseUp (e) {
+    if (this.longPressTimer) {
+      clearTimeout(this.longPressTimer)
+      this.longPressTimer = null
+    }
+  }
+
+  onMouseLeave (e) {
+    this.onMouseUp(e)
+    if (this.isLocked) {
+      this.isLocked = false
+    }
+  }
+
+  onClick (e) {
+    if (this.isLocked) {
+      this.isLocked = false
+      return
+    }
+    this.props.onClick()
+  }
+
+  render () {
+    return <span data-l10n-id={this.props.l10nId}
+      className={this.props.className}
+      disabled={this.props.disabled}
+      onClick={this.onClick}
+      onMouseDown={this.onMouseDown}
+      onMouseUp={this.onMouseUp}
+      onMouseLeave={this.onMouseLeave} />
+  }
+}
+
+module.exports = LongPressButton

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -35,6 +35,7 @@ const BookmarksToolbar = require('./bookmarksToolbar')
 const ContextMenu = require('./contextMenu')
 const PopupWindow = require('./popupWindow')
 const NoScriptInfo = require('./noScriptInfo')
+const LongPressButton = require('./longPressButton')
 
 // Constants
 const config = require('../constants/config')
@@ -61,6 +62,8 @@ class Main extends ImmutableComponent {
     this.onCloseFrame = this.onCloseFrame.bind(this)
     this.onBack = this.onBack.bind(this)
     this.onForward = this.onForward.bind(this)
+    this.onBackLongPress = this.onBackLongPress.bind(this)
+    this.onForwardLongPress = this.onForwardLongPress.bind(this)
     this.onMouseDown = this.onMouseDown.bind(this)
     this.onClickWindow = this.onClickWindow.bind(this)
     this.onDoubleClick = this.onDoubleClick.bind(this)
@@ -449,8 +452,16 @@ class Main extends ImmutableComponent {
     this.activeFrame.goBack()
   }
 
+  onBackLongPress (rect) {
+    contextMenus.onBackButtonHistoryMenu(this.activeFrame, this.activeFrame.getHistory(), rect)
+  }
+
   onForward () {
     this.activeFrame.goForward()
+  }
+
+  onForwardLongPress (rect) {
+    contextMenus.onForwardButtonHistoryMenu(this.activeFrame, this.activeFrame.getHistory(), rect)
   }
 
   onBraveMenu () {
@@ -530,7 +541,6 @@ class Main extends ImmutableComponent {
         if (node.classList.contains('contextMenu') && e.button === 1) {
           e.preventDefault()
         }
-
         return
       }
       node = node.parentNode
@@ -659,14 +669,20 @@ class Main extends ImmutableComponent {
           onDragOver={this.onDragOver}
           onDrop={this.onDrop}>
           <div className='backforward'>
-            <span data-l10n-id='backButton'
+            <LongPressButton
+              l10nId='backButton'
               className='back fa fa-angle-left'
               disabled={!activeFrame || !activeFrame.get('canGoBack')}
-              onClick={this.onBack} />
-            <span data-l10n-id='forwardButton'
+              onClick={this.onBack}
+              onLongPress={this.onBackLongPress}
+            />
+            <LongPressButton
+              l10nId='forwardButton'
               className='forward fa fa-angle-right'
               disabled={!activeFrame || !activeFrame.get('canGoForward')}
-              onClick={this.onForward} />
+              onClick={this.onForward}
+              onLongPress={this.onForwardLongPress}
+            />
           </div>
           <NavigationBar
             ref={(node) => { this.navBar = node }}

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -1063,6 +1063,50 @@ function onMoreBookmarksMenu (activeFrame, allBookmarkItems, overflowItems, e) {
   }))
 }
 
+function onBackButtonHistoryMenu (activeFrame, history, rect) {
+  const menuTemplate = []
+
+  if (activeFrame && history) {
+    for (let index = (history.currentIndex - 1); index > -1; index--) {
+      menuTemplate.push({
+        label: history.entries[index].display,
+        icon: history.entries[index].icon,
+        click: (item, focusedWindow) => {
+          activeFrame.goToIndex(index)
+        }
+      })
+    }
+  }
+
+  windowActions.setContextMenuDetail(Immutable.fromJS({
+    left: rect.left,
+    top: rect.bottom,
+    template: menuTemplate
+  }))
+}
+
+function onForwardButtonHistoryMenu (activeFrame, history, rect) {
+  const menuTemplate = []
+
+  if (activeFrame && history) {
+    for (let index = (history.currentIndex + 1); index < history.entries.length; index++) {
+      menuTemplate.push({
+        label: history.entries[index].display,
+        icon: history.entries[index].icon,
+        click: (item, focusedWindow) => {
+          activeFrame.goToIndex(index)
+        }
+      })
+    }
+  }
+
+  windowActions.setContextMenuDetail(Immutable.fromJS({
+    left: rect.left,
+    top: rect.bottom,
+    template: menuTemplate
+  }))
+}
+
 module.exports = {
   onHamburgerMenu,
   onMainContextMenu,
@@ -1074,5 +1118,7 @@ module.exports = {
   onBookmarkContextMenu,
   onShowBookmarkFolderMenu,
   onShowUsernameMenu,
-  onMoreBookmarksMenu
+  onMoreBookmarksMenu,
+  onBackButtonHistoryMenu,
+  onForwardButtonHistoryMenu
 }

--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -46,6 +46,10 @@ const UrlUtil = {
    * @returns {String} path with a scheme
    */
   prependScheme: function (input) {
+    if (input === undefined || input === null) {
+      return input
+    }
+
     // expand relative path
     if (input.startsWith('~/')) {
       input = input.replace(/^~/, os.homedir())
@@ -82,6 +86,10 @@ const UrlUtil = {
    * @returns {Boolean} Returns true if this is not a valid URL.
    */
   isNotURL: function (input) {
+    if (input === undefined || input === null) {
+      return true
+    }
+
     // for cases, quoted strings
     const case1Reg = /^".*"$/
     // for cases, ?abc and "a? b" which should searching query
@@ -116,6 +124,10 @@ const UrlUtil = {
    * @returns {String} The formatted URL.
    */
   getUrlFromInput: function (input) {
+    if (input === undefined || input === null) {
+      return ''
+    }
+
     input = input.trim()
 
     input = this.prependScheme(input)
@@ -276,13 +288,15 @@ const UrlUtil = {
   },
 
   /**
+   * Gets the default favicon URL for a URL.
+   * @param {string} url The URL to find a favicon for
+   * @return {string} url The base favicon URL
    */
-  getDefaultFavicon: function (url) {
+  getDefaultFaviconUrl: function (url) {
     if (this.isURL(url)) {
       const loc = new window.URL(url)
       return loc.protocol + '//' + loc.host + '/favicon.ico'
     }
-
     return ''
   }
 }

--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -273,6 +273,17 @@ const UrlUtil = {
       ['http:', 'https:'].includes(parsed.protocol) &&
       !exemptHostPattern.test(parsed.hostname) &&
       !['/search', '/search/'].includes(parsed.pathname)
+  },
+
+  /**
+   */
+  getDefaultFavicon: function (url) {
+    if (this.isURL(url)) {
+      const loc = new window.URL(url)
+      return loc.protocol + '//' + loc.host + '/favicon.ico'
+    }
+
+    return ''
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -112,6 +112,8 @@
     "empty-port": "0.0.2",
     "flow-bin": "^0.22.1",
     "gulp": "^3.9.0",
+    "jsdom": "9.4.1",
+    "jsdom-global": "2.0.0",
     "jsdox": "^0.4.9",
     "jsonfile": "^2.2.3",
     "less": "^2.5.3",

--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -2,6 +2,8 @@ require('babel-polyfill')
 var Application = require('spectron').Application
 var chai = require('chai')
 require('./coMocha')
+require('jsdom-global')()
+
 const path = require('path')
 const fs = require('fs')
 

--- a/test/lib/urlutilTest.js
+++ b/test/lib/urlutilTest.js
@@ -8,35 +8,76 @@ describe('urlutil', function () {
     it('null for empty', function * () {
       assert.equal(UrlUtil.getScheme('/file/path/to/file'), null)
     })
-
     it('localhost: for localhost', function * () {
       assert.equal(UrlUtil.getScheme('localhost://127.0.0.1'), 'localhost:')
     })
-
     it('gets scheme with :', function * () {
       assert.equal(UrlUtil.getScheme('data:datauri'), 'data:')
     })
-
     it('host:port is not recognized as a scheme', function * () {
       assert.equal(UrlUtil.getScheme('localhost:8089'), null)
     })
-
     it('gets scheme with ://', function * () {
       assert.equal(UrlUtil.getScheme('http://www.brave.com'), 'http://')
     })
   })
 
   describe('prependScheme', function () {
+    it('returns null when input is null', function () {
+      assert.equal(UrlUtil.prependScheme(null), null)
+    })
+    it('returns undefined when input is undefined', function () {
+      assert.equal(UrlUtil.prependScheme(), undefined)
+    })
     it('prepends file:// to absolute file path', function * () {
       assert.equal(UrlUtil.prependScheme('/file/path/to/file'), 'file:///file/path/to/file')
     })
-
     it('defaults to http://', function * () {
       assert.equal(UrlUtil.prependScheme('www.brave.com'), 'http://www.brave.com')
     })
-
     it('keeps schema if already exists', function * () {
       assert.equal(UrlUtil.prependScheme('https://www.brave.com'), 'https://www.brave.com')
+    })
+  })
+
+  describe('isNotURL', function () {
+    it('returns true when input is null', function () {
+      assert.equal(UrlUtil.isNotURL(null), true)
+    })
+    it('returns true when input is undefined', function () {
+      assert.equal(UrlUtil.isNotURL(), true)
+    })
+    it('returns false when input is "localhost"', function () {
+      assert.equal(UrlUtil.isNotURL('localhost'), false)
+    })
+    it('returns true when input is a quoted string', function () {
+      assert.equal(UrlUtil.isNotURL('"brave.com"'), true)
+    })
+    it('returns true when input is a pure string (no TLD)', function () {
+      assert.equal(UrlUtil.isNotURL('brave'), true)
+    })
+    describe('search query', function () {
+      it('returns true when input starts with ?', function () {
+        assert.equal(UrlUtil.isNotURL('?brave'), true)
+      })
+      it('returns true when input has a question mark followed by a space', function () {
+        assert.equal(UrlUtil.isNotURL('?brave'), true)
+      })
+    })
+    it('returns false when input is a valid URL', function () {
+      assert.equal(UrlUtil.isNotURL('brave.com'), false)
+    })
+  })
+
+  describe('getUrlFromInput', function () {
+    it('returns empty string when input is null', function () {
+      assert.equal(UrlUtil.getUrlFromInput(null), '')
+    })
+    it('returns empty string when input is undefined', function () {
+      assert.equal(UrlUtil.getUrlFromInput(), '')
+    })
+    it('calls prependScheme', function () {
+      assert.equal(UrlUtil.getUrlFromInput('/file/path/to/file'), 'file:///file/path/to/file')
     })
   })
 
@@ -44,19 +85,15 @@ describe('urlutil', function () {
     it('absolute file path without scheme', function * () {
       assert.equal(UrlUtil.isURL('/file/path/to/file'), true)
     })
-
     it('absolute file path with scheme', function * () {
       assert.equal(UrlUtil.isURL('file:///file/path/to/file'), true)
     })
-
     it('detects data URI', function * () {
       assert.equal(UrlUtil.isURL('data:text/html,hi'), true)
     })
-
     it('someBraveServer:8089', function * () {
       assert.equal(UrlUtil.isURL('someBraveServer:8089'), true)
     })
-
     it('localhost', function * () {
       assert.equal(UrlUtil.isURL('localhost:8089'), true)
     })
@@ -77,6 +114,15 @@ describe('urlutil', function () {
     })
     it('invalid URL', function * () {
       assert.equal(UrlUtil.isFileType('foo', 'jpg'), false)
+    })
+  })
+
+  describe('getHostname', function () {
+    it('returns undefined if the URL is invalid', function () {
+      assert.equal(UrlUtil.getHostname(null), undefined)
+    })
+    it('returns the host field (including port number)', function () {
+      assert.equal(UrlUtil.getHostname('https://brave.com:8080/test/'), 'brave.com:8080')
     })
   })
 
@@ -134,6 +180,18 @@ describe('urlutil', function () {
     })
     it('does not intercept on adobe site', function () {
       assert(!UrlUtil.shouldInterceptFlash('https://www.adobe.com/test'))
+    })
+  })
+
+  describe('getDefaultFaviconUrl', function () {
+    it('returns empty string if input is not a URL', function () {
+      assert.equal(UrlUtil.getDefaultFaviconUrl('invalid-url-goes-here'), '')
+    })
+    it('returns the default favicon URL when given a valid URL', function () {
+      assert.equal(UrlUtil.getDefaultFaviconUrl('https://brave.com'), 'https://brave.com/favicon.ico')
+    })
+    it('includes the port in the response when given a valid URL with a port number', function () {
+      assert.equal(UrlUtil.getDefaultFaviconUrl('https://brave.com:8080'), 'https://brave.com:8080/favicon.ico')
     })
   })
 })


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

History now shows in context menu after a long press on back button or forward button.

~~Depends on brave/electron#30 (must be merged before this can be accepted)~~
Fixes #1622
(although it doesn't match the proposed mockup- a new issue can be filed for that)

Ready for review!
cc: @bbondy @bridiver

- Adds dependency for jsdom-global (used for mocking window)
- Includes extra tests for urlutilTest.js