### PR TITLE
Remove extra separator menu item (doesn't show on Mac)

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -364,7 +364,7 @@ const createHistorySubmenu = (CommonMenu) => {
 }
 
 const createBookmarksSubmenu = (CommonMenu) => {
-  return [
+  let submenu = [
     {
       label: locale.translation('bookmarkPage'),
       type: 'checkbox',
@@ -386,9 +386,16 @@ const createBookmarksSubmenu = (CommonMenu) => {
     CommonMenu.bookmarksManagerMenuItem(),
     CommonMenu.bookmarksToolbarMenuItem(),
     CommonMenu.separatorMenuItem,
-    CommonMenu.importBookmarksMenuItem(),
-    CommonMenu.separatorMenuItem
-  ].concat(menuUtil.createBookmarkMenuItems())
+    CommonMenu.importBookmarksMenuItem()
+  ]
+
+  const bookmarks = menuUtil.createBookmarkMenuItems()
+  if (bookmarks.length > 0) {
+    submenu.push(CommonMenu.separatorMenuItem)
+    submenu = submenu.concat(bookmarks)
+  }
+
+  return submenu
 }
 
 const createWindowSubmenu = (CommonMenu) => {

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -870,7 +870,11 @@ function mainTemplateInit (nodeProps, frame) {
       label: locale.translation('redo'),
       accelerator: 'Shift+CmdOrCtrl+Z',
       role: 'redo'
-    }, CommonMenu.separatorMenuItem, ...editableItems, CommonMenu.separatorMenuItem)
+    }, CommonMenu.separatorMenuItem)
+
+    if (editableItems.length > 0) {
+      template.push(...editableItems, CommonMenu.separatorMenuItem)
+    }
   } else if (isTextSelected) {
     if (isDarwin) {
       template.push(showDefinitionMenuItem(nodeProps.selectionText),


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.

Fixes https://github.com/brave/browser-laptop/issues/3666

(Manually tested in dev mode on Windows 10 pro x64)

Auditors: @charbelrami @srirambv

Test Plan:
- With new code in place, launch Brave on Windows
- Delete all your bookmarks
- Confirm bookmarks menu looks good (no extra separator)
- Go to google.com
- Right click the "Google Search" button
- Confirm you don't see the extra separator