### PR TITLE
Add option to disable smooth scrolling

### DIFF
--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -79,6 +79,7 @@ bookmarkToolbarShowFavicon=Favicons
 bookmarkToolbarShowOnlyFavicon=Show only favicon
 contentSettings=Content Settings
 useHardwareAcceleration=Use hardware acceleration when available (requires browser restart)
+useSmoothScroll=Enable smooth scrolling (requires browser restart)
 defaultZoomLevel=Default zoom level
 en-US=English (U.S.)
 nl-NL=Dutch (Netherlands)

--- a/app/index.js
+++ b/app/index.js
@@ -186,9 +186,12 @@ let flashInitialized = false
 
 // Some settings must be set right away on startup, those settings should be handled here.
 loadAppStatePromise.then((initialState) => {
-  const { HARDWARE_ACCELERATION_ENABLED } = require('../js/constants/settings')
+  const { HARDWARE_ACCELERATION_ENABLED, SMOOTH_SCROLL_ENABLED } = require('../js/constants/settings')
   if (initialState.settings[HARDWARE_ACCELERATION_ENABLED] === false) {
     app.disableHardwareAcceleration()
+  }
+  if (initialState.settings[SMOOTH_SCROLL_ENABLED] === false) {
+    app.commandLine.appendSwitch('disable-smooth-scrolling')
   }
   if (initialState.flash && initialState.flash.enabled === true) {
     if (flash.init()) {

--- a/docs/state.md
+++ b/docs/state.md
@@ -156,6 +156,7 @@ AppStore
     'advanced.hardware-acceleration-enabled': boolean, // false if hardware acceleration should be explicitly disabled
     'advanced.default-zoom-level': number, // the default zoom level for sites that have no specific setting
     'advanced.pdfjs-enabled': boolean, // Whether or not to render PDF documents in the browser
+    'advanced.smooth-scroll-enabled': boolean, // false if smooth scrolling should be explicitly disabled
     'shutdown.clear-history': boolean, // true to clear history on shutdown
     'shutdown.clear-downloads': boolean, // true to clear downloads on shutdown
     'shutdown.clear-cache': boolean, // true to clear cache on shutdown

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -449,6 +449,7 @@ class AdvancedTab extends ImmutableComponent {
         </SettingItem>
         <SettingCheckbox dataL10nId='useHardwareAcceleration' prefKey={settings.HARDWARE_ACCELERATION_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
         <SettingCheckbox dataL10nId='usePDFJS' prefKey={settings.PDFJS_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
+        <SettingCheckbox dataL10nId='useSmoothScroll' prefKey={settings.SMOOTH_SCROLL_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
       </SettingsList>
     </div>
   }
@@ -608,7 +609,7 @@ class AboutPreferences extends React.Component {
     })
     aboutActions.changeSetting(key, value)
     if (key === settings.DO_NOT_TRACK || key === settings.HARDWARE_ACCELERATION_ENABLED ||
-      key === settings.PDFJS_ENABLED) {
+      key === settings.PDFJS_ENABLED || key === settings.SMOOTH_SCROLL_ENABLED) {
       ipc.send(messages.PREFS_RESTART)
     }
   }

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -110,6 +110,7 @@ module.exports = {
     'advanced.hardware-acceleration-enabled': true,
     'advanced.default-zoom-level': null,
     'advanced.pdfjs-enabled': true,
+    'advanced.smooth-scroll-enabled': true,
     'shutdown.clear-history': false,
     'shutdown.clear-downloads': false,
     'shutdown.clear-cache': false,

--- a/js/constants/settings.js
+++ b/js/constants/settings.js
@@ -43,7 +43,8 @@ const settings = {
   // Advanced settings
   HARDWARE_ACCELERATION_ENABLED: 'advanced.hardware-acceleration-enabled',
   PDFJS_ENABLED: 'advanced.pdfjs-enabled',
-  DEFAULT_ZOOM_LEVEL: 'advanced.default-zoom-level'
+  DEFAULT_ZOOM_LEVEL: 'advanced.default-zoom-level',
+  SMOOTH_SCROLL_ENABLED: 'advanced.smooth-scroll-enabled'
 }
 
 module.exports = settings


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fix #2795

Needs sign-off by someone on Windows/Linux; I don't think smooth scrolling can be disabled on macos

Auditors: @bbondy