### PR TITLE
- History now uses title (not custom title)

### DIFF
--- a/js/about/history.js
+++ b/js/about/history.js
@@ -43,8 +43,8 @@ class HistoryDay extends ImmutableComponent {
               : '',
             value: entry.get('lastAccessedTime')
           },
-          entry.get('customTitle') || entry.get('title')
-            ? entry.get('customTitle') || entry.get('title')
+          entry.get('title')
+            ? entry.get('title')
             : entry.get('location'),
           urlutils.getHostname(entry.get('location'), true)
         ])}
@@ -134,7 +134,7 @@ class AboutHistory extends React.Component {
   }
   searchedSiteDetails (searchTerm, siteDetails) {
     return siteDetails.filter((siteDetail) => {
-      const title = siteDetail.get('customTitle') + siteDetail.get('title') + siteDetail.get('location')
+      const title = siteDetail.get('title') + siteDetail.get('location')
       return title.match(new RegExp(searchTerm, 'gi'))
     })
   }

--- a/less/about/history.less
+++ b/less/about/history.less
@@ -118,6 +118,10 @@ body {
           margin-right: 10px;
         }
       }
+
+      .sortableTable {
+        cursor: default;
+      }
     }
   }
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

- History now uses title (not custom title)
- History page also uses cursor: default, to look more app-like

Fixes https://github.com/brave/browser-laptop/issues/4029

Auditors: @bbondy @srirambv

Test Plan:

Part 1
1. Visit https://clifton.io/about/
2. Bookmark the site; set the title to "TESTING 123"
3. Bring up the history page (Ctrl+Y / Cmd+Y)
4. Verify the entry shows up AND uses the title "About me" (not TESTING 123)

Part 2
5. Move mouse over the table data. Notice it stays as the cursor.