### PR TITLE
In the url bar, behavior for delete button now matches backspace button.

### DIFF
--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -77,6 +77,16 @@ class UrlBar extends ImmutableComponent {
     windowActions.setNavBarUserInput(location)
   }
 
+  // Temporarily disable the autocomplete when a user is pressing backspace.
+  // Otherwise, they'd have to hit backspace twice for each character they wanted
+  // to delete.
+  hideAutoComplete () {
+    if (this.autocompleteEnabled) {
+      windowActions.setUrlBarAutocompleteEnabled(false)
+    }
+    windowActions.setUrlBarSuggestions(undefined, null)
+  }
+
   onKeyDown (e) {
     switch (e.keyCode) {
       case KeyCodes.ENTER:
@@ -156,16 +166,12 @@ class UrlBar extends ImmutableComponent {
             const suggestionLocation = this.props.activeFrameProps.getIn(['navbar', 'urlbar', 'suggestions', 'suggestionList', selectedIndex - 1]).location
             appActions.removeSite({ location: suggestionLocation })
           }
+        } else {
+          this.hideAutoComplete()
         }
         break
       case KeyCodes.BACKSPACE:
-        // Temporarily disable the autocomplete when a user is pressing backspace.
-        // Otherwise, they'd have to hit backspace twice for each characater they wanted
-        // to delete.
-        if (this.autocompleteEnabled) {
-          windowActions.setUrlBarAutocompleteEnabled(false)
-        }
-        windowActions.setUrlBarSuggestions(undefined, null)
+        this.hideAutoComplete()
         break
       default:
         // Any other keydown is fair game for autocomplete to be enabled.


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

In the url bar, behavior for delete button now matches backspace button.

(Shift+Delete to delete entry is not affected)

Fixes https://github.com/brave/browser-laptop/issues/2647