### PR TITLE
fix: update swipe navigation for electron native implementation of swipe events, closes #3299

### DIFF
--- a/js/actions/webviewActions.js
+++ b/js/actions/webviewActions.js
@@ -4,8 +4,6 @@
 
 'use strict'
 
-const messages = require('../constants/messages.js')
-
 const getWebview = () =>
   document.querySelector('.frameWrapper.isActive webview')
 
@@ -50,21 +48,6 @@ const webviewActions = {
     const webview = getWebview()
     if (webview) {
       webview.showDefinitionForSelection()
-    }
-  },
-
-  /**
-   * Check two-finger gesture swipe back/forward ability
-   * @param {bool} back - true for back, false for forward
-   */
-  checkSwipe: function (back) {
-    const webview = getWebview()
-    if (webview) {
-      if (back) {
-        webview.send(messages.CHECK_SWIPE_BACK)
-      } else {
-        webview.send(messages.CHECK_SWIPE_FORWARD)
-      }
     }
   },
 


### PR DESCRIPTION
Because swipe events can hardly be tested currently there has been a regression with the recent electron build.

electron now implements swipe events natively with the nice side effect of detecting 3 or 2 finger swipes depending on system settings.

as far as i understand the manual swipe detection is now completely obsolete and was removed
- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
