### PR TITLE
Dismiss context menu when pressing tab and esc

### DIFF
--- a/js/components/contextMenu.js
+++ b/js/components/contextMenu.js
@@ -7,8 +7,17 @@ const Immutable = require('immutable')
 const ImmutableComponent = require('./immutableComponent')
 const windowActions = require('../actions/windowActions')
 const cx = require('../lib/classSet.js')
+const KeyCodes = require('../constants/keyCodes')
 
 class ContextMenuItem extends ImmutableComponent {
+  componentDidMount () {
+    window.addEventListener('keydown', this.onKeyDown.bind(this))
+  }
+  onKeyDown (e) {
+    if (e.keyCode === KeyCodes.ESC || e.keyCode === KeyCodes.TAB) {
+      windowActions.setContextMenuDetail()
+    }
+  }
   get submenu () {
     return this.props.contextMenuItem.get('submenu')
   }

--- a/js/constants/keyCodes.js
+++ b/js/constants/keyCodes.js
@@ -17,7 +17,8 @@ const KeyCodes = {
   RIGHT: 39,
   F12: 123,
   NUMPAD_PLUS: 107,
-  NUMPAD_MINUS: 109
+  NUMPAD_MINUS: 109,
+  TAB: 9
 }
 
 module.exports = KeyCodes


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bbondy

Test Plan:
1. Make input field popup autofill option or built in password manager
option
2. Press esc or tab should dismiss popup