### PR TITLE
Tweaks to fix autofill context menu position

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -375,10 +375,10 @@ function usernameTemplateInit (usernames, origin, action) {
 }
 
 function autofillTemplateInit (suggestions, frame) {
-  let items = []
+  const items = []
   for (let i = 0; i < suggestions.length; ++i) {
     let value
-    let frontendId = suggestions[i].frontend_id
+    const frontendId = suggestions[i].frontend_id
     if (frontendId >= 0) { //  POPUP_ITEM_ID_AUTOCOMPLETE_ENTRY and Autofill Entry
       value = suggestions[i].value
     } else if (frontendId === -1) { // POPUP_ITEM_ID_WARNING_MESSAGE
@@ -1091,9 +1091,13 @@ function onShowUsernameMenu (usernames, origin, action, boundingRect,
 
 function onShowAutofillMenu (suggestions, boundingRect, frame) {
   const menuTemplate = autofillTemplateInit(suggestions, frame)
+  const offset = {
+    x: (window.innerWidth - boundingRect.clientWidth),
+    y: (window.innerHeight - boundingRect.clientHeight)
+  }
   windowActions.setContextMenuDetail(Immutable.fromJS({
-    left: boundingRect.x,
-    top: boundingRect.y,
+    left: offset.x + boundingRect.x,
+    top: offset.y + (boundingRect.y + boundingRect.height),
     template: menuTemplate
   }))
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fixes https://github.com/brave/browser-laptop/issues/3359
Depends on https://github.com/brave/electron/pull/44