### PR TITLE
Regression: Text and button on Brave Payment panel are not aligned

### DIFF
--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -781,6 +781,10 @@ div.nextPaymentSubmission {
       position: relative;
       float: left;
 
+      .settingsListTitle {
+        margin: 0;
+      }
+
       &:nth-child(1) {
         text-align: left;
       }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #4180 

Auditors: @bradleyrichter @luixxiul 

Test Plan:

I caused this regression by adding back some top margin to the settingsTitles. We need top margin on them but not when they are inside panel dividers. See the attached image and make sure we don't have the titles pushed down. 

