### PR TITLE
Update getActivePasswordManager call to call getSettings

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -48,7 +48,7 @@ module.exports.getSetting = (settingKey, settingsCollection) => {
 }
 
 module.exports.getActivePasswordManager = (settingsCollection) => {
-  const passwordManager = resolveValue(settings.ACTIVE_PASSWORD_MANAGER, settingsCollection)
+  const passwordManager = module.exports.getSetting(settings.ACTIVE_PASSWORD_MANAGER, settingsCollection)
 
   let details = {
     name: passwordManager,

--- a/test/unit/settingsTest.js
+++ b/test/unit/settingsTest.js
@@ -111,5 +111,16 @@ describe('settings unit test', function () {
       const actualResult = settings.getActivePasswordManager(settingsCollection)
       assert.deepEqual(actualResult, expectedResult)
     })
+
+    it('calls getSetting to get the value (providing a default if none exists)', function () {
+      settingsCollection[settingsConst.ONE_PASSWORD_ENABLED] = true
+      const expectedResult = Immutable.fromJS({
+        name: passwordManagers.ONE_PASSWORD,
+        extensionId: extensionIds[passwordManagers.ONE_PASSWORD],
+        displayName: displayNames[passwordManagers.ONE_PASSWORD]
+      })
+      const actualResult = settings.getActivePasswordManager(settingsCollection)
+      assert.deepEqual(actualResult, expectedResult)
+    })
   })
 })


### PR DESCRIPTION
~~I couldn't find an existing issue for this~~

This change only affects the context menu after upgrading from 0.11.4 or earlier to 0.11.5 or newer. Currently, the context menu is the only caller for getActivePasswordManager

Fixes https://github.com/brave/browser-laptop/issues/3549

Auditors: @bbondy @alexwykoff 