### PR TITLE
Clear state if clear autofill data when shutdown.

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -252,6 +252,11 @@ module.exports.cleanAppData = (data, isShutdown) => {
   const clearAutofillData = isShutdown && getSetting(settings.SHUTDOWN_CLEAR_AUTOFILL_DATA) === true
   if (clearAutofillData) {
     autofill.clearAutofillData()
+    const date = new Date().getTime()
+    data.autofill.addresses.guid = []
+    data.autofill.addresses.timestamp = date
+    data.autofill.creditCards.guid = []
+    data.autofill.creditCards.timestamp = date
   }
   const clearSiteSettings = isShutdown && getSetting(settings.SHUTDOWN_CLEAR_SITE_SETTINGS) === true
   if (clearSiteSettings) {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

because we won't receive personal-data-changed on shutdown

fix #4818 

Auditors: @bridiver

Test Plan:
1. Add autofill data entries in about:autofill
2. Turn on clear "Autofill data" when closing brave in about:preferences#security
3. Restart brave
4. There shouldn't be anything left in about:autofill