### PR TITLE
Remove remaining getZoomValuePercentage

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -708,9 +708,6 @@ class Frame extends ImmutableComponent {
       }
     }
     this.webview.addEventListener('load-commit', (e) => {
-      // TODO: This is a temporary hack for zoom in 0.11.2.
-      // The code is being reworked to avoid in/out/in zoom effects.
-      this.webview.setZoomFactor(getZoomValuePercentage(this.zoomLevel) / 100)
       loadStart(e)
     })
     this.webview.addEventListener('load-start', (e) => {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

fix #2925