### PR TITLE
Improvements to Title Bar

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -37,6 +37,7 @@
   }
 
   .navbarMenubarFlexContainer {
+    overflow: hidden;
     padding-left: 5px;
     padding-top: 5px;
   }

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -40,6 +40,8 @@
     padding-left: 5px;
     padding-top: 5px;
   }
+  
+  #urlInput { width: 100%; }
 
   // changes to ensure window can be as small as 480px wide
   // and still be useable and have the caption buttons intact
@@ -49,8 +51,6 @@
     }
   }
   @media (max-width: @breakpointSmallWin32) {
-    .loadTime { display: none; }
-    #urlInput { max-width: 75px; }
     #titleBar { width: 100px; }
     .menubarContainer {
       .menubar {
@@ -61,7 +61,7 @@
     }
   }
   @media (max-width: @breakpointTinyWin32) {
-    #urlInput { max-width: 50px; }
+    .loadTime { display: none; }
     .menubarContainer {
       .menubar {
         .menubarItem {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues/4269) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

By overriding natural width of input element, it will no longer be too
large when the window is reduced in size. The input will now adjust its
dimensions relative to the dimensions of the container in which it is
positioned.

Before/After Reduction:

![resize-mq-reduction](https://cloud.githubusercontent.com/assets/815158/18813716/a3561762-82b8-11e6-8f21-3eb68531a76d.gif)

Fixes #4170 
Fixes #4241 

Auditors: @bsclifton, @luixxiul 