### PR TITLE
Remove border radius from Windows 7; it has issues on higher DPI setups.

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -78,11 +78,6 @@
 
   // Windows 7 specific styles
   &.win7 {
-    > div#window.frameless {
-      border-top-left-radius: 6px;
-      border-top-right-radius: 6px;
-    }
-
     .windowCaptionButtons {
       > .container {
         margin-right: 6px;


### PR DESCRIPTION
manually revert border radius change from https://github.com/brave/browser-laptop/pull/4342

Auditors: @bbondy

Test Plan:
1. Launch Brave on Windows 7
2. Ensure the top left and top right corners are not rounded with a black outline.
   They may be rounded with NO outline (and that's OK)
3. Crank DPI up to 150%
4. Ensure top left/right borders are square and look correct