### PR TITLE
Fix sortableTable hover effect and searchTab onClick

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -616,7 +616,7 @@ class SearchTab extends ImmutableComponent {
   }
 
   hoverCallback (rows) {
-    this.props.onChangeSetting(settings.DEFAULT_SEARCH_ENGINE, rows[1].props.children.props.name)
+    this.props.onChangeSetting(settings.DEFAULT_SEARCH_ENGINE, rows[1].value)
   }
 
   render () {

--- a/js/components/sortableTable.js
+++ b/js/components/sortableTable.js
@@ -99,7 +99,8 @@ class SortableTable extends ImmutableComponent {
             const rowAttributes = this.getRowAttributes(row, i)
             return <tr {...rowAttributes}
               data-context-menu-disable={rowAttributes.onContextMenu ? true : undefined}
-              className={this.hasRowClassNames ? this.props.rowClassNames[i] : undefined}>{entry}</tr>
+              className={this.hasRowClassNames ? this.props.rowClassNames[i] + ' ' + rowAttributes.className
+                : rowAttributes.className}>{entry}</tr>
           })
         }
       </tbody>


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

fix #4099

Auditors: @bbondy

Test Plan:

1. Go to "about:preferences#search"
2. There should be hover effect when hovering on row
3. Should be able to swtch default search engine