### PR TITLE
Blockscript/Favourite icons look faded

### DIFF
--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -167,7 +167,7 @@ class NavigationBar extends ImmutableComponent {
               })}
               onClick={this.onNoScript} />
           }
-          <Button iconClass={this.titleMode ? 'fa-star' : 'fa-star-o'}
+          <Button iconClass={this.bookmarked ? 'fa-star' : 'fa-star-o'}
             className={cx({
               navbutton: true,
               bookmarkButton: true,

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -225,7 +225,6 @@
       animation: fadeIn .6s;
       opacity: 0;
       animation-fill-mode: forwards;
-      width: 20px;
     }
   }
 
@@ -248,15 +247,7 @@
     }
 
     .endButtons {
-      position: absolute;
-      top: -2px;
-      right: 0;
-
-      .browserButton {
-        font-size: 10px;
-        width: 20px;
-        opacity: 0.6;
-      }
+      display: none;
     }
 
     .urlbarIcon {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #4035 #4042

Test Plan:

Check that the bookmark icon is filled in orange if bookmarked and not filled in gray when not. Also now the noscript and bookmark icons should both be hidden when not in title mode.

Auditors: @bradleyrichter @diracdeltas 