### PR TITLE
Fragment identifier always reflects tab in  about:preferences (fix #3441)

### DIFF
--- a/app/ledger.js
+++ b/app/ledger.js
@@ -196,7 +196,7 @@ if (ipc) {
         let win = electron.BrowserWindow.getFocusedWindow()
         if (win) {
           win.webContents.send(messages.SHORTCUT_NEW_FRAME,
-            'about:preferences#publishers', { singleFrame: true })
+            'about:preferences#payments', { singleFrame: true })
         }
       }
     }

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -972,8 +972,8 @@ class PreferenceNavigation extends ImmutableComponent {
       />
       <PreferenceNavigationButton icon='fa-bitcoin'
         dataL10nId='payments'
-        onClick={this.props.changeTab.bind(null, preferenceTabs.PUBLISHERS)}
-        selected={this.props.preferenceTab === preferenceTabs.PUBLISHERS}
+        onClick={this.props.changeTab.bind(null, preferenceTabs.PAYMENTS)}
+        selected={this.props.preferenceTab === preferenceTabs.PAYMENTS}
       />
       <PreferenceNavigationButton icon='fa-refresh'
         className='notImplemented'
@@ -1032,6 +1032,7 @@ class AboutPreferences extends React.Component {
   }
 
   changeTab (preferenceTab) {
+    window.location.hash = preferenceTab.toLowerCase()
     this.setState({
       preferenceTab
     })
@@ -1104,7 +1105,7 @@ class AboutPreferences extends React.Component {
       case preferenceTabs.SHIELDS:
         tab = <ShieldsTab settings={settings} siteSettings={siteSettings} braveryDefaults={braveryDefaults} onChangeSetting={this.onChangeSetting} />
         break
-      case preferenceTabs.PUBLISHERS:
+      case preferenceTabs.PAYMENTS:
         tab = <PaymentsTab settings={settings} siteSettings={siteSettings}
           braveryDefaults={braveryDefaults} ledgerData={ledgerData}
           onChangeSetting={this.onChangeSetting}

--- a/js/constants/preferenceTabs.js
+++ b/js/constants/preferenceTabs.js
@@ -12,7 +12,7 @@ const preferenceTabs = {
   SYNC: _,
   SHIELDS: _,
   SECURITY: _,
-  PUBLISHERS: _,
+  PAYMENTS: _,
   ADVANCED: _
 }
 


### PR DESCRIPTION
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.

- URL "about:preferences#payments" now navigates to Payments tab (was #publishers; out-of-date)
- New: Changing tabs by clicking them now always updates the fragment identifier
- fixes issue #3441