### PR TITLE
Fix overflow for URL autocomplete on Windows

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -908,6 +908,7 @@ class Main extends ImmutableComponent {
                 enableNoScript={this.enableNoScript(activeSiteSettings)}
                 settings={this.props.appState.get('settings')}
                 noScriptIsVisible={noScriptIsVisible}
+                menubarVisible={customTitlebar.menubarVisible}
               />
               <div className='topLevelEndButtons'>
                 <div className={cx({

--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -150,6 +150,7 @@ class NavigationBar extends ImmutableComponent {
         endLoadTime={this.props.endLoadTime}
         titleMode={this.titleMode}
         urlbar={this.props.navbar.get('urlbar')}
+        menubarVisible={this.props.menubarVisible}
         />
       {
         isSourceAboutUrl(this.props.location)

--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -453,7 +453,8 @@ class UrlBar extends ImmutableComponent {
             urlLocation={this.props.urlbar.get('location')}
             urlPreview={this.props.urlbar.get('urlPreview')}
             searchSelectEntry={this.searchSelectEntry}
-            previewActiveIndex={this.props.previewActiveIndex || 0} />
+            previewActiveIndex={this.props.previewActiveIndex || 0}
+            menubarVisible={this.props.menubarVisible} />
           : null
         }
     </form>

--- a/js/components/urlBarSuggestions.js
+++ b/js/components/urlBarSuggestions.js
@@ -156,8 +156,9 @@ class UrlBarSuggestions extends ImmutableComponent {
     addToItems(searchSuggestions, 'searchTitle', locale.translation('searchSuggestionTitle'), 'fa-search')
     addToItems(topSiteSuggestions, 'topSiteTitle', locale.translation('topSiteSuggestionTitle'), 'fa-link')
     const documentHeight = Number.parseInt(window.getComputedStyle(document.querySelector(':root')).getPropertyValue('--navbar-height'), 10)
+    const menuHeight = this.props.menubarVisible ? 30 : 0
     return <ul className='urlBarSuggestions' style={{
-      maxHeight: document.documentElement.offsetHeight - documentHeight - 2
+      maxHeight: document.documentElement.offsetHeight - documentHeight - 2 - menuHeight
     }}>
       {items}
     </ul>

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -41,11 +41,6 @@
     box-sizing: border-box;
   }
 
-  .navbarMenubarFlexContainer {
-    padding-left: 5px;
-    padding-top: 5px;
-  }
-
   #urlInput { width: 100%; }
 
   // changes to ensure window can be as small as 480px wide


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests). **N/A**
- [x] Ran `git rebase -i` to squash commits (if needed).

- removes padding (not required after accepting https://github.com/brave/browser-laptop/pull/4400)
- includes hardcoded size of menubar in offset calculation

Fixes https://github.com/brave/browser-laptop/issues/4539

Auditors: @bbondy @luixxiul


## screenshots
### before padding removed (5px top and 5px left of URL bar)
![screen shot 2016-10-06 at 1 52 53 am](https://cloud.githubusercontent.com/assets/4733304/19146287/ae0be832-8b67-11e6-819a-e4e4e72dbc0a.png)

### after padding removed
![screen shot 2016-10-06 at 1 52 21 am](https://cloud.githubusercontent.com/assets/4733304/19146274/a2b1ae40-8b67-11e6-8d0d-480a2a4de0b6.png)

### new URL autocomplete size with menubar open
![screen shot 2016-10-06 at 1 31 56 am](https://cloud.githubusercontent.com/assets/4733304/19146207/67ad8c24-8b67-11e6-9601-a71d17bcbcc5.png)
