### PR TITLE
History follow up

### DIFF
--- a/app/browser/lib/menuUtil.js
+++ b/app/browser/lib/menuUtil.js
@@ -3,12 +3,12 @@
 
 'use strict'
 
-const CommonMenu = require('../commonMenu')
-const messages = require('../constants/messages')
-const siteTags = require('../constants/siteTags')
-const eventUtil = require('./eventUtil')
-const siteUtil = require('../state/siteUtil')
-const locale = require('../../app/locale')
+const CommonMenu = require('../../common/commonMenu')
+const messages = require('../../../js/constants/messages')
+const siteTags = require('../../../js/constants/siteTags')
+const eventUtil = require('../../../js/lib/eventUtil')
+const siteUtil = require('../../../js/state/siteUtil')
+const locale = require('../../locale')
 
 // States which can trigger dynamic menus to change
 let lastSettingsState, lastSites, lastClosedFrames

--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -6,17 +6,17 @@
 
 const Immutable = require('immutable')
 const electron = require('electron')
-const appConfig = require('../js/constants/appConfig')
+const appConfig = require('../../js/constants/appConfig')
 const Menu = electron.Menu
 const MenuItem = electron.MenuItem
-const messages = require('../js/constants/messages')
-const settings = require('../js/constants/settings')
+const messages = require('../../js/constants/messages')
+const settings = require('../../js/constants/settings')
 const dialog = electron.dialog
-const appActions = require('../js/actions/appActions')
-const menuUtil = require('../js/lib/menuUtil')
-const getSetting = require('../js/settings').getSetting
-const locale = require('./locale')
-const {isSiteBookmarked} = require('../js/state/siteUtil')
+const appActions = require('../../js/actions/appActions')
+const menuUtil = require('./lib/menuUtil')
+const getSetting = require('../../js/settings').getSetting
+const locale = require('../locale')
+const {isSiteBookmarked} = require('../../js/state/siteUtil')
 const isDarwin = process.platform === 'darwin'
 const aboutUrl = 'https://brave.com/'
 
@@ -618,7 +618,7 @@ const updateMenu = (CommonMenu, appState, windowData) => {
  * @param {Object} appState - Application state. Used to fetch bookmarks and settings (like homepage)
  * @param {Object} windowData - Information specific to the current window (recently closed tabs, etc)
  */
-module.exports.init = (appState, windowData) => {
+module.exports.rebuild = (appState, windowData) => {
   // The menu will always be called once localization is done
   // so don't bother loading anything until it is done.
   if (!locale.initialized) {
@@ -626,7 +626,7 @@ module.exports.init = (appState, windowData) => {
   }
 
   // This needs to be within the init method to handle translations
-  const CommonMenu = require('../js/commonMenu')
+  const CommonMenu = require('../common/commonMenu')
   if (appMenu.items.length === 0) {
     createMenu(CommonMenu)
   } else {

--- a/app/common/commonMenu.js
+++ b/app/common/commonMenu.js
@@ -4,13 +4,13 @@
 
 'use strict'
 
-const appConfig = require('./constants/appConfig')
-const appActions = require('../js/actions/appActions')
-const messages = require('../js/constants/messages')
+const appConfig = require('../../js/constants/appConfig')
+const appActions = require('../../js/actions/appActions')
+const messages = require('../../js/constants/messages')
 const Immutable = require('immutable')
-const locale = require('../js/l10n')
-const settings = require('./constants/settings')
-const getSetting = require('./settings').getSetting
+const locale = require('../../js/l10n')
+const settings = require('../../js/constants/settings')
+const getSetting = require('../../js/settings').getSetting
 const issuesUrl = 'https://github.com/brave/browser-laptop/issues'
 const isDarwin = process.platform === 'darwin'
 

--- a/app/extensions/brave/locales/en-US/menu.properties
+++ b/app/extensions/brave/locales/en-US/menu.properties
@@ -93,6 +93,7 @@ editFolder=Edit Folder...
 editBookmark=Edit Bookmark...
 deleteFolder=Delete Folder
 deleteBookmark=Delete Bookmark
+deleteHistoryEntry=Delete History Entry
 stop=Stop
 clone=Clone
 reloadTab=Reload

--- a/app/locale.js
+++ b/app/locale.js
@@ -48,6 +48,7 @@ var rendererIdentifiers = function () {
     'unpinTab',
     'deleteFolder',
     'deleteBookmark',
+    'deleteHistoryEntry',
     'editFolder',
     'editBookmark',
     'unmuteTabs',

--- a/js/about/bookmarks.js
+++ b/js/about/bookmarks.js
@@ -18,6 +18,7 @@ const ipc = window.chrome.ipc
 
 // Stylesheets
 require('../../less/about/itemList.less')
+require('../../less/about/siteDetails.less')
 require('../../less/about/bookmarks.less')
 require('../../node_modules/font-awesome/css/font-awesome.css')
 
@@ -179,7 +180,7 @@ class BookmarkFolderList extends ImmutableComponent {
 
 class BookmarksList extends ImmutableComponent {
   render () {
-    return <list className='bookmarkList'>
+    return <list className='siteDetailsList'>
     {
       this.props.bookmarks.map((bookmark) =>
         <BookmarkItem bookmark={bookmark} />)
@@ -203,7 +204,7 @@ class SearchResults extends React.Component {
     })
 
     return (
-      <list className='bookmarkList'>
+      <list className='siteDetailsList'>
       {
         sortedBookmarks.map((bookmark, idx) => <BookmarkItem bookmark={bookmark} inSelectedFolder={selectedFolderIndex.get(idx)} />)
       }
@@ -254,13 +255,13 @@ class AboutBookmarks extends React.Component {
     })
   }
   render () {
-    return <div className='bookmarksPage'>
+    return <div className='siteDetailsPage'>
       <h2 data-l10n-id='folders' />
       <input type='text' className='searchInput' id='bookmarkSearch' value={this.state.search} onChange={this.onChangeSearch} data-l10n-id='bookmarkSearch' />
       {this.state.search
         ? <span onClick={this.onClearSearchText} className='fa fa-close searchInputClear'></span>
         : null}
-      <div className='bookmarkPageContent'>
+      <div className='siteDetailsPageContent'>
         <Sticky enabled top={10}>
           <BookmarkFolderList onChangeSelectedFolder={this.onChangeSelectedFolder}
             bookmarkFolders={this.state.bookmarkFolders.filter((bookmark) => bookmark.get('parentFolderId') === -1)}

--- a/js/about/history.js
+++ b/js/about/history.js
@@ -50,15 +50,13 @@ class HistoryItem extends ImmutableComponent {
       data-context-menu-disable
       onDoubleClick={this.navigate.bind(this)}>
     {
-      this.props.history.get('customTitle') || this.props.history.get('title') || this.props.history.get('location')
+      this.props.history.get('customTitle') || this.props.history.get('title')
       ? <span className='aboutListItem' title={this.props.history.get('location')}>
-        <span className='aboutItemDate'>{new Date(this.props.history.get('lastAccessedTime')).toLocaleDateString()}</span>
         <span className='aboutItemTitle'>{this.props.history.get('customTitle') || this.props.history.get('title')}</span>
         {partitionNumberInfo}
         <span className='aboutItemSeparator'>-</span><span className='aboutItemLocation'>{this.props.history.get('location')}</span>
       </span>
       : <span className='aboutListItem' title={this.props.history.get('location')}>
-        <span className='aboutItemDate'>{new Date(this.props.history.get('lastAccessedTime')).toLocaleDateString()}</span>
         <span>{this.props.history.get('location')}</span>
         {partitionNumberInfo}
       </span>

--- a/js/about/history.js
+++ b/js/about/history.js
@@ -14,6 +14,7 @@ const ipc = window.chrome.ipc
 
 // Stylesheets
 require('../../less/about/itemList.less')
+require('../../less/about/siteDetails.less')
 require('../../less/about/history.less')
 require('../../node_modules/font-awesome/css/font-awesome.css')
 
@@ -49,7 +50,7 @@ class HistoryItem extends ImmutableComponent {
       data-context-menu-disable
       onDoubleClick={this.navigate.bind(this)}>
     {
-      this.props.history.get('customTitle') || this.props.history.get('title')
+      this.props.history.get('customTitle') || this.props.history.get('title') || this.props.history.get('location')
       ? <span className='aboutListItem' title={this.props.history.get('location')}>
         <span className='aboutItemDate'>{new Date(this.props.history.get('lastAccessedTime')).toLocaleDateString()}</span>
         <span className='aboutItemTitle'>{this.props.history.get('customTitle') || this.props.history.get('title')}</span>
@@ -68,7 +69,7 @@ class HistoryItem extends ImmutableComponent {
 
 class HistoryList extends ImmutableComponent {
   render () {
-    return <list className='historyList'>
+    return <list className='siteDetailsList'>
     {
       this.props.history.map((entry) =>
         <HistoryItem history={entry} />)
@@ -111,12 +112,12 @@ class AboutHistory extends React.Component {
     })
   }
   render () {
-    return <div className='historyPage'>
+    return <div className='siteDetailsPage'>
       <h2 data-l10n-id='history' />
 
-      <div className='historyPageContent'>
+      <div className='siteDetailsPageContent'>
         <Sticky enabled top={10}>
-          <HistoryList history={this.state.history.filter((site) => site.get('tags').isEmpty())}
+          <HistoryList history={this.state.history.filter((site) => site.get('tags').isEmpty()).slice(-500)}
             onChangeSelectedEntry={this.onChangeSelectedEntry}
             selectedEntry={this.state.selectedEntry} />
         </Sticky>

--- a/js/actions/bookmarkActions.js
+++ b/js/actions/bookmarkActions.js
@@ -5,7 +5,6 @@
 'use strict'
 
 const siteUtil = require('../state/siteUtil')
-const siteTags = require('../constants/siteTags')
 const windowActions = require('./windowActions')
 const eventUtil = require('../lib/eventUtil.js')
 
@@ -13,7 +12,7 @@ const bookmarkActions = {
   openBookmarksInFolder: function (allBookmarkItems, folderDetail) {
     // We have a middle clicked folder
     allBookmarkItems
-      .filter((bookmark) => bookmark.get('parentFolderId') === folderDetail.get('folderId') && bookmark.get('tags').includes(siteTags.BOOKMARK))
+      .filter((bookmark) => bookmark.get('parentFolderId') === folderDetail.get('folderId') && siteUtil.isBookmark(bookmark))
       .forEach((bookmark) =>
         windowActions.newFrame(siteUtil.toFrameOpts(bookmark), false))
   },

--- a/js/components/bookmarksToolbar.js
+++ b/js/components/bookmarksToolbar.js
@@ -250,7 +250,7 @@ class BookmarksToolbar extends ImmutableComponent {
         appActions.addSite({ location: url }, siteTags.BOOKMARK))
   }
   openContextMenu (bookmark, e) {
-    contextMenus.onBookmarkContextMenu(bookmark, this.activeFrame, e)
+    contextMenus.onSiteDetailContextMenu(bookmark, this.activeFrame, e)
   }
   clickBookmarkItem (bookmark, e) {
     return bookmarkActions.clickBookmarkItem(this.bookmarks, bookmark, this.activeFrame, e)

--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -11,7 +11,6 @@ const Button = require('./button')
 const UrlBar = require('./urlBar')
 const appActions = require('../actions/appActions')
 const windowActions = require('../actions/windowActions')
-const {isSiteBookmarked} = require('../state/siteUtil')
 const siteTags = require('../constants/siteTags')
 const messages = require('../constants/messages')
 const settings = require('../constants/settings')
@@ -46,7 +45,7 @@ class NavigationBar extends ImmutableComponent {
     const siteDetail = siteUtil.getDetailFromFrame(this.activeFrame, siteTags.BOOKMARK)
     const showBookmarksToolbar = getSetting(settings.SHOW_BOOKMARKS_TOOLBAR)
     const hasBookmark = this.props.sites.find(
-      (site) => site.get('tags').includes(siteTags.BOOKMARK) || site.get('tags').includes(siteTags.BOOKMARK_FOLDER)
+      (site) => siteUtil.isBookmark(site) || siteUtil.isFolder(site)
     )
     if (!isBookmarked) {
       appActions.addSite(siteDetail, siteTags.BOOKMARK)
@@ -80,7 +79,7 @@ class NavigationBar extends ImmutableComponent {
 
   get bookmarked () {
     return this.props.activeFrameKey !== undefined &&
-      isSiteBookmarked(this.props.sites, Immutable.fromJS({
+      siteUtil.isSiteBookmarked(this.props.sites, Immutable.fromJS({
         location: this.props.location,
         partitionNumber: this.props.partitionNumber,
         title: this.props.title
@@ -115,7 +114,7 @@ class NavigationBar extends ImmutableComponent {
   componentDidUpdate (prevProps) {
     // Update the app menu to reflect whether the current page is bookmarked
     const prevBookmarked = this.props.activeFrameKey !== undefined &&
-      isSiteBookmarked(prevProps.sites, Immutable.fromJS({
+      siteUtil.isSiteBookmarked(prevProps.sites, Immutable.fromJS({
         location: prevProps.location,
         partitionNumber: prevProps.partitionNumber,
         title: prevProps.title

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -112,7 +112,7 @@ const messages = {
   // Menu rebuilding
   REQUEST_MENU_DATA_FOR_WINDOW: _,
   RESPONSE_MENU_DATA_FOR_WINDOW: _,
-  UPDATE_MENU_BOOKMARKED_STATUS: _, /** @arg {Object} currently only has a boolean "bookmarked" */
+  UPDATE_MENU_BOOKMARKED_STATUS: _, /** @isBookmarked {boolean} should menu show "Bookmark Page" as checked */
   // Ad block, safebrowsing, and tracking protection
   BLOCKED_RESOURCE: _,
   BLOCKED_PAGE: _,

--- a/js/entry.js
+++ b/js/entry.js
@@ -34,6 +34,7 @@ const messages = require('./constants/messages')
 const Immutable = require('immutable')
 const patch = require('immutablepatch')
 const l10n = require('./l10n')
+const FrameStateUtil = require('./state/frameStateUtil')
 
 // don't allow scaling or zooming of the ui
 webFrame.setPageScaleLimits(1, 1)
@@ -54,7 +55,13 @@ ipc.on(messages.REQUEST_WINDOW_STATE, () => {
 })
 
 ipc.on(messages.REQUEST_MENU_DATA_FOR_WINDOW, () => {
-  ipc.send(messages.RESPONSE_MENU_DATA_FOR_WINDOW, windowStore.getState().toJS())
+  const windowState = windowStore.getState()
+  const activeFrame = FrameStateUtil.getActiveFrame(Immutable.fromJS(windowState))
+  const windowData = {
+    location: activeFrame.get('location'),
+    closedFrames: windowState.get('closedFrames').toJS()
+  }
+  ipc.send(messages.RESPONSE_MENU_DATA_FOR_WINDOW, windowData)
 })
 
 if (process.env.NODE_ENV === 'test') {

--- a/js/state/frameStateUtil.js
+++ b/js/state/frameStateUtil.js
@@ -426,7 +426,6 @@ function removeFrame (frames, tabs, closedFrames, frameProps, activeFrameKey) {
 
   // If the frame being removed IS ACTIVE, then try to replace activeFrameKey with parentFrameKey
   let isActiveFrameBeingRemoved = frameProps.get('key') === activeFrameKey
-
   let parentFrameIndex = findIndexForFrameKey(frames, frameProps.get('parentFrameKey'))
   let activeFrameIndex
 

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -9,7 +9,10 @@ const getSetting = require('../settings').getSetting
 const urlParse = require('url').parse
 
 const isBookmark = (tags) => {
-  return tags && tags.includes(siteTags.BOOKMARK)
+  if (!tags) {
+    return false
+  }
+  return tags.includes(siteTags.BOOKMARK)
 }
 
 const isBookmarkFolder = (tags) => {
@@ -270,6 +273,18 @@ module.exports.isEquivalent = function (siteDetail1, siteDetail2) {
     return siteDetail1.get('folderId') === siteDetail2.get('folderId')
   }
   return siteDetail1.get('location') === siteDetail2.get('location') && siteDetail1.get('partitionNumber') === siteDetail2.get('partitionNumber')
+}
+
+/**
+ * Determines if the site detail is a bookmark.
+ * @param siteDetail The site detail to check.
+ * @return true if the site detail has a bookmark tag.
+ */
+module.exports.isBookmark = function (siteDetail) {
+  if (siteDetail) {
+    return isBookmark(siteDetail.get('tags'))
+  }
+  return false
 }
 
 /**

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -440,13 +440,16 @@ const doAction = (action) => {
       windowState = windowState.merge(FrameStateUtil.removeFrame(windowState.get('frames'), windowState.get('tabs'),
         windowState.get('closedFrames'), frameProps.set('closedAtIndex', index),
         activeFrameKey))
-      let totalOpenTabs = windowState.get('frames').filter((frame) => !frame.get('pinnedLocation')).size
-
       // History menu needs update (since it shows "Recently Closed" items)
-      ipc.send(messages.RESPONSE_MENU_DATA_FOR_WINDOW, windowState.toJS())
-
+      const activeFrameLocation = FrameStateUtil.getActiveFrame(windowState).get('location')
+      const windowData = {
+        location: activeFrameLocation,
+        closedFrames: windowState.get('closedFrames').toJS()
+      }
+      ipc.send(messages.RESPONSE_MENU_DATA_FOR_WINDOW, windowData)
       // If we reach the limit of opened tabs per page while closing tabs, switch to
       // the active tab's page otherwise the user will hang on empty page
+      let totalOpenTabs = windowState.get('frames').filter((frame) => !frame.get('pinnedLocation')).size
       if ((totalOpenTabs % getSetting(settings.TABS_PER_PAGE)) === 0) {
         updateTabPageIndex(FrameStateUtil.getActiveFrame(windowState))
       }

--- a/less/about/bookmarks.less
+++ b/less/about/bookmarks.less
@@ -1,27 +1,7 @@
 @import "./itemList.less";
 
-.bookmarksPage {
-  margin: 20px;
-
-  .bookmarkPageContent {
-    border-top: 1px solid @chromeBorderColor;
-    display: flex;
-
-    .bookmarkList {
-      padding-top: 10px;
-      overflow: hidden;
-
-      .listItem {
-        display: flex;
-        height: 1rem;
-
-        .aboutListItem {
-          align-items: center;
-          min-width: 0;
-        }
-      }
-    }
-
+.siteDetailsPage {
+  .siteDetailsPageContent {
     .bookmarkFolderList {
       min-width: 220px;
 
@@ -44,17 +24,4 @@
 
 .bookmarkFolderList list >* {
   padding-left: 12px;
-}
-
-.searchInput {
-    float: right;
-    padding: 5px;
-    margin-top: -35px;
-}
-
-.searchInputClear {
-    float: right;
-    padding: 8px;
-    margin-top: -39px;
-    color: #999;
 }

--- a/less/about/history.less
+++ b/less/about/history.less
@@ -1,47 +1,10 @@
 @import "./itemList.less";
 
-.historyPage {
-  margin: 20px;
-
-  .historyPageContent {
-    border-top: 1px solid @chromeBorderColor;
-    display: flex;
-
-    .historyList {
-      padding-top: 10px;
-      overflow: hidden;
-
-      .listItem {
-        display: flex;
-        height: 1rem;
-
-        .aboutListItem {
-          align-items: center;
-        }
-
-        .aboutItemDate {
-          color: #aaa;
-          margin-right: 10px;
-        }
-      }
-    }
-
+.siteDetailsPage {
+  .siteDetailsPageContent {
     .sticky-outer-wrapper {
       min-width: 100%;
       padding-top: 10px;
     }
   }
-}
-
-.searchInput {
-    float: right;
-    padding: 5px;
-    margin-top: -35px;
-}
-
-.searchInputClear {
-    float: right;
-    padding: 8px;
-    margin-top: -39px;
-    color: #999;
 }

--- a/less/about/siteDetails.less
+++ b/less/about/siteDetails.less
@@ -1,0 +1,38 @@
+@import "./itemList.less";
+
+.siteDetailsPage {
+  margin: 20px;
+
+  .siteDetailsPageContent {
+    border-top: 1px solid @chromeBorderColor;
+    display: flex;
+
+    .siteDetailsList {
+      padding-top: 10px;
+      overflow: hidden;
+
+      .listItem {
+        display: flex;
+        height: 1rem;
+
+        .aboutListItem {
+          align-items: center;
+          min-width: 0;
+        }
+      }
+    }
+  }
+}
+
+.searchInput {
+    float: right;
+    padding: 5px;
+    margin-top: -35px;
+}
+
+.searchInputClear {
+    float: right;
+    padding: 8px;
+    margin-top: -39px;
+    color: #999;
+}

--- a/test/unit/lib/menuUtilTest.js
+++ b/test/unit/lib/menuUtilTest.js
@@ -51,7 +51,7 @@ describe('menuUtil', function () {
     }
 
     mockery.registerMock('electron', fakeElectron)
-    menuUtil = require('../../../js/lib/menuUtil')
+    menuUtil = require('../../../app/browser/lib/menuUtil')
   })
 
   after(function () {

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -181,6 +181,15 @@ describe('siteUtil', function () {
       const expectedSites = sites.setIn([0, 'parentFolderId'], 0).setIn([0, 'tags'], Immutable.List([]))
       assert.deepEqual(processedSites, expectedSites)
     })
+    it('deletes a history entry (no tag specified)', function () {
+      const siteDetail = {
+        tags: [],
+        location: testUrl1
+      }
+      const sites = Immutable.fromJS([siteDetail])
+      const processedSites = siteUtil.removeSite(sites, Immutable.fromJS(siteDetail))
+      assert.deepEqual(processedSites, Immutable.fromJS([]))
+    })
   })
 
   describe('moveSite', function () {
@@ -285,19 +294,19 @@ describe('siteUtil', function () {
   })
 
   describe('isFolder', function () {
-    it('returns true if the input is a siteDetail and has a BOOKMARK_FOLDER tag', function () {
+    it('returns true if the input is a siteDetail and has a `BOOKMARK_FOLDER` tag', function () {
       const siteDetail = Immutable.fromJS({
         tags: [siteTags.BOOKMARK_FOLDER]
       })
       assert.equal(siteUtil.isFolder(siteDetail), true)
     })
-    it('returns false if the input does not have a BOOKMARK_FOLDER tag', function () {
+    it('returns false if the input does not have a `BOOKMARK_FOLDER` tag', function () {
       const siteDetail = Immutable.fromJS({
         tags: [siteTags.BOOKMARK]
       })
       assert.equal(siteUtil.isFolder(siteDetail), false)
     })
-    it('returns false if there is no `tags` property', function () {
+    it('returns false if there is not a `tags` property', function () {
       const siteDetail = Immutable.fromJS({
         notTags: null
       })
@@ -308,6 +317,30 @@ describe('siteUtil', function () {
     })
     it('returns false if the input is undefined', function () {
       assert.equal(siteUtil.isFolder(), false)
+    })
+  })
+
+  describe('isBookmark', function () {
+    it('returns true if the input is a siteDetail and has a `BOOKMARK` tag', function () {
+      const siteDetail = Immutable.fromJS({
+        tags: [siteTags.BOOKMARK]
+      })
+      assert.equal(siteUtil.isBookmark(siteDetail), true)
+    })
+    it('returns false if the input does not have a `BOOKMARK` tag', function () {
+      const siteDetail = Immutable.fromJS({
+        tags: [siteTags.BOOKMARK_FOLDER]
+      })
+      assert.equal(siteUtil.isBookmark(siteDetail), false)
+    })
+    it('returns false if there is not a `tags` property', function () {
+      const siteDetail = Immutable.fromJS({
+        notTags: null
+      })
+      assert.equal(siteUtil.isBookmark(siteDetail), false)
+    })
+    it('returns false if the input is falsey', function () {
+      assert.equal(siteUtil.isBookmark(null), false)
     })
   })
 


### PR DESCRIPTION
Follow up for https://github.com/brave/browser-laptop/pull/3206

cc: @bridiver @bbondy 

The only thing not addressed are the IPC calls. I definitely agree we can move:
- closed frame info
- active frame location

and more into AppStore (and then we'd just use actions). Those changes are "bigger than a breadbox" so I left them out of this PR.

Here's what's fixed:
- about:history now supports context menu (shares code w/ bookmarks)
- added isBookmark to siteUtil and updated code to use it
- fixed comment on UPDATE_MENU_BOOKMARKED_STATUS
- Delete history item now works
- Broke out common styles (between history and bookmarks about pages) to siteDetail.less, updated both to use it
- Sending menu update (via IPC) only sends what's needed; needs to be refactored to live in appState
- Updated directory structure for menu, menuUtil, and commonMenu per https://github.com/brave/browser-laptop/blob/master/docs/directoryStructure.md