### PR TITLE
Add tab-preview timer for non-previewmode. Closes #1434

### DIFF
--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -111,7 +111,7 @@ class Tab extends ImmutableComponent {
     const previewMode = new Date().getTime() - this.lastPreviewClearTime < 1500
     window.clearTimeout(this.hoverClearTimeout)
     this.hoverTimeout =
-      window.setTimeout(windowActions.setPreviewFrame.bind(null, this.props.frameProps), previewMode ? 0 : 400)
+      window.setTimeout(windowActions.setPreviewFrame.bind(null, this.props.frameProps), previewMode ? 200 : 400)
   }
 
   onClickTab (e) {


### PR DESCRIPTION
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.

I talked with Brad about this but I don't think this PR solves the problem fully, but adding a small delay could make it better. And by making the delay short it also doesn't make tabs lagging when slowly switching between them. 

Edit: Previously I added an enhancement [as requested by Brad here](https://github.com/brave/browser-laptop/pull/2644#issuecomment-234577026), but found a better solution that will be more suitable for another commit.