### PR TITLE
reset reconciliation time when publisher window is closed

### DIFF
--- a/app/ledger.js
+++ b/app/ledger.js
@@ -131,7 +131,7 @@ const doAction = (action) => {
     case appConstants.APP_CHANGE_SETTING:
       switch (action.key) {
         case settings.PAYMENTS_ENABLED:
-          initialize(action.value, 'changeSettingPaymentsEnabled')
+          initialize(action.value)
           break
         case settings.PAYMENTS_CONTRIBUTION_AMOUNT:
           setPaymentInfo(action.value)
@@ -415,7 +415,7 @@ eventStore.addChangeListener(() => {
  * module initialization
  */
 
-var initialize = (paymentsEnabled, reason) => {
+var initialize = (paymentsEnabled) => {
   enable(paymentsEnabled)
 
   // Check if relevant browser notifications should be shown every 15 minutes


### PR DESCRIPTION
test plan:
1. start with a browser that has ledger payments enabled.
2. quit the browser
3. _carefully_ edit `ledger-state.json` to change the line start starts as ` "reconcileStamp": 14...` to change the `4` to a `3`
4, start the browser
5. verify that the time to reconcile now occurs in the future!

auditor: @ayumi 

fixes #4058