### PR TITLE
Polished up full screen detection logic (Windows only)

### DIFF
--- a/app/renderer/components/windowCaptionButtons.js
+++ b/app/renderer/components/windowCaptionButtons.js
@@ -43,6 +43,12 @@ class WindowCaptionButtons extends ImmutableComponent {
   }
 
   onMaximizeClick (e) {
+    if (currentWindow.isFullScreen()) {
+      // If full screen, toggle full screen status and restore window (make smaller)
+      currentWindow.setFullScreen(false)
+      if (currentWindow.isMaximized()) currentWindow.unmaximize()
+      return false
+    }
     return (!currentWindow.isMaximized()) ? currentWindow.maximize() : currentWindow.unmaximize()
   }
 

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -501,7 +501,7 @@ class Main extends ImmutableComponent {
         windowActions.savePosition(event.sender.getPosition())
       }, 1000)
     })
-
+    // Full screen as in F11 (not full screen on a video)
     currentWindow.on('enter-full-screen', function (event) {
       windowActions.setWindowFullScreen(true)
     })
@@ -789,7 +789,7 @@ class Main extends ImmutableComponent {
         ? selectedIndex.slice(1)
         : null,
       lastFocusedSelector: this.props.windowState.getIn(['ui', 'menubar', 'lastFocusedSelector']),
-      isMaximized: this.props.windowState.getIn(['ui', 'isMaximized'])
+      isMaximized: currentWindow.isMaximized() || currentWindow.isFullScreen()
     }
   }
 


### PR DESCRIPTION
Polished up full screen detection logic (Windows only)

- Full screen mode shows button as restore
- Clicking the restore button (when full screen) will:
  - Undo full screen
  - Restore window back to the non-maximized size

Fixes https://github.com/brave/browser-laptop/issues/4416

Extra notes captured (below) since this is late into 0.12.3

Auditors: @alexwykoff @bbondy 

## Test Plan
1. Launch Brave and make sure your window is not maximized
2. Go into full screen mode (F11)
3. Notice the caption button for maximize/restore. It should be set as restore button.
4. Hit the restore button
5. Notice status of window and caption buttons:
  - window should no longer be "full screen"
  - window should be back to original size
  - maximize button should match the status (single square for not-maximized) 
6. Use `maximize` caption button to maximize window
7. Once maximized, hit F11 to enter full screen mode
8. Push the `restore` button and confirm:
  - window should no longer be "full screen"
  - window should now be smaller
  - maximize button should match the status (single square for not-maximized) 

## Notes about existing behavior
- You can double click any draggable area to maximize the window (executes different code than clicking the caption buttons)
- If window is full screen (via F11):
  - you can NOT drag the window (this is expected)
  - you can NOT double click a draggable are to maximize (also expected)
- Full screen and maximize status are persisted to session