### PR TITLE
Button icons are style-wonked

### DIFF
--- a/less/button.less
+++ b/less/button.less
@@ -19,6 +19,8 @@ span.buttonSeparator {
   margin: 4px 3px 4px 3px;
 }
 
+a.browserButton,
+span.browserButton,
 .browserButton {
   cursor: default;
   display: inline-block;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #3917 

Test Plan:

Make sure that refresh and stop icons are correctly centered.


Ok, so what happened here was we turned the span.browserButton selector into just .browserButton so it could be used as a mixin (https://github.com/brave/browser-laptop/commit/c63165f3a1c5b3d036b52234a6d7ac53c32c2f5b) but the problem is that then .browserButton conflicts with .fa and .fa is cancelling out the .browserButton line-height and font-size and some other things.

For a quick fix I just added back the element specific classes so it can still be used as a mixin but we should figure out a cleaner way to name classes / embed selectors so we don't have to hack around specificity.

Auditors @bradleyrichter @ayumi 

