### PR TITLE
Fix titlebar menu + titlebar resize issues

### DIFF
--- a/app/renderer/components/windowCaptionButtons.js
+++ b/app/renderer/components/windowCaptionButtons.js
@@ -55,7 +55,7 @@ class WindowCaptionButtons extends ImmutableComponent {
   }
 
   render () {
-    return <div className={this.buttonClass + ' windowCaptionButtons'}>
+    return <div className={this.buttonClass + ' windowCaptionButtons' + (this.props.shouldAllowWindowDrag ? ' allowDragging' : '')}>
       <div className={'container ' + this.osClass}>
         <button
           className={this.buttonClass + ' captionButton minimize'}

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -838,7 +838,8 @@ class Main extends ImmutableComponent {
       !autofillCreditCardPanelIsVisible &&
       !releaseNotesIsVisible &&
       !noScriptIsVisible &&
-      activeFrame && !activeFrame.getIn(['security', 'loginRequiredDetail'])
+      activeFrame && !activeFrame.getIn(['security', 'loginRequiredDetail']) &&
+      !customTitlebar.menubarSelectedIndex
 
     return <div id='window'
       className={cx({
@@ -868,7 +869,10 @@ class Main extends ImmutableComponent {
             <div className='navbarMenubarBlockContainer'>
               {
                 customTitlebar.menubarVisible
-                  ? <div className='menubarContainer'>
+                  ? <div className={cx({
+                    allowDragging: shouldAllowWindowDrag,
+                    menubarContainer: true
+                  })}>
                     <Menubar
                       template={customTitlebar.menubarTemplate}
                       selectedIndex={customTitlebar.menubarSelectedIndex}
@@ -939,7 +943,7 @@ class Main extends ImmutableComponent {
           </div>
           {
             customTitlebar.captionButtonsVisible
-              ? <WindowCaptionButtons windowMaximized={customTitlebar.isMaximized} />
+              ? <WindowCaptionButtons windowMaximized={customTitlebar.isMaximized} shouldAllowWindowDrag={shouldAllowWindowDrag} />
               : null
           }
         </div>

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -56,9 +56,23 @@
     .loadTime { display: none; }
     #urlInput { max-width: 75px; }
     #titleBar { width: 100px; }
+    .menubarContainer {
+      .menubar {
+        .menubarItem {
+          padding: 0 5px 1px;
+        }
+      }
+    }
   }
   @media (max-width: @breakpointTinyWin32) {
     #urlInput { max-width: 50px; }
+    .menubarContainer {
+      .menubar {
+        .menubarItem {
+          padding: 0 3px 1px;
+        }
+      }
+    }
   }
 }
 
@@ -83,7 +97,15 @@
 // Window Caption Buttons (for use w/ slim titlebar)
 .windowCaptionButtons {
   display: inline-block;
-  -webkit-app-region: drag;
+
+  &.allowDragging {
+    -webkit-app-region: drag;
+    >* {
+      -webkit-app-region: no-drag;
+    }
+  }
+
+  white-space: nowrap;
 
   .hidden {
     display: none;
@@ -111,10 +133,10 @@
       outline: 0;
       height: 18px;
       color: #b1acac;
-      border: 1px solid #838383;
+      border: 1px solid #adadad;
       border-top: 0;
       display: inline-block;
-      background-color: #e0e0e0;
+      background-color: #f5f5f5;
       box-shadow: inset 1px 1px rgba(255, 255, 255, 0.9);
       width: 25px;
 
@@ -122,7 +144,7 @@
         width: 28px;
         border-right: 0px;
         &:hover {
-          background-color: #f5f5f5;
+          background-color: #fff;
         }
         &:active {
           background-color: #cacacb;
@@ -133,7 +155,7 @@
           width: 10px;
           height: 3px;
           border: 1px solid #838383;
-          background: #fefefe;
+          background: #fff;
           display: inline-block;
           border-radius: 1px;
         }
@@ -143,10 +165,10 @@
         border-right: 0px;
         width: 27px;
         &:hover {
-          background-color: #f5f5f5;
+          background-color: #fff;
           .widget {
             .widget2 {
-              background-color: #f5f5f5;
+              background-color: #fff;
             }
           }
         }
@@ -176,7 +198,7 @@
               height: 8px;
               top: -5px;
               left: 6px;
-              background: #fefefe;
+              background: #fff;
               border-radius: 1px;
             }
             .widget3 {
@@ -184,7 +206,7 @@
               width: 2px;
               height: 2px;
               border: 1px solid #838383;
-              background: #fefefe;
+              background: #fff;
               position: relative;
               top: -20px;
               left: -2px;
@@ -197,7 +219,7 @@
             width: 10px;
             height: 8px;
             border: 1px solid #838383;
-            background: #fefefe;
+            background: #fff;
             position: relative;
             top: 2px;
             left: 7px;
@@ -207,7 +229,7 @@
             width: 4px;
             height: 2px;
             border: 1px solid #838383;
-            background-color: #e0e0e0;
+            background-color: #f5f5f5;
             position: relative;
             top: -5px;
             left: 10px;
@@ -269,6 +291,8 @@
           background: black;
           display: inline-block;
           vertical-align: middle;
+          position: relative;
+          left: -1px;
         }
       }
 
@@ -386,8 +410,8 @@
             display: inline-block;
             transform: rotate(315deg);
             position: relative;
-            top: -21px;
-            left: -2px;
+            top: -6px;
+            left: -16px;
           }
           .widget3 { display: none; }
         }
@@ -398,12 +422,18 @@
 
 // Menubar (for use w/ slim titlebar)
 .menubarContainer {
-  -webkit-app-region: drag;
   width: 100%;
   height: 29px;
   display: inline-block;
   margin-top: 5px;
   margin-left: 4px;
+
+  &.allowDragging {
+    -webkit-app-region: drag;
+    >* {
+      -webkit-app-region: no-drag;
+    }
+  }
 
   .menubar {
     display: inline-block;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests). N/A
- [x] Ran `git rebase -i` to squash commits (if needed).

- Both menubar and caption button controls will properly mark themsel…
…ves as draggable when they are allowed to be dragged

and then remove that style when they shouldn't be (for example, when a modal is showing or a context menu is being displayed).

Huge thanks to @bbondy for the assist :)
Fixes https://github.com/brave/browser-laptop/issues/4142

- Menu gets compressed nicely when making small (less padding). Caption buttons no longer wrap
Fixes https://github.com/brave/browser-laptop/issues/4185

Updated Windows 7 colors w/ @bradleyrichter

Auditors: @bbondy 

Test Plan:
for https://github.com/brave/browser-laptop/issues/4142
- launch Brave on Windows 7
- click one of the menus, so that the popup comes down
- move mouse down very slowly- it should highlight the first context menu as soon as it comes into the bounds of the control (previously, it didn't until it was well into the context menu).  See original issue ticket for a screencap of the issue 

for https://github.com/brave/browser-laptop/issues/4185
- Launch Brave on Windows (version 7 and a non-7 version, like 10)
- Make the window as small as you can width-wise. it should look good
- turn on "autohide menu"
- confirm making window small again looks correct

