### PR TITLE
Do not override handlers of rowAttributes when multiSelect is disabled

### DIFF
--- a/js/components/sortableTable.js
+++ b/js/components/sortableTable.js
@@ -218,8 +218,8 @@ class SortableTable extends ImmutableComponent {
                   : rowAttributes.className) +
                   (this.sortingDisabled ? ' no-sort' : '')
                 }
-                onClick={this.props.multiSelect ? this.onClick : undefined}
-                onContextMenu={this.props.multiSelect ? this.onContextMenu : undefined}>{entry}</tr>
+                onClick={this.props.multiSelect ? this.onClick : rowAttributes.onClick}
+                onContextMenu={this.props.multiSelect ? this.onContextMenu : rowAttributes.onContextMenu}>{entry}</tr>
               : null
           })
         }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

fix #4695

Auditors: @bsclifton

Test Plan:
1. Go to about:preferences#search
2. Should be able to change search engine