### PR TITLE
fix: nav button aspect ratio, closes #4355

### DIFF
--- a/less/main.less
+++ b/less/main.less
@@ -9,6 +9,14 @@ body {
   background-color: @bodyBG;
 }
 
+html {
+  box-sizing: border-box;
+}
+
+*, *:before, *:after {
+  box-sizing: inherit;
+}
+
 #windowContainer {
   color: @windowContainerFG;
 }


### PR DESCRIPTION
This fixes the button aspect ratio issue by setting a global 
box-sizing: border-box;

which is a pretty invasive step but will save us from major design headaches in the future as the box model becomes much simpler.

https://www.paulirish.com/2012/box-sizing-border-box-ftw/

- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.