### PR TITLE
Default Payments publisherURL protocol to http://

### DIFF
--- a/app/ledger.js
+++ b/app/ledger.js
@@ -532,7 +532,9 @@ var synopsisNormalizer = () => {
       faviconURL: publisher.faviconURL,
       score: results[i].scores[scorekeeper]
     }
-    if (results[i].protocol) data[i].publisherURL = results[i].protocol + '//' + results[i].publisher
+    // HACK: Protocol is sometimes blank here, so default to http:// so we can
+    // still generate publisherURL.
+    data[i].publisherURL = (results[i].protocol || 'http:') + '//' + results[i].publisher
 
     pct[i] = Math.round((results[i].scores[scorekeeper] * 100) / total)
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #3751

This isn't an ideal solution, but it bandaids #3751 such that publisher links on the Payments page always work.
In the future we might revisit the intermittently missing ledgerInfo favicon / protocol.

Auditors: @mrose17

Test Plan:

1. Browse various websites for >8s each
2. Check Preferences -> Payments and confirm that favicon-less publisher links work