### PR TITLE
Change RPM builds architecture to 'x86_64'

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Please see the [Building on Windows wiki entry](https://github.com/brave/browser
 
 * `apt-get install libgnome-keyring-dev build-essential`
 
+OR
+
+* `dnf install libgnome-keyring-devel rpm-build`
+
 ## Installation
 
 After installing the prerequisites:

--- a/docs/buildingReleases.md
+++ b/docs/buildingReleases.md
@@ -51,6 +51,7 @@ Check virus scan: https://www.virustotal.com/en/
 ```
 ./node_modules/.bin/webpack
 CHANNEL=dev npm run build-package
+CHANNEL=dev npm run build-installer
 tar -jcvf Brave.tar.bz2 ./Brave-linux-x64
 ```
 

--- a/docs/linuxInstall.md
+++ b/docs/linuxInstall.md
@@ -23,12 +23,12 @@ wget -O brave.deb https://laptop-updates.brave.com/latest/mint64
 sudo dpkg -i ./brave.deb
 ```
 
-## Fedora AMD64:
+## Fedora x86_64:
 
 ```
 sudo dnf install lsb
 wget -O brave.rpm https://laptop-updates.brave.com/latest/fedora64
-sudo rpm -i ./brave.rpm
+sudo dnf install ./brave.rpm
 ```
 
 ## OpenSUSE AMD64:

--- a/tools/buildInstaller.js
+++ b/tools/buildInstaller.js
@@ -82,7 +82,7 @@ if (isDarwin) {
   }, (e) => console.log(`No dice: ${e.message}`))
 } else if (isLinux) {
   console.log('Install with sudo dpkg -i dist/brave_' + VersionInfo.braveVersion + '_amd64.deb')
-  console.log('Or install with sudo rpm -i dist/brave_' + VersionInfo.braveVersion + '.amd64.rpm')
+  console.log('Or install with sudo dnf install dist/brave_' + VersionInfo.braveVersion + '.x86_64.rpm')
   cmds = [
     // .deb file
     'electron-installer-debian' +
@@ -94,7 +94,7 @@ if (isDarwin) {
     'electron-installer-redhat' +
       ' --src Brave-linux-x64/' +
       ' --dest dist/' +
-      ' --arch amd64' +
+      ' --arch x86_64' +
       ' --config res/linuxPackaging.json',
     // .tar.bz2 file
     'tar -jcvf dist/Brave.tar.bz2 ./Brave-linux-x64'


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

1. Build a release, install on Fedoara with `dnf install package.rpm`. Package name should end with `x86_64.rpm`. Package should install with no errors.
2. Build a new release (higher version number). Upgrade on Fedoara with `dnf install package.rpm`. Should update with no errors.
3. Debian/Ubuntu package names and installation should be unchanged.

Core issue:
Incorrect documentation from upstream. [Submitted correction](https://github.com/unindented/electron-installer-redhat/pull/38) to their documentation.

Commit message:
Red Hat/RPM universe expects 'x86_64' whereas Debian expects 'amd64'.

Also expands documentation in some areas.

This closes #3774.