### PR TITLE
Focus not set to active tab/tabset when second tabset is closed Fix #…

### DIFF
--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -395,13 +395,16 @@ const doAction = (action) => {
     case WindowConstants.WINDOW_CLOSE_FRAME:
       // Use the frameProps we passed in, or default to the active frame
       const frameProps = action.frameProps || FrameStateUtil.getActiveFrame(windowState)
-      const closingActive = !action.frameProps || action.frameProps === FrameStateUtil.getActiveFrame(windowState)
       const index = FrameStateUtil.getFramePropsIndex(windowState.get('frames'), frameProps)
       const activeFrameKey = FrameStateUtil.getActiveFrame(windowState).get('key')
       windowState = windowState.merge(FrameStateUtil.removeFrame(windowState.get('frames'), windowState.get('tabs'),
         windowState.get('closedFrames'), frameProps.set('closedAtIndex', index),
         activeFrameKey))
-      if (closingActive) {
+      let totalOpenTabs = windowState.get('frames').filter((frame) => !frame.get('pinnedLocation')).size
+
+      // If we reach the limit of opened tabs per page while closing tabs, switch to 
+      // the active tab's page otherwise the user will hang on empty page
+      if ((totalOpenTabs % getSetting(settings.TABS_PER_PAGE)) === 0) {
         updateTabPageIndex(FrameStateUtil.getActiveFrame(windowState))
       }
       break

--- a/test/components/tabPagesTest.js
+++ b/test/components/tabPagesTest.js
@@ -46,6 +46,10 @@ describe('tab pages', function () {
         })
     })
 
+    it('focuses active tab\'s page when closing last tab on page', function * () {
+      yield this.app.client.waitForVisible('.tab.active')
+    })
+
     describe('allows changing to tab pages', function () {
       before(function * () {
         // Make sure there are 2 tab pages


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist. #3092
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

…3092