### PR TITLE
[WIP] fix: update swipe navigation for electron native implementation of swipe events, closes #3299

### DIFF
--- a/js/actions/webviewActions.js
+++ b/js/actions/webviewActions.js
@@ -4,8 +4,6 @@
 
 'use strict'
 
-const messages = require('../constants/messages.js')
-
 const getWebview = () =>
   document.querySelector('.frameWrapper.isActive webview')
 
@@ -50,21 +48,6 @@ const webviewActions = {
     const webview = getWebview()
     if (webview) {
       webview.showDefinitionForSelection()
-    }
-  },
-
-  /**
-   * Check two-finger gesture swipe back/forward ability
-   * @param {bool} back - true for back, false for forward
-   */
-  checkSwipe: function (back) {
-    const webview = getWebview()
-    if (webview) {
-      if (back) {
-        webview.send(messages.CHECK_SWIPE_BACK)
-      } else {
-        webview.send(messages.CHECK_SWIPE_FORWARD)
-      }
     }
   },
 

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -7,7 +7,6 @@ const ImmutableComponent = require('./immutableComponent')
 const Immutable = require('immutable')
 const electron = global.require('electron')
 const ipc = electron.ipcRenderer
-const systemPreferences = electron.remote.systemPreferences
 
 // Actions
 const windowActions = require('../actions/windowActions')
@@ -184,29 +183,8 @@ class Main extends ImmutableComponent {
   }
 
   registerSwipeListener () {
-    // Navigates back/forward on macOS two-finger swipe
-    var trackingFingers = false
-    var swipeGesture = false
-    var canSwipeBack = false
-    var canSwipeForward = false
-    var isSwipeOnEdge = false
-    var deltaX = 0
-    var deltaY = 0
-    var startTime = 0
-    var time
+    // Navigates back/forward on macOS two or three-finger swipe
 
-    this.mainWindow.addEventListener('wheel', (e) => {
-      if (trackingFingers) {
-        deltaX = deltaX + e.deltaX
-        deltaY = deltaY + e.deltaY
-        time = (new Date()).getTime() - startTime
-        if (deltaX > 0) {
-          webviewActions.checkSwipe(false)
-        } else if (deltaX < 0) {
-          webviewActions.checkSwipe(true)
-        }
-      }
-    })
     ipc.on(messages.DEBUG_REACT_PROFILE, (e, args) => {
       window.perf = require('react-addons-perf')
       if (!window.perf.isRunning()) {
@@ -233,44 +211,15 @@ class Main extends ImmutableComponent {
         }, true)
       }
     })
-    ipc.on(messages.CAN_SWIPE_BACK, (e) => {
-      canSwipeBack = true
-    })
-    ipc.on(messages.CAN_SWIPE_FORWARD, (e) => {
-      canSwipeForward = true
-    })
-    ipc.on(messages.ENABLE_SWIPE_GESTURE, (e) => {
-      swipeGesture = true
-    })
-    ipc.on(messages.DISABLE_SWIPE_GESTURE, (e) => {
-      swipeGesture = false
-    })
-    ipc.on('scroll-touch-begin', function () {
-      if (swipeGesture &&
-        systemPreferences.isSwipeTrackingFromScrollEventsEnabled()) {
-        trackingFingers = true
-        isSwipeOnEdge = false
-        startTime = (new Date()).getTime()
+
+    currentWindow.on('swipe', (e, direction) => {
+      if (direction === 'left') {
+        ipc.emit(messages.SHORTCUT_ACTIVE_FRAME_BACK)
+      } else if (direction === 'right') {
+        ipc.emit(messages.SHORTCUT_ACTIVE_FRAME_FORWARD)
       }
     })
-    ipc.on('scroll-touch-end', function () {
-      if (time > 50 && trackingFingers && Math.abs(deltaY) < 50 && isSwipeOnEdge) {
-        if (deltaX > 70 && canSwipeForward) {
-          ipc.emit(messages.SHORTCUT_ACTIVE_FRAME_FORWARD)
-        } else if (deltaX < -70 && canSwipeBack) {
-          ipc.emit(messages.SHORTCUT_ACTIVE_FRAME_BACK)
-        }
-      }
-      trackingFingers = false
-      canSwipeBack = false
-      canSwipeForward = false
-      deltaX = 0
-      deltaY = 0
-      startTime = 0
-    })
-    ipc.on('scroll-touch-edge', function () {
-      isSwipeOnEdge = true
-    })
+
     ipc.on(messages.LEAVE_FULL_SCREEN, this.exitFullScreen.bind(this))
   }
 


### PR DESCRIPTION
Because swipe events can hardly be tested currently there has been a regression with the recent electron build.

electron now implements swipe events natively with the nice side effect of detecting 3 or 2 finger swipes depending on system settings.

as far as i understand the manual swipe detection is now completely obsolete and was removed

- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).

