### PR TITLE
History bugfixes

### DIFF
--- a/js/about/history.js
+++ b/js/about/history.js
@@ -13,6 +13,7 @@ const aboutActions = require('./aboutActions')
 const getSetting = require('../settings').getSetting
 const SortableTable = require('../components/sortableTable')
 const Button = require('../components/button')
+const siteUtil = require('../state/siteUtil')
 
 const ipc = window.chrome.ipc
 
@@ -71,7 +72,11 @@ class GroupedHistoryList extends ImmutableComponent {
       }
       return result
     })
-    if (reduced) return reduced
+    if (reduced) {
+      return Array.isArray(reduced)
+        ? reduced
+        : [{date: this.getDayString(locale, reduced), entries: [reduced]}]
+    }
     return []
   }
   render () {
@@ -125,7 +130,7 @@ class AboutHistory extends React.Component {
     })
   }
   historyDescendingOrder () {
-    return this.state.history.filter((site) => site.get('lastAccessedTime'))
+    return this.state.history.filter((site) => siteUtil.isHistoryEntry(site))
       .sort((left, right) => {
         if (left.get('lastAccessedTime') < right.get('lastAccessedTime')) return 1
         if (left.get('lastAccessedTime') > right.get('lastAccessedTime')) return -1

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -303,6 +303,21 @@ module.exports.isFolder = function (siteDetail) {
 }
 
 /**
+ * Determines if the site detail is a history entry.
+ * @param siteDetail The site detail to check.
+ * @return true if the site detail is a history entry.
+ */
+module.exports.isHistoryEntry = function (siteDetail) {
+  if (siteDetail && typeof siteDetail.get('location') === 'string') {
+    if (siteDetail.get('location').startsWith('about:')) {
+      return false
+    }
+    return !!siteDetail.get('lastAccessedTime') && !module.exports.isFolder(siteDetail)
+  }
+  return false
+}
+
+/**
  * Obtains an array of folders
  */
 module.exports.getFolders = function (sites, folderId, parentId, labelPrefix) {

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -414,6 +414,50 @@ describe('siteUtil', function () {
     })
   })
 
+  describe('isHistoryEntry', function () {
+    it('returns true for a typical history entry', function () {
+      const siteDetail = Immutable.fromJS({
+        location: testUrl1,
+        lastAccessedTime: 123
+      })
+      assert.equal(siteUtil.isHistoryEntry(siteDetail), true)
+    })
+    it('returns true for a bookmark history entry which has lastAccessedTime', function () {
+      const siteDetail = Immutable.fromJS({
+        location: testUrl1,
+        tags: [siteTags.BOOKMARK],
+        lastAccessedTime: 123
+      })
+      assert.equal(siteUtil.isHistoryEntry(siteDetail), true)
+    })
+    it('returns false for a bookmark entry with falsey lastAccessedTime', function () {
+      const siteDetail = Immutable.fromJS({
+        location: testUrl1,
+        tags: [siteTags.BOOKMARK]
+      })
+      assert.equal(siteUtil.isHistoryEntry(siteDetail), false)
+    })
+    it('returns false for a bookmarks folder', function () {
+      const siteDetail = Immutable.fromJS({
+        location: testUrl1,
+        tags: [siteTags.BOOKMARK_FOLDER],
+        lastAccessedTime: 123
+      })
+      assert.equal(siteUtil.isHistoryEntry(siteDetail), false)
+    })
+    it('returns false if input is falsey', function () {
+      assert.equal(siteUtil.isHistoryEntry(null), false)
+      assert.equal(siteUtil.isHistoryEntry(undefined), false)
+    })
+    it('returns false for about: pages', function () {
+      const siteDetail = Immutable.fromJS({
+        location: 'about:fake-page-here',
+        lastAccessedTime: 123
+      })
+      assert.equal(siteUtil.isHistoryEntry(siteDetail), false)
+    })
+  })
+
   describe('getFolders', function () {
   })
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

- Added a new isHistoryEntry method
- Folders are no longer considered history; fixes https://github.com/brave/browser-laptop/issues/3453
- Filters out about pages from history; fixes https://github.com/brave/browser-laptop/issues/3366
- Single history entries are now shown; there was no open defect for this; it would just throw an error