### PR TITLE
Show the caption buttons when in full screen mode (Windows only)

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -780,7 +780,7 @@ class Main extends ImmutableComponent {
 
   get customTitlebar () {
     const customTitlebarEnabled = isWindows
-    const captionButtonsVisible = customTitlebarEnabled && !this.props.windowState.getIn(['ui', 'isFullScreen'])
+    const captionButtonsVisible = customTitlebarEnabled
     const menubarVisible = customTitlebarEnabled && (!getSetting(settings.AUTO_HIDE_MENU) || this.props.windowState.getIn(['ui', 'menubar', 'isVisible']))
     const selectedIndex = this.props.windowState.getIn(['ui', 'menubar', 'selectedIndex'])
     return {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests). **N/A**
- [x] Ran `git rebase -i` to squash commits (if needed).

Show the caption buttons when in full screen mode (Windows only)

Fixes https://github.com/brave/browser-laptop/issues/4376

Auditor: @bbondy

Test plan:
1. Launch Brave
2. Go full screen by pushing F11
3. Notice the caption buttons are showing
4. Use the caption buttons to exit