### PR TITLE
Track extension states in a safer way

### DIFF
--- a/js/constants/extensionStates.js
+++ b/js/constants/extensionStates.js
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const mapValuesByKeys = require('../lib/functional').mapValuesByKeys
+
+const _ = null
+const extensionStates = {
+  REGISTERING: _,
+  REGISTERED: _,
+  LOADING: _,
+  LOADED: _,
+  ENABLED: _,
+  DISABLED: _,
+  INSTALL_FAILED: _
+}
+
+module.exports = mapValuesByKeys(extensionStates)


### PR DESCRIPTION
Test Plan: https://github.com/brave/browser-laptop/issues/4425#issue-180465791

This ensures a loaded extension is never loaded again, ditto an enabled extension is never enabled. etc.

Auditors: @bridiver

Fix #4425

Requires: https://github.com/brave/electron/commit/43f9830a90a768d251532932606d27ce181cc11c