### PR TITLE
Properly detect active password manager in contentSettings

### DIFF
--- a/js/state/contentSettings.js
+++ b/js/state/contentSettings.js
@@ -12,6 +12,7 @@ const {passwordManagers, defaultPasswordManager} = require('../constants/passwor
 const urlParse = require('url').parse
 const siteSettings = require('./siteSettings')
 const { registerUserPrefs } = require('./userPrefs')
+const { getSetting } = require('../settings')
 
 // backward compatibility with appState siteSettings
 const parseSiteSettingsPattern = (pattern) => {
@@ -32,7 +33,7 @@ const addContentSettings = (settingList, hostPattern, secondaryPattern = undefin
 const getPasswordManagerEnabled = (appState) => {
   let appSettings = appState.get('settings')
   if (appSettings) {
-    const passwordManager = appSettings.get(settings.ACTIVE_PASSWORD_MANAGER)
+    const passwordManager = getSetting(settings.ACTIVE_PASSWORD_MANAGER, appSettings)
     if (typeof passwordManager === 'string') {
       return passwordManager === passwordManagers.BUILT_IN
     }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Previous code would fail for anyone who had a session before PW manager was simplified down to a single choice, because they did not have ACTIVE_PASSWORD_MANAGER set.

Auditors: @dandart

Fixes https://github.com/brave/browser-laptop/issues/3516