### PR TITLE
Fix bookmark toolbar not showing on first bookmark from context menu

### DIFF
--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -9,7 +9,6 @@ const ImmutableComponent = require('./immutableComponent')
 const cx = require('../lib/classSet.js')
 const Button = require('./button')
 const UrlBar = require('./urlBar')
-const appActions = require('../actions/appActions')
 const windowActions = require('../actions/windowActions')
 const siteTags = require('../constants/siteTags')
 const messages = require('../constants/messages')
@@ -38,24 +37,10 @@ class NavigationBar extends ImmutableComponent {
     return this.props.activeFrameKey !== undefined && this.props.loading
   }
 
-  onToggleBookmark (isBookmarked) {
-    if (isBookmarked === undefined) {
-      isBookmarked = this.bookmarked
-    }
+  onToggleBookmark () {
+    // trigger the AddEditBookmark modal; saving/deleting takes place there
     const siteDetail = siteUtil.getDetailFromFrame(this.activeFrame, siteTags.BOOKMARK)
-    const showBookmarksToolbar = getSetting(settings.SHOW_BOOKMARKS_TOOLBAR)
-    const hasBookmark = this.props.sites.find(
-      (site) => siteUtil.isBookmark(site) || siteUtil.isFolder(site)
-    )
-    if (!isBookmarked) {
-      appActions.addSite(siteDetail, siteTags.BOOKMARK)
-    }
-    // Show bookmarks toolbar after first bookmark is saved
-    appActions.changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, !hasBookmark || showBookmarksToolbar)
-    // trigger the AddEditBookmark modal
     windowActions.setBookmarkDetail(siteDetail, siteDetail)
-    // Update checked/unchecked status in the Bookmarks menu
-    ipc.send(messages.UPDATE_MENU_BOOKMARKED_STATUS, this.bookmarked)
   }
 
   onReload (e) {
@@ -97,8 +82,8 @@ class NavigationBar extends ImmutableComponent {
   }
 
   componentDidMount () {
-    ipc.on(messages.SHORTCUT_ACTIVE_FRAME_BOOKMARK, () => this.onToggleBookmark(false))
-    ipc.on(messages.SHORTCUT_ACTIVE_FRAME_REMOVE_BOOKMARK, () => this.onToggleBookmark(true))
+    ipc.on(messages.SHORTCUT_ACTIVE_FRAME_BOOKMARK, () => this.onToggleBookmark())
+    ipc.on(messages.SHORTCUT_ACTIVE_FRAME_REMOVE_BOOKMARK, () => this.onToggleBookmark())
     // Set initial checked/unchecked status in Bookmarks menu
     ipc.send(messages.UPDATE_MENU_BOOKMARKED_STATUS, this.bookmarked)
   }

--- a/js/entry.js
+++ b/js/entry.js
@@ -59,7 +59,7 @@ ipc.on(messages.REQUEST_MENU_DATA_FOR_WINDOW, () => {
   const windowState = windowStore.getState()
   const activeFrame = FrameStateUtil.getActiveFrame(Immutable.fromJS(windowState))
   const windowData = {
-    location: activeFrame.get('location'),
+    location: activeFrame ? activeFrame.get('location') : null,
     closedFrames: windowState.get('closedFrames').toJS()
   }
   ipc.send(messages.RESPONSE_MENU_DATA_FOR_WINDOW, windowData)


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fixed error that was happening in entry.js

Moved the following to AddEditBookmark.js (taking logic out of navigator):
- Menu status for is site bookmarked is handled here, making it reliable
- Bookmarks toolbar showing for first time is handled here too. Fixes https://github.com/brave/browser-laptop/issues/3331