### PR TITLE
0.12.2dev titlebar fixes (round 1)

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -1034,7 +1034,7 @@ class Main extends ImmutableComponent {
             draggingOverData={this.props.windowState.getIn(['ui', 'dragging', 'draggingOver', 'dragType']) === dragTypes.BOOKMARK && this.props.windowState.getIn(['ui', 'dragging', 'draggingOver'])}
             showFavicon={showFavicon}
             showOnlyFavicon={showOnlyFavicon}
-            shouldAllowWindowDrag={shouldAllowWindowDrag}
+            shouldAllowWindowDrag={shouldAllowWindowDrag && !isWindows}
             activeFrameKey={activeFrame && activeFrame.get('key') || undefined}
             windowWidth={window.innerWidth}
             contextMenuDetail={this.props.windowState.get('contextMenuDetail')}
@@ -1043,7 +1043,7 @@ class Main extends ImmutableComponent {
         }
         <div className={cx({
           tabPages: true,
-          allowDragging: shouldAllowWindowDrag,
+          allowDragging: shouldAllowWindowDrag && !isWindows,
           singlePage: nonPinnedFrames.size <= tabsPerPage
         })}
           onContextMenu={this.onTabContextMenu}>
@@ -1058,7 +1058,7 @@ class Main extends ImmutableComponent {
         </div>
         <TabsToolbar
           paintTabs={getSetting(settings.PAINT_TABS)}
-          shouldAllowWindowDrag={shouldAllowWindowDrag}
+          shouldAllowWindowDrag={shouldAllowWindowDrag && !isWindows}
           draggingOverData={this.props.windowState.getIn(['ui', 'dragging', 'draggingOver', 'dragType']) === dragTypes.TAB && this.props.windowState.getIn(['ui', 'dragging', 'draggingOver'])}
           previewTabs={getSetting(settings.SHOW_TAB_PREVIEWS)}
           tabsPerTabPage={tabsPerPage}

--- a/less/bookmarksToolbar.less
+++ b/less/bookmarksToolbar.less
@@ -13,13 +13,6 @@
   --bookmarks-toolbar-padding: 10px;
 }
 
-// (Windows) Bookmarks toolbar not right-clickable unless it has no-drag
-.platform--win32 .bookmarksToolbar {
-  &.allowDragging {
-    -webkit-app-region: no-drag !important;
-  }
-}
-
 .bookmarksToolbar {
   background: @toolbarBackground;
   border-bottom: 1px solid #aaaaaa;

--- a/less/contextMenu.less
+++ b/less/contextMenu.less
@@ -157,12 +157,14 @@
 
 
 // Make context menu style match menubar (Windows only- for use w/ slim titlebar)
-.platform--win32 .contextMenuItem {
-  font: menu;
-  font-size: 12px;
-}
+.platform--win32 {
+  .contextMenuItem {
+    font: menu;
+    font-size: 12px;
+  }
 
-.platform--win32 .accelerator {
-  font: menu;
-  font-size: 12px !important;
+  .accelerator {
+    font: menu;
+    font-size: 12px !important;
+  }
 }

--- a/less/tabs.less
+++ b/less/tabs.less
@@ -4,13 +4,6 @@
 
 @import "variables.less";
 
-// (Windows) Tabs row not right-clickable unless it has no-drag
-.platform--win32 .tabStripContainer {
-  &.allowDragging {
-    -webkit-app-region: no-drag !important;
-  }
-}
-
 .tabs {
   background: @tabsBackground;
   box-sizing: border-box;


### PR DESCRIPTION
Don't set `allowDragging` class for Windows on:
- bookmarks toolbar
- tab pages control
- tabs toolbar

Cleaner fix than marking class as `no-drag !important` w/ CSS

Fixes https://github.com/brave/browser-laptop/issues/4171
Should fix https://github.com/brave/browser-laptop/issues/4232

Auditors: @bbondy (important that you try it- I couldn't reproduce 4232)