### PR TITLE
QR Code Popup from Add funds dialog scrolls independently

### DIFF
--- a/less/modalOverlay.less
+++ b/less/modalOverlay.less
@@ -62,7 +62,7 @@
     .qrcodeOverlay {
       width: 350px;
       height: auto;
-      margin: 200px auto;
+      margin: 100px auto;
       background: white;
       box-shadow: @buttonShadow;
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #4043

Test Plan:

Auditor: @bradleyrichter 

Make sure the qrcode doesn't scroll unnecessarily when opened.