### PR TITLE
fix cropped buttons in prefs panel

### DIFF
--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -18,7 +18,7 @@ body {
 
   .enablePaymentsSwitch {
     float: left;
-    min-width: 210px;
+    min-width: 215px;
     margin-right: 30px;
 
     span {
@@ -329,13 +329,14 @@ span.settingsListCopy {
   }
 }
 
-span.browserButton.primaryButton.addFunds {
-  font-size: 0.9em;
-  margin-right: 50px;
-}
-
 span.browserButton.primaryButton {
-  .clearBrowsingDataButton, .manageAutofillDataButton {
+  &.addFunds {
+    font-size: 0.9em;
+    margin-right: 50px;
+  }
+
+  &.clearBrowsingDataButton,
+  &.manageAutofillDataButton {
     font-size: 0.9em;
     margin-top: 20px;
     padding: 5px 20px;
@@ -597,7 +598,7 @@ div.nextPaymentSubmission {
     td {
       padding: 15px 30px 0 0;
       width: auto;
-      min-width: 210px;
+      min-width: 215px;
     }
     span.browserButton.primaryButton.addFunds {
       margin-right: 0;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fixes #3563 

Looks like a different commit (https://github.com/brave/browser-laptop/commit/540e918d0883bc54538255d8675b7f73d22eeea0) removed the padding we were adding to those prefs buttons. I don't think the new selector was applying to anything so I moved it back.

Auditors: @bradleyrichter @bsclifton  
