### PR TITLE
Make "Hide Brave" translatable

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -562,7 +562,7 @@ const createMenu = () => {
         },
         CommonMenu.separatorMenuItem,
         {
-          label: `Hide ${appConfig.name}`,
+          label: locale.translation('hideBrave'),
           accelerator: 'Command+H',
           role: 'hide'
         }, {

--- a/app/extensions/brave/locales/en-US/menu.properties
+++ b/app/extensions/brave/locales/en-US/menu.properties
@@ -64,6 +64,7 @@ bringAllToFront=Bring All to Front
 help=Help
 sendUsFeedback=Send us Feedback...
 services=Services
+hideBrave=Hide Brave
 hideOthers=Hide Others
 showAll=Show All
 newPrivateTab=New Private Tab

--- a/app/locale.js
+++ b/app/locale.js
@@ -128,6 +128,7 @@ var rendererIdentifiers = function () {
     'help',
     'sendUsFeedback',
     'services',
+    'hideBrave',
     'hideOthers',
     'showAll',
     'newPrivateTab',


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Closes #3983

Auditors: @aekeus

Test Plan:

1. Open Brave on Mac
2. Click "Brave" next to the apple icon on the menu bar
3. Make sure "Hide Brave" exists