### PR TITLE
Removed unneeded context menu items (Fix #3670)

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -407,30 +407,32 @@ function autofillTemplateInit (suggestions, frame) {
 function tabTemplateInit (frameProps) {
   const frameKey = frameProps.get('key')
   const items = []
-  items.push(
-    CommonMenu.newTabMenuItem(frameProps.get('key')),
-    CommonMenu.separatorMenuItem,
-    {
-      label: locale.translation('reloadTab'),
-      click: (item, focusedWindow) => {
-        if (focusedWindow) {
-          focusedWindow.webContents.send(messages.SHORTCUT_FRAME_RELOAD, frameKey)
+  const location = frameProps.get('location')
+  if (location !== 'about:newtab') {
+    items.push(
+      CommonMenu.newTabMenuItem(frameProps.get('key')),
+      CommonMenu.separatorMenuItem,
+      {
+        label: locale.translation('reloadTab'),
+        click: (item, focusedWindow) => {
+          if (focusedWindow) {
+            focusedWindow.webContents.send(messages.SHORTCUT_FRAME_RELOAD, frameKey)
+          }
         }
-      }
-    }, {
-      label: locale.translation('clone'),
-      click: (item, focusedWindow) => {
-        if (focusedWindow) {
-          focusedWindow.webContents.send(messages.SHORTCUT_FRAME_CLONE, frameKey, {
-            openInForeground: true
-          })
+      }, {
+        label: locale.translation('clone'),
+        click: (item, focusedWindow) => {
+          if (focusedWindow) {
+            focusedWindow.webContents.send(messages.SHORTCUT_FRAME_CLONE, frameKey, {
+              openInForeground: true
+            })
+          }
         }
-      }
-    })
+      })
+  }
 
   if (!frameProps.get('isPrivate')) {
     const isPinned = frameProps.get('pinnedLocation')
-    const location = frameProps.get('location')
     if (!(location === 'about:blank' || location === 'about:newtab' || isIntermediateAboutPage(location))) {
       items.push({
         label: locale.translation(isPinned ? 'unpinTab' : 'pinTab'),


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes #3670

Don't show "Reload" and "Clone" in the context menu of the new tab page.