### PR TITLE
Whitespace in url fixes #3167

### DIFF
--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -106,9 +106,7 @@ class UrlBar extends ImmutableComponent {
           // Filter javascript URLs to prevent self-XSS
           location = location.replace(/^(\s*javascript:)+/i, '')
           const isLocationUrl = isUrl(location)
-          // If control key is pressed and input has no space in it add www. as a prefix and .com as a suffix.
-          // For whitepsace we want a search no matter what.
-          if (!isLocationUrl && !/\s/g.test(location) && e.ctrlKey) {
+          if (!isLocationUrl && e.ctrlKey) {
             windowActions.loadUrl(this.activeFrame, `www.${location}.com`)
           } else if (this.shouldRenderUrlBarSuggestions && (this.urlBarSuggestions.activeIndex > 0 || this.props.locationValueSuffix)) {
             // Hack to make alt enter open a new tab for url bar suggestions when hitting enter on them.

--- a/js/lib/appUrlUtil.js
+++ b/js/lib/appUrlUtil.js
@@ -130,7 +130,7 @@ module.exports.isTargetAboutUrl = function (input) {
  */
 module.exports.isUrl = function (input) {
   input = input.trim()
-  return UrlUtil.isURL(input) && !/\s/g.test(input)
+  return UrlUtil.isURL(input)
 }
 
 /**

--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -91,28 +91,38 @@ const UrlUtil = {
       return true
     }
 
+    // for cases where we have scheme and we dont want spaces in domain names
+    const caseDomain = /^[\w]{2,5}:\/\/[^\s\/]+\//
     // for cases, quoted strings
     const case1Reg = /^".*"$/
     // for cases, ?abc and "a? b" which should searching query
     const case2Reg = /^(\?)|(\?.+\s)/
     // for cases, pure string
     const case3Reg = /[\?\.\/\s:]/
-    // for cases, data:uri and view-source:uri
-    const case4Reg = /^\w+:.*/
+    // for cases, data:uri, view-source:uri and about
+    const case4Reg = /^data|view-source|about|chrome-extension:.*/
 
     let str = input.trim()
+    let scheme = this.getScheme(str)
+
     if (str.toLowerCase() === 'localhost') {
       return false
     }
+
     if (case1Reg.test(str)) {
       return true
     }
+
     if (case2Reg.test(str) || !case3Reg.test(str) ||
-        this.getScheme(str) === str) {
+        (scheme === undefined && /\s/g.test(str))) {
       return true
     }
     if (case4Reg.test(str)) {
       return !this.canParseURL(str)
+    }
+
+    if (scheme && (scheme !== 'file://')) {
+      return !caseDomain.test(str + '/')
     }
 
     str = this.prependScheme(str)

--- a/test/unit/lib/urlutilTest.js
+++ b/test/unit/lib/urlutilTest.js
@@ -57,6 +57,24 @@ describe('urlutil', function () {
     it('returns true when input is a pure string (no TLD)', function () {
       assert.equal(UrlUtil.isNotURL('brave'), true)
     })
+    it('returns false when input is a string with whitespace but has schema', function () {
+      assert.equal(UrlUtil.isNotURL('https://wwww.brave.com/test space.jpg'), false)
+    })
+    it('returns true when input is a string with schema but invalid domain name', function () {
+      assert.equal(UrlUtil.isNotURL('https://www.bra ve.com/test space.jpg'), true)
+    })
+    it('returns true when input contains more than one word', function () {
+      assert.equal(UrlUtil.isNotURL('brave is cool'), true)
+    })
+    it('returns false when input has custom protocol', function () {
+      assert.equal(UrlUtil.isNotURL('brave://test'), false)
+    })
+    it('returns true when input has space in schema', function () {
+      assert.equal(UrlUtil.isNotURL('https ://brave.com'), true)
+    })
+    it('returns false when input is chrome-extension', function () {
+      assert.equal(UrlUtil.isNotURL('chrome-extension://fmfcbgogabcbclcofgocippekhfcmgfj/cast_sender.js'), false)
+    })
     describe('search query', function () {
       it('returns true when input starts with ?', function () {
         assert.equal(UrlUtil.isNotURL('?brave'), true)


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist. #3167 
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

cc @bbondy @bridiver @bsclifton 

This PR allows to open valid URLs whith whitespace in it such as 

`https://s10.postimg.org/snp1s3aah/Screenshot+from 2016-08-13 17-50-27.png`

The original behaviour to query the search engine is preserved if you type a word or set of words. But if the string starts with scheme, no matter it has whitespace in it it will try to load the url.

What is the behaviour now?

| String typed in the url bar        | Before                  | Now                     |
|-----------------------------------|-------------------------|-------------------------|
| google.com                        | open https://google.com | open https://google.com |
| test                              | searches for test       | searches for test       |
| test test                         | searches for test test  | searches for test test  |
| `http://example.com/test image.jpg` | searches for `http://example.com/test image.jpg` via default search engine         | opens `http://example.com/test image.jpg`           |

