### PR TITLE
Use png_data for favicon of bookmarks imported from HTML

### DIFF
--- a/app/importer.js
+++ b/app/importer.js
@@ -154,7 +154,11 @@ importer.on('add-bookmarks', (e, bookmarks, topLevelFolder) => {
 importer.on('add-favicons', (e, detail) => {
   let faviconMap = {}
   detail.forEach((entry) => {
-    faviconMap[entry.urls[0]] = entry.favicon_url
+    if (entry.favicon_url.startsWith('made-up-favicon:')) {
+      faviconMap[entry.urls[0]] = entry.png_data
+    } else {
+      faviconMap[entry.urls[0]] = entry.favicon_url
+    }
   })
   let sites = AppStore.getState().get('sites')
   sites = sites.map((site) => {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #4339

requires https://github.com/brave/electron/pull/64

Auditors: @bridiver, @bbondy

Test Plan:
1. Import bookmarks from HTML file
2. There should be favicon shows when show favicon option is on