### PR TITLE
If directly-entered URL load fails, show the location of the displayed page

### DIFF
--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -293,9 +293,6 @@ const doAction = (action) => {
         windowState = windowState.mergeIn(tabStatePath(action.key), {
           location: action.location
         })
-        // force a navbar update in case this was called from an app
-        // initiated navigation (bookmarks, etc...)
-        updateNavBarInput(action.location, frameStatePath(action.key))
       }
       break
     case WindowConstants.WINDOW_SET_NAVIGATED:

--- a/test/components/navigationBarTest.js
+++ b/test/components/navigationBarTest.js
@@ -82,6 +82,31 @@ describe('navigationBar', function () {
       })
     })
 
+    describe('document.write spoofing', function () {
+      Brave.beforeAll(this)
+
+      before(function * () {
+        var page1 = Brave.server.url('urlbarSpoof.html')
+        yield setup(this.app.client)
+        yield this.app.client
+          .tabByUrl(Brave.newTabUrl)
+          .url(page1)
+          .waitForUrl(page1)
+          .waitForExist('input')
+          .leftClick('input')
+      })
+
+      it('updates the location in the navbar to blank', function * () {
+        yield this.app.client
+          .windowByUrl(Brave.browserWindowUrl)
+          .waitUntil(function () {
+            return this.getValue(urlInput).then((val) => {
+              return val === ''
+            })
+          })
+      })
+    })
+
     describe('page with a title', function () {
       Brave.beforeAll(this)
 
@@ -559,6 +584,29 @@ describe('navigationBar', function () {
   })
 
   describe('submit', function () {
+    describe('page that does not load', function () {
+      Brave.beforeAll(this)
+
+      before(function * () {
+        var page1 = 'https://bayden.com/test/redir/goscript.aspx'
+        yield setup(this.app.client)
+        yield this.app.client.waitForExist(urlInput)
+        yield this.app.client.keys(page1)
+        // hit enter
+        yield this.app.client.keys('\uE007')
+      })
+
+      it('clears urlbar if page does not load', function * () {
+        yield this.app.client
+          .waitUntil(function () {
+            return this.getValue(urlInput).then((val) => {
+              console.log('value', val)
+              return val === ''
+            })
+          })
+      })
+    })
+
     describe('with url input value', function () {
       Brave.beforeAll(this)
 

--- a/test/fixtures/urlbarSpoof.html
+++ b/test/fixtures/urlbarSpoof.html
@@ -1,0 +1,10 @@
+<html>
+<script>
+function spoof() {
+  w = window.open('https:/www.google.com', 'target');
+  w.document.write('<h1 id="message">Here we could place a phishing login panel</h1>');
+  w.document.close();
+}
+</script>
+<input type="submit" onclick="spoof()" value="PoC!">
+</html>


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #3851
Add regression test for #2723

Auditors: @bridiver

Test Plan:
open bankofamerica.com in a tab
put http://bayden.com/test/redir/goscript.aspx in the urlbar and hit enter
verify that the URL bar still says bankofamerica.com