### PR TITLE
use origin for the notification message and for site settings and cho…

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -324,12 +324,15 @@ function registerPermissionHandler (session, partition) {
       origin = 'Brave Browser'
       // display on all tabs
       mainFrameUrl = null
+    } else {
+      // Strip trailing slash
+      origin = getOrigin(origin)
     }
 
     // Check whether there is a persistent site setting for this host
     const appState = AppStore.getState()
-    const settings = siteSettings.getSiteSettingsForURL(appState.get('siteSettings'), origin)
-    const tempSettings = siteSettings.getSiteSettingsForURL(appState.get('temporarySiteSettings'), origin)
+    const settings = siteSettings.getSiteSettingsForHostPattern(appState.get('siteSettings'), origin)
+    const tempSettings = siteSettings.getSiteSettingsForHostPattern(appState.get('temporarySiteSettings'), origin)
     const permissionName = permission + 'Permission'
     if (settings) {
       let isAllowed = settings.get(permissionName)

--- a/app/index.js
+++ b/app/index.js
@@ -450,13 +450,6 @@ app.on('ready', () => {
       electron.clipboard.writeText(text)
     })
 
-    ipcMain.on(messages.SHOW_NOTIFICATION, (e, msg) => {
-      if (BrowserWindow.getFocusedWindow()) {
-        BrowserWindow.getFocusedWindow().webContents.send(messages.SHOW_NOTIFICATION,
-                                                          locale.translation(msg))
-      }
-    })
-
     ipcMain.on(messages.CHECK_FLASH_INSTALLED, (e) => {
       flash.checkFlashInstalled((installed) => {
         e.sender.send(messages.FLASH_UPDATED, installed)

--- a/js/about/aboutActions.js
+++ b/js/about/aboutActions.js
@@ -156,10 +156,6 @@ const AboutActions = {
     ipc.send(messages.CHECK_FLASH_INSTALLED)
   },
 
-  showNotification: function (msg) {
-    ipc.send(messages.SHOW_NOTIFICATION, msg)
-  },
-
   setResourceEnabled: function (resourceName, enabled) {
     AboutActions.dispatchAction({
       actionType: AppConstants.APP_SET_RESOURCE_ENABLED,

--- a/js/about/passwords.js
+++ b/js/about/passwords.js
@@ -63,7 +63,6 @@ class PasswordItem extends React.Component {
   onCopy () {
     if (this.state.decrypted !== null) {
       aboutActions.setClipboard(this.state.decrypted)
-      aboutActions.showNotification('passwordCopied')
     } else {
       this.decrypt(false)
     }
@@ -74,7 +73,6 @@ class PasswordItem extends React.Component {
       return
     }
     aboutActions.setClipboard(details.decrypted)
-    aboutActions.showNotification('passwordCopied')
     this.setState({
       decrypted: details.decrypted
     })

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -580,8 +580,7 @@ class Frame extends ImmutableComponent {
     } else {
       flash.checkFlashInstalled((installed) => {
         if (installed) {
-          currentWindow.webContents.send(messages.SHOW_NOTIFICATION,
-                                         locale.translation('flashInstalled'))
+          void new window.Notification(locale.translation('flashInstalled'))
         } else if (noFlashCallback) {
           noFlashCallback()
         }

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -340,10 +340,6 @@ class Main extends ImmutableComponent {
       frameProps && windowActions.setRedirectedBy(frameProps, ruleset, details.url)
     })
 
-    ipc.on(messages.SHOW_NOTIFICATION, (e, text) => {
-      void new window.Notification(text)
-    })
-
     ipc.on(messages.SHORTCUT_ACTIVE_FRAME_BACK, this.onBack)
     ipc.on(messages.SHORTCUT_ACTIVE_FRAME_FORWARD, this.onForward)
 

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -72,7 +72,6 @@ const messages = {
   ENTER_FULL_SCREEN: _,
   SET_CLIPBOARD: _,
   GOT_CANVAS_FINGERPRINTING: _,
-  SHOW_NOTIFICATION: _, /** @arg {string} l10n id of desktop notification message */
   GO_BACK: _,
   GO_FORWARD: _,
   RELOAD: _,


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Go to https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/Using_geolocation
2. notification should display for https://mdn.mozillademos.org vs page origin of http://developer.mozilla.org
3. change tabs or open a new tab
4. notification should not appear
5. return to the original tab
6. notification should be displayed

The changes for Brave Browser notifications aren't currently  testable because we don't get the mainFrameUrl for notifications yet, but I have tested them with a local hack

don't allow Brave to display notifications without permission
remove unnecessary password copied notifications
cc @bbondy @diracdeltas
fix #3877