### PR TITLE
Clearing history using modal now clears bookmark timestamps

### DIFF
--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -372,7 +372,13 @@ module.exports.filterSitesRelativeTo = function (sites, relSite) {
  * @param sites The application state's Immutable sites list.
  */
 module.exports.clearSitesWithoutTags = function (sites) {
-  return sites.filter((site) => site.get('tags') && site.get('tags').size > 0)
+  let clearedSites = sites.filter((site) => site.get('tags') && site.get('tags').size > 0)
+  clearedSites.forEach((site, index) => {
+    if (site.get('lastAccessedTime')) {
+      clearedSites = clearedSites.setIn([index, 'lastAccessedTime'], null)
+    }
+  })
+  return clearedSites
 }
 
 /**

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -469,15 +469,33 @@ describe('siteUtil', function () {
 
   describe('clearSitesWithoutTags', function () {
     it('does not remove sites which have a valid `tags` property', function () {
-      const sites = [
-        Immutable.fromJS({
-          tags: [siteTags.BOOKMARK_FOLDER]
-        }),
-        Immutable.fromJS({
-          tags: [siteTags.BOOKMARK]
-        })]
+      const sites = Immutable.fromJS([
+        { tags: [siteTags.BOOKMARK_FOLDER] },
+        { tags: [siteTags.BOOKMARK] }
+      ])
       const processedSites = siteUtil.clearSitesWithoutTags(sites)
-      assert.deepEqual(sites, processedSites)
+      assert.deepEqual(processedSites.toJS(), sites.toJS())
+    })
+    it('sets the lastAccessedTime for all entries to null', function () {
+      const sites = Immutable.fromJS([
+        {
+          location: 'location1',
+          tags: [],
+          lastAccessedTime: 123
+        },
+        {
+          location: 'location2',
+          tags: [siteTags.BOOKMARK],
+          lastAccessedTime: 123
+        }
+      ])
+      const expectedSites = Immutable.fromJS([{
+        location: 'location2',
+        tags: [siteTags.BOOKMARK],
+        lastAccessedTime: null
+      }])
+      const processedSites = siteUtil.clearSitesWithoutTags(sites)
+      assert.deepEqual(processedSites.toJS(), expectedSites.toJS())
     })
   })
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fixes https://github.com/brave/browser-laptop/issues/3346