### PR TITLE
URL bar does not change position/size when navigating from about:newtab

### DIFF
--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -112,12 +112,11 @@ class NavigationBar extends ImmutableComponent {
       className={cx({
         titleMode: this.titleMode
       })}>
-      {
-        isSourceAboutUrl(this.props.location) || this.titleMode
-        ? null
-        : <div className='startButtons'>
-          {
-            this.loading
+      <div className='startButtons'>
+        {
+          isSourceAboutUrl(this.props.location) || this.titleMode
+          ? <span className='browserButton' />
+          : this.loading
             ? <Button iconClass='fa-times'
               l10nId='reloadButton'
               className='navbutton stop-button'
@@ -126,9 +125,8 @@ class NavigationBar extends ImmutableComponent {
               l10nId='reloadButton'
               className='navbutton reload-button'
               onClick={this.onReload} />
-          }
-        </div>
-      }
+        }
+      </div>
       {
         !this.titleMode && getSetting(settings.SHOW_HOME_BUTTON)
         ? <Button iconClass='fa-home'
@@ -155,7 +153,9 @@ class NavigationBar extends ImmutableComponent {
         />
       {
         isSourceAboutUrl(this.props.location)
-        ? null
+        ? <div className='endButtons'>
+          <span className='browserButton' />
+        </div>
         : <div className='endButtons'>
           {
             !this.showNoScriptInfo


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests). *N/A*
- [x] Ran `git rebase -i` to squash commits (if needed).

URL bar does not change position/size when navigating from about:newtab to an actual URL.

Fixes https://github.com/brave/browser-laptop/issues/4303

Auditors: @srirambv

Test Plan:
1) Launch Brave (any platform) and open a new blank tab
2) Notice the size/position of the URL bar (both left and right sides)
3) Navigate to http://example.com
4) Notice the size and position of the URL bar do not change