### PR TITLE
Add margin-left to the notification button

### DIFF
--- a/less/notificationBar.less
+++ b/less/notificationBar.less
@@ -87,6 +87,7 @@
 
     .options {
       float: right;
+      margin-left: 6px;
     }
 
     .spacer {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

The value is based on ``padding-top`` here: https://github.com/brave/browser-laptop/blob/master/less/notificationBar.less#L16

Addresses #3939

Auditors: @ayumi

Test Plan:

1. Go to https://trac.torproject.org/projects/tor
2. Log in with your username and password
3. Change the window size

<img width="567" alt="screenshot 2016-09-13 14 44 41" src="https://cloud.githubusercontent.com/assets/3362943/18463651/a7e42b2a-79c6-11e6-8d4c-cd6568c830b0.png">
