### PR TITLE
Fixes #2839: Brave Linux packages configure correct MimeType and appl…

### DIFF
--- a/res/linuxPackaging.json
+++ b/res/linuxPackaging.json
@@ -1,6 +1,7 @@
 {
   "icon": "res/app.png",
   "section": "web",
-  "categories": ["Network"]
+  "categories": ["Network","WebBrowser"],
+  "mimeType": ["text/html", "text/xml", "application/xhtml_xml", "image/webp","x-scheme-handler/http", "x-scheme-handler/https", "x-scheme-handler/ftp"]
 }
 


### PR DESCRIPTION

- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.

- This fixes #2839 for Debian
- For Red Hat, our dependency electron-installer-redhat needs an update to make MimeType configurable
  (they need to make change similar the one in electron-installer-debian, https://github.com/unindented/electron-installer-debian/commit/70586c5dfeb25437839531c9141bf7b8c9b926de ).