### PR TITLE
allow setting of user data dir

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -28,6 +28,7 @@ var locale = require('./locale')
 
 const Immutable = require('immutable')
 const electron = require('electron')
+const path = require('path')
 const BrowserWindow = electron.BrowserWindow
 const dialog = electron.dialog
 const ipcMain = electron.ipcMain
@@ -63,6 +64,14 @@ const flash = require('../js/flash')
 const contentSettings = require('../js/state/contentSettings')
 const privacy = require('../js/state/privacy')
 const basicAuth = require('./browser/basicAuth')
+
+if (!process.env.BRAVE_USER_DATA_DIR && ['development', 'test'].includes(process.env.NODE_ENV)) {
+  process.env.BRAVE_USER_DATA_DIR = path.join(app.getPath('appData'), app.getName() + '-' + process.env.NODE_ENV)
+}
+
+if (process.env.BRAVE_USER_DATA_DIR) {
+  app.setPath('userData', process.env.BRAVE_USER_DATA_DIR)
+}
 
 // Used to collect the per window state when shutting down the application
 let perWindowState = []

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -23,17 +23,13 @@ const sessionStorageVersion = 1
 const filtering = require('./filtering')
 // const tabState = require('./common/state/tabState')
 
-let suffix = ''
-if (process.env.NODE_ENV === 'development') {
-  suffix = '-dev'
-}
-const sessionStorageName = `session-store-${sessionStorageVersion}${suffix}`
-const storagePath = process.env.NODE_ENV !== 'test'
-  ? path.join(app.getPath('userData'), sessionStorageName)
-  : path.join(process.env.HOME, '.brave-test-session-store-1')
 const getSetting = require('../js/settings').getSetting
 const promisify = require('../js/lib/promisify')
+const sessionStorageName = `session-store-${sessionStorageVersion}`
 
+const getStoragePath = () => {
+  return path.join(app.getPath('userData'), sessionStorageName)
+}
 /**
  * Saves the specified immutable browser state to storage.
  *
@@ -78,7 +74,7 @@ module.exports.saveAppState = (payload, isShutdown) => {
       : path.join(process.env.HOME, '.brave-test-session-store-tmp-' + epochTimestamp)
 
     let p = promisify(fs.writeFile, tmpStoragePath, JSON.stringify(payload))
-      .then(() => promisify(fs.rename, tmpStoragePath, storagePath))
+      .then(() => promisify(fs.rename, tmpStoragePath, getStoragePath()))
     if (isShutdown) {
       p = p.then(module.exports.cleanSessionDataOnShutdown())
     }
@@ -314,7 +310,7 @@ module.exports.loadAppState = () => {
   return new Promise((resolve, reject) => {
     let data
     try {
-      data = fs.readFileSync(storagePath)
+      data = fs.readFileSync(getStoragePath())
     } catch (e) {
     }
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -41,6 +41,20 @@ If you'd like to see code run on each page load, you can edit `app/extensions/br
 Calls to `console.log` and related functions go into the per page dev tools console mentioned above.
 
 
+## Debugging Session Data
+
+The session data is stored in OS specific user data directories. Within those directories there will be a `brave` directory for release builds and a `brave-development` directory for dev (from NODE_ENV). If you want to use a different directory for dev you can set the environment variable `BRAVE_USER_DATA_DIR` to the directory you want to use. Each test run goes in a new tmp directory inside the OS specific tmpdir. Normally these directories are removed when the test is finished, but if you want to keep them you can the enviroment variable `KEEP_BRAVE_USER_DATA_DIR` to true.
+
+MacOS
+~/Library/Application Support/brave
+
+Linux
+linux ~/.config/brave
+
+Windows
+C:\Users\username\AppData\Roaming\brave
+
+
 ## Profiling React code
 
 The `Debug` menu has a `Toggle React Profiling` option which will start/stop the React addon for profiling.

--- a/test/app/sessionStoreTest.js
+++ b/test/app/sessionStoreTest.js
@@ -38,8 +38,8 @@ describe('sessionStore', function () {
         .waitUntil(function () {
           return this.getValue(urlInput).then((val) => val === page1Url)
         })
-      yield Brave.stopApp()
-      yield Brave.startApp(false)
+      yield Brave.stopApp(false)
+      yield Brave.startApp()
       yield setup(Brave.app.client)
     })
 

--- a/test/fixtures/formfill.html
+++ b/test/fixtures/formfill.html
@@ -239,6 +239,7 @@
                   </tr></tbody></table>
 
                   <p><input type="reset" value="Reset"></p>
+                  <p><input id="submit" type="submit" value="Submit"></p>
 
                 </form>
               </div>

--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -5,6 +5,7 @@ require('./coMocha')
 
 const path = require('path')
 const fs = require('fs')
+const os = require('os')
 const {getTargetAboutUrl, isSourceAboutUrl} = require('../../js/lib/appUrlUtil')
 
 var chaiAsPromised = require('chai-as-promised')
@@ -12,6 +13,30 @@ chai.should()
 chai.use(chaiAsPromised)
 
 const Server = require('./server')
+
+const generateUserDataDir = () => {
+  return path.join(os.tmpdir(), 'brave-test', (new Date().getTime()) + Math.floor(Math.random() * 1000).toString())
+}
+
+const rmDir = (dirPath) => {
+  try {
+    var files = fs.readdirSync(dirPath)
+  } catch (e) {
+    console.error(e)
+    return
+  }
+  if (files.length > 0) {
+    for (var i = 0; i < files.length; i++) {
+      var filePath = path.join(dirPath, files[i])
+      if (fs.statSync(filePath).isFile()) {
+        fs.unlinkSync(filePath)
+      } else {
+        rmDir(filePath)
+      }
+    }
+  }
+  fs.rmdirSync(dirPath)
+}
 
 var promiseMapSeries = function (array, iterator) {
   var length = array.length
@@ -26,6 +51,7 @@ var promiseMapSeries = function (array, iterator) {
   return Promise.all(results)
 }
 
+let userDataDir = generateUserDataDir()
 var exports = {
   keys: {
     COMMAND: '\ue03d',
@@ -411,36 +437,29 @@ var exports = {
     this.app.client.waitUntilWindowLoaded().windowByUrl(exports.browserWindowUrl)
   },
 
-  startApp: function (cleanSessionStore = true) {
-    if (cleanSessionStore) {
-      let ledgerDir = path.join(process.env.HOME, '.brave-test-ledger')
-      try {
-        fs.unlinkSync(path.join(process.env.HOME, '.brave-test-session-store-1'))
-      } catch (e) {
-      }
-      try {
-        ['publisher', 'state', 'scores', 'synopsis'].forEach((name) => {
-          try {
-            fs.unlinkSync(path.join(ledgerDir, `ledger-${name}-test.json`))
-          } catch (e) {
-          }
-        })
-      } catch (e) {
-        // probably ledgerDir does not exist yet
-        fs.mkdirSync(ledgerDir)
-      }
+  startApp: function () {
+    if (process.env.KEEP_BRAVE_USER_DATA_DIR) {
+      console.log('BRAVE_USER_DATA_DIR=' + userDataDir)
+    }
+    let env = {
+      NODE_ENV: 'test',
+      BRAVE_USER_DATA_DIR: userDataDir
     }
     this.app = new Application({
       path: './node_modules/.bin/electron',
-      env: {
-        NODE_ENV: 'test'
-      },
-      args: ['./', '--debug=5858', '--enable-logging', '--v=0']
+      env,
+      args: ['./', '--debug=5858', '--enable-logging', '--v=1']
     })
     return this.app.start()
   },
 
-  stopApp: function () {
+  stopApp: function (cleanSessionStore = true) {
+    if (cleanSessionStore) {
+      if (!process.env.KEEP_BRAVE_USER_DATA_DIR) {
+        userDataDir && rmDir(userDataDir)
+      }
+      userDataDir = generateUserDataDir()
+    }
     // this.app.client.getMainProcessLogs().then(function (logs) {
     //   logs.forEach(function (log) {
     //     console.log(log)


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

use a different user data dir for each test run
refactor autofill tests
fixes #3618