### PR TITLE
Using temporarySiteSettings to store private tab preferences

### DIFF
--- a/js/components/braveryPanel.js
+++ b/js/components/braveryPanel.js
@@ -75,6 +75,9 @@ class BraveryPanel extends ImmutableComponent {
   get isFpShown () {
     return this.props.braveryPanelDetail.get('expandFp')
   }
+  get isPrivate () {
+    return this.props.frameProps.getIn(['isPrivate'])
+  }
   get redirectedResources () {
     return this.props.frameProps.get('httpsEverywhere')
   }
@@ -144,7 +147,7 @@ class BraveryPanel extends ImmutableComponent {
     if (setting !== 'noScript' && (parsedUrl.protocol === 'https:' || parsedUrl.protocol === 'http:')) {
       ruleKey = `https?://${parsedUrl.host}`
     }
-    appActions.changeSiteSetting(ruleKey, setting, e.target.value)
+    appActions.changeSiteSetting(ruleKey, setting, e.target.value, this.isPrivate)
     this.onReload()
   }
   get displayHost () {

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -210,11 +210,11 @@ class Frame extends ImmutableComponent {
     }
     if (typeof activeSiteSettings.get('flash') === 'number') {
       if (activeSiteSettings.get('flash') < Date.now()) {
-        appActions.removeSiteSetting(origin, 'flash')
+        appActions.removeSiteSetting(origin, 'flash', this.props.isPrivate)
       }
     }
     if (activeSiteSettings.get('noScript') === 0) {
-      appActions.removeSiteSetting(origin, 'noScript')
+      appActions.removeSiteSetting(origin, 'noScript', this.props.isPrivate)
     }
   }
 
@@ -314,7 +314,7 @@ class Frame extends ImmutableComponent {
 
   get zoomLevel () {
     const zoom = this.props.frameSiteSettings && this.props.frameSiteSettings.get('zoomLevel')
-    appActions.removeSiteSetting(this.origin, 'zoomLevel')
+    appActions.removeSiteSetting(this.origin, 'zoomLevel', this.props.isPrivate)
     return zoom
   }
 

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -717,7 +717,7 @@ class Main extends ImmutableComponent {
   get allSiteSettings () {
     const activeFrame = FrameStateUtil.getActiveFrame(this.props.windowState)
     if (activeFrame && activeFrame.get('isPrivate')) {
-      return this.props.appState.get('siteSettings').merge(this.props.appState.get('temporarySiteSettings'))
+      return this.props.appState.get('siteSettings').mergeDeep(this.props.appState.get('temporarySiteSettings'))
     }
     return this.props.appState.get('siteSettings')
   }

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -715,6 +715,10 @@ class Main extends ImmutableComponent {
   }
 
   get allSiteSettings () {
+    const activeFrame = FrameStateUtil.getActiveFrame(this.props.windowState)
+    if (activeFrame && activeFrame.get('isPrivate')) {
+      return this.props.appState.get('temporarySiteSettings')
+    }
     return this.props.appState.get('siteSettings')
   }
 
@@ -741,11 +745,6 @@ class Main extends ImmutableComponent {
   }
 
   get braveShieldsDisabled () {
-    const activeFrame = FrameStateUtil.getActiveFrame(this.props.windowState)
-    if (activeFrame && activeFrame.get('isPrivate')) {
-      return true
-    }
-
     const activeRequestedLocation = this.activeRequestedLocation
     if (!activeRequestedLocation) {
       return true

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -717,7 +717,7 @@ class Main extends ImmutableComponent {
   get allSiteSettings () {
     const activeFrame = FrameStateUtil.getActiveFrame(this.props.windowState)
     if (activeFrame && activeFrame.get('isPrivate')) {
-      return this.props.appState.get('temporarySiteSettings')
+      return this.props.appState.get('siteSettings').merge(this.props.appState.get('temporarySiteSettings'))
     }
     return this.props.appState.get('siteSettings')
   }

--- a/js/components/siteInfo.js
+++ b/js/components/siteInfo.js
@@ -101,10 +101,6 @@ class SiteInfo extends ImmutableComponent {
           </ul>
         </li>
     }
-    // Disable in private mode for now
-    if (this.isPrivate) {
-      runInsecureContentInfo = null
-    }
 
     return <Dialog onHide={this.props.onHide} className='siteInfo' isClickDismiss>
       <ul onClick={(e) => e.stopPropagation()}>

--- a/js/state/userPrefs.js
+++ b/js/state/userPrefs.js
@@ -45,19 +45,19 @@ const runCallback = (cb, name, incognito) => {
 
   if (name) {
     if (prefs[name]) {
-      setUserPref(name, prefs[name], incognito)
+      module.exports.setUserPref(name, prefs[name], incognito)
       return true
     }
     return false
   }
 
   for (name in prefs) {
-    setUserPref(name, prefs[name], incognito)
+    module.exports.setUserPref(name, prefs[name], incognito)
   }
   return true
 }
 
-const setUserPref = (path, value, incognito = false) => {
+module.exports.setUserPref = (path, value, incognito = false) => {
   let partitions = incognito ? Object.keys(registeredPrivateSessions) : Object.keys(registeredSessions)
   partitions.forEach((partition) => {
     setUserPrefType(registeredSessions[partition], path, value)


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

fix #4468

Auditors: @diracdeltas , @bridiver

Test Plan:
Test bravery panel, site permissions, mixed content, flash in private tabs and the preferences should not write to disk and affect regular tabs

---

There is a better way to achieve this but require architectural change.
We plan to supersede siteSettings and temporarySiteSettings by reading and writing user prefs directly. Private sessions will keep in-memory overlaid user prefs, but still be able to read the normal session prefs that haven’t been changed in private tabs. 