### PR TITLE
On new tab don't clear URL bar

### DIFF
--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -302,7 +302,12 @@ const doAction = (action) => {
           title: ''
         })
       }
-      updateNavBarInput(action.location, frameStatePath(key))
+
+      // Update nav bar unless when spawning a new tab. The user might have
+      // typed in the URL bar while we were navigating -- we should preserve it.
+      if (!(action.location === 'about:newtab' && !FrameStateUtil.getActiveFrame(windowState).get('canGoForward'))) {
+        updateNavBarInput(action.location, frameStatePath(key))
+      }
       break
     case WindowConstants.WINDOW_SET_NAVBAR_INPUT:
       updateNavBarInput(action.location)


### PR DESCRIPTION
Fix #2197
Fix #2812

Adds a check in windowStore.js WINDOW_SET_NAVIGATED for new tab.

I'm not sure if this is a legit way to check for a new tab, but it fixes the problem for me :)