### PR TITLE
Fix suggestions list overflow (unintentionally introduced when fixing resizing)

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -37,7 +37,6 @@
   }
 
   .navbarMenubarFlexContainer {
-    overflow: hidden;
     padding-left: 5px;
     padding-top: 5px;
   }
@@ -609,6 +608,7 @@
 }
 
 .urlbarForm {
+  width: 0; // Fixes #4298
   align-items: center;
   justify-content: center;
   height: 24px;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

While the `overflow: hidden` resolved the titlebar issue, it did so at
the cost of clipping suggestions. This approach achieves the desired
results, without clipping.

Fixes #4298 

Auditors: @bsclifton, @bbondy 

Before:

![image](https://cloud.githubusercontent.com/assets/815158/18822618/c0e76f8e-8366-11e6-8231-c5098e04d584.png)

After:

![image](https://cloud.githubusercontent.com/assets/815158/18822632/e63c4368-8366-11e6-82d7-11beb194ce2a.png)
