### PR TITLE
Fix bookmark clipping

### DIFF
--- a/less/bookmarksToolbar.less
+++ b/less/bookmarksToolbar.less
@@ -44,7 +44,7 @@
     color: black;
     cursor: default;
     font-size: 11px;
-    line-height: 11px;
+    line-height: 12px;
     margin: auto var(--bookmark-item-margin);
     padding: 2px var(--bookmark-item-padding);
     text-overflow: ellipsis;

--- a/less/variables.less
+++ b/less/variables.less
@@ -65,7 +65,7 @@
 @navbarHeight: 36px;
 @tabsToolbarHeight: 23px;
 @tabPagesHeight: 12px;
-@bookmarksToolbarHeight: 23px;
+@bookmarksToolbarHeight: 24px;
 @bookmarksToolbarWithFaviconsHeight: 28px;
 @bookmarksFileIconSize: 13px;
 @bookmarksFolderIconSize: 15px;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Create a bookmark for any page.
2. Set the title to `q y p g j`.
3. Make sure the letters are not clipped at the bottom.

Fixes #4614