### PR TITLE
Add ledger payment success notification

### DIFF
--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -169,6 +169,7 @@ addFunds=Add funds
 notificationPasswordWithUserName=Would you like Brave to remember the password for {{username}} on {{origin}}?
 notificationPassword=Would you like Brave to remember your password on {{origin}}?
 notificationPasswordSettings=[Password settings]
+notificationPaymentDone=Your contribution of {{amount}} {{currency}} has been processed. Thanks for supporting your favorite websites!
 prefsRestart=Do you want to restart now?
 yes=Yes
 no=No

--- a/app/ledger.js
+++ b/app/ledger.js
@@ -99,6 +99,7 @@ const msecs = { year: 365 * 24 * 60 * 60 * 1000,
 
 let addFundsMessage
 let reconciliationMessage
+let notificationPaymentDoneMessage
 let suppressNotifications = false
 let reconciliationNotificationShown = false
 let notificationTimeout = null
@@ -227,6 +228,8 @@ if (ipc) {
       // If > 24 hours has passed, it might be time to show the reconciliation
       // message again
       setTimeout(() => { reconciliationNotificationShown = false }, 1 * msecs.day)
+    } else if (message === notificationPaymentDoneMessage) {
+      appActions.hideMessageBox(message)
     }
   })
 
@@ -1048,7 +1051,26 @@ var getStateInfo = (state) => {
                                                                    { ballots: ballots }))
   }
 
+  observeTransactions(state.transactions)
   updateLedgerInfo()
+}
+
+// Observe ledger client state.transactions for changes.
+// Called by getStateInfo(). Updated state provided by ledger-client.
+var cachedTransactions = null
+var observeTransactions = (transactions) => {
+  if (underscore.isEqual(cachedTransactions, transactions)) {
+    return
+  }
+  // Notify the user of new transactions.
+  if (getSetting(settings.PAYMENTS_NOTIFICATIONS) && cachedTransactions !== null) {
+    const newTransactions = underscore.difference(transactions, cachedTransactions)
+    if (newTransactions.length > 0) {
+      const newestTransaction = newTransactions[newTransactions.length - 1]
+      showNotificationPaymentDone(newestTransaction.contribution.fiat)
+    }
+  }
+  cachedTransactions = transactions
 }
 
 var balanceTimeoutId = false
@@ -1289,6 +1311,24 @@ const showNotifications = () => {
       reconciliationNotificationShown = true
     }
   }
+}
+
+// Called from observeTransactions() when we see a new payment (transaction).
+const showNotificationPaymentDone = (transactionContributionFiat) => {
+  notificationPaymentDoneMessage = locale.translation('notificationPaymentDone')
+    .replace(/{{\s*amount\s*}}/, transactionContributionFiat.amount)
+    .replace(/{{\s*currency\s*}}/, transactionContributionFiat.currency)
+  appActions.showMessageBox({
+    greeting: locale.translation('updateHello'),
+    message: notificationPaymentDoneMessage,
+    buttons: [
+      {text: locale.translation('Ok'), className: 'primary'}
+    ],
+    options: {
+      style: 'greetingStyle',
+      persist: false
+    }
+  })
 }
 
 module.exports = {

--- a/app/ledger.js
+++ b/app/ledger.js
@@ -1070,7 +1070,7 @@ var observeTransactions = (transactions) => {
       showNotificationPaymentDone(newestTransaction.contribution.fiat)
     }
   }
-  cachedTransactions = transactions
+  cachedTransactions = underscore.clone(transactions)
 }
 
 var balanceTimeoutId = false

--- a/app/locale.js
+++ b/app/locale.js
@@ -192,6 +192,7 @@ var rendererIdentifiers = function () {
     'notificationPasswordWithUserName',
     'notificationPassword',
     'notificationPasswordSettings',
+    'notificationPaymentDone',
     'prefsRestart',
     'yes',
     'no',


### PR DESCRIPTION
Adds notification on payment completion

Partially implement #3257

Auditors: @mrose17

Test Plan:
1. Trigger a payment
2. Observe payment complete notification