### PR TITLE
Disable new Windows titlebar

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -779,7 +779,7 @@ class Main extends ImmutableComponent {
   }
 
   get customTitlebar () {
-    const customTitlebarEnabled = isWindows
+    const customTitlebarEnabled = false
     const captionButtonsVisible = customTitlebarEnabled
     const menubarVisible = customTitlebarEnabled && (!getSetting(settings.AUTO_HIDE_MENU) || this.props.windowState.getIn(['ui', 'menubar', 'isVisible']))
     const selectedIndex = this.props.windowState.getIn(['ui', 'menubar', 'selectedIndex'])

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -131,14 +131,12 @@ const createWindow = (browserOpts, defaults, frameOpts, windowState) => {
     // smaller min size for "modal" windows
     minWidth,
     minHeight,
-    // Neither a frame nor a titlebar
-    // frame: false,
     // A frame but no title bar and windows buttons in titlebar 10.10 OSX and up only?
     titleBarStyle: 'hidden-inset',
     autoHideMenuBar: autoHideMenuBarSetting,
     title: appConfig.name,
     webPreferences: defaults.webPreferences,
-    frame: !isWindows
+    frame: true
   }
 
   if (process.platform === 'linux') {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests). **N/A**
- [x] Ran `git rebase -i` to squash commits (if needed).

Disable new Windows titlebar (until we have more confidence / complete more testing)

Fixes https://github.com/brave/browser-laptop/issues/4378

Auditors: @bbondy @aekeus 

Test plan:
1) Launch Brave
2) Confirm we can right click in bookmarks toolbar area and menu shows up
3) Confirm close button works as expected