### PR TITLE
Autofill guid migration

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -341,6 +341,28 @@ module.exports.loadAppState = () => {
           })
           data.autofill.creditCards = creditCards
         }
+        if (data.autofill.addresses.guid) {
+          let guids = []
+          data.autofill.addresses.guid.forEach((guid) => {
+            if (typeof guid === 'object') {
+              guids.push(guid['persist:default'])
+            } else {
+              guids.push(guid)
+            }
+          })
+          data.autofill.addresses.guid = guids
+        }
+        if (data.autofill.creditCards.guid) {
+          let guids = []
+          data.autofill.creditCards.guid.forEach((guid) => {
+            if (typeof guid === 'object') {
+              guids.push(guid['persist:default'])
+            } else {
+              guids.push(guid)
+            }
+          })
+          data.autofill.creditCards.guid = guids
+        }
       }
       // xml migration
       if (data.settings) {

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -119,7 +119,6 @@ class Frame extends ImmutableComponent {
         const guids = this.props.autofillAddresses.get('guid')
         let list = []
         guids.forEach((entry) => {
-          console.log(entry)
           const address = currentWindow.webContents.session.autofill.getProfile(entry)
           const valid = Object.getOwnPropertyNames(address).length > 0
           let addressDetail = {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #4208, #4209

Auditors: @bridiver, @bbondy

Test Plan:
1. Create autofill data from "0.12.1" and close brave
2. Copy "session-store-1" and "Web Data" to somewhere else
3. Copy the files in step 2 to your brave folder
4. Lauch brave "0.12.2"
5. Autofill data created from "0.12.1" should be listed in "about:autofill"
6. Should be able to add new autofill data