### PR TITLE
remove mutation observers from brave content scripts

### DIFF
--- a/app/extensions/brave/content/scripts/flashListener.js
+++ b/app/extensions/brave/content/scripts/flashListener.js
@@ -30,16 +30,14 @@ if (chrome.contentSettings.flashActive != 'allow' &&
         }
       })
     }
-    setTimeout(() => {
-      var observer = new window.MutationObserver(function (mutations) {
-        replaceAdobeLinks()
-      })
-      replaceAdobeLinks()
-      observer.observe(document.documentElement, {
-        childList: true,
-        subtree: true
-      })
-    }, 1000)
+    replaceAdobeLinks()
+    let interval = setInterval(replaceAdobeLinks, 1000)
+    document.addEventListener('visibilitychange', () => {
+      clearInterval(interval)
+      if (document.visibilityState !== 'hidden') {
+        interval = setInterval(replaceAdobeLinks, 1000)
+      }
+    })
   })()
 }
 
@@ -131,7 +129,7 @@ function getFlashObjects (elem) {
  * Inserts Flash placeholders.
  * @param {Element} elem - HTML element to search
  */
-function insertFlashPlaceholders (elem) {
+function insertFlashPlaceholders (elem = document.documentElement) {
   const minWidth = 200
   const minHeight = 100
   let flashObjects = getFlashObjects(elem)
@@ -161,16 +159,12 @@ function insertFlashPlaceholders (elem) {
 
 if (chrome.contentSettings.flashActive != 'allow' ||
     chrome.contentSettings.flashEnabled != 'allow') {
-  insertFlashPlaceholders(document.documentElement)
-  setTimeout(() => {
-    var observer = new window.MutationObserver(function (mutations) {
-      insertFlashPlaceholders(document.documentElement)
-    })
-
-    insertFlashPlaceholders(document.documentElement)
-    observer.observe(document.documentElement, {
-      childList: true,
-      subtree: true
-    })
-  }, 1000)
+  insertFlashPlaceholders()
+  let interval = setInterval(insertFlashPlaceholders, 1000)
+  document.addEventListener('visibilitychange', () => {
+    clearInterval(interval)
+    if (document.visibilityState !== 'hidden') {
+      interval = setInterval(insertFlashPlaceholders, 1000)
+    }
+  })
 }


### PR DESCRIPTION
Test Plan:
Check password capture on submit
1. Go to Facebook.com
2. Enter a username and password
3. Brave password save dialog should appear

1. Go to https://mint.intuit.com/login.event
2. Enter a username and password
3. Brave password save dialog should appear

Check password fill for both immediate and delayed load password forms
1. Go to Facebook.com
2. Password should autofill

1. Go to https://mint.intuit.com/login.event
2. Password should autofill

don't add duplicate submit and click event listeners on every password check
only check for changes while page is visible

cc @bbondy @diracdeltas 