### PR TITLE
Show "Bring All to Front" only on macOS

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -405,7 +405,7 @@ const createBookmarksSubmenu = () => {
 }
 
 const createWindowSubmenu = () => {
-  return [
+  const submenu = [
     {
       label: locale.translation('minimize'),
       accelerator: 'CmdOrCtrl+M',
@@ -438,13 +438,20 @@ const createWindowSubmenu = () => {
     CommonMenu.separatorMenuItem,
     CommonMenu.bookmarksManagerMenuItem(),
     CommonMenu.downloadsMenuItem(),
-    CommonMenu.passwordsMenuItem(),
-    CommonMenu.separatorMenuItem,
-    {
-      label: locale.translation('bringAllToFront'),
-      role: 'front'
-    }
+    CommonMenu.passwordsMenuItem()
   ]
+
+  if (isDarwin) {
+    submenu.push(
+      CommonMenu.separatorMenuItem,
+      {
+        label: locale.translation('bringAllToFront'),
+        role: 'front'
+      }
+    )
+  }
+
+  return submenu
 }
 
 const createHelpSubmenu = () => {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes #3664 
If there is a linux distribution where it works, please let me know. Thanks.

Auditors: @bbondy

Test Plan:
1. Make sure "Bring All to Front" appears in the menu "Window" on macOS
2. Make sure it does not appear in the menu on Windows