### PR TITLE
Fix global table indexing

### DIFF
--- a/js/components/sortableTable.js
+++ b/js/components/sortableTable.js
@@ -83,10 +83,11 @@ class SortableTable extends ImmutableComponent {
       entry.className = entry.className.replace(' selected', '')
       const tableID = entry.id
       const index = entry.rowIndex - 1
+      const globalIndex = parseInt(entry.getAttribute('data-global-index'))
       const handlerInput = this.props.totalRowObjects
-        ? (typeof this.props.totalRowObjects[parseInt(tableID)][index].toJS === 'function'
-          ? this.props.totalRowObjects[parseInt(tableID)][index].toJS()
-          : this.props.totalRowObjects[parseInt(tableID)][index])
+        ? (typeof this.props.totalRowObjects[parseInt(tableID)][globalIndex].toJS === 'function'
+          ? this.props.totalRowObjects[parseInt(tableID)][globalIndex].toJS()
+          : this.props.totalRowObjects[parseInt(tableID)][globalIndex])
         : (this.props.rowObjects.size > 0 || this.props.rowObjects.length > 0)
           ? (typeof this.props.rowObjects.toJS === 'function'
             ? this.props.rowObjects.get(index).toJS()
@@ -212,6 +213,7 @@ class SortableTable extends ImmutableComponent {
               ? <tr {...rowAttributes}
                 data-context-menu-disable={rowAttributes.onContextMenu ? true : undefined}
                 id={this.props.tableID}
+                data-global-index={i}
                 className={
                   (this.hasRowClassNames
                   ? this.props.rowClassNames[i] + ' ' + rowAttributes.className


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #4741

Auditors: @bsclifton

Test Plan:
1. go to about:history
2. sort the table
3. multi select entries
4. right click on them
5. perform any actions in context menu
6. the action tagets should be correct