### PR TITLE
Make toolbar messages non-selectable

### DIFF
--- a/less/notificationBar.less
+++ b/less/notificationBar.less
@@ -70,12 +70,16 @@
       color: @braveOrange;
       font-size: 16px;
       margin: auto 10px auto 0;
+      user-select: none;
+      -webkit-user-select: none;
     }
 
     .message {
       color: #000;
       font-size: 15px;
       margin: auto 0;
+      user-select: none;
+      -webkit-user-select: none;
 
       &.secondary {
         color: #888;


### PR DESCRIPTION
Not bothering with the below because the process overhead involved for fixing two CSS rules is uncalled for.

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

1. Help menu: Check for updates
2. Try to select text in the notification message toolbar