### PR TITLE
Fixes extra separator in about:history context menu

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -262,12 +262,12 @@ function siteDetailTemplateInit (siteDetail, activeFrame) {
       {
         label: locale.translation(deleteLabel),
         click: () => appActions.removeSite(siteDetail, deleteTag)
-      },
-      CommonMenu.separatorMenuItem)
+      })
   }
 
   if (!isHistoryEntry) {
     template.push(
+      CommonMenu.separatorMenuItem,
       addBookmarkMenuItem('addBookmark', siteUtil.getDetailFromFrame(activeFrame, siteTags.BOOKMARK), siteDetail, true),
       addFolderMenuItem(siteDetail, true))
   }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/4733304/17996072/5a044282-6b1b-11e6-94b8-6971e3ed6ea6.png)

For some reason it was only showing on Windows

Auditors: @luixxiul