### PR TITLE
stop favicon in ledger from being cropped

### DIFF
--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -673,7 +673,7 @@ div.nextPaymentSubmission {
         img {
           width: 1.5em;
           height: 1.5em;
-          margin: -0.375em 0.375em 0 0;
+          margin-right: 6px;
           vertical-align: middle;
         }
       }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fixes #3581 

I'm not sure I understand why this is a problem but here is a fix.

The problem is that we currently have negative margin on those favicons which overflow. That's fine but what is weird is when you "disable" the switch it just adds an opacity to the entire row (https://github.com/brave/browser-laptop/blob/master/less/about/preferences.less#L656) but for some reason that opacity means the overflow is getting clipped. 

Anyway, we really don't need that negative top margin so this fixes that and here's how they look.

<img width="643" alt="screen shot 2016-08-30 at 6 47 06 pm" src="https://cloud.githubusercontent.com/assets/490294/18113128/2d99e92a-6ee2-11e6-825a-4802eb1c75bd.png">


Auditors: @bradleyrichter @bbondy 