### PR TITLE
Style ledger notifications like update notifications

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -352,7 +352,10 @@ function registerPermissionHandler (session, partition) {
     }
 
     appActions.showMessageBox({
-      buttons: [locale.translation('deny'), locale.translation('allow')],
+      buttons: [
+        {text: locale.translation('deny')},
+        {text: locale.translation('allow')}
+      ],
       frameOrigin,
       options: {
         persist: true

--- a/app/index.js
+++ b/app/index.js
@@ -421,7 +421,10 @@ app.on('ready', () => {
         appActions.hideMessageBox(message)
       } else {
         appActions.showMessageBox({
-          buttons: [locale.translation('yes'), locale.translation('no')],
+          buttons: [
+            {text: locale.translation('yes')},
+            {text: locale.translation('no')}
+          ],
           options: {
             persist: false
           },
@@ -639,9 +642,9 @@ app.on('ready', () => {
         // Notification not shown already
         appActions.showMessageBox({
           buttons: [
-            locale.translation('yes'),
-            locale.translation('no'),
-            locale.translation('neverForThisSite')
+            {text: locale.translation('yes')},
+            {text: locale.translation('no')},
+            {text: locale.translation('neverForThisSite')}
           ],
           options: {
             persist: false,

--- a/app/ledger.js
+++ b/app/ledger.js
@@ -1222,21 +1222,23 @@ const showNotifications = () => {
         balance + unconfirmed < 0.9 * Number(ledgerInfo.btc)) {
       addFundsMessage = addFundsMessage || locale.translation('addFundsNotification')
       appActions.showMessageBox({
+        greeting: locale.translation('updateHello'),
         message: addFundsMessage,
         buttons: [locale.translation('updateLater'),
           locale.translation('addFunds')],
         options: {
-          updateStyle: true, // TODO: Show this in the style of updateBar.less
+          style: 'greetingStyle',
           persist: false
         }
       })
     } else if (!reconciliationNotificationShown) {
       reconciliationMessage = reconciliationMessage || locale.translation('reconciliationNotification')
       appActions.showMessageBox({
+        greeting: locale.translation('updateHello'),
         message: reconciliationMessage,
         buttons: [locale.translation('reviewSites')],
         options: {
-          updateStyle: true,
+          style: 'greetingStyle',
           persist: false
         }
       })

--- a/app/ledger.js
+++ b/app/ledger.js
@@ -1224,8 +1224,10 @@ const showNotifications = () => {
       appActions.showMessageBox({
         greeting: locale.translation('updateHello'),
         message: addFundsMessage,
-        buttons: [locale.translation('updateLater'),
-          locale.translation('addFunds')],
+        buttons: [
+          {text: locale.translation('updateLater')},
+          {text: locale.translation('addFunds'), className: 'primary'}
+        ],
         options: {
           style: 'greetingStyle',
           persist: false
@@ -1236,7 +1238,9 @@ const showNotifications = () => {
       appActions.showMessageBox({
         greeting: locale.translation('updateHello'),
         message: reconciliationMessage,
-        buttons: [locale.translation('reviewSites')],
+        buttons: [
+          {text: locale.translation('reviewSites'), className: 'primary'}
+        ],
         options: {
           style: 'greetingStyle',
           persist: false

--- a/docs/state.md
+++ b/docs/state.md
@@ -127,9 +127,10 @@ AppStore
     buttons: Array<string>,
     frameOrigin: (string|undefined), // origin that the notification is from, or undefined if not applicable.
     options: {
-      persist: boolean, // whether to show a 'Remember this decision' checkbox
       advancedText: string, // more info text
       advancedLink: string, // more info link URL
+      persist: boolean, // whether to show a 'Remember this decision' checkbox
+      style: string // css class for notification bar. See notificationBar.less
     }
   }], // the notifications for the frame. not preserved across restart.
   settings: [{

--- a/docs/state.md
+++ b/docs/state.md
@@ -124,7 +124,10 @@ AppStore
   },
   notifications: [{
     message: string,
-    buttons: Array<string>,
+    buttons: [{
+      text: string, // button text
+      className: string, // button class e.g. 'primary'. see notificationBar.less
+    }],
     frameOrigin: (string|undefined), // origin that the notification is from, or undefined if not applicable.
     options: {
       advancedText: string, // more info text

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -544,7 +544,10 @@ class Frame extends ImmutableComponent {
       const message = locale.translation('allowFlashPlayer').replace(/{{\s*origin\s*}}/, this.origin)
       // Show Flash notification bar
       appActions.showMessageBox({
-        buttons: [locale.translation('deny'), locale.translation('allow')],
+        buttons: [
+          {text: locale.translation('deny')},
+          {text: locale.translation('allow')}
+        ],
         message,
         frameOrigin: this.origin,
         options: {

--- a/js/components/notificationBar.js
+++ b/js/components/notificationBar.js
@@ -61,8 +61,8 @@ class NotificationItem extends ImmutableComponent {
           this.props.detail.get('buttons').map((button) =>
             <button
               type='button'
-              className='button'
-              onClick={this.clickHandler.bind(this, i++)}>{button}</button>
+              className={'button ' + (button.get('className') || '')}
+              onClick={this.clickHandler.bind(this, i++)}>{button.get('text')}</button>
           )
         }
       </span>

--- a/js/components/notificationBar.js
+++ b/js/components/notificationBar.js
@@ -34,7 +34,7 @@ class NotificationItem extends ImmutableComponent {
     let i = 0
     const options = this.props.detail.get('options')
     const greeting = this.props.detail.get('greeting')
-    return <div className='notificationItem'>
+    return <div className={'notificationItem ' + (options.get('style') || '')}>
       {
         greeting
           ? <span className='greeting'>{greeting}</span>
@@ -83,8 +83,7 @@ class NotificationBar extends ImmutableComponent {
       return null
     }
 
-    const style = 'notificationBar ' + (activeNotifications.get(0).get('options').get('style') || '')
-    return <div className={style}>
+    return <div className='notificationBar'>
     {
       activeNotifications.takeLast(3).map((notificationDetail) =>
         <NotificationItem detail={notificationDetail} />

--- a/js/components/notificationBar.js
+++ b/js/components/notificationBar.js
@@ -33,8 +33,14 @@ class NotificationItem extends ImmutableComponent {
   render () {
     let i = 0
     const options = this.props.detail.get('options')
+    const greeting = this.props.detail.get('greeting')
     return <div className='notificationItem'>
-      <span className='notificationMessage'>{this.props.detail.get('message')}</span>
+      {
+        greeting
+          ? <span className='greeting'>{greeting}</span>
+          : null
+      }
+      <span className='message'>{this.props.detail.get('message')}</span>
       <span className='notificationAdvanced'>
         {
           options.get('advancedText') && options.get('advancedLink')
@@ -42,7 +48,7 @@ class NotificationItem extends ImmutableComponent {
             : null
         }
       </span>
-      <span className='notificationOptions'>
+      <span className='options'>
         {
           options.get('persist')
             ? <span id='rememberOption'>
@@ -55,7 +61,7 @@ class NotificationItem extends ImmutableComponent {
           this.props.detail.get('buttons').map((button) =>
             <button
               type='button'
-              className='notificationButton'
+              className='button'
               onClick={this.clickHandler.bind(this, i++)}>{button}</button>
           )
         }
@@ -77,7 +83,8 @@ class NotificationBar extends ImmutableComponent {
       return null
     }
 
-    return <div className='notificationBar'>
+    const style = 'notificationBar ' + (activeNotifications.get(0).get('options').get('style') || '')
+    return <div className={style}>
     {
       activeNotifications.takeLast(3).map((notificationDetail) =>
         <NotificationItem detail={notificationDetail} />

--- a/js/components/updateBar.js
+++ b/js/components/updateBar.js
@@ -45,7 +45,7 @@ class UpdateHello extends ImmutableComponent {
   }
 
   render () {
-    return <span className='updateHello'>
+    return <span className='greeting'>
       <span onClick={this.onSpinnerClick.bind(this)}
         className={cx({
           fa: this.loading,
@@ -59,7 +59,7 @@ class UpdateHello extends ImmutableComponent {
 
 class UpdateHide extends ImmutableComponent {
   render () {
-    return <Button className='updateButton updateSecondaryButton'
+    return <Button className='button secondary'
       l10nId='updateHide'
       onClick={appActions.setUpdateStatus.bind(null, this.props.reset ? UpdateStatus.UPDATE_NONE : undefined, false, undefined)} />
   }
@@ -70,7 +70,7 @@ class UpdateLog extends ImmutableComponent {
     remote.shell.openItem(path.join(remote.app.getPath('userData'), 'updateLog.log'))
   }
   render () {
-    return <Button className='updateButton updateViewLogButton updateSecondaryButton'
+    return <Button className='button updateViewLogButton secondary'
       l10nId='updateViewLog'
       onClick={this.onViewLog.bind(this)} />
   }
@@ -80,22 +80,24 @@ class UpdateAvailable extends ImmutableComponent {
   render () {
     return <div>
       <UpdateHello updateStatus={this.props.updateStatus} l10nId='updateHello' />
-      <span className='updateMessage' data-l10n-id='updateAvail' />
-      <span className='updateRequiresRelaunch' data-l10n-id='updateRequiresRelaunch' />
-      <span className='updateSpacer' />
-      {
-        this.props.metadata && this.props.metadata.get('notes')
-        ? <Button className='updateButton updateDetails updateSecondaryButton'
-          l10nId='updateDetails'
-          onClick={windowActions.setReleaseNotesVisible.bind(null, true)} />
-        : null
-      }
-      <Button className='updateButton updateLaterButton updateSecondaryButton'
-        l10nId='updateLater'
-        onClick={appActions.setUpdateStatus.bind(null, UpdateStatus.UPDATE_AVAILABLE_DEFERRED, false, undefined)} />
-      <Button className='updateButton updateNowButton'
-        l10nId='updateNow'
-        onClick={appActions.setUpdateStatus.bind(null, UpdateStatus.UPDATE_APPLYING_RESTART, false, undefined)} />
+      <span className='message' data-l10n-id='updateAvail' />
+      <span className='message secondary' data-l10n-id='updateRequiresRelaunch' />
+      <span className='spacer' />
+      <span className='options'>
+        {
+          this.props.metadata && this.props.metadata.get('notes')
+          ? <Button className='button updateDetails secondary'
+            l10nId='updateDetails'
+            onClick={windowActions.setReleaseNotesVisible.bind(null, true)} />
+          : null
+        }
+        <Button className='button updateLaterButton secondary'
+          l10nId='updateLater'
+          onClick={appActions.setUpdateStatus.bind(null, UpdateStatus.UPDATE_AVAILABLE_DEFERRED, false, undefined)} />
+        <Button className='button primary'
+          l10nId='updateNow'
+          onClick={appActions.setUpdateStatus.bind(null, UpdateStatus.UPDATE_APPLYING_RESTART, false, undefined)} />
+      </span>
     </div>
   }
 }
@@ -104,10 +106,12 @@ class UpdateChecking extends ImmutableComponent {
   render () {
     return <div>
       <UpdateHello updateStatus={this.props.updateStatus} />
-      <span className='updateMessage' data-l10n-id='updateChecking' />
-      <span className='updateSpacer' />
-      <UpdateLog />
-      <UpdateHide />
+      <span className='message' data-l10n-id='updateChecking' />
+      <span className='spacer' />
+      <span className='options'>
+        <UpdateLog />
+        <UpdateHide />
+      </span>
     </div>
   }
 }
@@ -116,10 +120,12 @@ class UpdateDownloading extends ImmutableComponent {
   render () {
     return <div>
       <UpdateHello updateStatus={this.props.updateStatus} />
-      <span className='updateMessage' data-l10n-id='updateDownloading' />
-      <span className='updateSpacer' />
-      <UpdateLog />
-      <UpdateHide />
+      <span className='message' data-l10n-id='updateDownloading' />
+      <span className='spacer' />
+      <span className='options'>
+        <UpdateLog />
+        <UpdateHide />
+      </span>
     </div>
   }
 }
@@ -128,10 +134,12 @@ class UpdateError extends ImmutableComponent {
   render () {
     return <div>
       <UpdateHello updateStatus={this.props.updateStatus} l10nId='updateOops' />
-      <span className='updateMessage' data-l10n-id='updateError' />
-      <span className='updateSpacer' />
-      <UpdateLog />
-      <UpdateHide reset />
+      <span className='message' data-l10n-id='updateError' />
+      <span className='spacer' />
+      <span className='options'>
+        <UpdateLog />
+        <UpdateHide reset />
+      </span>
     </div>
   }
 }
@@ -140,9 +148,11 @@ class UpdateNotAvailable extends ImmutableComponent {
   render () {
     return <div>
       <UpdateHello updateStatus={this.props.updateStatus} l10nId='updateNotYet' />
-      <span className='updateMessage' data-l10n-id='updateNotAvail' />
-      <span className='updateSpacer' />
-      <UpdateHide reset />
+      <span className='message' data-l10n-id='updateNotAvail' />
+      <span className='spacer' />
+      <span className='options'>
+        <UpdateHide reset />
+      </span>
     </div>
   }
 }

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -360,7 +360,9 @@ const handleAppAction = (action) => {
         })
 
         appActions.showMessageBox({
-          buttons: [locale.translation('ok')],
+          buttons: [
+            {text: locale.translation('ok')}
+          ],
           options: {
             persist: false
           },

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -507,13 +507,34 @@ const handleAppAction = (action) => {
       break
     case AppConstants.APP_SHOW_MESSAGE_BOX:
       let notifications = appState.get('notifications')
-      appState = appState.set('notifications', notifications.filterNot((notification) => {
+      notifications = notifications.filterNot((notification) => {
         let message = notification.get('message')
         // action.detail is a regular mutable object only when running tests
         return action.detail.get
           ? message === action.detail.get('message')
           : message === action.detail['message']
-      }).push(Immutable.fromJS(action.detail)))
+      })
+
+      // Insert notification next to those with the same style, or at the end
+      let insertIndex = notifications.size
+      const style = action.detail.get
+        ? action.detail.get('options').get('style')
+        : action.detail['options']['style']
+      if (style) {
+        const styleIndex = notifications.findLastIndex((notification) => {
+          return notification.get('options').get('style') === style
+        })
+        if (styleIndex > -1) {
+          insertIndex = styleIndex
+        } else {
+          // Insert after the last notification with a style
+          insertIndex = notifications.findLastIndex((notification) => {
+            return typeof notification.get('options').get('style') === 'string'
+          }) + 1
+        }
+      }
+      notifications = notifications.insert(insertIndex, Immutable.fromJS(action.detail))
+      appState = appState.set('notifications', notifications)
       break
     case AppConstants.APP_HIDE_MESSAGE_BOX:
       appState = appState.set('notifications', appState.get('notifications').filterNot((notification) => {

--- a/less/button.less
+++ b/less/button.less
@@ -13,7 +13,7 @@
   padding: 0px 20px;
 }
 
-span.browserButton {
+.browserButton {
   cursor: default;
   display: inline-block;
   line-height: 30px;

--- a/less/notificationBar.less
+++ b/less/notificationBar.less
@@ -19,14 +19,13 @@
     padding: 6px 8px;
 
     .notificationItem {
-      padding: 2px 24px 2px 12px;
+      padding: 2px 28px 2px 12px;
 
       .button {
         .browserButton();
 
         background-color: #eee;
         border-style: none;
-        float: right;
         font-size: 14px;
         height: 25px;
         line-height: 27px;

--- a/less/notificationBar.less
+++ b/less/notificationBar.less
@@ -6,20 +6,18 @@
 @import (reference) "button.less";
 
 .notificationBar {
-  background-color: #ffefc0;
-  border-bottom: 1px solid #888;
   display: inline-block;
   width: 100%;
-  padding: 6px 0;
 
-  // e.g. Update available bar
-  &.greetingStyle {
-    background-color: #fff;
+  .notificationItem {
+    background-color: #ffefc0;
     border-bottom: 1px solid #888;
-    padding: 6px 8px;
+    line-height: 24px;
+    padding: 6px 12px 6px 20px;
 
-    .notificationItem {
-      padding: 2px 28px 2px 12px;
+    &.greetingStyle {
+      background-color: #fff;
+      padding: 8px 20px 6px 20px;
 
       .button {
         .browserButton();
@@ -49,11 +47,6 @@
         }
       }
     }
-  }
-
-  .notificationItem {
-    padding: 0 12px 0 20px;
-    line-height: 24px;
 
     label {
       font-size: 15px;

--- a/less/notificationBar.less
+++ b/less/notificationBar.less
@@ -3,6 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 @import "variables.less";
+@import (reference) "button.less";
 
 .notificationBar {
   background-color: #ffefc0;
@@ -11,33 +12,49 @@
   width: 100%;
   padding: 6px 0;
 
+  // e.g. Update available bar
+  &.greetingStyle {
+    background-color: #fff;
+    border-bottom: 1px solid #888;
+    padding: 6px 8px;
+
+    .notificationItem {
+      padding: 2px 24px 2px 12px;
+
+      .button {
+        .browserButton();
+
+        background-color: #eee;
+        border-style: none;
+        float: right;
+        font-size: 14px;
+        height: 25px;
+        line-height: 27px;
+        margin: auto 4px;
+        padding: 0px 25px;
+        width: auto;
+
+        &.primary {
+          background-color: @braveOrange;
+          color: #fff;
+          margin-right: 0px;
+
+          &:hover {
+            background-color: lighten(@braveOrange, 10%);
+            color: #fff !important;
+          }
+          &:active {
+            background-color: darken(@braveOrange, 10%);
+            color: #fff !important;
+          }
+        }
+      }
+    }
+  }
+
   .notificationItem {
-    padding: 0 12px;
+    padding: 0 12px 0 20px;
     line-height: 24px;
-
-    .notificationMessage {
-      color: #000;
-      font-size: 15px;
-      margin: auto 0;
-    }
-
-    .notificationSecondaryButton {
-      background-color: #eee;
-    }
-
-    .notificationButton {
-      padding: 2px 15px;
-      width: auto;
-      margin-right: 10px;
-    }
-
-    .notificationOptions {
-      float: right;
-    }
-
-    .notificationSpacer {
-      flex-grow: 1;
-    }
 
     label {
       font-size: 15px;
@@ -50,8 +67,38 @@
       margin: 0 3px;
     }
 
-    button {
+    .button {
       font-size: 13px;
+      margin-right: 10px;
+      padding: 2px 15px;
+      width: auto;
+    }
+
+    .greeting {
+      color: @braveOrange;
+      font-size: 16px;
+      margin: auto 10px auto 0;
+    }
+
+    .message {
+      color: #000;
+      font-size: 15px;
+      margin: auto 0;
+
+      &.secondary {
+        color: #888;
+        font-size: 14px;
+        padding: 0;
+        margin: auto 0 auto 10px;
+      }
+    }
+
+    .options {
+      float: right;
+    }
+
+    .spacer {
+      flex-grow: 1;
     }
 
     .notificationAdvanced {

--- a/less/updateBar.less
+++ b/less/updateBar.less
@@ -3,69 +3,12 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 @import "variables.less";
+@import (reference) "notificationBar.less";
 
 .updateBar {
-  background-color: #fff;
-  border-bottom: 1px solid #888;
-  padding: 8px 20px;
+  &:extend(.notificationBar.greetingStyle);
+  .notificationBar .notificationItem();
+  .notificationBar.greetingStyle  .notificationItem();
 
-  span.browserButton {
-    font-size: 14px;
-    line-height: 27px;
-    height: 25px;
-  }
-
-  >div {
-    display: flex;
-  }
-
-  .updateHello {
-    color: @braveOrange;
-    font-size: 16px;
-    margin: auto 0;
-  }
-
-  .updateMessage {
-    color: #000;
-    font-size: 15px;
-    padding-left: 10px;
-    margin: auto 0;
-  }
-
-  .updateSecondaryButton {
-    background-color: #eee;
-  }
-
-  .updateButton {
-    padding: 0px 25px;
-    float: right;
-    font-size: 14px;
-    width: auto;
-    margin: auto 4px;
-  }
-
-  .updateRequiresRelaunch {
-    color: #888;
-    font-size: 14px;
-    margin: auto 0 auto 10px;
-  }
-
-  .updateSpacer {
-    flex-grow: 1;
-  }
-
-  .updateNowButton {
-    background-color: @braveOrange;
-    color: #fff;
-    margin-right: 0px;
-
-    &:hover {
-      background-color: lighten(@braveOrange, 10%);
-      color: #fff !important;
-    }
-    &:active {
-      background-color: darken(@braveOrange, 10%);
-      color: #fff !important;
-    }
-  }
+  padding: 8px 16px 8px 20px;
 }

--- a/less/updateBar.less
+++ b/less/updateBar.less
@@ -8,7 +8,7 @@
 .updateBar {
   &:extend(.notificationBar.greetingStyle);
   .notificationBar .notificationItem();
-  .notificationBar.greetingStyle  .notificationItem();
+  .notificationBar .notificationItem.greetingStyle();
 
   padding: 8px 16px 8px 20px;
 }

--- a/test/components/notificationBarTest.js
+++ b/test/components/notificationBarTest.js
@@ -46,7 +46,7 @@ describe('notificationBar', function () {
       .loadUrl(this.notificationUrl)
       .windowByUrl(Brave.browserWindowUrl)
       .waitForExist(notificationBar)
-      .element('.notificationItem:nth-Child(1) .notificationOptions')
+      .element('.notificationItem:nth-Child(1) .options')
       .click('button=Deny')
       .moveToObject(activeWebview)
       .waitForExist(titleBar)


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Partially implements #3257

- Extract/refactor updateBar HTML and CSS for use in notificationBar
- Add custom styling of notification bar and buttons

Auditors: @bradleyrichter @diracdeltas 

Test Plan:
1. Change conditional in https://github.com/brave/browser-laptop/blob/feature/ledger-notifications-update-style/app/ledger.js#L1220 to `true`
2. Observe the funding notification is styled like the update bar

Preview:
<img width="1318" alt="screen shot 2016-09-09 at 17 26 40" src="https://cloud.githubusercontent.com/assets/521861/18406613/27172368-76b4-11e6-80bb-6b1a750a6f03.png">
