### PR TITLE
Fix URL bar shifting when suggestions show

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -613,8 +613,7 @@
     background: #fff;
     border: 2px solid @focusUrlbarOutline;
     border-radius: 4px;
-    box-shadow: 0 0 1px @focusUrlbarOutline, inset 0 0 2px @focusUrlbarOutline;
-    box-shadow: inset 0 1px 8px rgba(0, 137, 255, 0.5);
+    box-shadow: 0 0 1px @focusUrlbarOutline, inset 0 0 2px @focusUrlbarOutline, inset 0 1px 8px rgba(0, 137, 255, 0.5);
     color: #333;
     outline: none;
     top: 0;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests). *N/A*
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1) Launch Brave on Windows
2) Open a new tab
3) Type "goo" into URL bar... you should see suggestions pop up below
4) With suggestions open, the URL bar should no longer shift under the reload button. 

Remove second box-shadow attribute, add as a 3rd item (in a comma separated list)

Fixes https://github.com/brave/browser-laptop/issues/4309

Auditors: @jonathansampson @srirambv