### PR TITLE
Disable spellcheck for custom filters list

### DIFF
--- a/js/about/adblock.js
+++ b/js/about/adblock.js
@@ -95,7 +95,8 @@ class AboutAdBlock extends React.Component {
               value={getSetting(ADBLOCK_CUSTOM_RULES, this.state.settings) || ''}
               className='customFiltersInput'
               cols='100'
-              rows='10' />
+              rows='10'
+              spellCheck='false' />
           </div>
         </div>
       </list>


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

1. Navigate to `about:adblock`.
2. Type random text in the custom filters text area.
3. Make sure the text does not have a red underline (spellcheck).

Fixes #4619