### PR TITLE
Payment History receipt filenames for transactions with same date get unique suffix (#4605)

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -9,7 +9,9 @@ const Immutable = require('immutable')
 const SwitchControl = require('../components/switchControl')
 const ModalOverlay = require('../components/modalOverlay')
 const cx = require('../lib/classSet')
-const transactionsToCSVDataURL = require('../lib/ledgerExportUtil').transactionsToCSVDataURL
+const ledgerExportUtil = require('../lib/ledgerExportUtil')
+const transactionsToCSVDataURL = ledgerExportUtil.transactionsToCSVDataURL
+const addExportFilenamePrefixToTransactions = ledgerExportUtil.addExportFilenamePrefixToTransactions
 const {getZoomValuePercentage} = require('../lib/zoom')
 const config = require('../constants/config')
 const appConfig = require('../constants/appConfig')
@@ -465,7 +467,9 @@ class PaymentHistory extends ImmutableComponent {
   }
 
   render () {
-    const transactions = this.props.ledgerData.get('transactions')
+    const transactions = Immutable.fromJS(
+        addExportFilenamePrefixToTransactions(this.props.ledgerData.get('transactions').toJS())
+    )
 
     return <div id='paymentHistory'>
       <table className='sort'>
@@ -502,10 +506,6 @@ class PaymentHistoryRow extends ImmutableComponent {
     return formattedDateFromTimestamp(this.timestamp)
   }
 
-  get numericDateStr () {
-    return (new Date(this.timestamp)).toLocaleDateString().replace(/\//g, '-')
-  }
-
   get ledgerData () {
     return this.props.ledgerData
   }
@@ -528,7 +528,7 @@ class PaymentHistoryRow extends ImmutableComponent {
   }
 
   get receiptFileName () {
-    return `Brave_Payments_${this.numericDateStr}.csv`
+    return `${this.transaction.get('exportFilenamePrefix')}.csv`
   }
 
   get dataURL () {

--- a/js/lib/ledgerExportUtil.js
+++ b/js/lib/ledgerExportUtil.js
@@ -284,14 +284,18 @@ let getTransactionCSVText = function (transactions, viewingIds, addTotalRow) {
  * of form `Brave_Payments_${MM-D(D)-YYYY}`, with "_<n>" added for the nth time a date occurs (n > 1)
  *
  * @param {Object[]} transactions - an array of transaction(s) or single transaction object
+ *
+ * @returns {Object[]} transactions (with each element having an added field `exportFilenamePrefix`)
  */
 let addExportFilenamePrefixToTransactions = function (transactions) {
-  if (!transactions) {
-    return transactions
-  }
+  transactions = transactions || []
 
   if (!underscore.isArray(transactions)) {
     transactions = [transactions]
+  }
+
+  if (!transactions.length) {
+    return transactions
   }
 
   var dateCountMap = {}

--- a/js/lib/ledgerExportUtil.js
+++ b/js/lib/ledgerExportUtil.js
@@ -279,11 +279,46 @@ let getTransactionCSVText = function (transactions, viewingIds, addTotalRow) {
   return getTransactionCSVRows(transactions, viewingIds, addTotalRow).join('\n')
 }
 
+/**
+ * Adds an `exportFilenamePrefix` field to the provided transaction(s)
+ * of form `Brave_Payments_${MM-D(D)-YYYY}`, with "_<n>" added for the nth time a date occurs (n > 1)
+ *
+ * @param {Object[]} transactions - an array of transaction(s) or single transaction object
+ */
+let addExportFilenamePrefixToTransactions = function (transactions) {
+  if (!transactions) {
+    return transactions
+  }
+
+  if (!underscore.isArray(transactions)) {
+    transactions = [transactions]
+  }
+
+  var dateCountMap = {}
+
+  return transactions.map(function (transaction) {
+    let timestamp = transaction.submissionStamp
+    let numericDateStr = (new Date(timestamp)).toLocaleDateString().replace(/\//g, '-')
+
+    let dateCount = (dateCountMap[numericDateStr] ? dateCountMap[numericDateStr] : 1)
+    dateCountMap[numericDateStr] = dateCount + 1
+
+    if (dateCount > 1) {
+      numericDateStr = `${numericDateStr}_${dateCount}`
+    }
+
+    transaction.exportFilenamePrefix = `Brave_Payments_${numericDateStr}`
+
+    return transaction
+  })
+}
+
 module.exports = {
   transactionsToCSVDataURL,
   getTransactionCSVText,
   getTransactionCSVRows,
   getPublisherVoteData,
   getTransactionsByViewingIds,
-  getTotalContribution
+  getTotalContribution,
+  addExportFilenamePrefixToTransactions
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist: Fixes #4605
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed): Squashed to two commits, the "feature" and the tests, rebased onto tag v0.12.4dev-RC1

Test Plan:
  1. Enable Brave Payments, create wallet, fund it (use testnet if you want to save BTC)
  2. Trigger reconciliation multiple times by editing /\<UserDataPath\>/ledger-state.json reconcileStamp to be in past (e.g. set to 100)
  3. Open Brave Payments -> Payment History
  4. Observe "Receipt Link" column
  5. Receipt filenames should all be unique
  6. All Receipt filenames **after** the 1st for a given day should end in "_\${n}.csv", like "Brave_Payments_\${MM-D(D)-YYYY}_\${n}.csv" (where n=2 for the 2nd transaction on that day, n=3 for 3rd
  7. Unit tests verifying this should be present and passing

To check unit tests, run:
```
NODE_ENV=test mocha --compilers js:babel-register --recursive test/unit/lib/ledgerExportUtilTest.js
```
and check the block of tests beginning w/ `addExportFilenamePrefixToTransactions`