### PR TITLE
fix browser crash if you close a window was the browser is launching

### DIFF
--- a/js/actions/windowActions.js
+++ b/js/actions/windowActions.js
@@ -385,10 +385,12 @@ const windowActions = {
    * @param {Object} frameProps - the frame properties for the webview in question.
    */
   setFocusedFrame: function (frameProps) {
-    dispatch({
-      actionType: WindowConstants.WINDOW_SET_FOCUSED_FRAME,
-      frameProps: frameProps
-    })
+    if (frameProps) {
+      dispatch({
+        actionType: WindowConstants.WINDOW_SET_FOCUSED_FRAME,
+        frameProps: frameProps
+      })
+    }
   },
 
   /**


### PR DESCRIPTION
if you start the browser and before it “settles”, you close a tab/window, then you get a crash. because `WINDOW_SET_FOCUS_FRAME` is generated by `action.frameProps` is empty. in this case, `eventStore.js` falls over taking the entire browser with it.

auditor: @bridiver 