### PR TITLE
serialize app state saves

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   "dependencies": {
     "abp-filter-parser-cpp": "1.1.x",
     "acorn": "3.2.0",
+    "async": "^2.0.1",
     "electron-localshortcut": "^0.6.0",
     "electron-prebuilt": "brave/electron-prebuilt",
     "electron-squirrel-startup": "^1.0.0",
@@ -92,8 +93,8 @@
     "ledger-client": "^0.8.55",
     "ledger-publisher": "^0.8.57",
     "lru_cache": "^1.0.0",
-    "random-lib": "2.1.0",
     "qr-image": "^3.1.0",
+    "random-lib": "2.1.0",
     "react": "^15.0.1",
     "react-dom": "^15.0.1",
     "react-stickynode": "1.1.x",


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

fixes #3543

cc @BrendanEich 

There is still an issue with `initiateSessionStateSave` because it's possible for the calls to overlap and potentially call `saveIfAllCollected` before getting state from all the windows. This is possible because it only checks the count and doesn't check to make sure it has state for each active window id.