### PR TITLE
Show "Bookmark This Link" for selected text links

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -896,6 +896,12 @@ function mainTemplateInit (nodeProps, frame) {
       template.push(showDefinitionMenuItem(nodeProps.selectionText),
         CommonMenu.separatorMenuItem
       )
+      if (isLink) {
+        template.push(addBookmarkMenuItem('bookmarkLink', {
+          location: nodeProps.linkURL,
+          tags: [siteTags.BOOKMARK]
+        }, false))
+      }
     }
 
     template.push(searchSelectionMenuItem(nodeProps.selectionText), {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan (macOS-only):

1. Open Brave and navigate to https://github.com/brave/browser-laptop
2. Right-click the "browser-laptop" link
3. Verify that "Bookmark This Link" appears in the context menu

Fixes #3807