### PR TITLE
Hide Advanced Settings button when Brave Payments is disabled

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -1177,7 +1177,7 @@ class PaymentsTab extends ImmutableComponent {
             <span data-l10n-id='off' />
             <SettingCheckbox dataL10nId='on' prefKey={settings.PAYMENTS_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
           </div>
-          <Button l10nId='advancedSettings' className='whiteButton inlineButton' onClick={this.props.showOverlay.bind(this, 'advancedSettings')} />
+          { this.enabled ? <Button l10nId='advancedSettings' className='whiteButton inlineButton' onClick={this.props.showOverlay.bind(this, 'advancedSettings')} /> : null }
         </div>
       </div>
       {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist. (fixes issue #4790)
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).

Most of the base tests in `test/components/ledgerPanelTest.js` are failing for me (e.g. enabling / disabling payments). I'm working on this.

- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Open Brave
2. Open Brave Preferences -> Payments tab
3. When Payments is disabled, observe that there is no "Advanced Settings" button in upper right
4. Click the Payments toggle, observe "Advanced Settings" appears when Payments are enabled
5. Click toggle again and confirm the "Advanced Settings" button is hidden again

fixes #4790