### PR TITLE
height and width of newFrameButton is set to 24px

### DIFF
--- a/less/button.less
+++ b/less/button.less
@@ -54,8 +54,8 @@ span.browserButton,
 
   &.newFrameButton {
     font-size: 0px;
-    width: 23px;
-    height: 23px;
+    width: 24px;
+    height: 24px;
     opacity: 0.5;
     background: url('../img/icon_new_frame.svg') 0 0 / contain no-repeat;
     &:hover {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #4323

Auditors: @Sh1d0w

Test Plan: n/a