### PR TITLE
View Page Source don't work for SVG files

### DIFF
--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -82,7 +82,7 @@ const UrlUtil = {
   },
 
   isImageAddress (url) {
-    return (url.match(/\.(jpeg|jpg|gif|png|svg|bmp)$/))
+    return (url.match(/\.(jpeg|jpg|gif|png|bmp)$/))
   },
 
   isHttpAddress (url) {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes #4054

Auditors:
@bbondy

Test Plan:
1.Open an svg link Eg: https://w3c.github.io/svgwg/specs/svg-authoring/examples/clock-animate-1.svg
2.Right click to open the context menu
3.Click "View page source"