### PR TITLE
Padding next to Brave logo- gives extra drag area on smaller windows

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -94,7 +94,7 @@
 
     .braveMenu {
       width: @navbarBraveButtonWidth;
-      margin-left: @navbarButtonSpacing;
+      margin-left: @navbarBraveButtonMarginLeft;
       margin-right: @navbarButtonSpacing;
       -webkit-app-region: no-drag;
       -webkit-user-select: none;

--- a/less/variables.less
+++ b/less/variables.less
@@ -49,9 +49,9 @@
 @switchBG_dis: #e8e8e8;
 @switchHeight: 16px;
 @switchWidth: 45px;
-@switchRadius: 10px; 
+@switchRadius: 10px;
 @switchShadow: inset 0 1px 4px rgba(0, 0, 0, 0.35);
-@switchNubDiameter: 12px; 
+@switchNubDiameter: 12px;
 @switchNubTopMargin: 2px;
 @switchNubLeftMargin: 2px;
 @switchNubRightMargin: 2px;
@@ -68,6 +68,7 @@
 @navbarButtonSpacing: 4px;
 @navbarButtonWidth: 35px;
 @navbarBraveButtonWidth: 23px;
+@navbarBraveButtonMarginLeft: 80px;
 @navbarLeftMarginDarwin: 70px;
 
 @carotRadius: 8px;


### PR DESCRIPTION
Added spacing left of Brave icon, per Brad's suggestion. Adds more draggable area when the window is smaller (when the URL bar takes up most of the window)