### PR TITLE
Block script icon is off location when URL bar is hidden

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -225,6 +225,7 @@
       animation: fadeIn .6s;
       opacity: 0;
       animation-fill-mode: forwards;
+      width: 20px;
     }
   }
 
@@ -250,15 +251,12 @@
       position: absolute;
       top: -2px;
       right: 0;
-    }
 
-    .noScript {
-      font-size: 12px;
-      position: absolute;
-      left: -30px;
-      top: 7px;
-      opacity: 1;
-      color: @braveOrange;
+      .browserButton {
+        font-size: 10px;
+        width: 20px;
+        opacity: 0.6;
+      }
     }
 
     .urlbarIcon {
@@ -279,10 +277,6 @@
     }
 
     .bookmarkButton {
-      transform: scale(0.6);
-      opacity: 0.6;
-      text-align: left;
-
       &:not(.removeBookmarkButton) {
         display: none;
       }
@@ -314,11 +308,6 @@
     font-size: 16px;
     margin-left: 10px;
     color: @braveOrange;
-    opacity: 0.6;
-    &:hover {
-      opacity: 1;
-    }
-    display: inline;
   }
 
   /* Disable selection of button text */


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #4007 

Test Plan:

Experiment with both bookmarking and blocking scripts on websites and make sure both icons look correct on the top of the browser.

Auditors @diracdeltas @bradleyrichter 

Also, @bradleyrichter I noticed some code in there that looks like maybe those icons used to be somewhat see through and then bolden on hover? Is that still desired?

