### PR TITLE
Change URL suggestions to consider last access timestamp and access count

### DIFF
--- a/app/renderer/lib/suggestion.js
+++ b/app/renderer/lib/suggestion.js
@@ -1,0 +1,84 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const appConfig = require('../../../js/constants/appConfig')
+
+const sigmoid = (t) => {
+  return 1 / (1 + Math.pow(Math.E, -t))
+}
+
+const ONE_DAY = 1000 * 60 * 60 * 24
+
+/*
+ * Calculate the sorting priority for a history item based on number of
+ * accesses and time since last access
+ *
+ * @param {number} count - The number of times this site has been accessed
+ * @param {number} currentTime - Current epoch millisecnds
+ * @param {boolean} lastAccessedTime - Epoch milliseconds of last access
+ *
+ */
+module.exports.sortingPriority = (count, currentTime, lastAccessedTime, ageDecayConstant) => {
+  // number of days since last access (with fractional component)
+  const ageInDays = (currentTime - (lastAccessedTime || currentTime)) / ONE_DAY
+  // decay factor based on age
+  const ageFactor = 1 - ((sigmoid(ageInDays / ageDecayConstant) - 0.5) * 2)
+  // sorting priority
+  // console.log(count, ageInDays, ageFactor, count * ageFactor)
+  return count * ageFactor
+}
+
+/*
+ * Sort two history items by priority
+ *
+ * @param {ImmutableObject} s1 - first history item
+ * @param {ImmutableObject} s2 - second history item
+ *
+ * Return the relative order of two site entries taking into consideration
+ * the number of times the site has been accessed and the length of time
+ * since the last access.
+ *
+ * The base sort order is determined by the count attribute of the site
+ * entry. A modifier is then computed based on the length of time since
+ * the last access. A sigmoid function is used to weight more recent
+ * entries higher than entries in the past. This is not a linear function,
+ * entries in the far past with many counts will still be discounted
+ * heavily as the sigmoid modifier will cancel most of the count
+ * base parameter.
+ *
+ * Below is a sample comparison of two sites that have been accessed
+ * recently (but not at the identical time). Each site is accessed
+ * 9 times. The count is discounted by an aging factor calculated
+ * using the sigmoid decay function.
+ *
+ *   http://www.gm.ca/gm/
+ *
+ *   ageInDays 0.17171469907407408
+ *   ageFactor 0.9982828546969802
+ *   count     9
+ *   priority  0.9982828546969802
+ *
+ *   http://www.gm.com/index.html
+ *
+ *   ageInDays 0.17148791666666666
+ *   ageFactor 0.9982851225143763
+ *   count     9
+ *   priority  0.9982851225143763
+ *
+ */
+module.exports.sortByAccessCountWithAgeDecay = (s1, s2) => {
+  const s1Priority = module.exports.sortingPriority(
+    s1.get('count') || 0,
+    (new Date()).getTime(),
+    s1.get('lastAccessedTime') || (new Date()).getTime(),
+    appConfig.urlSuggestions.ageDecayConstant
+  )
+  const s2Priority = module.exports.sortingPriority(
+    s2.get('count') || 0,
+    (new Date()).getTime(),
+    s2.get('lastAccessedTime') || (new Date()).getTime(),
+    appConfig.urlSuggestions.ageDecayConstant
+  )
+  return s2Priority - s1Priority
+}

--- a/app/renderer/lib/suggestion.js
+++ b/app/renderer/lib/suggestion.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const urlParser = require('url')
 const appConfig = require('../../../js/constants/appConfig')
 
 const sigmoid = (t) => {
@@ -81,4 +82,20 @@ module.exports.sortByAccessCountWithAgeDecay = (s1, s2) => {
     appConfig.urlSuggestions.ageDecayConstant
   )
   return s2Priority - s1Priority
+}
+
+/*
+ * Return a 1 if the url is 'simple' as in without query, search or
+ * hash components. Return 0 otherwise.
+ *
+ * @param {ImmutableObject} site - object represent history entry
+ *
+ */
+module.exports.simpleDomainNameValue = (site) => {
+  const parsed = urlParser.parse(site.get('location'))
+  if (parsed.hash === null && parsed.search === null && parsed.query === null && parsed.pathname === '/') {
+    return 1
+  } else {
+    return 0
+  }
 }

--- a/js/components/urlBarSuggestions.js
+++ b/js/components/urlBarSuggestions.js
@@ -255,9 +255,16 @@ class UrlBarSuggestions extends ImmutableComponent {
         if (pos1 - pos2 !== 0) {
           return pos1 - pos2
         } else {
-          // If there's a tie on the match location, use the age
-          // decay modified access count
-          return suggestion.sortByAccessCountWithAgeDecay(s1, s2)
+          // sort site.com higher than site.com/somepath
+          const sdnv1 = suggestion.simpleDomainNameValue(s1)
+          const sdnv2 = suggestion.simpleDomainNameValue(s2)
+          if (sdnv1 !== sdnv2) {
+            return sdnv2 - sdnv1
+          } else {
+            // If there's a tie on the match location, use the age
+            // decay modified access count
+            return suggestion.sortByAccessCountWithAgeDecay(s1, s2)
+          }
         }
       }
     }

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -85,6 +85,9 @@ module.exports = {
     baseUrl: `${updateHost}/1/releases`,
     winBaseUrl: `${winUpdateHost}/multi-channel/releases/CHANNEL/`
   },
+  urlSuggestions: {
+    ageDecayConstant: 50
+  },
   defaultSettings: {
     'adblock.customRules': '',
     'general.language': null, // null means to use the OS lang

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -124,6 +124,10 @@ const mergeSiteDetails = (oldSiteDetail, newSiteDetail, tag, folderId) => {
   if (newSiteDetail.get('themeColor') || oldSiteDetail && oldSiteDetail.get('themeColor')) {
     site = site.set('themeColor', newSiteDetail.get('themeColor') || oldSiteDetail.get('themeColor'))
   }
+  if (site.get('tags').size === 0) {
+    // Increment the visit count for history items
+    site = site.set('count', ((oldSiteDetail || site).get('count') || 0) + 1)
+  }
 
   return site
 }

--- a/test/unit/lib/urlSuggestionTest.js
+++ b/test/unit/lib/urlSuggestionTest.js
@@ -1,6 +1,7 @@
 /* global describe, it */
 const suggestion = require('../../../app/renderer/lib/suggestion')
 const assert = require('assert')
+const Immutable = require('immutable')
 
 require('../braveUnit')
 
@@ -12,4 +13,12 @@ describe('suggestion', function () {
     assert.ok(suggestion.sortingPriority(10, 100, 50, AGE_DECAY) < suggestion.sortingPriority(11, 100, 40, AGE_DECAY), 'Sites with higher access counts sort earlier (unless time delay overriden)')
     assert.ok(suggestion.sortingPriority(10, 10000000000, 10000000000, AGE_DECAY) > suggestion.sortingPriority(11, 10000000000, 1000000000, AGE_DECAY), 'much newer sites without lower counts sort with higher priority')
   })
+
+  it('sorts simple sites higher than complex sites', function () {
+    const siteSimple = Immutable.Map({ location: 'http://www.site.com' })
+    const siteComplex = Immutable.Map({ location: 'http://www.site.com/?foo=bar#a' })
+    assert.ok(suggestion.simpleDomainNameValue(siteSimple) === 1, 'simple site returns 1')
+    assert.ok(suggestion.simpleDomainNameValue(siteComplex) === 0, 'complex site returns 0')
+  })
 })
+

--- a/test/unit/lib/urlSuggestionTest.js
+++ b/test/unit/lib/urlSuggestionTest.js
@@ -1,0 +1,15 @@
+/* global describe, it */
+const suggestion = require('../../../app/renderer/lib/suggestion')
+const assert = require('assert')
+
+require('../braveUnit')
+
+const AGE_DECAY = 50
+
+describe('suggestion', function () {
+  it('sorts sites correctly', function () {
+    assert.ok(suggestion.sortingPriority(10, 100, 50, AGE_DECAY) > suggestion.sortingPriority(10, 100, 40, AGE_DECAY), 'newer sites with equal access counts sort earlier')
+    assert.ok(suggestion.sortingPriority(10, 100, 50, AGE_DECAY) < suggestion.sortingPriority(11, 100, 40, AGE_DECAY), 'Sites with higher access counts sort earlier (unless time delay overriden)')
+    assert.ok(suggestion.sortingPriority(10, 10000000000, 10000000000, AGE_DECAY) > suggestion.sortingPriority(11, 10000000000, 1000000000, AGE_DECAY), 'much newer sites without lower counts sort with higher priority')
+  })
+})

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -27,6 +27,10 @@ describe('siteUtil', function () {
     parentFolderId: 0,
     tags: [siteTags.BOOKMARK_FOLDER]
   })
+  const siteMinFields = Immutable.fromJS({
+    location: testUrl1,
+    title: 'sample'
+  })
 
   describe('getSiteIndex', function () {
     it('returns -1 if sites is falsey', function () {
@@ -178,7 +182,17 @@ describe('siteUtil', function () {
       const expectedSites = Immutable.fromJS([bookmarkAllFields])
       assert.deepEqual(processedSites.getIn([0, 'tags']), expectedSites.getIn([0, 'tags']))
     })
-
+    describe('record count', function () {
+      var processedSites
+      it('create history record with count', function () {
+        processedSites = siteUtil.addSite(emptySites, siteMinFields)
+        assert.deepEqual(processedSites.getIn([0, 'count']), 1)
+      })
+      it('increments count for history item', function () {
+        processedSites = siteUtil.addSite(processedSites, siteMinFields)
+        assert.deepEqual(processedSites.getIn([0, 'count']), 2)
+      })
+    })
     describe('for new entries (oldSite is null)', function () {
       describe('when adding bookmark', function () {
         it('preserves existing siteDetail fields', function () {
@@ -192,7 +206,6 @@ describe('siteUtil', function () {
           assert.deepEqual(processedSites.getIn([0, 'tags']).toJS(), [siteTags.BOOKMARK])
         })
       })
-
       describe('when adding bookmark folder', function () {
         it('assigns a folderId', function () {
           const processedSites = siteUtil.addSite(emptySites, folderMinFields)


### PR DESCRIPTION
- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Ran `git rebase -i` to squash commits (if needed).

      * Re-order results to show history items before bookmark items
      * Record number of times site is visited
      * Re-order history items based on number of times visited and last access timestamp
      * Update and create tests

    Fixes: #3049

    Auditors: @bbondy

    Test plan:

    A new attribute, count, is added to history items in the sites section of save-session-1. This attribute records the number of times a site has been accessed. The test plan is broken in two components, one to verify the count attribute is incremented on access, the second to verify that the count and last access time are used when sorting history suggestions.

    Scenario 1

    Part A

      1. Clear save-session-1
      2. Access a site
      3. Close browser
      4. Verify that the count attribute for the saved site in save-session-1 has a value of 1

    Part B

      1. Open browser
      2. Navigate to site from Part A
      3. Close browser
      4. Verify that the count attribute for the saved site in save-session-1 has an incremented value

    Scenario 2

      1. Clear save-session-1
      2. Open browser
      3. Visit gm.com and gm.ca
      4. Close browser
      5. Verify that the count attributes of the two new sites are identical (1)
      6. Open browser to a new tab
      7. Enter ‘gm’ into the url bar
      8. Verify that the most recently visited of the two gm sites is the first entry in the history auto-suggest list