### PR TITLE
In payments status, show next contribution date

### DIFF
--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -28,6 +28,7 @@ accountBalanceConnectionError=error, can't retrieve data
 accountBalanceLoading=loading...
 monthlyBudget=monthly budget
 status=status
+statusNextReconcileDate=Next contribution: {{reconcileDate}}.
 createWallet=create wallet
 createWalletStatus=Click the Create Wallet button to get started.
 creatingWallet=creating...

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -686,6 +686,18 @@ class PaymentsTab extends ImmutableComponent {
     </div>
   }
 
+  get nextReconcileDate () {
+    const ledgerData = this.props.ledgerData
+    if (!ledgerData.get('reconcileStamp')) {
+      return null
+    }
+    const nextReconcileDate = formattedDateFromTimestamp(ledgerData.get('reconcileStamp'))
+    const l10nDataArgs = {
+      reconcileDate: nextReconcileDate
+    }
+    return <div className='nextReconcileDate' data-l10n-args={JSON.stringify(l10nDataArgs)} data-l10n-id='statusNextReconcileDate' />
+  }
+
   btcToCurrencyString (btc) {
     const balance = Number(btc || 0)
     const currency = this.props.ledgerData.get('currency') || 'USD'
@@ -753,8 +765,10 @@ class PaymentsTab extends ImmutableComponent {
                   </SettingItem>
                 </SettingsList>
               </td>
-              <td id='walletStatus' data-l10n-id={this.walletStatus.id}
-                data-l10n-args={this.walletStatus.args ? JSON.stringify(this.walletStatus.args) : null} />
+              <td>
+                <div id='walletStatus' data-l10n-id={this.walletStatus.id} data-l10n-args={this.walletStatus.args ? JSON.stringify(this.walletStatus.args) : null} />
+                {this.nextReconcileDate}
+              </td>
             </tr>
           </tbody>
         </table>

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -616,6 +616,10 @@ div.nextPaymentSubmission {
       height: 30px;
       line-height: 30px;
     }
+    .nextReconcileDate {
+      font-size: 14px;
+      margin: 10px 0;
+    }
   }
 
   .sort {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #3801

Auditors: @bradleyrichter @diracdeltas

Test Plan:
1. Open Brave to Preferences > Payments
2. Confirm the "status" column has "Next contribution: {date}" on the bottom

First run
<img width="806" alt="screen shot 2016-09-08 at 16 55 43" src="https://cloud.githubusercontent.com/assets/521861/18371040/5822f4a6-75e6-11e6-829b-cd91e92be353.png">
Created a wallet
<img width="781" alt="screen shot 2016-09-08 at 16 55 54" src="https://cloud.githubusercontent.com/assets/521861/18371041/5d45ca6c-75e6-11e6-8ef9-57f4138c7519.png">
Funded 💰
<img width="722" alt="screen shot 2016-09-08 at 16 55 06" src="https://cloud.githubusercontent.com/assets/521861/18371044/620ed2d2-75e6-11e6-9fab-d03a552e6412.png">
