### PR TITLE
updateLedgerInfo should run before client is assigned if previous state is present

### DIFF
--- a/app/ledger.js
+++ b/app/ledger.js
@@ -828,6 +828,7 @@ var roundtrip = (params, options, callback) => {
     var payload
 
     if ((response) && (options.verboseP)) {
+      console.log('[ response for ' + params.method + ' ' + parts.protocol + '//' + parts.hostname + params.path + ' ]')
       console.log('>>> HTTP/' + response.httpVersionMajor + '.' + response.httpVersionMinor + ' ' + response.statusCode +
                  ' ' + (response.statusMessage || ''))
       underscore.keys(response.headers).forEach((header) => { console.log('>>> ' + header + ': ' + response.headers[header]) })
@@ -961,7 +962,7 @@ var getBalance = () => {
   setTimeout(getBalance, msecs.minute)
   if (!ledgerInfo.address) return
 
-  ledgerBalance.getBalance(ledgerInfo.address, underscore.extend({ balancesP: true, roundtrip: roundtrip }, clientOptions),
+  ledgerBalance.getBalance(ledgerInfo.address, underscore.extend({ balancesP: true }, client.options),
   (err, provider, result) => {
     if (err) return console.log('ledger balance error: ' + JSON.stringify(err, null, 2))
 


### PR DESCRIPTION
it appears the concern that @diracdeltas  has regarding https://github.com/brave/browser-laptop/blob/master/app/ledger.js#L735 is proven, as it explains https://github.com/brave/browser-laptop/issues/3440

time for an extra-large helping of [humble pie](https://en.wikipedia.org/wiki/Humble_pie)

auditor: @diracdeltas 