### PR TITLE
No need for .mem file in .gitignore anymore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,3 @@ httpse.sqlite
 
 # vim swap files
 *.swp
-
-# node-anonize2-relic-emscripten
-anonize2.js.mem


### PR DESCRIPTION
As of brave/node-anonize2-relic-emscripten#1 we
shouldn't need this anymore.

Auditors: @mrose17

PR for ledger-delta