### PR TITLE
Update sortableTable styles to be consistent

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -681,7 +681,8 @@ class SearchTab extends ImmutableComponent {
       <div className='sectionTitle' data-l10n-id='searchSettings' />
       <SortableTable headings={['default', 'searchEngine', 'engineGoKey']} rows={this.searchProviders}
         defaultHeading='searchEngine'
-        addHoverClass onClick={this.hoverCallback.bind(this)} />
+        addHoverClass onClick={this.hoverCallback.bind(this)}
+        columnClassNames={['default', 'searchEngine', 'engineGoKey']} />
       <div className='sectionTitle' data-l10n-id='locationBarSettings' />
       <SettingsList>
         <SettingCheckbox dataL10nId='showOpenedTabMatches' prefKey={settings.OPENED_TAB_SUGGESTIONS} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />

--- a/less/about/history.less
+++ b/less/about/history.less
@@ -87,9 +87,6 @@ body {
     }
 
     .sortableTable {
-      border-spacing: 0px;
-      cursor: default;
-
       // Time visited
       .time {
         font-size: 11pt;

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -75,8 +75,10 @@ body {
 
 .sectionTitle {
   color: @braveOrange;
+  cursor: default;
   font-size: 1.2em;
   margin-bottom: 0.7em;
+  -webkit-user-select: none;
 }
 
 .prefTabContainer {
@@ -522,6 +524,16 @@ table.sortableTable {
     color: @braveOrange;
     font-weight: 800;
   }
+
+  .default {
+    width: 150px;
+  }
+  .searchEngine {
+    width: 304px !important;
+  }
+  .engineGoKey {
+    width: 250px;
+  }
 }
 
 .paymentsMessage {
@@ -558,41 +570,42 @@ table.sortableTable {
   }
 
   .fixed-table-container {
-     height: 500px;
-     position: relative;
- 
-     .table-header {
-       height: 30px;
-       background: @veryLightGray;
-       position: absolute;
-       top: 0;
-       right: 0;
-       left: 0;
-     }
- 
-     .fixed-table-container-inner {
-       overflow-x: hidden;
-       overflow-y: auto;
-       height: 100%;
- 
-       table {
-         width: 100%;
-         overflow-x: hidden;
-         overflow-y: auto;
- 
-         .th-inner {
-           color: @darkGray;
-           font-weight: 600;
-           position: absolute;
-           top: 0;
-           line-height: 30px;
-           z-index: 9;
-           background: @veryLightGray;
-         }
-       }
-     }
-   }
+    height: 500px;
+    position: relative;
 
+    .table-header {
+      height: 30px;
+      background: @veryLightGray;
+      position: absolute;
+      top: 0;
+      right: 0;
+      left: 0;
+    }
+
+    .fixed-table-container-inner {
+      overflow-x: hidden;
+      overflow-y: auto;
+      height: 100%;
+
+      table {
+        width: 100%;
+        overflow-x: hidden;
+        overflow-y: auto;
+
+        .th-inner {
+          color: @darkGray;
+          cursor: default;
+          font-weight: 600;
+          position: absolute;
+          top: 0;
+          line-height: 30px;
+          z-index: 9;
+          background: @veryLightGray;
+          -webkit-user-select: none;
+        }
+      }
+    }
+  }
 }
 
 .modal .dialog.paymentHistory .sectionTitle {

--- a/less/about/siteDetails.less
+++ b/less/about/siteDetails.less
@@ -25,14 +25,14 @@
 }
 
 .searchInput {
-    float: right;
-    padding: 5px;
-    margin-top: -35px;
+  float: right;
+  padding: 5px;
+  margin-top: -35px;
 }
 
 .searchInputClear {
-    float: right;
-    padding: 8px;
-    margin-top: -39px;
-    color: #999;
+  float: right;
+  padding: 8px;
+  margin-top: -39px;
+  color: #999;
 }

--- a/less/sortableTable.less
+++ b/less/sortableTable.less
@@ -17,9 +17,12 @@ table.sort {
 table.sortableTable {
   width: 100%;
   border: solid 1px @lightGray;
-  border-radius: @borderRadius;
+  border-bottom-left-radius: @borderRadius;
+  border-bottom-right-radius: @borderRadius;
   margin-bottom: 40px;
   box-shadow: @softBoxShadow;
+  cursor: default;
+  border-spacing: 0;
 
   tr {
     height: 1.7em;
@@ -32,7 +35,11 @@ table.sortableTable {
       font-weight: 300;
       padding: 8px;
       box-sizing: border-box;
-      -webkit-user-select: none;
+
+      .th-inner {
+        display: inline-block;
+        -webkit-user-select: none;
+      }
 
       &:after {
         font-family: FontAwesome;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests). **N/A (CSS change)**
- [x] Ran `git rebase -i` to squash commits (if needed).

## Update sortableTable styles to be consistent
- Preferences > search no longer has cell padding (matches history)
- Preferences > search columns resized to allow for up/down chevron (sort)
- All: updated new th-inner style added w/ https://github.com/brave/browser-laptop/pull/4395 to be inline-block to allow for up/down chevron (sort)
- removes border radius from top left and top right (didn't look correct anymore with the new 1px border on top)
- styles now mark headers on preferences as non-selectable and leaves cursor as default (to remain app-like)

Fixes https://github.com/brave/browser-laptop/issues/4492
Fixes https://github.com/brave/browser-laptop/issues/4493

Auditors: @bbondy @bradleyrichter

## Test Plan
1) Launch Brave and open history- check out styles
2) Open preferences and check out styles on Search page
  - mouse over any section titles; notice cursor doesn't change anymore
3) Check out styles on Payments page
  - mouse over column header; notice cursor doesn't change anymore

## Screenshots (the important part!)

### Search screen updates (https://github.com/brave/browser-laptop/issues/4493)
**Before**
![screen shot 2016-10-04 at 1 38 30 am](https://cloud.githubusercontent.com/assets/4733304/19067484/54a695c0-89d3-11e6-8d3e-3e0bd143f2dc.png)

**After**
![screen shot 2016-10-04 at 11 06 38 am](https://cloud.githubusercontent.com/assets/4733304/19086364/aeb1f93e-8a22-11e6-8025-f942ec89ccae.png)

### Fixing the column style issue (https://github.com/brave/browser-laptop/issues/4492)
**Before**
![screen shot 2016-10-04 at 1 03 12 am](https://cloud.githubusercontent.com/assets/4733304/19066624/fa95e85a-89ce-11e6-9773-10719aa05931.png)

**After**
![screen shot 2016-10-04 at 11 08 29 am](https://cloud.githubusercontent.com/assets/4733304/19086419/ec562346-8a22-11e6-92fb-0bdcf947bc1f.png)

### Border radius update
**Before**
N/A- style was changed when fixing https://github.com/brave/browser-laptop/issues/4493

**After** (zoomed in to show pixels)
![screen shot 2016-10-04 at 11 10 08 am](https://cloud.githubusercontent.com/assets/4733304/19086503/4a47e99e-8a23-11e6-902c-719d9866dccb.png)

### Updates to text selection
Screenshots show what happens if you click and drag to try to select all text on the screen

**Before**
![before](https://cloud.githubusercontent.com/assets/4733304/19086557/8508c4fe-8a23-11e6-845c-eec87e912f7f.png)

**After**
![screen shot 2016-10-04 at 11 13 14 am](https://cloud.githubusercontent.com/assets/4733304/19086583/98f96554-8a23-11e6-9a89-33118e4867fb.png)