### PR TITLE
Horizontal Scroll bar appears with just one entry in Brave Payments

### DIFF
--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -539,7 +539,7 @@ table.sortableTable {
 
 #ledgerTable {
   height: ~"-webkit-calc(100vh - 300px)";
-  overflow-y: scroll;
+  overflow-y: auto;
 
   tr {
     th,


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #3792 

Test Plan:

View the payments tab on a Windows machine and make sure there is no scrollbar unless you have enough publishers to merit one.

