### PR TITLE
Minor toolbar visual refinement suggestions

### DIFF
--- a/less/button.less
+++ b/less/button.less
@@ -24,10 +24,10 @@ span.browserButton,
 .browserButton {
   cursor: default;
   display: inline-block;
-  line-height: 30px;
-  width: 30px;
-  height: 28px;
-  font-size: 16px;
+  line-height: 25px;
+  width: 25px;
+  height: 25px;
+  font-size: 15px;
   color: @buttonColor;
   border-radius: @borderRadius;
   margin: 0 3px;
@@ -57,7 +57,7 @@ span.browserButton,
     width: 24px;
     height: 100%;
     opacity: 0.5;
-    background: url('../img/icon_new_frame.svg') 0 0 / contain no-repeat;
+    background: url('../img/icon_new_frame.svg') 50% 20% scroll / 20px no-repeat;
     &:hover {
       opacity: 0.8;
     }

--- a/less/contextMenu.less
+++ b/less/contextMenu.less
@@ -118,6 +118,11 @@
       &:hover {
         background-color: lighten(@menuSelectionColor, 5%);
         color: white;
+
+        .accelerator,
+        .submenuIndicator {
+          color: #fff;
+        }
       }
     }
   }

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -568,7 +568,7 @@
       -webkit-app-region: no-drag;
       -webkit-user-select: none;
       color: @buttonColor;
-      border-radius: 50%;
+      border-radius: 4px;
       font-weight: 300;
       opacity: 0.2;
 
@@ -585,7 +585,7 @@
 
     .back,
     .forward {
-      font-size: 35px;
+      font-size: 25px;
       text-align: center;
     }
   }
@@ -595,7 +595,7 @@
   width: 0; // Fixes #4298
   align-items: center;
   justify-content: center;
-  height: 24px;
+  height: 25px;
   padding: 0 10px;
 
   display: flex;
@@ -611,9 +611,9 @@
     content: ' ';
     position: absolute;
     background: #fff;
-    border: 2px solid @focusUrlbarOutline;
+    border: 1px solid @focusUrlbarOutline;
     border-radius: 4px;
-    box-shadow: 0 0 1px @focusUrlbarOutline, inset 0 0 2px @focusUrlbarOutline, inset 0 1px 8px rgba(0, 137, 255, 0.5);
+    box-shadow: 0 0 1px @focusUrlbarOutline, inset 0 0 2px @focusUrlbarOutline, inset 0 1px 8px rgba(0, 137, 255, 0.1);
     color: #333;
     outline: none;
     top: 0;
@@ -626,7 +626,7 @@
   #navigator:not(.titleMode) & {
     background: white;
     border-radius: @borderRadiusURL;
-    box-shadow: inset 0 1px 1px rgba(0,0,0,0.3);
+    box-shadow: inset 0 0 0 1px rgba(0,0,0,0.1), inset 0 1px 0 rgba(0,0,0,0.05), inset 0 1px 1px rgba(0,0,0,0.1);
     color: @chromeText;
   }
   @media (max-width: @breakpointNarrowViewport) {
@@ -671,11 +671,15 @@
       display: inline-block;
       background:rgba(243, 243, 243, 0);
       color: @chromeText;
-      font-size: 15px;
+      font-size: 13px;
       max-width: 100%;
       overflow-x: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+
+      strong {
+        font-weight: 600;
+      }
     }
 
     .endButtons {
@@ -691,7 +695,7 @@
 
       &[class*=" fa-"] {
         margin-right: 5px;
-        margin-top: 3px;
+        margin-top: 1px;
         font-size: 14px;
         min-height: 12px;
         color: @chromeText;
@@ -766,7 +770,7 @@
     cursor: text;
     font-size: @defaultFontSize;
     font-weight: normal;
-    margin: 3px 0 0 3px;
+    margin: 2px 0 0 3px;
     outline: none;
     text-overflow: ellipsis;
     flex-grow: 1;
@@ -820,7 +824,5 @@
                                       url(../app/extensions/brave/img/braveBtn2x.png) 2x,
                                       url(../app/extensions/brave/img/braveBtn3x.png) 3x);
   background-repeat: no-repeat;
-  height: 27px;
-  margin-top: 3px;
+  height: 24px;
 }
-

--- a/less/tabs.less
+++ b/less/tabs.less
@@ -250,7 +250,7 @@
   padding-right: 2px;
   .browserButton {
     display: inline-block;
-    line-height: 21px;
+    line-height: 20px;
   }
 }
 

--- a/less/variables.less
+++ b/less/variables.less
@@ -18,7 +18,7 @@
 @chromeTertiary: #c7c7c7;
 @chromeText: #555555;
 
-@tabsBackground: #ccc;
+@tabsBackground: #dcdcdc;
 @navigationBarBackground: @chromeSecondary;
 @navigationBarBackground: white;
 @chromeBorderColor: @chromePrimary;
@@ -71,10 +71,10 @@
 @bookmarksFolderIconSize: 15px;
 
 @navbarButtonSpacing: 4px;
-@navbarButtonWidth: 35px;
+@navbarButtonWidth: 21px;
 @navbarBraveButtonWidth: 23px;
 @navbarBraveButtonMarginLeft: 80px;
-@navbarLeftMarginDarwin: 70px;
+@navbarLeftMarginDarwin: 76px;
 
 @findbarBackground: #F7F7F7;
 

--- a/less/window.less
+++ b/less/window.less
@@ -15,7 +15,7 @@
   }
 }
 :root {
-  --default-font-family: "Arial";
+  --default-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 }
 
 * {


### PR DESCRIPTION
Hi everyone! 👋  after chatting with some of the team yesterday I had a couple of suggestions for visual refinements. Rather than write a wordy issue or mess around with mockups -- I thought I'd offer a PR with a few minor refinement suggestions (and explanation).

If this is totally off-base / not how you guys work, please feel free to close. I won't be butthurt.

If you're all "uh, who the hell is this guy" (understandable) -- I'm John from https://github.com/TryGhost/Ghost -- I do all the design / front end over there. (Hi!)

This PR has a mix of bug fixes, refinements, and one enhancement. I'll briefly cover each and offer before/after screenshots to explain my work. All of these changes, by themselves, are miniscule and barely noticeable - but in concert, they contribute to (imo) a far more slick and native "feel".

**Summary, before/after: (click on any image to see larger version)**
![brave](https://cloud.githubusercontent.com/assets/120485/18990682/de8fab7c-8713-11e6-834c-23e29b5232bd.png)

of course, all of this is mostly FAO @bradleyrichter :)

<br>
---

## 1. Tame the back buttons. 

The back buttons in the tool bar feel a little overwhelming when alongside other native applications. They're pretty huge, and a little bit squished up against the browser window controls.

I reduced them down to a more standard 25px height baseline across all toolbar elements, which gives a more consistent/proportional horizontal flow -- and gave them a tiny bit more breathing room from the window controls.

[Note: Out of context, these look pretty small - but if you take the PR for a test-drive, you'll see that this size fits in far more with native application controls // feels "normal"]

![image](https://cloud.githubusercontent.com/assets/120485/18989857/a20d9cb8-870e-11e6-821a-23687cb96b0c.png)

Also, the hover state border radius wasn't working because the back button elements aren't square - so they come out as weird ovals. Adjusted to a more standard button shape:

![image](https://cloud.githubusercontent.com/assets/120485/18989797/2a5976a6-870e-11e6-80e5-6930f34ac267.png)

<br>
---

## 2. Refined focus state of address bar

Move from a slightly in-your-face 2px border to a slightly less-obtrusive 1px 

![image](https://cloud.githubusercontent.com/assets/120485/18990035/a5fe9f10-870f-11e6-9c99-d1768bfe9035.png)

<br>
---

## 3. Slightly refine tab bar

The + icon, despite being svg, was slightly pixelated due to the CSS `contain` value. This sets a pixel size value which delivers a sharper icon, and also very slightly lightens the tab-bar background to make it feel less muddy, and naturally gives more emphasis to the tab's `box-shadow` due to greater contrast.

![image](https://cloud.githubusercontent.com/assets/120485/18990109/19b378cc-8710-11e6-8932-715021d882e2.png)

<br>
---

## 4. Bugfix: Brave menu hover state

Previously the icons in the brave context menu had no hover state color, but now they do!

![image](https://cloud.githubusercontent.com/assets/120485/18990210/b6f08f30-8710-11e6-82d3-7ed1528d07a0.png)

<br>
---

## 5. Enhancement: Move to Native System Font Stack

So the default font right now is just plain `arial` - which is cool and mostly works, but we can have **way** more cross-platform compatibility and better rendering by using a native system font stack that caters to all devices / operating systems. 

```CSS
font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
```

![image](https://cloud.githubusercontent.com/assets/120485/18990367/9e367be8-8711-11e6-823d-bf79426d28a8.png)

Reference material to describe how this works and why it's awesome:

- https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/
- https://medium.design/system-shock-6b1dc6d6596f#.rhqx5fmyz

In the screenshot above, other than a small size tweak to better fit with native styles, you'll see there's barely any difference - which is a good thing. But this should be much more future-proof.

<br>
---

## 6. Shadow Pedantry

This is the most nerdtastic thing ever... but: Replace slightly-bold default box shadow on address bar with a 3 box-shadow alpha transparency symphony.

The main difference is a slightly less "heavy" feel to the shadow, which is a bit web 2.0 - and to make the address input feel more enclosed within the toolbar. Note the contrast between input and border, particularly in the bottom left corner.

![image](https://cloud.githubusercontent.com/assets/120485/18990532/ef6ba636-8712-11e6-8472-c4f2adda1e62.png)

_Note: ^ You can actually notice the better font-family rendering here, on `http`_