### PR TITLE
set ledger column items to right align

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -213,12 +213,12 @@ class LedgerTableRow extends ImmutableComponent {
     const defaultSiteSetting = true
 
     return <tr className={this.enabled ? '' : 'paymentsDisabled'}>
-      <td className='narrow' data-sort={this.padLeft(rank)}>{rank}</td>
-      <td className='wide'><a href={publisherURL} target='_blank'><img src={faviconURL} alt={site} /><span>{site}</span></a></td>
-      <td className='narrow'><SiteSettingCheckbox hostPattern={this.hostPattern} defaultValue={defaultSiteSetting} prefKey='ledgerPayments' siteSettings={this.props.siteSettings} checked={this.enabled} /></td>
-      <td data-sort={this.padLeft(views)}>{views}</td>
-      <td data-sort={this.padLeft(duration)}>{this.formattedTime}</td>
-      <td data-sort={this.padLeft(percentage)}>{percentage}</td>
+      <td className='alignRight' data-sort={this.padLeft(rank)}>{rank}</td>
+      <td><a href={publisherURL} target='_blank'><img src={faviconURL} alt={site} /><span>{site}</span></a></td>
+      <td><SiteSettingCheckbox hostPattern={this.hostPattern} defaultValue={defaultSiteSetting} prefKey='ledgerPayments' siteSettings={this.props.siteSettings} checked={this.enabled} /></td>
+      <td className='alignRight' data-sort={this.padLeft(views)}>{views}</td>
+      <td className='alignRight' data-sort={this.padLeft(duration)}>{this.formattedTime}</td>
+      <td className='alignRight' data-sort={this.padLeft(percentage)}>{percentage}</td>
     </tr>
   }
 }
@@ -409,8 +409,8 @@ class PaymentHistoryRow extends ImmutableComponent {
     var totalAmountStr = `${this.totalAmount} ${this.currency}`
 
     return <tr>
-      <td className='narrow' data-sort={this.timestamp}>{date}</td>
-      <td className='wide' data-sort={this.satoshis}>{totalAmountStr}</td>
+      <td data-sort={this.timestamp}>{date}</td>
+      <td data-sort={this.satoshis}>{totalAmountStr}</td>
     </tr>
   }
 }

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -499,6 +499,14 @@ table.sortableTable {
 #ledgerTable {
   height: ~"-webkit-calc(100vh - 300px)";
   overflow-y: scroll;
+
+  tr {
+    th,
+    td {
+      padding: 0 15px;
+    }
+  }
+
 }
 
 .modal .dialog.paymentHistory .sectionTitle {
@@ -652,7 +660,6 @@ div.nextPaymentSubmission {
       color: @mediumGray;
       -webkit-font-smoothing: antialiased;
       text-align: left;
-      width: 8%;
       vertical-align: top;
 
       a {
@@ -671,13 +678,8 @@ div.nextPaymentSubmission {
         }
       }
 
-      &.narrow {
-        width: 5%;
-      }
-
-      &.wide {
-        width: 20%;
-        text-align: left;
+      &.alignRight {
+        text-align: right;
       }
 
       input[type='range'] {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fixes #3567 

Ok so instead of using fixed widths like we were, I moved them to flex width with padding so we can have some items be right aligned. They look a little condensed right now but I was worried about giving them too much padding in case people end up with really long URLs in their ledger.

Thoughts?

Auditors: @bsclifton @bradleyrichter 

<img width="822" alt="screen shot 2016-08-30 at 11 33 21 am" src="https://cloud.githubusercontent.com/assets/490294/18102023/ec02b0dc-6ea5-11e6-8bee-12144087ffd1.png">
