### PR TITLE
remove the word visit for non-us bitcoin links

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -354,7 +354,6 @@ class BitcoinDashboard extends ImmutableComponent {
           <div className='settingsListTitle' data-l10n-id='outsideUSAPayment' />
         </div>
         <div className='settingsPanelDivider'>
-          <span className='visitText' data-l10n-id='visit' />
           <a target='_blank' className='browserButton primaryButton' href={url}>
             {name}
           </a>

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -807,12 +807,6 @@ div.nextPaymentSubmission {
         top: 0;
       }
     }
-    .visitText {
-      color: @braveOrange;
-      line-height: 45px;
-      margin: 0 13px;
-      font-size: 14px;
-    }
     #bitcoinPaymentURL {
       cursor: pointer;
       background-color: @lightGray;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditor: @bradleyrichter 

Fix #4212 

Test Plan:

Use a VPN or something to fake a non-us address and click the 'add funds' dialog in the payments preferences. Make sure it still gives you a button for cubits or some such but no longer says the word visit.
