### PR TITLE
Brave wallet address text is not properly aligned

### DIFF
--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -819,6 +819,7 @@ div.nextPaymentSubmission {
       text-decoration: none;
     }
     .labelText {
+      clear: both;
       font-size: 1em;
       color: @braveOrange;
       margin-bottom: 5px;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #3910 

Test Plan:

+ Go to https://jsfiddle.net/LnwtLckc/5/ and click the register button.
+ In Payments tab the text is not aligned properly next to the Transfer BTC button 3.
