### PR TITLE
Brave doesn't remember last position and size if homepage is set

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -59,7 +59,14 @@ module.exports.saveAppState = (payload, isShutdown) => {
         wndPayload.tabs = wndPayload.tabs.filter((tab) => !tab.isPrivate)
       })
     } else {
-      delete payload.perWindowState
+      // Reset the window state except for the ui data
+      payload.perWindowState.forEach((wndPayload) => {
+        Object.keys(wndPayload).forEach((key) => {
+          if (key !== 'ui') {
+            delete wndPayload[key]
+          }
+        })
+      })
     }
 
     try {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).


Brave doesn't remember last position and size if you set it to start with homepage

When closed Brave does not retain last window position and size as it should be when re-launched.

This happens only if in Settings -> General you set the value for Brave starts with to My homepage. If you select Session and tabs from last time it correctly remembers the position and the size of the window.

Fixes ##3754

Auditors
@bbondy

Test Plan:
1. In settings -> general set Brave starts with to My homepage
2. Launch Brave, move the window around and close
3. Re-launch Brave and compare the last window position