### PR TITLE
Fix Redhat desktop launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
   },
   "optionalDependencies": {
     "electron-installer-debian": "^0.3.0",
-    "electron-installer-redhat": "^0.2.0"
+    "electron-installer-redhat": "^0.3.0"
   },
   "standard": {
     "ignore": [


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

The problem is that under RHEL the generated desktop launcher does not
have the correct mine types, so Brave can not be set as default browser.

This was reported and fixed here https://github.com/brave/browser-laptop/issues/2839
in both Brave and electron-redhat-installer package. However the fixed version
of the installer package was never used by Brave. This PR bumps the version
so it should work ok now.

Fixes #3776

Auditors:
@bbondy

Test Plan:
1. Install Brave under Fedora 24 and make sure it can be set as default
browser from the Default applications menu