### PR TITLE
Fixes #2926 - Notification bar (restart dialog) for crashes does not dismiss

### DIFF
--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -338,11 +338,16 @@ const handleAppAction = (action) => {
       mainWindow.webContents.on('crashed', (e) => {
         console.error('Window crashed. Reloading...')
         mainWindow.loadURL(appUrlUtil.getIndexHTML())
-        ipcMain.once(messages.NOTIFICATION_RESPONSE, (e, message, buttonIndex, persist) => {
+
+        function notificationResponseCallback (e, message, buttonIndex, persist) {
           if (message === locale.translation('unexpectedErrorWindowReload')) {
             appActions.hideMessageBox(message)
+          } else {
+            ipcMain.once(messages.NOTIFICATION_RESPONSE, notificationResponseCallback)
           }
-        })
+        }
+        ipcMain.once(messages.NOTIFICATION_RESPONSE, notificationResponseCallback)
+
         appActions.showMessageBox({
           buttons: [locale.translation('ok')],
           options: {


### PR DESCRIPTION
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.