### PR TITLE
only update the menu when bookmarks or closed tabs change

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -24,8 +24,6 @@ if (process.platform === 'win32') {
   require('./windowsInit')
 }
 
-var locale = require('./locale')
-
 const path = require('path')
 const electron = require('electron')
 const app = electron.app
@@ -64,9 +62,9 @@ const showAbout = require('./aboutDialog').showAbout
 const urlParse = require('url').parse
 const CryptoUtil = require('../js/lib/cryptoUtil')
 const keytar = require('keytar')
-const settings = require('../js/constants/settings')
 const siteSettings = require('../js/state/siteSettings')
 const spellCheck = require('./spellCheck')
+const locale = require('./locale')
 const ledger = require('./ledger')
 const flash = require('../js/flash')
 const contentSettings = require('../js/state/contentSettings')
@@ -227,9 +225,7 @@ const initiateSessionStateSave = (beforeQuit) => {
   }
 }
 
-let loadAppStatePromise = SessionStore.loadAppState().catch(() => {
-  return SessionStore.defaultAppState()
-})
+let loadAppStatePromise = SessionStore.loadAppState()
 
 let flashInitialized = false
 
@@ -249,7 +245,6 @@ loadAppStatePromise.then((initialState) => {
       return
     }
   }
-  app.setLocale(initialState.settings[settings.LANGUAGE])
 })
 
 app.on('ready', () => {
@@ -322,13 +317,6 @@ app.on('ready', () => {
     saveIfAllCollected()
   })
 
-  // Window state is fetched via the renderer process; this is fired once it's retrieved
-  ipcMain.on(messages.RESPONSE_MENU_DATA_FOR_WINDOW, (wnd, windowData) => {
-    if (windowData) {
-      Menu.rebuild(AppStore.getState(), Immutable.fromJS(windowData))
-    }
-  })
-
   ipcMain.on(messages.LAST_WINDOW_STATE, (wnd, data) => {
     if (data) {
       lastWindowState = data
@@ -383,19 +371,13 @@ app.on('ready', () => {
   })
 
   loadAppStatePromise.then((initialState) => {
-    // Initiate the translation for a configured language and
-    // reset the browser window. This will default to en-US if
-    // not yet configured.
-    locale.init(initialState.settings[settings.LANGUAGE], (strings) => {
-      Menu.rebuild(AppStore.getState(), null)
-    })
-
     // Do this after loading the state
     // For tests we always want to load default app state
     const loadedPerWindowState = initialState.perWindowState
     delete initialState.perWindowState
     initialState.flashInitialized = flashInitialized
     appActions.setState(Immutable.fromJS(initialState))
+    Menu.init(initialState, null)
     return loadedPerWindowState
   }).then((loadedPerWindowState) => {
     basicAuth.init()
@@ -461,12 +443,6 @@ app.on('ready', () => {
       }
     })
 
-    ipcMain.on(messages.UPDATE_MENU_BOOKMARKED_STATUS, (e, isBookmarked) => {
-      if (typeof isBookmarked === 'boolean') {
-        Menu.updateBookmarkedStatus(isBookmarked)
-      }
-    })
-
     ipcMain.on(messages.SET_CLIPBOARD, (e, text) => {
       electron.clipboard.writeText(text)
     })
@@ -524,14 +500,6 @@ app.on('ready', () => {
 
     // save app state every 5 minutes regardless of update frequency
     sessionStateSaveInterval = setInterval(initiateSessionStateSave, 1000 * 60 * 5)
-
-    AppStore.addChangeListener(() => {
-      if (BrowserWindow.getFocusedWindow()) {
-        BrowserWindow.getFocusedWindow().webContents.send(messages.REQUEST_MENU_DATA_FOR_WINDOW)
-      } else {
-        Menu.rebuild(AppStore.getState(), null)
-      }
-    })
 
     ledger.init()
 

--- a/js/components/addEditBookmark.js
+++ b/js/components/addEditBookmark.js
@@ -10,11 +10,9 @@ const windowActions = require('../actions/windowActions')
 const appActions = require('../actions/appActions')
 const KeyCodes = require('../constants/keyCodes')
 const siteTags = require('../constants/siteTags')
-const messages = require('../constants/messages')
 const settings = require('../constants/settings')
 const siteUtil = require('../state/siteUtil')
 const getSetting = require('../settings').getSetting
-const ipc = global.require('electron').ipcRenderer
 
 class AddEditBookmark extends ImmutableComponent {
   constructor () {
@@ -97,9 +95,6 @@ class AddEditBookmark extends ImmutableComponent {
     )
     appActions.changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, !isFirstBookmark || showBookmarksToolbar)
   }
-  updateMenuBookmarkedStatus (isBookmarked) {
-    ipc.send(messages.UPDATE_MENU_BOOKMARKED_STATUS, isBookmarked)
-  }
   onSave () {
     // First check if the title of the currentDetail is set
     if (!this.bookmarkNameValid) {
@@ -109,13 +104,11 @@ class AddEditBookmark extends ImmutableComponent {
     this.showToolbarOnFirstBookmark()
     const tag = this.isFolder ? siteTags.BOOKMARK_FOLDER : siteTags.BOOKMARK
     appActions.addSite(this.props.currentDetail, tag, this.props.originalDetail, this.props.destinationDetail)
-    this.updateMenuBookmarkedStatus(true)
     this.onClose()
   }
   onRemoveBookmark () {
     const tag = this.isFolder ? siteTags.BOOKMARK_FOLDER : siteTags.BOOKMARK
     appActions.removeSite(this.props.currentDetail, tag)
-    this.updateMenuBookmarkedStatus(false)
     this.onClose()
   }
   get displayBookmarkName () {

--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -84,8 +84,6 @@ class NavigationBar extends ImmutableComponent {
   componentDidMount () {
     ipc.on(messages.SHORTCUT_ACTIVE_FRAME_BOOKMARK, () => this.onToggleBookmark())
     ipc.on(messages.SHORTCUT_ACTIVE_FRAME_REMOVE_BOOKMARK, () => this.onToggleBookmark())
-    // Set initial checked/unchecked status in Bookmarks menu
-    ipc.send(messages.UPDATE_MENU_BOOKMARKED_STATUS, this.bookmarked)
   }
 
   get showNoScriptInfo () {
@@ -97,17 +95,6 @@ class NavigationBar extends ImmutableComponent {
   }
 
   componentDidUpdate (prevProps) {
-    // Update the app menu to reflect whether the current page is bookmarked
-    const prevBookmarked = this.props.activeFrameKey !== undefined &&
-      siteUtil.isSiteBookmarked(prevProps.sites, Immutable.fromJS({
-        location: prevProps.location,
-        partitionNumber: prevProps.partitionNumber,
-        title: prevProps.title
-      }))
-
-    if (this.bookmarked !== prevBookmarked) {
-      ipc.send(messages.UPDATE_MENU_BOOKMARKED_STATUS, this.bookmarked)
-    }
     if (this.props.noScriptIsVisible && !this.showNoScriptInfo) {
       // There are no blocked scripts, so hide the noscript dialog.
       windowActions.setNoScriptVisible(false)

--- a/js/constants/appConstants.js
+++ b/js/constants/appConstants.js
@@ -44,7 +44,9 @@ const AppConstants = {
   APP_SET_LOGIN_RESPONSE_DETAIL: _,
   APP_WINDOW_BLURRED: _,
   APP_IDLE_STATE_CHANGED: _,
-  APP_CHANGE_NEW_TAB_DETAIL: _
+  APP_CHANGE_NEW_TAB_DETAIL: _,
+  APP_TAB_CREATED: _,
+  APP_TAB_DESTROYED: _
 }
 
 module.exports = mapValuesByKeys(AppConstants)

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -104,10 +104,6 @@ const messages = {
   LAST_WINDOW_STATE: _,
   UNDO_CLOSED_WINDOW: _,
   CLEAR_CLOSED_FRAMES: _,
-  // Menu rebuilding
-  REQUEST_MENU_DATA_FOR_WINDOW: _,
-  RESPONSE_MENU_DATA_FOR_WINDOW: _,
-  UPDATE_MENU_BOOKMARKED_STATUS: _, /** @isBookmarked {boolean} should menu show "Bookmark Page" as checked */
   // Ad block, safebrowsing, and tracking protection
   BLOCKED_RESOURCE: _,
   BLOCKED_PAGE: _,

--- a/js/dispatcher/appDispatcher.js
+++ b/js/dispatcher/appDispatcher.js
@@ -93,7 +93,11 @@ if (process.type === 'browser') {
     let registrant = event.sender
     const callback = function (payload) {
       try {
-        registrant.send(messages.DISPATCH_ACTION, Serializer.serialize(payload))
+        if (registrant.isDestroyed()) {
+          appDispatcher.unregister(callback)
+        } else {
+          registrant.send(messages.DISPATCH_ACTION, Serializer.serialize(payload))
+        }
       } catch (e) {
         console.error('unregistering callback', e)
         appDispatcher.unregister(callback)

--- a/js/entry.js
+++ b/js/entry.js
@@ -35,7 +35,6 @@ const messages = require('./constants/messages')
 const Immutable = require('immutable')
 const patch = require('immutablepatch')
 const l10n = require('./l10n')
-const FrameStateUtil = require('./state/frameStateUtil')
 
 // don't allow scaling or zooming of the ui
 webFrame.setPageScaleLimits(1, 1)
@@ -53,16 +52,6 @@ ipc.on(messages.INITIALIZE_WINDOW, (e, disposition, appState, frames, initWindow
 
 ipc.on(messages.REQUEST_WINDOW_STATE, () => {
   ipc.send(messages.RESPONSE_WINDOW_STATE, windowStore.getState().toJS())
-})
-
-ipc.on(messages.REQUEST_MENU_DATA_FOR_WINDOW, () => {
-  const windowState = windowStore.getState()
-  const activeFrame = FrameStateUtil.getActiveFrame(Immutable.fromJS(windowState))
-  const windowData = {
-    location: activeFrame ? activeFrame.get('location') : null,
-    closedFrames: windowState.get('closedFrames').toJS()
-  }
-  ipc.send(messages.RESPONSE_MENU_DATA_FOR_WINDOW, windowData)
 })
 
 if (process.env.NODE_ENV === 'test') {

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -155,10 +155,6 @@ const createWindow = (browserOpts, defaults, frameOpts, windowState) => {
     appActions.windowBlurred(mainWindow.id)
   })
 
-  mainWindow.on('focus', function () {
-    mainWindow.webContents.send(messages.REQUEST_MENU_DATA_FOR_WINDOW)
-  })
-
   mainWindow.on('resize', function (evt) {
     // the default window size is whatever the last window resize was
     appActions.setDefaultWindowSize(evt.sender.getSize())
@@ -540,7 +536,6 @@ const handleAppAction = (action) => {
       if (action.clearDataDetail.get('browserHistory')) {
         handleAppAction({actionType: AppConstants.APP_CLEAR_HISTORY})
         BrowserWindow.getAllWindows().forEach((wnd) => wnd.webContents.send(messages.CLEAR_CLOSED_FRAMES))
-        BrowserWindow.getAllWindows().forEach((wnd) => wnd.webContents.send(messages.REQUEST_MENU_DATA_FOR_WINDOW))
       }
       if (action.clearDataDetail.get('downloadHistory')) {
         handleAppAction({actionType: AppConstants.APP_CLEAR_COMPLETED_DOWNLOADS})

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -442,13 +442,6 @@ const doAction = (action) => {
       windowState = windowState.merge(FrameStateUtil.removeFrame(windowState.get('frames'), windowState.get('tabs'),
         windowState.get('closedFrames'), frameProps.set('closedAtIndex', index),
         activeFrameKey))
-      // History menu needs update (since it shows "Recently Closed" items)
-      const activeFrameLocation = FrameStateUtil.getActiveFrame(windowState).get('location')
-      const windowData = {
-        location: activeFrameLocation,
-        closedFrames: windowState.get('closedFrames').toJS()
-      }
-      ipc.send(messages.RESPONSE_MENU_DATA_FOR_WINDOW, windowData)
       // If we reach the limit of opened tabs per page while closing tabs, switch to
       // the active tab's page otherwise the user will hang on empty page
       let totalOpenTabs = windowState.get('frames').filter((frame) => !frame.get('pinnedLocation')).size

--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -35,7 +35,12 @@ const rmDir = (dirPath) => {
       }
     }
   }
-  fs.rmdirSync(dirPath)
+  try {
+    fs.rmdirSync(dirPath)
+  } catch (e) {
+    console.error(e)
+    return
+  }
 }
 
 var promiseMapSeries = function (array, iterator) {

--- a/test/unit/lib/menuUtilTest.js
+++ b/test/unit/lib/menuUtilTest.js
@@ -93,72 +93,24 @@ describe('menuUtil', function () {
     })
   })
 
-  describe('checkForUpdate', function () {
-    const appStateSettings = Immutable.fromJS({
-      settings: {
-        key: 'value'
-      }
-    })
-    const appStateSites = Immutable.fromJS({
-      sites: {
-        key: 'value'
-      }
-    })
-    const windowStateClosedFrames = Immutable.fromJS({
-      closedFrames: [{
-        frameId: 1
-      }]
-    })
-    it('sets updated.nothing to false if `settings` was updated', function () {
-      const updated = menuUtil.checkForUpdate(appStateSettings, null)
-      assert.equal(updated.nothing, false)
-    })
-    it('sets updated.nothing to false if `sites` was updated', function () {
-      const updated = menuUtil.checkForUpdate(appStateSites, null)
-      assert.equal(updated.nothing, false)
-      console.log(menuUtil.lastSites)
-    })
-    it('sets updated.nothing to false if `closedFrames` was updated', function () {
-      const updated = menuUtil.checkForUpdate(null, windowStateClosedFrames)
-      assert.equal(updated.nothing, false)
-    })
-    it('leaves updated.nothing as true if nothing was updated', function () {
-      const updated = menuUtil.checkForUpdate(null, null)
-      assert.equal(updated.nothing, true)
-    })
-    it('does not save falsey values', function () {
-      menuUtil.checkForUpdate(appStateSites, null)
-      menuUtil.checkForUpdate(null, null)
-      // NOTE: there should be no change, since last calls values weren't recorded
-      const updated = menuUtil.checkForUpdate(appStateSites, null)
-      assert.equal(updated.nothing, true)
-    })
-  })
-
   describe('createBookmarkMenuItems', function () {
     it('returns an array of items w/ the bookmark tag', function () {
-      const appStateSites = Immutable.fromJS({
-        sites: [
-          { tags: [siteTags.BOOKMARK], title: 'my website', location: 'https://brave.com' }
-        ]
-      })
+      const appStateSites = Immutable.fromJS([
+        { tags: [siteTags.BOOKMARK], title: 'my website', location: 'https://brave.com' }
+      ])
 
-      menuUtil.checkForUpdate(appStateSites, null)
-      const menuItems = menuUtil.createBookmarkMenuItems()
+      const menuItems = menuUtil.createBookmarkMenuItems(appStateSites)
 
       assert.equal(Array.isArray(menuItems), true)
       assert.equal(menuItems.length, 1)
       assert.equal(menuItems[0].label, 'my website')
     })
     it('prefers the customTitle field for the bookmark title (over the page title)', function () {
-      const appStateSites = Immutable.fromJS({
-        sites: [
-          { tags: [siteTags.BOOKMARK], customTitle: 'use this', title: 'not this', location: 'https://brave.com' }
-        ]
-      })
+      const appStateSites = Immutable.fromJS([
+        { tags: [siteTags.BOOKMARK], customTitle: 'use this', title: 'not this', location: 'https://brave.com' }
+      ])
 
-      menuUtil.checkForUpdate(appStateSites, null)
-      const menuItems = menuUtil.createBookmarkMenuItems()
+      const menuItems = menuUtil.createBookmarkMenuItems(appStateSites)
 
       assert.equal(menuItems[0].label, 'use this')
     })
@@ -169,8 +121,7 @@ describe('menuUtil', function () {
         ]
       })
 
-      menuUtil.checkForUpdate(appStateSites, null)
-      const menuItems = menuUtil.createBookmarkMenuItems()
+      const menuItems = menuUtil.createBookmarkMenuItems(appStateSites)
 
       assert.deepEqual(menuItems, [])
     })
@@ -181,34 +132,26 @@ describe('menuUtil', function () {
         ]
       })
 
-      menuUtil.checkForUpdate(appStateSites, null)
-      const menuItems = menuUtil.createBookmarkMenuItems()
+      const menuItems = menuUtil.createBookmarkMenuItems(appStateSites)
 
       assert.deepEqual(menuItems, [])
     })
     it('does not count pinned tabs as bookmarks', function () {
-      const appStateSites = Immutable.fromJS({
-        sites: [
-          { tags: [siteTags.PINNED], title: 'pinned site', location: 'https://pinned-website.com' },
-          { tags: [siteTags.BOOKMARK], title: 'my website', location: 'https://brave.com' }
-        ]
-      })
-      menuUtil.checkForUpdate(appStateSites, null)
-      const menuItems = menuUtil.createBookmarkMenuItems()
+      const appStateSites = Immutable.fromJS([
+        { tags: [siteTags.PINNED], title: 'pinned site', location: 'https://pinned-website.com' },
+        { tags: [siteTags.BOOKMARK], title: 'my website', location: 'https://brave.com' }
+      ])
+      const menuItems = menuUtil.createBookmarkMenuItems(appStateSites)
 
       assert.equal(menuItems.length, 1)
       assert.equal(menuItems[0].label, 'my website')
     })
     it('processes folders', function () {
-      const appStateSites = Immutable.fromJS({
-        sites: [
-          { tags: [siteTags.BOOKMARK_FOLDER], title: 'my folder', folderId: 123 },
-          { tags: [siteTags.BOOKMARK], title: 'my website', location: 'https://brave.com', parentFolderId: 123 }
-        ]
-      })
-
-      menuUtil.checkForUpdate(appStateSites, null)
-      const menuItems = menuUtil.createBookmarkMenuItems()
+      const appStateSites = Immutable.fromJS([
+        { tags: [siteTags.BOOKMARK_FOLDER], title: 'my folder', folderId: 123 },
+        { tags: [siteTags.BOOKMARK], title: 'my website', location: 'https://brave.com', parentFolderId: 123 }
+      ])
+      const menuItems = menuUtil.createBookmarkMenuItems(appStateSites)
 
       assert.equal(menuItems.length, 1)
       assert.equal(menuItems[0].label, 'my folder')
@@ -216,15 +159,12 @@ describe('menuUtil', function () {
       assert.equal(menuItems[0].submenu[0].label, 'my website')
     })
     it('considers customTitle when processing folders', function () {
-      const appStateSites = Immutable.fromJS({
-        sites: [
-          { tags: [siteTags.BOOKMARK_FOLDER], customTitle: 'use this', title: 'not this', folderId: 123 },
-          { tags: [siteTags.BOOKMARK], title: 'my website', location: 'https://brave.com', parentFolderId: 123 }
-        ]
-      })
+      const appStateSites = Immutable.fromJS([
+        { tags: [siteTags.BOOKMARK_FOLDER], customTitle: 'use this', title: 'not this', folderId: 123 },
+        { tags: [siteTags.BOOKMARK], title: 'my website', location: 'https://brave.com', parentFolderId: 123 }
+      ])
 
-      menuUtil.checkForUpdate(appStateSites, null)
-      const menuItems = menuUtil.createBookmarkMenuItems()
+      const menuItems = menuUtil.createBookmarkMenuItems(appStateSites)
 
       assert.equal(menuItems.length, 1)
       assert.equal(menuItems[0].label, 'use this')
@@ -233,47 +173,39 @@ describe('menuUtil', function () {
 
   describe('createRecentlyClosedMenuItems', function () {
     it('returns an array of closedFrames preceded by a separator and "Recently Closed" items', function () {
-      const windowStateClosedFrames = Immutable.fromJS({
-        closedFrames: [{
-          title: 'sample',
-          location: 'https://brave.com'
-        }]
-      })
-
-      menuUtil.checkForUpdate(null, windowStateClosedFrames)
-      const menuItems = menuUtil.createRecentlyClosedMenuItems()
+      const windowStateClosedFrames = Immutable.fromJS([{
+        title: 'sample',
+        location: 'https://brave.com'
+      }])
+      const menuItems = menuUtil.createRecentlyClosedMenuItems(windowStateClosedFrames)
 
       assert.equal(Array.isArray(menuItems), true)
       assert.equal(menuItems.length, 3)
       assert.equal(menuItems[0].type, 'separator')
       assert.equal(menuItems[1].label, 'RECENTLYCLOSED')
       assert.equal(menuItems[1].enabled, false)
-      assert.equal(menuItems[2].label, windowStateClosedFrames.get('closedFrames').first().get('title'))
+      assert.equal(menuItems[2].label, windowStateClosedFrames.first().get('title'))
       assert.equal(typeof menuItems[2].click === 'function', true)
     })
     it('only shows the last 10 items', function () {
-      const windowStateClosedFrames = Immutable.fromJS({
-        closedFrames: [
-          { title: 'site01', location: 'https://brave01.com' },
-          { title: 'site02', location: 'https://brave02.com' },
-          { title: 'site03', location: 'https://brave03.com' },
-          { title: 'site04', location: 'https://brave04.com' },
-          { title: 'site05', location: 'https://brave05.com' },
-          { title: 'site06', location: 'https://brave06.com' },
-          { title: 'site07', location: 'https://brave07.com' },
-          { title: 'site08', location: 'https://brave08.com' },
-          { title: 'site09', location: 'https://brave09.com' },
-          { title: 'site10', location: 'https://brave10.com' },
-          { title: 'site11', location: 'https://brave11.com' }
-        ]
-      })
-
-      menuUtil.checkForUpdate(null, windowStateClosedFrames)
-      const menuItems = menuUtil.createRecentlyClosedMenuItems()
+      const windowStateClosedFrames = Immutable.fromJS([
+        { title: 'site01', location: 'https://brave01.com' },
+        { title: 'site02', location: 'https://brave02.com' },
+        { title: 'site03', location: 'https://brave03.com' },
+        { title: 'site04', location: 'https://brave04.com' },
+        { title: 'site05', location: 'https://brave05.com' },
+        { title: 'site06', location: 'https://brave06.com' },
+        { title: 'site07', location: 'https://brave07.com' },
+        { title: 'site08', location: 'https://brave08.com' },
+        { title: 'site09', location: 'https://brave09.com' },
+        { title: 'site10', location: 'https://brave10.com' },
+        { title: 'site11', location: 'https://brave11.com' }
+      ])
+      const menuItems = menuUtil.createRecentlyClosedMenuItems(windowStateClosedFrames)
 
       assert.equal(menuItems.length, 12)
-      assert.equal(menuItems[2].label, windowStateClosedFrames.get('closedFrames').get(1).get('title'))
-      assert.equal(menuItems[11].label, windowStateClosedFrames.get('closedFrames').get(10).get('title'))
+      assert.equal(menuItems[2].label, windowStateClosedFrames.get(1).get('title'))
+      assert.equal(menuItems[11].label, windowStateClosedFrames.get(10).get('title'))
     })
   })
 })


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
Add bookmark
1. Go to brave.com
2. Add bookmark
3. Bookmark should appear in menu

Bookmark indicator
1. Open a new tab
2. Bookmark indicator should not be activated
3. Bookmarks menu "Bookmark this page" should not be checked
4. Go back to brave.com tab
5. Bookmark indicator should be active
6. Bookmarks menu "Bookmark this page" should be checked

Last closed Frame
1. Close the brave.com tab
2. History menu should show brave.com under recently closed

Language
1. Change language
2. Restart Brave
3. Text should be translated by language setting
4. Change back and restart Brave
5. Text should be translated by language setting

State
1. Open brave.com
2. Close Brave
3. Reopen Brave and cnn.com tab should be loaded

Fix #3782