### PR TITLE
Disable toggle site settings when shield is down

### DIFF
--- a/js/components/braveryPanel.js
+++ b/js/components/braveryPanel.js
@@ -136,6 +136,9 @@ class BraveryPanel extends ImmutableComponent {
     ipc.emit(messages.SHORTCUT_NEW_FRAME, {}, config.fingerprintingInfoUrl)
   }
   onToggleSiteSetting (setting, e) {
+    if (setting !== 'shieldsUp' && !this.props.braverySettings.shieldsUp) {
+      return
+    }
     let ruleKey = siteUtil.getOrigin(this.props.activeRequestedLocation)
     const parsedUrl = urlParse(this.props.activeRequestedLocation)
     if (setting !== 'noScript' && (parsedUrl.protocol === 'https:' || parsedUrl.protocol === 'http:')) {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

fix #2797