### PR TITLE
handle getBraveryProperties error

### DIFF
--- a/app/ledger.js
+++ b/app/ledger.js
@@ -1245,9 +1245,15 @@ var getPaymentInfo = () => {
 }
 
 var setPaymentInfo = (amount) => {
+  var bravery
+
   if (!client) return
 
-  var bravery = client.getBraveryProperties()
+  try { bravery = client.getBraveryProperties() } catch (ex) {
+// wallet being created...
+
+    return setTimeout(function () { setPaymentInfo(amount) }, 2 * msecs.second)
+  }
 
   amount = parseInt(amount, 10)
   if (isNaN(amount) || (amount <= 0)) return


### PR DESCRIPTION
Test Plan: enable 'brave payments', then IMMEDIATELY change the monthly budget. the browser should *not* crash

if a wallet is under creation, but not yet creating, `getBraveryProperties` should not be invoked.

fixes #4421

auditor: @ayumi