### PR TITLE
Extra polish for showing history on back/forward long press

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -2,9 +2,9 @@
 
 ## About tests
 
-Tests use the [mocha test frameowrk](https://mochajs.org/).
+Tests use the [mocha test framework](https://mochajs.org/).
 
-Most tests use [webdriver.io](http://webdriver.io/) to bring up the browser and run through the tests.
+Most tests use [webdriver.io](http://webdriver.io/) framework (via [Spectron](https://github.com/electron/spectron) to bring up the browser and run through the tests.
 
 Tests are located in the top level `test` directory and their filenames have a suffix of `Test.js`.
 

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -786,42 +786,44 @@ class Frame extends ImmutableComponent {
     this.webview.goBack()
   }
 
+  getHistoryEntry (sites, webContent, index) {
+    const url = webContent.getURLAtIndex(index)
+    const title = webContent.getTitleAtIndex(index)
+
+    let entry = {
+      index: index,
+      url: url,
+      display: title || url,
+      icon: null
+    }
+
+    if (url.startsWith('chrome-extension://')) {
+      // TODO: return brave lion (or better: get icon from extension if possible as data URI)
+    } else {
+      if (sites) {
+        const site = sites.find(function (element) { return element.get('location') === url })
+        if (site) { entry.icon = site.get('favicon') }
+      }
+
+      if (!entry.icon) { entry.icon = UrlUtil.getDefaultFaviconUrl(url) }
+    }
+
+    return entry
+  }
+
   getHistory (appState) {
     const webContent = this.webview.getWebContents()
-    const currentIndex = webContent.getCurrentEntryIndex()
     const historyCount = webContent.getEntryCount()
+    const sites = appState ? appState.get('sites') : null
 
     let history = {
       count: historyCount,
-      currentIndex: currentIndex,
+      currentIndex: webContent.getCurrentEntryIndex(),
       entries: []
     }
 
     for (let index = 0; index < historyCount; index++) {
-      const url = webContent.getURLAtIndex(index)
-      const title = webContent.getTitleAtIndex(index)
-      let favicon = null
-
-      if (url.startsWith('chrome-extension://')) {
-        // TODO: return brave lion (or better: get icon from extension if possible as data URI)
-      } else if (appState) {
-        const sites = appState.get('sites')
-
-        if (sites) {
-          const site = sites.find(function (element) { return element.get('location') === url })
-          if (site) { favicon = site.get('favicon') }
-        }
-
-        if (!favicon) { favicon = UrlUtil.getDefaultFaviconUrl(url) }
-      }
-
-      history.entries.push({
-        index: index,
-        url: url,
-        title: title,
-        display: title || url,
-        icon: favicon
-      })
+      history.entries.push(this.getHistoryEntry(sites, webContent, index))
     }
 
     return history

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -786,7 +786,7 @@ class Frame extends ImmutableComponent {
     this.webview.goBack()
   }
 
-  getHistory () {
+  getHistory (appState) {
     const webContent = this.webview.getWebContents()
     const currentIndex = webContent.getCurrentEntryIndex()
     const historyCount = webContent.getEntryCount()
@@ -800,13 +800,27 @@ class Frame extends ImmutableComponent {
     for (let index = 0; index < historyCount; index++) {
       const url = webContent.getURLAtIndex(index)
       const title = webContent.getTitleAtIndex(index)
+      let favicon = null
+
+      if (url.startsWith('chrome-extension://')) {
+        // TODO: return brave lion (or better: get icon from extension if possible as data URI)
+      } else if (appState) {
+        const sites = appState.get('sites')
+
+        if (sites) {
+          const site = sites.find(function (element) { return element.get('location') === url })
+          if (site) { favicon = site.get('favicon') }
+        }
+
+        if (!favicon) { favicon = UrlUtil.getDefaultFaviconUrl(url) }
+      }
 
       history.entries.push({
         index: index,
         url: url,
         title: title,
         display: title || url,
-        icon: UrlUtil.getDefaultFaviconUrl(url)
+        icon: favicon
       })
     }
 

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -453,7 +453,7 @@ class Main extends ImmutableComponent {
   }
 
   onBackLongPress (rect) {
-    contextMenus.onBackButtonHistoryMenu(this.activeFrame, this.activeFrame.getHistory(), rect)
+    contextMenus.onBackButtonHistoryMenu(this.activeFrame, this.activeFrame.getHistory(this.props.appState), rect)
   }
 
   onForward () {
@@ -461,7 +461,7 @@ class Main extends ImmutableComponent {
   }
 
   onForwardLongPress (rect) {
-    contextMenus.onForwardButtonHistoryMenu(this.activeFrame, this.activeFrame.getHistory(), rect)
+    contextMenus.onForwardButtonHistoryMenu(this.activeFrame, this.activeFrame.getHistory(this.props.appState), rect)
   }
 
   onBraveMenu () {

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -31,6 +31,7 @@ const textUtils = require('./lib/text')
 const {isIntermediateAboutPage, isUrl} = require('./lib/appUrlUtil')
 const {getBase64FromImageUrl} = require('./lib/imageUtil')
 const urlParse = require('url').parse
+const eventUtil = require('./lib/eventUtil')
 
 const isDarwin = process.platform === 'darwin'
 
@@ -1066,11 +1067,20 @@ function onBackButtonHistoryMenu (activeFrame, history, rect) {
 
   if (activeFrame && history) {
     for (let index = (history.currentIndex - 1); index > -1; index--) {
+      const url = history.entries[index].url
+
       menuTemplate.push({
         label: history.entries[index].display,
         icon: history.entries[index].icon,
-        click: (item, focusedWindow) => {
-          activeFrame.goToIndex(index)
+        click: (e, focusedWindow) => {
+          if (eventUtil.isForSecondaryAction(e)) {
+            windowActions.newFrame({
+              location: url,
+              partitionNumber: activeFrame.props.frame.get('partitionNumber')
+            }, !!e.shiftKey)
+          } else {
+            activeFrame.goToIndex(index)
+          }
         }
       })
     }
@@ -1088,11 +1098,20 @@ function onForwardButtonHistoryMenu (activeFrame, history, rect) {
 
   if (activeFrame && history) {
     for (let index = (history.currentIndex + 1); index < history.entries.length; index++) {
+      const url = history.entries[index].url
+
       menuTemplate.push({
         label: history.entries[index].display,
         icon: history.entries[index].icon,
-        click: (item, focusedWindow) => {
-          activeFrame.goToIndex(index)
+        click: (e, focusedWindow) => {
+          if (eventUtil.isForSecondaryAction(e)) {
+            windowActions.newFrame({
+              location: url,
+              partitionNumber: activeFrame.props.frame.get('partitionNumber')
+            }, !!e.shiftKey)
+          } else {
+            activeFrame.goToIndex(index)
+          }
         }
       })
     }

--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -2,7 +2,6 @@ require('babel-polyfill')
 var Application = require('spectron').Application
 var chai = require('chai')
 require('./coMocha')
-require('jsdom-global')()
 
 const path = require('path')
 const fs = require('fs')

--- a/test/unit/braveUnit.js
+++ b/test/unit/braveUnit.js
@@ -1,0 +1,1 @@
+require('jsdom-global')()

--- a/test/unit/lib/cryptoUtilTest.js
+++ b/test/unit/lib/cryptoUtilTest.js
@@ -1,6 +1,8 @@
 /* global describe, it */
-const CryptoUtil = require('../../js/lib/cryptoUtil')
+const CryptoUtil = require('../../../js/lib/cryptoUtil')
 const assert = require('assert')
+
+require('../braveUnit')
 
 describe('crypto util test', function () {
   it('gets random bytes', function () {

--- a/test/unit/lib/urlutilTest.js
+++ b/test/unit/lib/urlutilTest.js
@@ -1,7 +1,8 @@
 /* global describe, it */
-
-const UrlUtil = require('../../js/lib/urlutil')
+const UrlUtil = require('../../../js/lib/urlutil')
 const assert = require('assert')
+
+require('../braveUnit')
 
 describe('urlutil', function () {
   describe('getScheme', function () {

--- a/test/unit/state/frameStateUtilTest.js
+++ b/test/unit/state/frameStateUtilTest.js
@@ -1,9 +1,9 @@
-/* global describe, before, it */
-const frameStateUtil = require('../../js/state/frameStateUtil')
+/* global describe, before, it, beforeEach */
+const frameStateUtil = require('../../../js/state/frameStateUtil')
 const Immutable = require('immutable')
 const assert = require('assert')
 
-/*global beforeEach */
+require('../braveUnit')
 
 const defaultWindowStore = Immutable.fromJS({
   activeFrameKey: null,

--- a/tools/lib/ignoredPaths.js
+++ b/tools/lib/ignoredPaths.js
@@ -46,5 +46,6 @@ module.exports = [
   'flow-bin',
   'mkdirp',
   'babel$',
-  'babel-(?!polyfill|regenerator-runtime)'
+  'babel-(?!polyfill|regenerator-runtime)',
+  'jsdom-global'
 ]


### PR DESCRIPTION
- Back/Forward buttons now consider secondary actions (holding meta key, including honoring shift).
- History will attempt to load icons from appState if possible before defaulting favicon URL.
- Refactored getHistory method in Frame
- Organized unit test better; tried to write Frame unit tests but ran into complications :frowning: 