### PR TITLE
Using customTitle for folder of imported bookmark

### DIFF
--- a/app/importer.js
+++ b/app/importer.js
@@ -113,7 +113,7 @@ importer.on('add-bookmarks', (e, bookmarks, topLevelFolder) => {
         parentFolderId = nextFolderId++
         pathMap[parentFolder] = parentFolderId
         const folder = {
-          title: parentFolder,
+          customTitle: parentFolder,
           folderId: parentFolderId,
           parentFolderId: pathMap[bookmarks[i].path[pathLen - 2]] === undefined ? topLevelFolderId : pathMap[bookmarks[i].path[pathLen - 2]],
           lastAccessedTime: (new Date()).getTime(),
@@ -126,7 +126,7 @@ importer.on('add-bookmarks', (e, bookmarks, topLevelFolder) => {
       const folderId = nextFolderId++
       pathMap[bookmarks[i].title] = folderId
       const folder = {
-        title: bookmarks[i].title,
+        customTitle: bookmarks[i].title,
         folderId: folderId,
         parentFolderId: parentFolderId,
         lastAccessedTime: bookmarks[i].creation_time * 1000,

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -109,11 +109,11 @@ module.exports.addSite = function (sites, siteDetail, tag, originalSiteDetail) {
     folderId = module.exports.getNextFolderId(sites)
   }
 
-  // Remve duplicate folder
+  // Remove duplicate folder
   if (!oldSite && tag === siteTags.BOOKMARK_FOLDER) {
     const dupFolder = sites.find((site) => isBookmarkFolder(site.get('tags')) &&
       site.get('parentFolderId') === siteDetail.get('parentFolderId') &&
-      site.get('title') === siteDetail.get('title'))
+      site.get('customTitle') === siteDetail.get('customTitle'))
     if (dupFolder) {
       sites = module.exports.removeSite(sites, dupFolder, siteTags.BOOKMARK_FOLDER)
     }

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -229,14 +229,16 @@ describe('siteUtil', function () {
         const sites = Immutable.fromJS([
           {
             lastAccessedTime: 123,
-            title: 'folder1',
+            customTitle: 'folder1',
+            title: undefined,
             folderId: 1,
             parentFolderId: 0,
             tags: [siteTags.BOOKMARK_FOLDER]
           },
           {
             lastAccessedTime: 123,
-            title: 'folder2',
+            customTitle: 'folder2',
+            title: undefined,
             folderId: 2,
             parentFolderId: 1,
             tags: [siteTags.BOOKMARK_FOLDER]


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #4280

Auditors: @bbondy

Test Plan:
1. Create folder "test1" on bookmarks toolbar
2. Create folder "test2" on bookmarks toolbar
3. There should be "test1" and "test2" on bookmarks toolbar

1. Import bookmarks from the same browser twice
2. There should not exist any duplicate folders