### PR TITLE
Fix #2831. Remove intermediate pages from about page URLs

### DIFF
--- a/js/about/about.js
+++ b/js/about/about.js
@@ -4,7 +4,7 @@
 
 const React = require('react')
 const ImmutableComponent = require('../components/immutableComponent')
-const { aboutUrls } = require('../lib/appUrlUtil')
+const { aboutUrls, isIntermediateAboutPage }  = require('../lib/appUrlUtil')
 
 class AboutAbout extends ImmutableComponent {
   render () {
@@ -12,7 +12,7 @@ class AboutAbout extends ImmutableComponent {
       <h1 data-l10n-id='listOfAboutPages' />
       <ul>
       {
-      aboutUrls.keySeq().sort().map((aboutSourceUrl) =>
+      aboutUrls.keySeq().sort().filter((aboutSourceUrl) => !isIntermediateAboutPage(aboutSourceUrl)).map((aboutSourceUrl) =>
         <li>
           <a href={aboutUrls.get(aboutSourceUrl)} target='_blank'>
             {aboutSourceUrl}


### PR DESCRIPTION
- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

-- Filter intermediate pages from about page URLs