### PR TITLE
Fixes #2913: Closing an inactive tab should not change the active tab

### DIFF
--- a/js/actions/windowActions.js
+++ b/js/actions/windowActions.js
@@ -13,6 +13,7 @@ const siteTags = require('../constants/siteTags')
 const siteUtil = require('../state/siteUtil')
 const UrlUtil = require('../lib/urlutil')
 const currentWindow = require('../../app/renderer/currentWindow')
+const windowStore = require('../stores/windowStore')
 
 function dispatch (action) {
   AppDispatcher.dispatch(action)
@@ -335,7 +336,11 @@ const windowActions = {
         return
       }
 
-      if (!forceClosePinned) {
+      const frameKey = frameProps ? frameProps.get('key') : null
+      const activeFrameKey = windowStore.getState().get('activeFrameKey')
+      const isActiveFrame = frameKey === activeFrameKey
+
+      if (!forceClosePinned && isActiveFrame) {
         // Go to next frame if the user tries to close a pinned tab
         ipc.emit(messages.SHORTCUT_NEXT_TAB)
         return
@@ -677,7 +682,7 @@ const windowActions = {
    * @param {Object} frameToSkip - Properties of the frame to keep audio
    */
   muteAllAudioExcept: function (frameToSkip) {
-    let framePropsList = require('../stores/windowStore').getState().get('frames')
+    let framePropsList = windowStore.getState().get('frames')
 
     framePropsList.forEach((frameProps) => {
       if (frameProps.get('key') !== frameToSkip.get('key') && frameProps.get('audioPlaybackActive') && !frameProps.get('audioMuted')) {

--- a/js/state/frameStateUtil.js
+++ b/js/state/frameStateUtil.js
@@ -439,16 +439,25 @@ function removeFrame (frames, tabs, closedFrames, frameProps, activeFrameKey) {
       closedFrames = closedFrames.shift()
     }
   }
-  let activeFrameIndex = findIndexForFrameKey(frames, frameProps.get('parentFrameKey'))
-  if (activeFrameIndex === -1) {
+
+  // If the frame being removed IS ACTIVE, then try to replace activeFrameKey with parentFrameKey
+  let isActiveFrameBeingRemoved = frameProps.get('key') === activeFrameKey
+
+  let parentFrameIndex = findIndexForFrameKey(frames, frameProps.get('parentFrameKey'))
+  let activeFrameIndex
+
+  if (!isActiveFrameBeingRemoved || parentFrameIndex === -1) {
     activeFrameIndex = findIndexForFrameKey(frames, activeFrameKey)
+  } else {
+    activeFrameIndex = parentFrameIndex
   }
+
   const framePropsIndex = getFramePropsIndex(frames, frameProps)
   frames = frames.splice(framePropsIndex, 1)
   tabs = tabs.splice(framePropsIndex, 1)
 
   let newActiveFrameKey = activeFrameKey
-  if (frameProps.get('key') === activeFrameKey && frames.size > 0) {
+  if (isActiveFrameBeingRemoved && frames.size > 0) {
     // Frame with focus was closed; let's find new active NON-PINNED frame.
     newActiveFrameKey = getNewActiveFrame(activeFrameIndex)
   }

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -396,9 +396,10 @@ const doAction = (action) => {
       const frameProps = action.frameProps || FrameStateUtil.getActiveFrame(windowState)
       const closingActive = !action.frameProps || action.frameProps === FrameStateUtil.getActiveFrame(windowState)
       const index = FrameStateUtil.getFramePropsIndex(windowState.get('frames'), frameProps)
+      const activeFrameKey = FrameStateUtil.getActiveFrame(windowState).get('key')
       windowState = windowState.merge(FrameStateUtil.removeFrame(windowState.get('frames'), windowState.get('tabs'),
         windowState.get('closedFrames'), frameProps.set('closedAtIndex', index),
-        frameProps.get('key')))
+        activeFrameKey))
       if (closingActive) {
         updateTabPageIndex(FrameStateUtil.getActiveFrame(windowState))
       }


### PR DESCRIPTION
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.

