### PR TITLE
when the idle state changes, flush the timer

### DIFF
--- a/app/ledger.js
+++ b/app/ledger.js
@@ -110,7 +110,24 @@ let notificationTimeout = null
 const doAction = (action) => {
   var i, publisher
 
+/* TBD: handle
+
+    { actionType: "window-set-blocked-by"
+    , frameProps:
+      { audioPlaybackActive: true
+        ...
+      }
+    , ...
+    }
+ */
+  if (publisherInfo._internal.verboseP) {
+    console.log('\napplication event: ' + JSON.stringify(underscore.pick(action, [ 'actionType', 'key' ]), null, 2))
+  }
   switch (action.actionType) {
+    case appConstants.APP_IDLE_STATE_CHANGED:
+      visit('NOOP', underscore.now(), null)
+      break
+
     case appConstants.APP_CHANGE_SETTING:
       if (action.key === settings.PAYMENTS_ENABLED) return initialize(action.value)
       if (action.key === settings.PAYMENTS_CONTRIBUTION_AMOUNT) return setPaymentInfo(action.value)


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/4051

Auditor: @ayumi

Test Plan:

1. invoke the browser via `LEDGER_PUBLISHER_VERBOSE=true ...`

2. go to a publisher site

3. do NOT touch the keyboard and wait *more* than 15m

4. go to another site and browser around, or restart the browser, etc.

5. go to `about:preferences#payments` and verify that the publisher got no more than 15m of update
