### PR TITLE
View page source should respect private windows

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -476,7 +476,12 @@ class Frame extends ImmutableComponent {
       case 'view-source':
         const sourceLocation = UrlUtil.getViewSourceUrlFromUrl(this.webview.getURL())
         if (sourceLocation !== null) {
-          windowActions.newFrame({location: sourceLocation}, true)
+          windowActions.newFrame({
+            location: sourceLocation,
+            isPrivate: this.frame.get('isPrivate'),
+            partitionNumber: this.frame.get('partitionNumber'),
+            parentFrameKey: this.frame.get('key')
+          }, true)
         }
         // TODO: Make the URL bar show the view-source: prefix
         break


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes #4069

@bbondy

Test Plan:
Open a private tab and load any website
Right click on the page and choose Show Source