### PR TITLE
Reorder Brave Payments buttons to improve 1st-time flow

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -674,18 +674,16 @@ class PaymentsTab extends ImmutableComponent {
       return null
     }
 
-    return <span id='fundsAmount'>
+    return <div>
       {
       !(this.props.ledgerData.get('balance') === undefined || this.props.ledgerData.get('balance') === null)
-        ? <span>
-          {this.btcToCurrencyString(this.props.ledgerData.get('balance'))}
-          <a href='https://brave.com/Payments_FAQ.html' target='_blank'>
-            <span className='fa fa-question-circle fundsFAQ' />
-          </a>
-        </span>
+        ? <input className='fundsAmount' readOnly value={this.btcToCurrencyString(this.props.ledgerData.get('balance'))} />
         : <span><span data-l10n-id='accountBalanceLoading' /></span>
       }
-    </span>
+      <a href='https://brave.com/Payments_FAQ.html' target='_blank'>
+        <span className='fa fa-question-circle fundsFAQ' />
+      </a>
+    </div>
   }
 
   get walletButton () {
@@ -820,24 +818,13 @@ class PaymentsTab extends ImmutableComponent {
         <table>
           <thead>
             <tr>
-              <th data-l10n-id='accountBalance' />
               <th data-l10n-id='monthlyBudget' />
+              <th data-l10n-id='accountBalance' />
               <th data-l10n-id='status' />
             </tr>
           </thead>
           <tbody>
             <tr>
-              <td>
-                {
-                  this.props.ledgerData.get('error') && this.props.ledgerData.get('error').get('caller') === 'getWalletProperties'
-                    ? <span data-l10n-id='accountBalanceConnectionError' />
-                    : <span>
-                      {this.fundsAmount}
-                      {this.walletButton}
-                      {this.paymentHistoryButton}
-                    </span>
-                }
-              </td>
               <td>
                 <SettingsList>
                   <SettingItem>
@@ -853,6 +840,21 @@ class PaymentsTab extends ImmutableComponent {
                     </select>
                   </SettingItem>
                 </SettingsList>
+              </td>
+              <td>
+                {
+                  this.props.ledgerData.get('error') && this.props.ledgerData.get('error').get('caller') === 'getWalletProperties'
+                    ? <span data-l10n-id='accountBalanceConnectionError' />
+                    : <span>
+                      <SettingsList>
+                        <SettingItem>
+                          {this.fundsAmount}
+                          {this.walletButton}
+                          {this.paymentHistoryButton}
+                        </SettingItem>
+                      </SettingsList>
+                    </span>
+                }
               </td>
               <td>
                 <div id='walletStatus' data-l10n-id={this.walletStatus.id} data-l10n-args={this.walletStatus.args ? JSON.stringify(this.walletStatus.args) : null} />

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -67,16 +67,6 @@ body {
   display: inline-block;
 }
 
-#fundsAmount {
-  margin-right: 10px;
-
-  .fundsFAQ {
-    position: relative;
-    margin: 0 10px;
-    top: -1px;
-  }
-}
-
 .bitcoinQRTitle {
   color: @braveOrange;
   margin-bottom: 70px;
@@ -410,8 +400,8 @@ span.browserButton.primaryButton {
       margin-left: 10px;
     }
 
-    > input,
-    > select {
+    input,
+    select {
       display: block;
       border-radius: @borderRadius;
       height: 2.25em;
@@ -424,20 +414,20 @@ span.browserButton.primaryButton {
       outline: none;
     }
 
-    > input {
+    input {
       box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
     }
 
-    > select  {
+    select  {
       box-shadow: @lightBoxShadow;
     }
 
-    > input[type="number"] {
+    input[type="number"] {
       width: 50px;
       min-width: 50px;
     }
 
-    > select[disabled] {
+    select[disabled] {
       color: #ccc
     }
 
@@ -639,7 +629,6 @@ div.nextPaymentSubmission {
     margin: 30px 0px;
     th {
       text-align: left;
-      font-weight: normal;
     }
     tr {
       height: 1em;
@@ -652,10 +641,22 @@ div.nextPaymentSubmission {
     span.browserButton.primaryButton.addFunds {
       margin-right: 0;
     }
+    .fundsAmount {
+      display: inline;
+      margin: 0;
+      width: auto;
+    }
+    .fundsFAQ {
+      display: inline;
+      position: relative;
+      top: 1px;
+      left: 5px;
+    }
     .addFunds {
       margin: 0;
       height: 30px;
-      line-height: 30px;
+      line-height: 24px;
+      box-sizing: border-box;
     }
     .nextReconcileDate {
       font-size: 14px;
@@ -1044,6 +1045,5 @@ div.nextPaymentSubmission {
 
 #fundsSelectBox {
   margin-top: 0px;
-  min-width: 130px;
   width: auto;
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #3963

Test Plan:

Make sure the new Payments tab looks like @bradleyrichter's spec in #3963 

Screenshot of this branch here for convenience:
![screen shot 2016-09-15 at 3 23 15 pm](https://cloud.githubusercontent.com/assets/490294/18569636/b1b6f914-7b58-11e6-852f-65de1e593e27.png)


