### PR TITLE
Fix line height on add funds dialog

### DIFF
--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -843,7 +843,7 @@ div.nextPaymentSubmission {
       float: left;
 
       .settingsListTitle {
-        margin: 0;
+        margin-top: 0;
       }
 
       &:nth-child(1) {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #4566 

Test Plan:

This is a regression I caused which removed the margin between the bold title and the subtext. Here is a picture of the bug (lines too close together). Make sure they now have appropriate height.

![bitcoin](https://cloud.githubusercontent.com/assets/490294/19182618/060be200-8c29-11e6-828a-2540a0891ba2.jpg)

