### PR TITLE
Crash reporting toggle in advanced > preferences

### DIFF
--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -222,3 +222,4 @@ enableAutofill=Enable Autofill
 importBrowserData=Import Browser Data
 importNow=Import now…
 clearAll=Clear all
+sendCrashReports=Send anonymous crash reports to Brave (requires browser restart)

--- a/app/index.js
+++ b/app/index.js
@@ -9,7 +9,6 @@ let ready = false
 
 // Setup the crash handling
 const CrashHerald = require('./crash-herald')
-CrashHerald.init()
 
 const handleUncaughtError = (error) => {
   var message, ref, stack
@@ -244,9 +243,13 @@ let flashInitialized = false
 
 // Some settings must be set right away on startup, those settings should be handled here.
 loadAppStatePromise.then((initialState) => {
-  const {HARDWARE_ACCELERATION_ENABLED, SMOOTH_SCROLL_ENABLED} = require('../js/constants/settings')
+  const {HARDWARE_ACCELERATION_ENABLED, SMOOTH_SCROLL_ENABLED, SEND_CRASH_REPORTS} = require('../js/constants/settings')
   if (initialState.settings[HARDWARE_ACCELERATION_ENABLED] === false) {
     app.disableHardwareAcceleration()
+  }
+  if (initialState.settings[SEND_CRASH_REPORTS]) {
+    console.log('Crash reporting enabled')
+    CrashHerald.init()
   }
   if (initialState.settings[SMOOTH_SCROLL_ENABLED] === false) {
     app.commandLine.appendSwitch('disable-smooth-scrolling')

--- a/app/index.js
+++ b/app/index.js
@@ -244,7 +244,6 @@ let flashInitialized = false
 // Some settings must be set right away on startup, those settings should be handled here.
 loadAppStatePromise.then((initialState) => {
   const {HARDWARE_ACCELERATION_ENABLED, SMOOTH_SCROLL_ENABLED, SEND_CRASH_REPORTS} = require('../js/constants/settings')
-  console.log(initialState)
   if (initialState.settings[HARDWARE_ACCELERATION_ENABLED] === false) {
     app.disableHardwareAcceleration()
   }

--- a/app/index.js
+++ b/app/index.js
@@ -244,12 +244,15 @@ let flashInitialized = false
 // Some settings must be set right away on startup, those settings should be handled here.
 loadAppStatePromise.then((initialState) => {
   const {HARDWARE_ACCELERATION_ENABLED, SMOOTH_SCROLL_ENABLED, SEND_CRASH_REPORTS} = require('../js/constants/settings')
+  console.log(initialState)
   if (initialState.settings[HARDWARE_ACCELERATION_ENABLED] === false) {
     app.disableHardwareAcceleration()
   }
-  if (initialState.settings[SEND_CRASH_REPORTS]) {
+  if (initialState.settings[SEND_CRASH_REPORTS] !== false) {
     console.log('Crash reporting enabled')
     CrashHerald.init()
+  } else {
+    console.log('Crash reporting disabled')
   }
   if (initialState.settings[SMOOTH_SCROLL_ENABLED] === false) {
     app.commandLine.appendSwitch('disable-smooth-scrolling')

--- a/docs/state.md
+++ b/docs/state.md
@@ -176,6 +176,7 @@ AppStore
     'advanced.default-zoom-level': number, // the default zoom level for sites that have no specific setting
     'advanced.pdfjs-enabled': boolean, // Whether or not to render PDF documents in the browser
     'advanced.smooth-scroll-enabled': boolean, // false if smooth scrolling should be explicitly disabled
+    'advanced.send-crash-reports': boolean, // true or undefined if crash reports should be sent
     'shutdown.clear-history': boolean, // true to clear history on shutdown
     'shutdown.clear-downloads': boolean, // true to clear downloads on shutdown
     'shutdown.clear-cache': boolean, // true to clear cache on shutdown

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -1281,6 +1281,7 @@ class AdvancedTab extends ImmutableComponent {
         <SettingCheckbox dataL10nId='useHardwareAcceleration' prefKey={settings.HARDWARE_ACCELERATION_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
         <SettingCheckbox dataL10nId='usePDFJS' prefKey={settings.PDFJS_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
         <SettingCheckbox dataL10nId='useSmoothScroll' prefKey={settings.SMOOTH_SCROLL_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
+        <SettingCheckbox dataL10nId='sendCrashReports' prefKey={settings.SEND_CRASH_REPORTS} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
       </SettingsList>
     </div>
   }
@@ -1455,7 +1456,8 @@ class AboutPreferences extends React.Component {
     })
     aboutActions.changeSetting(key, value)
     if (key === settings.DO_NOT_TRACK || key === settings.HARDWARE_ACCELERATION_ENABLED ||
-      key === settings.PDFJS_ENABLED || key === settings.SMOOTH_SCROLL_ENABLED) {
+        key === settings.PDFJS_ENABLED || key === settings.SMOOTH_SCROLL_ENABLED ||
+        key === settings.SEND_CRASH_REPORTS) {
       ipc.send(messages.PREFS_RESTART, key, value)
     }
     if (key === settings.PAYMENTS_ENABLED) {

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -123,6 +123,7 @@ module.exports = {
     'advanced.default-zoom-level': null,
     'advanced.pdfjs-enabled': true,
     'advanced.smooth-scroll-enabled': false,
+    'advanced.send-crash-reports': true,
     'shutdown.clear-history': false,
     'shutdown.clear-downloads': false,
     'shutdown.clear-cache': false,

--- a/js/constants/settings.js
+++ b/js/constants/settings.js
@@ -57,6 +57,7 @@ const settings = {
   PDFJS_ENABLED: 'advanced.pdfjs-enabled',
   DEFAULT_ZOOM_LEVEL: 'advanced.default-zoom-level',
   SMOOTH_SCROLL_ENABLED: 'advanced.smooth-scroll-enabled',
+  SEND_CRASH_REPORTS: 'advanced.send-crash-reports',
 
   ADBLOCK_CUSTOM_RULES: 'adblock.customRules'
 }


### PR DESCRIPTION
Fixes: #4479

Test Plan:

  * Navigate to Preferences > Advanced
  * Toggle crash reporting to off (restart browser)
  * Load browser and select crash from debug menu
    -> Confirm crash report NOT sent to stats.brave.com
  * Load browser and navigate to Preferences > Advanced
  * Toggle crash reporting to on (restart browser)
  * Load browser and select crash from debug menu
    -> Confirm crash report SENT to stats.brave.com

cc @bridiver @bsclifton @bbondy 