### PR TITLE
Updates to help Windows developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,11 @@ For a more user-friendly download page, [please visit our website](https://brave
 
 You'll need certain packages installed before you can build and run Brave locally.
 
-### All platforms
+### Windows
+
+Please see the [Building on Windows wiki entry](https://github.com/brave/browser-laptop/wiki/Building-on-Windows)
+
+### All other platforms
 
 1. `nodejs` **`>= 6.1`**
 
@@ -35,15 +39,6 @@ You'll need certain packages installed before you can build and run Brave locall
 2. `node-gyp` **`3.3.1`**
 
         sudo npm install -g node-gyp@3.3.1
-
-### Windows
-
-Ensure you also have the following installed (required by node-gyp):
-
-* [Python 2.7](https://www.python.org/downloads/)
-* [Visual Studio 2013 or 2015](https://www.visualstudio.com/en-us/products/visual-studio-community-vs.aspx)
-
-After being installed, Visual Studio 2015 may [require some additional configuration](https://github.com/brave/browser-laptop/wiki/Configuring-Visual-Studio-2015).
 
 ###  Linux
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
     "watch": "webpack-dev-server --inline --hot --colors --content-base=./app/extensions/brave",
     "watch-all": "npm run watch & npm run watch-test",
     "watch-test": "NODE_ENV=test webpack --watch",
-    "webpack": "webpack"
+    "webpack": "webpack",
+    "win-fixelectron": "powershell ./tools/windows/fix-electron.ps1",
+    "win-fixnpm": "powershell ./tools/windows/vs2015-sp3-fix-npm.ps1",
+    "win-renpm": "powershell ./tools/windows/re-npm.ps1"
   },
   "repository": "brave/browser-laptop",
   "author": {

--- a/tools/windows/fix-electron.ps1
+++ b/tools/windows/fix-electron.ps1
@@ -1,0 +1,23 @@
+﻿$script_path = Split-Path $MyInvocation.MyCommand.Definition
+$expected_path = [string]::Join([IO.Path]::DirectorySeparatorChar, ("browser-laptop", "tools", "windows"))
+if (-Not $script_path.EndsWith($expected_path)) {
+    "ERROR: aborting. This script expected to be in the following folder: $expected_path"
+    exit
+}
+
+$repo_root_path = (Get-Item $script_path ).parent.parent.FullName
+cd $repo_root_path
+
+if (-Not (Test-Path .\node_modules\electron-prebuilt\dist)) {
+    "ERROR: installation appears to be missing node_modules\electron-prebuilt\dist. Has `"npm install`" been ran yet?"
+    exit
+}
+
+"INFO: building brave as a package"
+npm run build-package
+
+"INFO: copying the binaries created from package into electron-prebuilt"
+xcopy .\Brave-win32-x64\* .\node_modules\electron-prebuilt\dist\ /Y /S /I /F /R
+
+"INFO: Done."
+Read-Host -Prompt "Press Enter to exit"

--- a/tools/windows/re-npm.ps1
+++ b/tools/windows/re-npm.ps1
@@ -1,0 +1,29 @@
+$script_path = Split-Path $MyInvocation.MyCommand.Definition
+$expected_path = [string]::Join([IO.Path]::DirectorySeparatorChar, ("browser-laptop", "tools", "windows"))
+if (-Not $script_path.EndsWith($expected_path)) {
+    "ERROR: aborting. This script expected to be in the following folder: $expected_path"
+    exit
+}
+
+$repo_root_path = (Get-Item $script_path ).parent.parent.FullName
+cd $repo_root_path
+
+if (Test-Path ~\.electron) {
+    "INFO: removing your old electron install..."
+    Remove-Item ~/.electron -Recurse
+} else {
+    "INFO: you don't appear to have electron installed. Skipping this cleanup step."
+}
+
+if (Test-Path .\node_modules) {
+    "INFO: removing your old node_modules directory..."
+    Remove-Item .\node_modules -Recurse
+} else {
+    "INFO: you don't appear to have done an npm install. Skipping this cleanup step."
+}
+
+"INFO: Running npm install (this will take a while)..."
+npm install
+
+"INFO: Done."
+Read-Host -Prompt "Press Enter to exit"

--- a/tools/windows/vs2015-sp3-fix-npm.ps1
+++ b/tools/windows/vs2015-sp3-fix-npm.ps1
@@ -1,0 +1,97 @@
+﻿# Elevation based on original script courtesy of Ben Armstrong
+# https://blogs.msdn.microsoft.com/virtual_pc_guy/2010/09/23/a-self-elevating-powershell-script/
+
+# Get the ID and security principal of the current user account
+$myWindowsID=[System.Security.Principal.WindowsIdentity]::GetCurrent()
+$myWindowsPrincipal=new-object System.Security.Principal.WindowsPrincipal($myWindowsID)
+ 
+# Get the security principal for the Administrator role
+$adminRole=[System.Security.Principal.WindowsBuiltInRole]::Administrator
+ 
+# Check to see if we are currently running "as Administrator"
+if ($myWindowsPrincipal.IsInRole($adminRole)) {
+   # We are running "as Administrator" - so change the title and background color to indicate this
+   $Host.UI.RawUI.WindowTitle = $myInvocation.MyCommand.Definition + "(Elevated)"
+   $Host.UI.RawUI.BackgroundColor = "DarkBlue"
+   Clear-Host
+} else {
+   # We are not running "as Administrator" - so relaunch as administrator
+   
+   # Create a new process object that starts PowerShell
+   $newProcess = new-object System.Diagnostics.ProcessStartInfo "PowerShell";
+   
+   # Specify the current script path and name as a parameter
+   $newProcess.Arguments = $myInvocation.MyCommand.Definition;
+   
+   # Indicate that the process should be elevated
+   $newProcess.Verb = "runas";
+   
+   # Start the new process
+   [System.Diagnostics.Process]::Start($newProcess);
+   
+   # Exit from the current, unelevated, process
+   exit
+}
+ 
+# Run your code that needs to be elevated here
+$node_path = Get-Command("node")
+if ($? -eq $false) {
+    "ERROR: `"node`" was not found. Is it installed? Does the `"PATH`" environment variable include the path to nodejs? (ex: `"c:\Program Files\nodejs\`""
+    exit
+}
+
+$node_install_dir = Split-Path $node_path.Path
+if (-Not (Test-Path($node_install_dir))) {
+    "ERROR: directory not found `"$node_install_dir`""
+    exit
+}
+
+$npm_install_dir = [string]::Join([IO.Path]::DirectorySeparatorChar, ($node_install_dir, "node_modules", "npm"))
+if (-Not (Test-Path($npm_install_dir))) {
+    "ERROR: directory not found `"$npm_install_dir`""
+    exit
+}
+
+$package_json = [string]::Join([IO.Path]::DirectorySeparatorChar, ($npm_install_dir, "package.json"))
+if (-Not (Test-Path($package_json))) {
+    "ERROR: package.json for node_module/npm not found"
+    exit
+}
+
+$json = ConvertFrom-Json "$(Get-Content($package_json))"
+$modified = $false
+
+$index = $json.bundleDependencies.IndexOf('node-gyp')
+if ($index -ne -1) {
+    $modified = $true
+    [System.Collections.ArrayList]$modifiedList = $json.bundleDependencies
+    $modifiedList.RemoveAt($index)
+    $json.bundleDependencies = $modifiedList
+}
+
+if ($json.dependencies.'node-gyp' -eq "~3.3.1") {
+    $modified = $true
+    $json.dependencies.'node-gyp' = "~3.4.0"
+}
+
+if ($modified) {
+    "INFO: backing up old file"
+    Move-Item $package_json "$package_json.old" -Force
+
+    "INFO: writing new package.json"
+    $json_text = $json | ConvertTo-Json -Compress
+    $raw_bytes = [System.Text.Encoding]::ASCII.GetBytes($json_text)
+    $stream = [System.IO.File]::OpenWrite($package_json)
+    $writer = [System.IO.BinaryWriter]::new($stream)
+    $writer.Write($raw_bytes)
+    $writer.Close()
+} else {
+    "INFO: no change needed"
+}
+
+"INFO: Running npm install"
+cd $npm_install_dir
+npm install
+
+"INFO: Done."
+Read-Host -Prompt "Press Enter to exit"


### PR DESCRIPTION
Fixes #3548

Accompanied by a new wiki entry:
https://github.com/brave/browser-laptop/wiki/Building-on-Windows

Powershell scripts for:
- automating the fix needed on Windows w/ VS2015 SP3 to resolve the following issue:
  "error C2373: '__pfnDliNotifyHook2': redefinition; different type modifiers"
- automating cleanup/re-initialization needed for fresh npm install
- fixing electron on initial Windows run

Added npm tasks for executing the above scripts and updated the README.md

Auditors: @bbondy @bridiver @aekeus