### PR TITLE
add confirmation dialog after successful import of data from other browser

### DIFF
--- a/app/aboutDialog.js
+++ b/app/aboutDialog.js
@@ -39,3 +39,17 @@ module.exports.showImportWarning = function () {
     })
   }, 50)
 }
+
+module.exports.showImportSuccess = function () {
+  // The timeout is in case there's a call just after the modal to hide the menu.
+  // showMessageBox is a modal and blocks everything otherwise, so menu would remain open
+  // while the dialog is displayed.
+  setTimeout(() => {
+    dialog.showMessageBox({
+      title: 'Brave',
+      message: `${locale.translation('importSuccess')}`,
+      icon: path.join(__dirname, '..', 'app', 'extensions', 'brave', 'img', 'braveAbout.png'),
+      buttons: ['Ok']
+    })
+  }, 50)
+}

--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -214,6 +214,7 @@ importBrowserData=Import browser data
 import=Import
 importDataWarning=Note: Each browser has a different set of importable data.
 importDataCloseBrowserWarning=Please make sure the selected browser is closed before importing your data.
+importSuccess=Your data has been imported to Brave successfully.
 closeFirefoxWarning=Firefox must be closed during data import. Please close and try again.
 favoritesOrBookmarks=Favorites/Bookmarks
 mergeIntoBookmarksToolbar=Merge Favorites into Bookmarks Toolbar

--- a/app/importer.js
+++ b/app/importer.js
@@ -10,7 +10,7 @@ const dialog = electron.dialog
 const BrowserWindow = electron.BrowserWindow
 const session = electron.session
 const Immutable = require('immutable')
-const showImportWarning = require('./aboutDialog').showImportWarning
+const { showImportWarning, showImportSuccess } = require('./aboutDialog')
 const siteUtil = require('../js/state/siteUtil')
 const AppStore = require('../js/stores/appStore')
 const siteTags = require('../js/constants/siteTags')
@@ -178,4 +178,11 @@ importer.on('add-cookies', (e, cookies) => {
 
 importer.on('show-warning-dialog', (e) => {
   showImportWarning()
+})
+
+importer.on('import-success', (e) => {
+  showImportSuccess()
+})
+
+importer.on('import-dismiss', (e) => {
 })

--- a/app/locale.js
+++ b/app/locale.js
@@ -217,7 +217,8 @@ var rendererIdentifiers = function () {
     'windowCaptionButtonMaximize',
     'windowCaptionButtonRestore',
     'windowCaptionButtonClose',
-    'closeFirefoxWarning'
+    'closeFirefoxWarning',
+    'importSuccess'
   ]
 }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #4188

requires https://github.com/brave/electron/commit/58efa3ce28da513e0776a7d6d9b884263450bad3

Auditors: @bbondy

Test Plan:
dialog should show up after importing