### PR TITLE
different paths for MacOS v. Linux/Windows

### DIFF
--- a/app/ledger.js
+++ b/app/ledger.js
@@ -711,9 +711,7 @@ var updateLedgerInfo = () => {
     underscore.extend(ledgerInfo, ledgerInfo._internal.cache || {})
 
     if (typeof protocolHandler.isNavigatorProtocolHandled === 'function') {
-/* YAN: this comment is temporary until the preferences panel for payments can handle only one of these properties defined
-      delete ledgerInfo[protocolHandler.isNavigatorProtocolHandled('', 'bitcoin') ? 'buyURL' : 'paymentURL']
- */
+      if (!protocolHandler.isNavigatorProtocolHandled('', 'bitcoin')) delete ledgerInfo.paymentURL
     }
   }
 

--- a/tools/buildPackage.js
+++ b/tools/buildPackage.js
@@ -123,7 +123,12 @@ if (isLinux) {
 cmds.push('mkdirp ' + path.join(buildDir, 'resources', 'app.asar.unpacked', 'node_modules', 'spellchecker', 'vendor', 'hunspell_dictionaries'))
 cmds.push('ncp ' + path.join('node_modules', 'spellchecker', 'vendor', 'hunspell_dictionaries') + ' ' + path.join(buildDir, 'resources', 'app.asar.unpacked', 'node_modules', 'spellchecker', 'vendor', 'hunspell_dictionaries'))
 
-cmds.push('mkdirp ' + path.join(buildDir, 'Brave.app', 'Contents', 'Resources', 'app.asar.unpacked', 'node_modules', 'node-anonize2-relic-emscripten'))
-cmds.push('ncp ' + path.join('node_modules', 'node-anonize2-relic-emscripten', 'anonize2.js.mem') + ' ' + path.join(buildDir, 'Brave.app', 'Contents', 'Resources', 'app.asar.unpacked', 'node_modules', 'node-anonize2-relic-emscripten', 'anonize2.js.mem'))
+if (isDarwin) {
+  cmds.push('mkdirp ' + path.join(buildDir, 'Brave.app', 'Contents', 'Resources', 'app.asar.unpacked', 'node_modules', 'node-anonize2-relic-emscripten'))
+  cmds.push('ncp ' + path.join('node_modules', 'node-anonize2-relic-emscripten', 'anonize2.js.mem') + ' ' + path.join(buildDir, 'Brave.app', 'Contents', 'Resources', 'app.asar.unpacked', 'node_modules', 'node-anonize2-relic-emscripten', 'anonize2.js.mem'))
+} else {
+  cmds.push('mkdirp ' + path.join(buildDir, 'resources', 'app.asar.unpacked', 'node_modules', 'node-anonize2-relic-emscripten'))
+  cmds.push('ncp ' + path.join('node_modules', 'node-anonize2-relic-emscripten', 'anonize2.js.mem') + ' ' + path.join(buildDir, 'resources', 'app.asar.unpacked', 'node_modules', 'node-anonize2-relic-emscripten', 'anonize2.js.mem'))
+}
 
 execute(cmds, env, console.log.bind(null, 'done'))


### PR DESCRIPTION
1. use different install paths for MacOS and Linux/Windows for the `anonize2.js.mem` file

2. if `bitcoin:` URI handler not defined, then don't define `ledgerInfo.paymentURL`

auditor: @bbondy 