### PR TITLE
guard against race condition

### DIFF
--- a/app/ledger.js
+++ b/app/ledger.js
@@ -812,7 +812,7 @@ var roundtrip = (params, options, callback) => {
 var run = (delayTime) => {
   if ((typeof delayTime === 'undefined') || (!client)) return
 
-  var state
+  var active, state
   var ballots = client.ballots()
   var siteSettings = appStore.getState().get('siteSettings')
   var winners = ((synopsis) && (ballots > 0) && (synopsis.winners(ballots))) || []
@@ -838,7 +838,10 @@ var run = (delayTime) => {
     delayTime = client.timeUntilReconcile()
     if (delayTime === false) delayTime = 0
   }
-  if (delayTime > 0) return setTimeout(() => { if (client.sync(callback) === true) return run(0) }, delayTime)
+  if (delayTime > 0) {
+    active = client
+    return setTimeout(() => { if ((active === client) && (client.sync(callback) === true)) return run(0) }, delayTime)
+  }
 
   if (client.isReadyToReconcile()) return client.reconcile(uuid.v4().toLowerCase(), callback)
 

--- a/app/ledger.js
+++ b/app/ledger.js
@@ -840,7 +840,10 @@ var run = (delayTime) => {
   }
   if (delayTime > 0) {
     active = client
-    return setTimeout(() => { if ((active === client) && (client.sync(callback) === true)) return run(0) }, delayTime)
+    return setTimeout(() => {
+      if (!client) return console.log('\n\n*** MTR says this can\'t happen... please tell him that he\'s wrong!\n\n')
+      if ((active === client) && (client.sync(callback) === true)) return run(0)
+    }, delayTime)
   }
 
   if (client.isReadyToReconcile()) return client.reconcile(uuid.v4().toLowerCase(), callback)


### PR DESCRIPTION
`run` uses `setTimeout` to invoke `client.sync()` in the future.

but if the user disables the ledger before then, hilarity ensues.

this patch prevents that from happening…

auditor: @diracdeltas or @bbondy 