### PR TITLE
Update tab title on back/forward fixes #3200

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -764,6 +764,7 @@ class Frame extends ImmutableComponent {
       if (this.props.findbarShown) {
         this.onFindHide()
       }
+
       for (let message in this.notificationCallbacks) {
         appActions.hideMessageBox(message)
       }
@@ -773,6 +774,10 @@ class Frame extends ImmutableComponent {
         this.webview.focus()
       }
       windowActions.setNavigated(e.url, this.props.frameKey, false)
+      // After navigating to the URL, set correct frame title
+      let webContents = this.webview.getWebContents()
+      let title = webContents.getTitleAtIndex(webContents.getCurrentEntryIndex())
+      windowActions.setFrameTitle(this.frame, title)
     })
     this.webview.addEventListener('crashed', (e) => {
       windowActions.setFrameError(this.frame, {

--- a/test/components/tabTest.js
+++ b/test/components/tabTest.js
@@ -3,7 +3,7 @@
 const Brave = require('../lib/brave')
 const messages = require('../../js/constants/messages')
 const settings = require('../../js/constants/settings')
-const {urlInput} = require('../lib/selectors')
+const {urlInput, backButton, forwardButton, activeTabTitle} = require('../lib/selectors')
 
 describe('tabs', function () {
   function * setup (client) {
@@ -14,6 +14,48 @@ describe('tabs', function () {
       .waitForVisible('#window')
       .waitForVisible(urlInput)
   }
+
+  describe('back forward actions', function () {
+    Brave.beforeAll(this)
+    before(function * () {
+      yield setup(this.app.client)
+    })
+
+    it('sets correct title', function * () {
+      var page1 = Brave.server.url('page1.html')
+      var page2 = Brave.server.url('page2.html')
+
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(page1)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitUntil(function () {
+          return this.getText(activeTabTitle)
+            .then((title) => title === 'Page 1')
+        })
+        .tabByIndex(0)
+        .loadUrl(page2)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitUntil(function () {
+          return this.getText(activeTabTitle)
+            .then((title) => title === 'Page 2')
+        })
+        .click(backButton)
+        .waitForUrl(page1)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitUntil(function () {
+          return this.getText(activeTabTitle)
+            .then((title) => title === 'Page 1')
+        })
+        .click(forwardButton)
+        .waitForUrl(page2)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitUntil(function () {
+          return this.getText(activeTabTitle)
+            .then((title) => title === 'Page 2')
+        })
+    })
+  })
 
   describe('new tab signal', function () {
     Brave.beforeAll(this)

--- a/test/lib/selectors.js
+++ b/test/lib/selectors.js
@@ -2,6 +2,7 @@ module.exports = {
   urlInput: '#urlInput',
   activeWebview: '.frameWrapper.isActive webview',
   activeTab: '.tab.active',
+  activeTabTitle: '.tab.active .tabTitle',
   activeTabFavicon: '.tab.active .tabIcon',
   pinnedTabs: '.pinnedTabs',
   pinnedTabsTabs: '.pinnedTabs .tab',


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist. #3200 
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

The `page-title-updated` event on webview is not triggered when invoking back/forward actions. This PR adds ipc message that makes sure window data such as title is always sent back to electron, so it can be properly updated when the page changes.

Reviewers: @bbondy @bridiver @bsclifton @diracdeltas 

