### PR TITLE
Move importBrowserData option to obvious place

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -379,7 +379,9 @@ const createBookmarksSubmenu = () => {
     },
     CommonMenu.separatorMenuItem,
     CommonMenu.bookmarksManagerMenuItem(),
-    CommonMenu.bookmarksToolbarMenuItem()
+    CommonMenu.bookmarksToolbarMenuItem(),
+    CommonMenu.separatorMenuItem,
+    CommonMenu.importBrowserDataMenuItem()
   ]
 
   const bookmarks = menuUtil.createBookmarkMenuItems(appStore.getState().get('sites'))
@@ -458,8 +460,6 @@ const createHelpSubmenu = () => {
   if (!isDarwin) {
     submenu.push(CommonMenu.separatorMenuItem)
     submenu.push(CommonMenu.checkForUpdateMenuItem())
-    submenu.push(CommonMenu.separatorMenuItem)
-    submenu.push(CommonMenu.importBrowserDataMenuItem())
     submenu.push(CommonMenu.separatorMenuItem)
     submenu.push(CommonMenu.aboutBraveMenuItem())
   }

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -620,7 +620,9 @@ function hamburgerTemplateInit (location, e) {
       label: locale.translation('bookmarks'),
       submenu: [
         CommonMenu.bookmarksManagerMenuItem(),
-        CommonMenu.bookmarksToolbarMenuItem()
+        CommonMenu.bookmarksToolbarMenuItem(),
+        CommonMenu.separatorMenuItem,
+        CommonMenu.importBrowserDataMenuItem()
       ]
     }, {
       label: locale.translation('bravery'),
@@ -642,8 +644,6 @@ function hamburgerTemplateInit (location, e) {
         CommonMenu.aboutBraveMenuItem(),
         CommonMenu.separatorMenuItem,
         CommonMenu.checkForUpdateMenuItem(),
-        CommonMenu.separatorMenuItem,
-        CommonMenu.importBrowserDataMenuItem(),
         CommonMenu.separatorMenuItem,
         CommonMenu.reportAnIssueMenuItem(),
         CommonMenu.submitFeedbackMenuItem()


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bsclifton

fix #4177

Test Plan:
for menubar:
1. importBrowserData option is under "Brave" and "Bookmarks" on mac
2. importBrowserData option is under "Bookmarks" on linux and windows

for hamburger menu:
importBrowserData option is under "Bookmarks" on all platforms