### PR TITLE
Stop partner logos from floating below brave payments text

### DIFF
--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -473,13 +473,13 @@ table.sortableTable {
 
 .paymentsMessage {
   background-color: @lightGray;
+  border-radius: @borderRadiusUIbox;
   margin: 1em 0;
   padding: 40px;
   font-size: 1.3em;
   line-height: 1.3em;
   color: @mediumGray;
-  min-width: 440px;
-  max-width: 600px;
+  width: 500px;
   float: left;
   > div {
     padding: 0.5em 0;
@@ -567,6 +567,7 @@ div.nextPaymentSubmission {
 #paymentsContainer {
   position: relative;
   overflow-x: hidden;
+  width: 805px;
 
   .titleBar {
     overflow: hidden;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fixes #3551 

Auditors @bbondy @bradleyrichter 