### PR TITLE
Make buttons in aboutDialog.js translatable

### DIFF
--- a/app/aboutDialog.js
+++ b/app/aboutDialog.js
@@ -21,7 +21,7 @@ ${locale.translation('updateChannel')}: ${Channel.channel()}
 
 ${locale.translation('licenseText')}`,
       icon: path.join(__dirname, '..', 'app', 'extensions', 'brave', 'img', 'braveAbout.png'),
-      buttons: ['Ok']
+      buttons: [locale.translation('licenseTextOk')]
     })
   }, 50)
 }
@@ -35,7 +35,7 @@ module.exports.showImportWarning = function () {
       title: 'Brave',
       message: `${locale.translation('closeFirefoxWarning')}`,
       icon: path.join(__dirname, '..', 'app', 'extensions', 'brave', 'img', 'braveAbout.png'),
-      buttons: ['Ok']
+      buttons: [locale.translation('closeFirefoxWarningOk')]
     })
   }, 50)
 }
@@ -49,7 +49,7 @@ module.exports.showImportSuccess = function () {
       title: 'Brave',
       message: `${locale.translation('importSuccess')}`,
       icon: path.join(__dirname, '..', 'app', 'extensions', 'brave', 'img', 'braveAbout.png'),
-      buttons: ['Ok']
+      buttons: [locale.translation('importSuccessOk')]
     })
   }, 50)
 }

--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -219,3 +219,6 @@ closeFirefoxWarning=Firefox must be closed during data import. Please close and 
 favoritesOrBookmarks=Favorites/Bookmarks
 mergeIntoBookmarksToolbar=Merge Favorites into Bookmarks Toolbar
 cookies=Cookies
+licenseTextOk=Ok
+closeFirefoxWarningOk=Ok
+importSuccessOk=Ok

--- a/app/locale.js
+++ b/app/locale.js
@@ -218,7 +218,10 @@ var rendererIdentifiers = function () {
     'windowCaptionButtonRestore',
     'windowCaptionButtonClose',
     'closeFirefoxWarning',
-    'importSuccess'
+    'importSuccess',
+    'licenseTextOk',
+    'closeFirefoxWarningOk',
+    'importSuccessOk'
   ]
 }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

The buttons may be translated differently based on their context. Let translators decide how to handle them.

Auditors: @bbondy