### PR TITLE
Brave Payment panel is not aligned

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -350,7 +350,7 @@ class BitcoinDashboard extends ImmutableComponent {
   get panelFooter () {
     return <div className='panelFooter'>
       <div id='coinbaseLogo' />
-      <span data-l10n-id='coinbaseMessage' />
+      <span className='coinbaseMessage' data-l10n-id='coinbaseMessage' />
       <Button l10nId='done' className='pull-right whiteButton' onClick={this.props.hideParentOverlay} />
     </div>
   }

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -45,6 +45,11 @@ body {
   margin-right: 10px;
 }
 
+.coinbaseMessage {
+  display: inline-block;
+  max-width: 450px;
+}
+
 #appstoreLogo {
   background: url('../../app/extensions/brave/img/ios_download.svg');
   width: 130.5px;
@@ -324,7 +329,6 @@ a {
 .settingsList .subtext {
   color: @darkGray;
   font-size: 0.9em;
-  margin: 1.2em 2px 7px;
 }
 
 .settingsListCopy {
@@ -777,7 +781,6 @@ div.nextPaymentSubmission {
       .fa {
         position: absolute;
         left: -45px;
-        top: 15px;
 
         &.fa-credit-card {
           font-size: 30px;


### PR DESCRIPTION
- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Fix #3952

Test Plan:

Look at the screenshots in #3952 to make sure the add funds dialog looks like @bradleyrichter's spec

Auditors @bbondy @bradleyrichter 