### PR TITLE
fix urlbar escape tests and behavior

### DIFF
--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -250,9 +250,13 @@ class UrlBar extends ImmutableComponent {
   }
 
   onActiveFrameStop () {
-    this.restore()
-    windowActions.setUrlBarSelected(true)
-    windowActions.setUrlBarActive(false)
+    if (this.isFocused()) {
+      windowActions.setUrlBarActive(false)
+      if (!this.shouldRenderUrlBarSuggestions) {
+        this.restore()
+        windowActions.setUrlBarSelected(true)
+      }
+    }
   }
 
   componentWillMount () {

--- a/test/components/navigationBarTest.js
+++ b/test/components/navigationBarTest.js
@@ -445,14 +445,52 @@ describe('navigationBar', function () {
       })
     })
 
-    describe('escape', function * () {
+    describe('type escape once', function () {
       before(function * () {
-        yield this.app.client.ipcSend('shortcut-active-frame-stop')
+        this.page = Brave.server.url('page1.html')
+        return yield this.app.client
+          .tabByIndex(0)
+          .loadUrl(this.page)
+          .windowByUrl(Brave.browserWindowUrl)
+          .ipcSend('shortcut-focus-url')
+          .waitForElementFocus(urlInput)
+          .setValue(urlInput, 'blah')
+          // hit escape
+          .keys('\uE00C')
+          .waitForElementFocus(urlInput)
       })
 
-      it('reverts typing on escape', function * () {
-        yield this.app.client.getValue(urlInput).should.eventually.be.equal(config.defaultUrl)
-        yield selectsText(this.app.client)
+      it('does not select the urlbar text', function * () {
+        yield selectsText(this.app.client, '')
+      })
+
+      it('does not revert the urlbar text', function * () {
+        yield this.app.client.getValue(urlInput).should.eventually.be.equal('blah')
+      })
+    })
+
+    describe('type escape twice', function () {
+      before(function * () {
+        this.page = Brave.server.url('page1.html')
+        return yield this.app.client
+          .tabByIndex(0)
+          .loadUrl(this.page)
+          .windowByUrl(Brave.browserWindowUrl)
+          .ipcSend('shortcut-focus-url')
+          .waitForElementFocus(urlInput)
+          .setValue(urlInput, 'blah')
+          // hit escape
+          .keys('\uE00C')
+          .waitForElementFocus(urlInput)
+          .keys('\uE00C')
+      })
+
+      it('selects the urlbar text', function * () {
+        yield selectsText(this.app.client, this.page)
+      })
+
+      it('sets the urlbar text to the webview src', function * () {
+        yield this.app.client.getValue(urlInput).should.eventually.be.equal(this.page)
       })
     })
 
@@ -641,12 +679,6 @@ describe('navigationBar', function () {
         yield selectsText(this.app.client, '')
       })
     })
-  })
-
-  describe('escape', function () {
-    it('sets the urlbar text to the webview src')
-
-    it('selects the urlbar text')
   })
 
   describe('shortcut-focus-url', function () {

--- a/test/components/urlBarSuggestionsTest.js
+++ b/test/components/urlBarSuggestionsTest.js
@@ -30,6 +30,20 @@ describe('urlbarSuggestions', function () {
       .waitForElementFocus(urlInput)
   })
 
+  it('deactivates suggestions on escape', function * () {
+    yield this.app.client.ipcSend('shortcut-focus-url')
+      .waitForElementFocus(urlInput)
+      .setValue(urlInput, 'Page 1')
+      .waitUntil(function () {
+        return this.getValue(urlInput).then((val) => val === 'Page 1')
+      })
+      .waitForExist(urlBarSuggestions)
+      .keys('\uE00C')
+      .waitUntil(function () {
+        return this.isExisting(urlBarSuggestions).then((exists) => exists === false)
+      })
+  })
+
   it('navigates to a suggestion when clicked', function * () {
     yield this.app.client.ipcSend('shortcut-focus-url')
       .waitForElementFocus(urlInput)


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

fixes #2914
related #2920
cc @bbondy @willy-b