### PR TITLE
Bookmark fixes for 0.12.5

### DIFF
--- a/js/about/bookmarks.js
+++ b/js/about/bookmarks.js
@@ -37,14 +37,17 @@ class BookmarkFolderItem extends ImmutableComponent {
 
   onDrop (e) {
     const bookmark = dndData.getDragData(e.dataTransfer, dragTypes.BOOKMARK)
+
     if (bookmark) {
+      // Don't allow a bookmark folder to be moved into itself
+      if (bookmark.get('folderId') === this.props.bookmarkFolder.get('folderId')) {
+        return
+      }
       aboutActions.moveSite(bookmark.toJS(), this.props.bookmarkFolder.toJS(), dndData.shouldPrependVerticalItem(e.target, e.clientY), true)
     }
   }
   render () {
-    const childBookmarkFolders = this.props.bookmarkFolder.get('folderId') === -1
-      ? []
-      : this.props.allBookmarkFolders
+    const childBookmarkFolders = this.props.allBookmarkFolders
           .filter((bookmarkFolder) => (bookmarkFolder.get('parentFolderId') || 0) === this.props.bookmarkFolder.get('folderId'))
     return <div>
       <div role='listitem'
@@ -106,7 +109,9 @@ class BookmarkFolderList extends ImmutableComponent {
       }
       {
         this.props.bookmarkFolders.map((bookmarkFolder) =>
-          <BookmarkFolderItem bookmarkFolder={bookmarkFolder}
+          this.props.isRoot && bookmarkFolder.get('parentFolderId') === -1
+          ? null
+          : <BookmarkFolderItem bookmarkFolder={bookmarkFolder}
             allBookmarkFolders={this.props.allBookmarkFolders}
             selected={!this.props.search && this.props.selectedFolderId === bookmarkFolder.get('folderId')}
             selectedFolderId={this.props.selectedFolderId}

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -240,7 +240,8 @@ function fillParentFolders (parentFolderIds, bookmarkFolder, allBookmarks) {
 module.exports.moveSite = function (sites, sourceDetail, destinationDetail, prepend, destinationIsParent, disallowReparent) {
   // Disallow loops
   let parentFolderIds = []
-  if (destinationDetail.get('parentFolderId') && sourceDetail.get('folderId')) {
+  if (typeof destinationDetail.get('parentFolderId') === 'number' &&
+      typeof sourceDetail.get('folderId') === 'number') {
     fillParentFolders(parentFolderIds, destinationDetail, sites)
     if (sourceDetail.get('folderId') === destinationDetail.get('folderId') ||
         parentFolderIds.includes(sourceDetail.get('folderId'))) {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @jkup @darkdh 

## Other Bookmarks
Other Bookmarks in about:bookmarks now displays sub-folders properly

Fixes https://github.com/brave/browser-laptop/issues/4685

Test Plan:
1. Open Brave and go to about:bookmarks
2. Create a bookmark if you don't already have one
3. Drag and drop this bookmark into the "Other Bookmarks" folder
4. Confirm when "Other Bookmarks" is clicked that it shows in the right pane
5. Create a new bookmark folder and put this bookmark into it
6. Drag and drop this new bookmark folder into "Other Bookmarks"
7. Confirm the UI shows a subfolder under "Other Bookmarks"
8. Click the subfolder and confirm bookmark shows in right pane

## Fix disappearing bookmark folders
Bookmark folders can no longer be moved into themselves (which causes them to disappear).
(This was a long-standing bug and this commit adds a test to ensure it's not possible)

Fixes https://github.com/brave/browser-laptop/issues/4751

Test Plan:
This was hard to reproduce... I would suggest trying to drag and drop a lot in the UI. @alexwykoff had captured the steps as dragging a bookmark folder into the right pane.  The bookmark folders should **never** disappear