### PR TITLE
Address bar is not "active" when it should be

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -349,9 +349,18 @@ class Frame extends ImmutableComponent {
       }
       this.webview.setActive(this.props.isActive)
       this.handleShortcut()
+
       // give focus when switching tabs
       if (this.props.isActive && !prevProps.isActive) {
-        this.webview.focus()
+        // If the tab we switch to is a new tab page, give focus
+        // to the UrlBar
+        if (this.props.location === 'about:newtab') {
+          windowActions.setUrlBarActive(true)
+          windowActions.setUrlBarSelected(false)
+        } else {
+          // If it is a regular webpage, just focus the webcontents
+          this.webview.focus()
+        }
       }
       // make sure the webview content updates to
       // match the fullscreen state of the frame

--- a/test/components/navigationBarTest.js
+++ b/test/components/navigationBarTest.js
@@ -695,6 +695,19 @@ describe('navigationBar', function () {
         })
       })
     })
+
+    describe('switch to new tab page', function () {
+      before(function * () {
+        yield this.app.client
+          .ipcSend('shortcut-set-active-frame-by-index', 1)
+      })
+
+      it('focuses on the urlbar', function * () {
+        this.app.client
+        .waitForExist('.tab[data-frame-key="1"].active')
+        .waitForElementFocus(urlInput)
+      })
+    })
   })
 
   describe('clicking on navbar', function () {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Makes the url bar active when switching to a about:newtab
page, as the user is expecting to be able to enter his url
when he switches back to a new tab page.

Fixes #3712

Auditors:
@bbondy

Test Plan:
1- Open a new tab
2- Switch to the new blank tab
3- Go back to the tab you were browsing before you opened the new tab
4- Go to the blank new tab you opened in step 1

On step 4, the address bar should be "active", so users could be able to write the web address without need to click on it.