### PR TITLE
UrlbarSuggestions does not work if you are offline

### DIFF
--- a/js/components/urlBarSuggestions.js
+++ b/js/components/urlBarSuggestions.js
@@ -395,6 +395,11 @@ class UrlBarSuggestions extends ImmutableComponent {
         windowActions.setUrlBarSuggestionSearchResults(Immutable.fromJS(xhr.response[1]))
         this.updateSuggestions(props.selectedIndex)
       }
+
+      xhr.onerror = () => {
+        windowActions.setUrlBarSuggestionSearchResults(Immutable.fromJS([]))
+        this.updateSuggestions(props.selectedIndex)
+      }
     } else {
       windowActions.setUrlBarSuggestionSearchResults(Immutable.fromJS([]))
       this.updateSuggestions(props.selectedIndex)


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

Fixes #3730

Auditors:
@bbondy

Test Plan:
1. Make sure you turned on every type of suggestions you want to get via typing from the settings menu and set default Search Engine to duckduckgo
2. Disconnect from internet
3. Start typing something in the url bar