### PR TITLE
Hide the load time from URL bar on all platforms if below the narrow breakpoint

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -18,6 +18,11 @@
   }
 }
 
+// All platforms - media queries
+@media (max-width: @breakpointNarrowViewport) {
+  .loadTime { display: none; }
+}
+
 // (macOS) We need to keep a padding left to avoid overlapping
 // with the window buttons to close/maximize/minimize the window.
 .platform--darwin .navigatorWrapper .backforward {
@@ -40,7 +45,7 @@
     padding-left: 5px;
     padding-top: 5px;
   }
-  
+
   #urlInput { width: 100%; }
 
   // changes to ensure window can be as small as 480px wide


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests). *N/A*
- [x] Ran `git rebase -i` to squash commits (if needed).

Hide the load time from URL bar on all platforms if below the narrow breakpoint (600px)

Fixes https://github.com/brave/browser-laptop/issues/1046

Auditors: @bradleyrichter

Test Plan:

1) Make sure browser width is greater than 600px
2) Open http://example.com and ensure the load timer shows up in the URL bar
3) Resize the window until it's less than 600px
4) Confirm load timer no longer shows