### PR TITLE
Long bookmark folder names should be truncated

### DIFF
--- a/less/about/bookmarks.less
+++ b/less/about/bookmarks.less
@@ -103,6 +103,12 @@
       }
     }
   }
+
+  @media (min-width: @breakpointNarrowViewport) {
+    .folderView {
+      max-width: 50%;
+    }
+  }
 }
 
 .bookmarkFolderList list >* {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #4739

Auditors: @bradleyrichter @alexwykoff 

Test Plan:

We can't just add max-width: 50% because then it'll only take up half the screen when the columns float underneath each other but wrapping it in a breakpoint works.

Add a bookmark folder with a really long name and make sure it looks good with both a huge and small screen.
![screen shot 2016-10-13 at 2 44 34 pm](https://cloud.githubusercontent.com/assets/490294/19368171/a384abe6-9153-11e6-92ea-8a6942049506.png)
![screen shot 2016-10-13 at 2 44 44 pm](https://cloud.githubusercontent.com/assets/490294/19368170/a38335cc-9153-11e6-8663-869578899d6a.png)





