### PR TITLE
Fix overflowing notification buttons

### DIFF
--- a/js/components/notificationBar.js
+++ b/js/components/notificationBar.js
@@ -35,19 +35,6 @@ class NotificationItem extends ImmutableComponent {
     const options = this.props.detail.get('options')
     const greeting = this.props.detail.get('greeting')
     return <div className={'notificationItem ' + (options.get('style') || '')}>
-      {
-        greeting
-          ? <span className='greeting'>{greeting}</span>
-          : null
-      }
-      <span className='message'>{this.props.detail.get('message')}</span>
-      <span className='notificationAdvanced'>
-        {
-          options.get('advancedText') && options.get('advancedLink')
-            ? <span onClick={this.openAdvanced.bind(this)}>{options.get('advancedText')}</span>
-            : null
-        }
-      </span>
       <span className='options'>
         {
           options.get('persist')
@@ -64,6 +51,19 @@ class NotificationItem extends ImmutableComponent {
               className={'button ' + (button.get('className') || '')}
               onClick={this.clickHandler.bind(this, i++)}>{button.get('text')}</button>
           )
+        }
+      </span>
+      {
+        greeting
+          ? <span className='greeting'>{greeting}</span>
+          : null
+      }
+      <span className='message'>{this.props.detail.get('message')}</span>
+      <span className='notificationAdvanced'>
+        {
+          options.get('advancedText') && options.get('advancedLink')
+            ? <span onClick={this.openAdvanced.bind(this)}>{options.get('advancedText')}</span>
+            : null
         }
       </span>
     </div>

--- a/js/components/updateBar.js
+++ b/js/components/updateBar.js
@@ -79,10 +79,6 @@ class UpdateLog extends ImmutableComponent {
 class UpdateAvailable extends ImmutableComponent {
   render () {
     return <div>
-      <UpdateHello updateStatus={this.props.updateStatus} l10nId='updateHello' />
-      <span className='message' data-l10n-id='updateAvail' />
-      <span className='message secondary' data-l10n-id='updateRequiresRelaunch' />
-      <span className='spacer' />
       <span className='options'>
         {
           this.props.metadata && this.props.metadata.get('notes')
@@ -98,6 +94,10 @@ class UpdateAvailable extends ImmutableComponent {
           l10nId='updateNow'
           onClick={appActions.setUpdateStatus.bind(null, UpdateStatus.UPDATE_APPLYING_RESTART, false, undefined)} />
       </span>
+      <UpdateHello updateStatus={this.props.updateStatus} l10nId='updateHello' />
+      <span className='message' data-l10n-id='updateAvail' />
+      <span className='message secondary' data-l10n-id='updateRequiresRelaunch' />
+      <span className='spacer' />
     </div>
   }
 }
@@ -105,13 +105,13 @@ class UpdateAvailable extends ImmutableComponent {
 class UpdateChecking extends ImmutableComponent {
   render () {
     return <div>
-      <UpdateHello updateStatus={this.props.updateStatus} />
-      <span className='message' data-l10n-id='updateChecking' />
-      <span className='spacer' />
       <span className='options'>
         <UpdateLog />
         <UpdateHide />
       </span>
+      <UpdateHello updateStatus={this.props.updateStatus} />
+      <span className='message' data-l10n-id='updateChecking' />
+      <span className='spacer' />
     </div>
   }
 }
@@ -119,13 +119,13 @@ class UpdateChecking extends ImmutableComponent {
 class UpdateDownloading extends ImmutableComponent {
   render () {
     return <div>
-      <UpdateHello updateStatus={this.props.updateStatus} />
-      <span className='message' data-l10n-id='updateDownloading' />
-      <span className='spacer' />
       <span className='options'>
         <UpdateLog />
         <UpdateHide />
       </span>
+      <UpdateHello updateStatus={this.props.updateStatus} />
+      <span className='message' data-l10n-id='updateDownloading' />
+      <span className='spacer' />
     </div>
   }
 }
@@ -133,13 +133,13 @@ class UpdateDownloading extends ImmutableComponent {
 class UpdateError extends ImmutableComponent {
   render () {
     return <div>
-      <UpdateHello updateStatus={this.props.updateStatus} l10nId='updateOops' />
-      <span className='message' data-l10n-id='updateError' />
-      <span className='spacer' />
       <span className='options'>
         <UpdateLog />
         <UpdateHide reset />
       </span>
+      <UpdateHello updateStatus={this.props.updateStatus} l10nId='updateOops' />
+      <span className='message' data-l10n-id='updateError' />
+      <span className='spacer' />
     </div>
   }
 }
@@ -147,12 +147,12 @@ class UpdateError extends ImmutableComponent {
 class UpdateNotAvailable extends ImmutableComponent {
   render () {
     return <div>
-      <UpdateHello updateStatus={this.props.updateStatus} l10nId='updateNotYet' />
-      <span className='message' data-l10n-id='updateNotAvail' />
-      <span className='spacer' />
       <span className='options'>
         <UpdateHide reset />
       </span>
+      <UpdateHello updateStatus={this.props.updateStatus} l10nId='updateNotYet' />
+      <span className='message' data-l10n-id='updateNotAvail' />
+      <span className='spacer' />
     </div>
   }
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Notification options have float: right. I moved them to precede other content in the DOM, so now the other content flows around it rather than "pushing" it away.

Fix #3920

Auditors: @luixxiul @jkup

Test Plan:

1. Open Brave and trigger a notification e.g. visit https://www.browserleaks.com/geo
2. Horizontally resize window so the notification text overflows
3. Confirm that the buttons don't overflow out of the notification

Should now look like:
<img width="482" alt="screen shot 2016-09-12 at 16 34 09" src="https://cloud.githubusercontent.com/assets/521861/18456616/2997acde-7907-11e6-9fba-c94b08a645ce.png">
<img width="783" alt="screen shot 2016-09-12 at 16 29 57" src="https://cloud.githubusercontent.com/assets/521861/18456617/29988596-7907-11e6-9e74-c86d9c1fd58b.png">
