### PR TITLE
fix flickering effect between tabs. closes #2817

### DIFF
--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -107,12 +107,11 @@ class Tab extends ImmutableComponent {
     // relatedTarget inside mouseenter checks which element before this event was the pointer on
     // if this element has a tab-like class, then it's likely that the user was previewing
     // a sequency of tabs. Called here as previewMode.
-    const previewMode = /tab/i.test(e.relatedTarget.classList)
+    const previewMode = /tab(?!pages)/i.test(e.relatedTarget.classList)
 
     // If user isn't in previewMode, we add a bit of delay to avoid tab from flashing out
     // as reported here: https://github.com/brave/browser-laptop/issues/1434
-    this.hoverTimeout =
-      window.setTimeout(windowActions.setPreviewFrame.bind(null, this.props.frameProps), previewMode ? 200 : 400)
+    this.hoverTimeout = window.setTimeout(windowActions.setPreviewFrame.bind(null, this.props.frameProps), previewMode ? 0 : 200)
   }
 
   onClickTab (e) {

--- a/less/tabs.less
+++ b/less/tabs.less
@@ -10,7 +10,7 @@
   display: flex;
   flex: 1;
   overflow: auto;
-  padding: 0 4px 0 6px;
+  padding: 0 4px 0 0;
   height: @tabsToolbarHeight;
   position: relative;
   white-space: nowrap;
@@ -182,6 +182,15 @@
 
   &:not(.isPinned) {
     flex: 1;
+    &:first-child {
+      padding-left: 6px;
+    }
+  }
+
+  &.isPinned {
+    &:last-child {
+      padding-right: 6px;
+    }
   }
 
   &.draggingOverLeft {


### PR DESCRIPTION
**Preview:**

![tab_preview_fix](https://cloud.githubusercontent.com/assets/4672033/17299898/7f56499c-57e6-11e6-957a-49deceefef7a.gif)
