### PR TITLE
Bookmarks and siteUtil hardening

### DIFF
--- a/js/components/sortableTable.js
+++ b/js/components/sortableTable.js
@@ -143,22 +143,23 @@ class SortableTable extends ImmutableComponent {
       rowAttributes.onContextMenu = this.props.onContextMenu.bind(this, handlerInput, this.props.contextMenuName)
     }
     // Bindings for row-specific event handlers
+    const thisArg = this.props.thisArg || this
     if (typeof this.props.onClick === 'function') {
-      rowAttributes.onClick = this.props.onClick.bind(this, handlerInput)
+      rowAttributes.onClick = this.props.onClick.bind(thisArg, handlerInput)
     }
     if (typeof this.props.onDoubleClick === 'function') {
-      rowAttributes.onDoubleClick = this.props.onDoubleClick.bind(this, handlerInput)
+      rowAttributes.onDoubleClick = this.props.onDoubleClick.bind(thisArg, handlerInput)
     }
     if (typeof this.props.onDragStart === 'function') {
-      rowAttributes.onDragStart = this.props.onDragStart.bind(this, Immutable.fromJS(handlerInput))
+      rowAttributes.onDragStart = this.props.onDragStart.bind(thisArg, Immutable.fromJS(handlerInput))
       rowAttributes.draggable = true
     }
     if (typeof this.props.onDragOver === 'function') {
-      rowAttributes.onDragOver = this.props.onDragOver.bind(this, Immutable.fromJS(handlerInput))
+      rowAttributes.onDragOver = this.props.onDragOver.bind(thisArg, Immutable.fromJS(handlerInput))
       rowAttributes.draggable = true
     }
     if (typeof this.props.onDrop === 'function') {
-      rowAttributes.onDrop = this.props.onDrop.bind(this, Immutable.fromJS(handlerInput))
+      rowAttributes.onDrop = this.props.onDrop.bind(thisArg, Immutable.fromJS(handlerInput))
       rowAttributes.draggable = true
     }
     return rowAttributes


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

- new isMoveAllowed (pulled out from moveSite)
- added unit test to ensure moveSite can't put an ancestor into a descendant
- about:bookmarks now calls isMoveAllowed before submitting action
- about:bookmarks allows folder drag onto bookmark; it gets parent folder ID and puts there
- fixed folder selection bug when searching on about:bookmarks (selection cleared during search)

Fixes https://github.com/brave/browser-laptop/issues/4766

Auditors: @bbondy

Test Plan:
1. Open about:bookmarks
2. Create two folders and also bookmark several items, under Bookmarks Toolbar
3. Click to select a folder which has bookmarks
4. Drag one of the folders and drop it on a bookmark
5. Folder should move into the folder that contains bookmark that was dropped onto
6. Making sure a folder you created is selected on the left (one that is NOT bookmarks toolbar or other bookmarks), do a search
7. Validate folder selection is cleared on left, in favor of "All Folders"
8. Drag one of the search results onto a folder on the left
9. Validate bookmark was moved