### PR TITLE
Fixes #3068 Implements 'Switch to new tabs immediately' setting'

### DIFF
--- a/js/about/aboutActions.js
+++ b/js/about/aboutActions.js
@@ -52,7 +52,7 @@ const AboutActions = {
    * It is important that it is not a simple anchor because it should not
    * preserve the about preload script. See #672
    */
-  newFrame: function (frameOpts, openInForeground = true) {
+  newFrame: function (frameOpts, openInForeground) {
     ipc.sendToHost(messages.NEW_FRAME, frameOpts, openInForeground)
   },
 

--- a/js/components/window.js
+++ b/js/components/window.js
@@ -42,10 +42,10 @@ class Window extends React.Component {
       if (this.props.frames.length === 0) {
         windowActions.newFrame({
           location: config.defaultUrl
-        })
+        }, true)
       } else {
         this.props.frames.forEach((frame) => {
-          windowActions.newFrame(frame)
+          windowActions.newFrame(frame, true)
         })
       }
     }

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -14,6 +14,7 @@ const messages = require('../constants/messages')
 const debounce = require('../lib/debounce.js')
 const getSetting = require('../settings').getSetting
 const importFromHTML = require('../lib/importer').importFromHTML
+const AppUrlUtil = require('../lib/appUrlUtil')
 const UrlUtil = require('../lib/urlutil')
 const urlParse = require('url').parse
 const currentWindow = require('../../app/renderer/currentWindow')
@@ -158,11 +159,9 @@ const newFrame = (frameOpts, openInForeground) => {
   if (frameOpts === undefined) {
     frameOpts = {}
   }
-  if (openInForeground === undefined) {
-    openInForeground = true
-  }
+
   frameOpts.location = frameOpts.location || config.defaultUrl
-  if (frameOpts.location && UrlUtil.isURL(frameOpts.location)) {
+	if (frameOpts.location && UrlUtil.isURL(frameOpts.location)) {
     frameOpts.location = UrlUtil.getUrlFromInput(frameOpts.location)
   } else {
     const defaultURL = windowStore.getState().getIn(['searchDetail', 'searchURL'])
@@ -173,6 +172,14 @@ const newFrame = (frameOpts, openInForeground) => {
       // Bad URLs passed here can actually crash the browser
       frameOpts.location = ''
     }
+  }
+
+  if (openInForeground === undefined || openInForeground === null) {
+    openInForeground = getSetting(settings.SWITCH_TO_NEW_TABS)
+		// About urls (expect about:newtab) should open in foreground 
+		if(!openInForeground && AppUrlUtil.isSourceAboutUrl(frameOpts.location) && frameOpts.location !== 'about:newtab') {
+			openInForeground = true
+		}
   }
 
   const nextKey = incrementNextKey()


### PR DESCRIPTION
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

1. Added functionality for the 'Switch to new tab immediately' setting
2. Applied setting to work for redirects from about:bookmarks page
3. Added condition to ignore pages starting with 'about:' except 'about:newtab'