### PR TITLE
Recovery keys are misaligned

### DIFF
--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -932,7 +932,6 @@ div.nextPaymentSubmission {
 
     .copyKeyContainer {
       display: flex;
-      justify-content: space-between;
       width: 75%;
       margin: 20px auto;
 
@@ -941,6 +940,8 @@ div.nextPaymentSubmission {
       }
 
       .keyContainer {
+        margin-left: 75px;
+
         h3 {
           margin-bottom: 15px;
         }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #4743

Auditor @alexwykoff 

Test Plan:

Recovery keys should now be nicely aligned like in the screenshot below
![screen shot 2016-10-13 at 10 57 47 am](https://cloud.githubusercontent.com/assets/490294/19360567/eabcd09e-9133-11e6-87ca-3c9ee2c461f8.png)


