### PR TITLE
enable-plugins is now required for some reason

### DIFF
--- a/js/flash.js
+++ b/js/flash.js
@@ -50,6 +50,7 @@ module.exports.init = () => {
     }
 
     const pepperFlashManifest = JSON.parse(data)
+    app.commandLine.appendSwitch('enable-plugins')
     app.commandLine.appendSwitch('ppapi-flash-path', pepperFlashSystemPluginPath)
     app.commandLine.appendSwitch('ppapi-flash-version', pepperFlashManifest.version)
     return true


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

related #3878

full fix requires https://github.com/brave/electron/pull/56