### PR TITLE
dialog is cropped at low resolution

### DIFF
--- a/less/modalOverlay.less
+++ b/less/modalOverlay.less
@@ -6,6 +6,7 @@
 
 .modal {
   opacity: 1;
+  overflow: auto;
   position: fixed;
   background: @white50;
   width: 100vw;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #3879 

Test Plan:

Open the 'Add Funds' dialog with a very small browser window and make sure you can scroll around and interact / see all the dialog.


@bradleyrichter I tried centering it vertically and horizontally but it ends up looking really bad on small screen. I think the best approach is just to allow scrolling.