### PR TITLE
#323 - differentiate between external and internal navigation when hiding findbar

### DIFF
--- a/js/components/findbar.js
+++ b/js/components/findbar.js
@@ -69,9 +69,6 @@ class FindBar extends ImmutableComponent {
       // Redo search if details have changed
       this.onFindFirst()
     }
-    if (this.props.frame.get('location') !== prevProps.frame.get('location')) {
-      this.props.onFindHide()
-    }
   }
 
   onKeyDown (e) {

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -678,7 +678,11 @@ class Frame extends ImmutableComponent {
       // XXX: loadstart probably does not need to be called twice anymore.
       loadStart(e)
     })
+
     this.webview.addEventListener('did-navigate', (e) => {
+      if (this.props.frame.get('findbarShown')) {
+        this.onFindHide()
+      }
       for (let message in this.notificationCallbacks) {
         appActions.hideMessageBox(message)
       }


### PR DESCRIPTION
differentiate between external and internal navigation when hiding findbar

closes #323 
The code was moved from findbar.js to frame.js, as it is more logic for the frame to decide who closes him
I wanted originally use will-navigate as it is better to close the find dialog beforehands, but for some reason the event did not fire when using   this.webview.addEventListener('will-navigate'
So i used did-navigate. This means that the search box will be closed after the user navigated.

