### PR TITLE
route safebrowsing and httpse messages by tabId

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -315,27 +315,26 @@ class Main extends ImmutableComponent {
       windowActions.setActiveFrame(self.props.windowState.getIn(['frames', self.props.windowState.get('frames').size - 1])))
 
     ipc.on(messages.BLOCKED_RESOURCE, (e, blockType, details) => {
-      const filteredFrameProps = this.props.windowState.get('frames').filter((frame) => frame.get('provisionalLocation') === details.firstPartyUrl)
-      filteredFrameProps.forEach((frameProps) =>
-        windowActions.setBlockedBy(frameProps, blockType, details.url))
+      const frameProps = FrameStateUtil.getFrameByTabId(self.props.windowState, details.tabId)
+      frameProps && windowActions.setBlockedBy(frameProps, blockType, details.url)
     })
 
     ipc.on(messages.BLOCKED_PAGE, (e, blockType, details) => {
-      const filteredFrameProps = this.props.windowState.get('frames').filter((frame) => frame.get('provisionalLocation') === details.firstPartyUrl)
-      filteredFrameProps.forEach((frameProps) => {
-        if (blockType === appConfig.resourceNames.SAFE_BROWSING) {
-          // Since Safe Browsing never actually loads the main frame we need to add history here.
-          // That way about:safebrowsing can figure out the correct location.
-          windowActions.addHistory(frameProps)
-        }
-        windowActions.loadUrl(frameProps, blockType === appConfig.resourceNames.SAFE_BROWSING ? 'about:safebrowsing' : 'about:blank')
-      })
+      const frameProps = FrameStateUtil.getFrameByTabId(self.props.windowState, details.tabId)
+      if (!frameProps) {
+        return
+      }
+      if (blockType === appConfig.resourceNames.SAFE_BROWSING) {
+        // Since Safe Browsing never actually loads the main frame we need to add history here.
+        // That way about:safebrowsing can figure out the correct location.
+        windowActions.addHistory(frameProps)
+      }
+      windowActions.loadUrl(frameProps, blockType === appConfig.resourceNames.SAFE_BROWSING ? 'about:safebrowsing' : 'about:blank')
     })
 
     ipc.on(messages.HTTPSE_RULE_APPLIED, (e, ruleset, details) => {
-      const filteredFrameProps = this.props.windowState.get('frames').filter((frame) => frame.get('provisionalLocation') === details.firstPartyUrl)
-      filteredFrameProps.forEach((frameProps) =>
-        windowActions.setRedirectedBy(frameProps, ruleset, details.url))
+      const frameProps = FrameStateUtil.getFrameByTabId(self.props.windowState, details.tabId)
+      frameProps && windowActions.setRedirectedBy(frameProps, ruleset, details.url)
     })
 
     ipc.on(messages.SHOW_NOTIFICATION, (e, text) => {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

fixes #3367
requires https://github.com/brave/electron/commit/a6046ca92d776f09e1cc8208bcb5c13b23b50e88