### PR TITLE
Fixes #3068 Implements 'Switch to new tabs immediately' setting

### DIFF
--- a/js/components/window.js
+++ b/js/components/window.js
@@ -42,10 +42,10 @@ class Window extends React.Component {
       if (this.props.frames.length === 0) {
         windowActions.newFrame({
           location: config.defaultUrl
-        })
+        }, true)
       } else {
         this.props.frames.forEach((frame) => {
-          windowActions.newFrame(frame)
+          windowActions.newFrame(frame, true)
         })
       }
     }

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -14,6 +14,7 @@ const messages = require('../constants/messages')
 const debounce = require('../lib/debounce.js')
 const getSetting = require('../settings').getSetting
 const importFromHTML = require('../lib/importer').importFromHTML
+const AppUrlUtil = require('../lib/appUrlUtil')
 const UrlUtil = require('../lib/urlutil')
 const urlParse = require('url').parse
 const currentWindow = require('../../app/renderer/currentWindow')
@@ -169,11 +170,8 @@ const newFrame = (frameOpts, openInForeground, insertionIndex) => {
     frameOpts = {}
   }
   frameOpts = frameOpts.toJS ? frameOpts.toJS() : frameOpts
-
-  if (openInForeground === undefined) {
-    openInForeground = true
-  }
   frameOpts.location = frameOpts.location || config.defaultUrl
+
   if (frameOpts.location && UrlUtil.isURL(frameOpts.location)) {
     frameOpts.location = UrlUtil.getUrlFromInput(frameOpts.location)
   } else {
@@ -185,6 +183,14 @@ const newFrame = (frameOpts, openInForeground, insertionIndex) => {
       // Bad URLs passed here can actually crash the browser
       frameOpts.location = ''
     }
+  }
+
+	if (openInForeground === undefined || openInForeground === null) {
+    openInForeground = getSetting(settings.SWITCH_TO_NEW_TABS)
+		// About urls (expect about:newtab) should open in foreground 
+		if (!openInForeground && AppUrlUtil.isSourceAboutUrl(frameOpts.location) && frameOpts.location !== 'about:newtab') {
+			openInForeground = true
+		}
   }
 
   const nextKey = incrementNextKey()


### PR DESCRIPTION
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits if needed.
1. Added functionality for the 'Switch to new tab immediately' setting
2. Applied setting to work for redirects from about:bookmarks page
3. Added condition to ignore pages starting with 'about:' except 'about:newtab'

@bbondy Sorry, but after rebasing my branch to master, I managed to pull every single commit that I did not have with comments and remarks. So my PR got the entire comment history for the past 20 days! I didn't really know how to fix it so I just made a clean PR for you. For future reference, how do I fast forward my branch to incorporate new changes while maintaining only my changes in the PR? Was I suppose to rebase twice to squash the new commits? Again, I apologize, I don't really have much experience with rebasing. I have also included my firefox research comment from the other PR below.

**Firefox implementation**
I looked how firefox handles this setting. Here are some of the things I noticed:
- [ ] Switch immediately to new tab
- "about" pages are prioritized and ignore this setting
- bookmarks and history links open in the currently active tab
- Ctrl/Cmd + click obeys preference value
- using Ctrl/Cmd + Shift + click overrides the preference and opens tab as active frame
- [x] Switch immediately to new tab
- Ctrl/Cmd + click obeys preference value
- using Ctrl/Cmd + Shift + click overrides the preference and opens tab as background frame

So the most interesting behaviour is the Ctrl/Cmd + Shift + click override which basically does the opposite of the current value specified in the preferences. If I remove my check for "about:newtab" we will basically have the same behaviour as firefox.

Regarding the calls of `newFrame` not being updated, I saw these were previously defaulting to true, I'm not sure which calls lead to this, it's been there before this update. Let me know in more detail what you would like regarding this though, I can look into it.
