### PR TITLE
Adding back the 5px padding left of back/forward nav buttons (Windows…

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -41,6 +41,10 @@
     box-sizing: border-box;
   }
 
+  .backforward {
+    padding-left: 5px;
+  }
+
   #urlInput { width: 100%; }
 
   // changes to ensure window can be as small as 480px wide


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests). **N/A**
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

Adding back the 5px padding left of back/forward nav buttons (Windows only)

Fixes https://github.com/brave/browser-laptop/issues/4624

Auditors: @luixxiul