### PR TITLE
Update crash URL to point to Heroku endpoint

### DIFF
--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -6,7 +6,7 @@ const { getTargetAboutUrl } = require('../lib/appUrlUtil')
 // BRAVE_UPDATE_HOST should be set to the host name for the auto-updater server
 const updateHost = process.env.BRAVE_UPDATE_HOST || 'https://brave-laptop-updates.global.ssl.fastly.net'
 const winUpdateHost = process.env.BRAVE_WIN_UPDATE_HOST || 'https://brave-download.global.ssl.fastly.net'
-const crashURL = process.env.BRAVE_CRASH_URL || 'https://laptop-updates.brave.com/1/crashes'
+const crashURL = process.env.BRAVE_CRASH_URL || 'https://brave-laptop-updates.herokuapp.com/1/crashes'
 const adHost = process.env.AD_HOST || 'https://oip.brave.com'
 
 module.exports = {


### PR DESCRIPTION
  * This change will point the crash client directly at the Heroku instance recording crashes.
  * Tested on macOS and Windows.
