### PR TITLE
Typo in scripts/pageInformation.js

### DIFF
--- a/app/extensions/brave/content/scripts/pageInformation.js
+++ b/app/extensions/brave/content/scripts/pageInformation.js
@@ -136,7 +136,7 @@
   if (node) results.faviconURL = node.getAttribute('href')
 
   var pubinfo = chrome.ipc.sendSync('ledger-publisher', document.location.href)
-  if ((!pubinfo) || (!pubinfo.context) || (!pubinfo.rules)) return console.log('no pubinfo avaialble')
+  if ((!pubinfo) || (!pubinfo.context) || (!pubinfo.rules)) return console.log('no pubinfo available')
 
   var context = pubinfo.context
   var rules = pubinfo.rules


### PR DESCRIPTION
- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

s/no pubinfo avaialble/o pubinfo available/g