### PR TITLE
Context menu search respects session setting of current tab

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -745,8 +745,12 @@ const searchSelectionMenuItem = (location) => {
     label: locale.translation('openSearch').replace(/{{\s*selectedVariable\s*}}/, searchText),
     click: (item, focusedWindow) => {
       if (focusedWindow && location) {
+        let activeFrame = windowStore.getState().get('activeFrameKey')
+        let frame = windowStore.getFrame(activeFrame)
         let searchUrl = windowStore.getState().getIn(['searchDetail', 'searchURL']).replace('{searchTerms}', encodeURIComponent(location))
-        windowActions.newFrame({ location: searchUrl }, true)
+        windowActions.newFrame({ location: searchUrl,
+          isPrivate: frame.get('isPrivate'),
+          partitionNumber: frame.get('partitionNumber') }, true)
       }
     }
   }
@@ -844,10 +848,14 @@ function mainTemplateInit (nodeProps, frame) {
         {
           label: locale.translation('searchImage'),
           click: (item) => {
+            let activeFrame = windowStore.getState().get('activeFrameKey')
+            let frame = windowStore.getFrame(activeFrame)
             let searchUrl = windowStore.getState().getIn(['searchDetail', 'searchURL'])
               .replace('{searchTerms}', encodeURIComponent(nodeProps.srcURL))
               .replace('?q', 'byimage?image_url')
-            windowActions.newFrame({ location: searchUrl }, true)
+            windowActions.newFrame({ location: searchUrl,
+              isPrivate: frame.get('isPrivate'),
+              partitionNumber: frame.get('partitionNumber')}, true)
           }
         }
       )


### PR DESCRIPTION
- [ N/A ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ YES ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ NO ] Added/updated tests for this change (for new code or code which already has tests).
- [ N/A ] Ran `git rebase -i` to squash commits (if needed).

Fixed right click to search not respecting session setting of current tab

New tabs opened by Search Image or Search for ... will open with the same session and privacy settings as the tab it was opened from.

Test Plan:

New tabs opened by Search Image or Search for ... will open with the same session and privacy settings as the tab it was opened from.

Fix #3662

I didn't write tests as I didn't see any related to the context menu, if I need to please show me an example and I can ammend my commit.  This is my first time contributing so please inform me of any mistakes I have made! 