### PR TITLE
Fix secondary actions

### DIFF
--- a/js/lib/eventUtil.js
+++ b/js/lib/eventUtil.js
@@ -3,11 +3,10 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const isDarwin = process.platform === 'darwin'
-module.exports.isForSecondaryAction = (e) => {
+module.exports.isForSecondaryAction = (e) =>
   e.ctrlKey && !isDarwin ||
   e.metaKey && isDarwin ||
   e.button === 1
-}
 
 module.exports.eventElHasAncestorWithClasses = (e, classesToCheck) => {
   let node = e.target


### PR DESCRIPTION
Fix secondary actions. Adding the parens breaks this method (causing all secondary actions to fail)

Inadvertently introduced with https://github.com/brave/browser-laptop/pull/3225

Auditors: @bbondy