### PR TITLE
Add *.jpg extension to webpack file-loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,7 +38,7 @@ function config () {
           loader: 'url-loader?limit=10000&minetype=application/font-woff'
         },
         {
-          test: /\.(ttf|eot|svg|png)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+          test: /\.(ttf|eot|svg|png|jpg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
           loader: 'file-loader'
         }
       ]


### PR DESCRIPTION
Currently I can't call `*.jpg` images directly inside `*.less` files. 

Adding this will be necessary in a near future when [background-preview](https://github.com/brave/browser-laptop/issues/3001#issue-169700482) is implemented.