### PR TITLE
Add npm script to generate sample Publisher visit/duration count (ledger-synopsis.json)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "scripts": {
     "add-simulated-payment-history": "node ./tools/addSimulatedPaymentHistory.js",
+    "add-simulated-synopsis-visits": "node ./tools/addSimulatedSynopsisVisits.js",
     "build-installer": "node ./tools/buildInstaller.js",
     "build-package": "node ./tools/buildPackage.js",
     "check-security": "nsp check",

--- a/tools/addSimulatedSynopsisVisits.js
+++ b/tools/addSimulatedSynopsisVisits.js
@@ -1,0 +1,10 @@
+let runUtilApp = require('./utilAppRunner')
+
+let cmd = 'addSimulatedSynopsisVisits'
+
+// if user has specified number of simulated publishers to add
+if (process.argv[2]) {
+  cmd += ' ' + process.argv[2]
+}
+
+runUtilApp(cmd, undefined, ['inherit', 'inherit', 'inherit'])

--- a/tools/lib/randomHostname.js
+++ b/tools/lib/randomHostname.js
@@ -1,0 +1,28 @@
+const ALPHABET = 'abcdefghijklmnopqrstuvwxyz'
+const _chooseRandomLetter = function () {
+  return ALPHABET[Math.round(Math.random() * (ALPHABET.length - 1))]
+}
+
+const _generateRandomString = function (len) {
+  return (new Array(len)).fill(null).map(_chooseRandomLetter).join('')
+}
+
+const TLDS = ['com', 'net', 'org', 'io', 'info']
+
+const generateRandomHostname = function (maxLength, minLength) {
+  maxLength = maxLength || 10
+  minLength = minLength || 4
+
+  let tld = TLDS[Math.round(Math.random() * (TLDS.length - 1))]
+
+  let numParts = Math.round(Math.random()) + 1
+
+  let host = (new Array(numParts)).fill(null).map(function () {
+    let partLen = Math.max(Math.round(Math.random() * maxLength), minLength)
+    return _generateRandomString(partLen)
+  }).join('.') + '.' + tld
+
+  return host
+}
+
+module.exports = generateRandomHostname

--- a/tools/lib/synopsisHelpers.js
+++ b/tools/lib/synopsisHelpers.js
@@ -1,0 +1,35 @@
+const fs = require('fs')
+
+const randomHostname = require('./randomHostname')
+
+const Synopsis = require('ledger-publisher').Synopsis
+
+const PROTOCOL_PREFIXES = ['http://', 'https://']
+
+const generateSynopsisVisits = function (synopsis, numPublishers) {
+  let numHosts = numPublishers || Math.round(Math.random() * 100)
+
+  let hosts = (new Array(numHosts)).fill(null).map(function () { return randomHostname() })
+
+  hosts.forEach(function (host) {
+    let numVisits = Math.round(Math.random() * 10)
+
+    for (let i = 0; i < numVisits; i++) {
+      synopsis.addVisit(PROTOCOL_PREFIXES[Math.round(Math.random())] + host + '/', Math.round(Math.random() * 60 * 1000))
+    }
+  })
+
+  return synopsis
+}
+
+const updateExistingSynopsisFile = function (synopsisPath, numPublishers) {
+  let synopsis = new Synopsis(JSON.parse(fs.readFileSync(synopsisPath).toString()))
+
+  synopsis = generateSynopsisVisits(synopsis, numPublishers)
+
+  fs.writeFileSync(synopsisPath, JSON.stringify(synopsis, null, 2))
+}
+
+module.exports = {
+  updateExistingSynopsisFile: updateExistingSynopsisFile
+}

--- a/tools/lib/transactionHelpers.js
+++ b/tools/lib/transactionHelpers.js
@@ -1,4 +1,5 @@
 let Joi = require('joi')
+let generateRandomHost = require('./randomHostname')
 
 const SATOSHIS_PER_BTC = Math.pow(10, 8)
 
@@ -155,41 +156,12 @@ const generateBallots = function (votes) {
 
   while (votesRemaining) {
     let votesToCast = Math.min(Math.round(Math.random() * votesRemaining) + 1, votesRemaining)
-    let host = _generateRandomHost()
+    let host = generateRandomHost()
     ballots[host] = votesToCast
     votesRemaining -= votesToCast
   }
 
   return ballots
-}
-
-const ALPHABET = 'abcdefghijklmnopqrstuvwxyz'
-const _chooseRandomLetter = function () {
-  return ALPHABET[Math.round(Math.random() * (ALPHABET.length - 1))]
-}
-
-const _generateRandomString = function (len) {
-  return (new Array(len)).fill(null).map(_chooseRandomLetter).join('')
-}
-
-const TLDS = ['com', 'net', 'org', 'io', 'info']
-
-const _generateRandomHost = function (maxLength, minLength) {
-  maxLength = maxLength || 10
-  minLength = minLength || 4
-
-  let len = Math.max(Math.round(Math.random() * maxLength), minLength)
-
-  let tld = TLDS[Math.round(Math.random() * (TLDS.length - 1))]
-
-  let numParts = Math.round(Math.random()) + 1
-
-  let host = (new Array(numParts)).fill(null).map(function () {
-    let partLen = Math.max(Math.round(Math.random() * len), minLength)
-    return _generateRandomString(partLen)
-  }).join('.') + '.' + tld
-
-  return host
 }
 
 module.exports = {

--- a/tools/lib/utilApp/index.js
+++ b/tools/lib/utilApp/index.js
@@ -40,6 +40,14 @@ function addSimulatedLedgerTransactions (numTx) {
   }
 }
 
+const updateExistingSynopsisFile = require('../synopsisHelpers').updateExistingSynopsisFile
+function addSimulatedSynopsisVisits (numPublishers) {
+  let userDataPath = app.getPath('userData')
+  let ledgerSynopsisPath = path.join(userDataPath, 'ledger-synopsis.json')
+
+  updateExistingSynopsisFile(ledgerSynopsisPath, numPublishers)
+}
+
 app.on('ready', () => {
   const cmd = process.argv[2]
   switch (cmd) {
@@ -48,6 +56,9 @@ app.on('ready', () => {
       break
     case 'addSimulatedLedgerTransactions':
       addSimulatedLedgerTransactions(process.argv[3])
+      break
+    case 'addSimulatedSynopsisVisits':
+      addSimulatedSynopsisVisits(process.argv[3])
       break
   }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.

Test Plan:
- Clear Brave user data (`npm run clean userData`)
- Run Brave, enable Payments
- Observe empty synopsis table (no publishers listed)
- In a terminal, run `npm run add-simulated-synopsis-visits`
- Back in Brave, toggle Payments
- Observe Synopsis table is populated with random Publishers with random visit counts and durations

![add_synopsis_visits gif final](https://cloud.githubusercontent.com/assets/6969859/19314105/c5748016-904d-11e6-826e-dc4569cf585b.gif)

This probably should have been part of #4199, my bad.

(We did add simulated payment history, but the issue was more generic than that and my last PR did not generate a browsing synopsis, which this does.)
