### PR TITLE
Fix checked status on menu template (impacts Windows only)

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -582,13 +582,31 @@ const createMenu = () => {
   }
 }
 
+const setMenuItemChecked = (label, checked) => {
+  // Update electron menu (Mac / Linux)
+  const systemMenuItem = menuUtil.getMenuItem(appMenu, label)
+  systemMenuItem.checked = checked
+
+  // Update in-memory menu template (Windows)
+  const oldTemplate = appStore.getState().getIn(['menu', 'template'])
+  const newTemplate = menuUtil.setTemplateItemChecked(oldTemplate, label, checked)
+  if (newTemplate) {
+    appActions.setMenubarTemplate(newTemplate)
+  }
+}
+
 const doAction = (action) => {
   switch (action.actionType) {
     case windowConstants.WINDOW_SET_FOCUSED_FRAME:
-      // TODO check/uncheck menu item instead of recreating menu
+      // Update the checkbox next to "Bookmark Page" (Bookmarks menu)
       currentLocation = action.frameProps.get('location')
-      let menuItem = menuUtil.getMenuItem(appMenu, locale.translation('bookmarkPage'))
-      menuItem.checked = isCurrentLocationBookmarked()
+      setMenuItemChecked(locale.translation('bookmarkPage'), isCurrentLocationBookmarked())
+      break
+    case appConstants.APP_CHANGE_SETTING:
+      if (action.key === settings.SHOW_BOOKMARKS_TOOLBAR) {
+        // Update the checkbox next to "Bookmarks Toolbar" (Bookmarks menu)
+        setMenuItemChecked(locale.translation('bookmarksToolbar'), action.value)
+      }
       break
     case windowConstants.WINDOW_UNDO_CLOSED_FRAME:
       appDispatcher.waitFor([appStore.dispatchToken], () => {

--- a/app/renderer/components/menubar.js
+++ b/app/renderer/components/menubar.js
@@ -294,7 +294,8 @@ class Menubar extends ImmutableComponent {
     }
   }
   shouldComponentUpdate (nextProps, nextState) {
-    return this.props.selectedIndex !== nextProps.selectedIndex
+    return this.props.selectedIndex !== nextProps.selectedIndex ||
+      this.props.template !== nextProps.template
   }
   render () {
     let i = 0

--- a/js/components/addEditBookmark.js
+++ b/js/components/addEditBookmark.js
@@ -89,11 +89,12 @@ class AddEditBookmark extends ImmutableComponent {
     windowActions.setBookmarkDetail(currentDetail, this.props.originalDetail, this.props.destinationDetail)
   }
   showToolbarOnFirstBookmark () {
-    const showBookmarksToolbar = getSetting(settings.SHOW_BOOKMARKS_TOOLBAR)
-    const isFirstBookmark = this.props.sites.find(
+    const hasOneBookmark = this.props.sites.find(
       (site) => siteUtil.isBookmark(site) || siteUtil.isFolder(site)
     )
-    appActions.changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, !isFirstBookmark || showBookmarksToolbar)
+    if (!hasOneBookmark && !getSetting(settings.SHOW_BOOKMARKS_TOOLBAR)) {
+      appActions.changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, true)
+    }
   }
   onSave () {
     // First check if the title of the currentDetail is set

--- a/test/unit/lib/menuUtilTest.js
+++ b/test/unit/lib/menuUtilTest.js
@@ -5,56 +5,15 @@ const assert = require('assert')
 const Immutable = require('immutable')
 require('../braveUnit')
 
-const defaultMenu = {
-  items: [
-    {
-      label: 'File',
-      submenu: {
-        items: [
-          { label: 'open', temp: 1 },
-          { label: 'quit', temp: 2 }
-        ]
-      }
-    },
-    {
-      label: 'Edit',
-      submenu: {
-        items: [
-          { label: 'copy', temp: 3 },
-          { label: 'paste', temp: 4 }
-        ]
-      }
-    },
-    {
-      label: 'Bookmarks',
-      submenu: {
-        items: [
-          {
-            label: 'bookmark folder 1',
-            submenu: {
-              items: [
-                { label: 'my bookmark', url: 'https://brave.com' }
-              ]
-            }
-          }
-        ]
-      }
-    }
-  ]
-}
-
 describe('menuUtil', function () {
   let menuUtil
 
   before(function () {
-    // https://github.com/mfncooper/mockery
-    // TODO: consider moving to braveUnit.js
     mockery.enable({
       warnOnReplace: false,
       warnOnUnregistered: false,
       useCleanCache: true
     })
-
     mockery.registerMock('electron', require('./fakeElectron'))
     menuUtil = require('../../../app/browser/lib/menuUtil')
   })
@@ -64,6 +23,49 @@ describe('menuUtil', function () {
   })
 
   describe('getMenuItem', function () {
+    const defaultMenu = {
+      items: [
+        {
+          label: 'File',
+          submenu: {
+            items: [
+              { label: 'open', temp: 1 },
+              { label: 'quit', temp: 2 }
+            ]
+          }
+        },
+        {
+          label: 'Edit',
+          submenu: {
+            items: [
+              { label: 'copy', temp: 3 },
+              { label: 'paste', temp: 4 }
+            ]
+          }
+        },
+        {
+          label: 'Bookmarks',
+          submenu: {
+            items: [
+              {
+                label: 'Bookmarks Toolbar',
+                type: 'checkbox',
+                checked: false
+              },
+              {
+                label: 'bookmark folder 1',
+                submenu: {
+                  items: [
+                    { label: 'my bookmark', url: 'https://brave.com' }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+
     it('returns the electron MenuItem based on the label', function () {
       const menuItem = menuUtil.getMenuItem(defaultMenu, 'quit')
       assert.equal(menuItem.temp, 2)
@@ -75,6 +77,42 @@ describe('menuUtil', function () {
     it('searches the menu recursively based on the label', function () {
       const menuItem = menuUtil.getMenuItem(defaultMenu, 'my bookmark')
       assert.equal(menuItem.url, 'https://brave.com')
+    })
+  })
+
+  describe('setTemplateItemChecked', function () {
+    const defaultTemplate = Immutable.fromJS([
+      {
+        'label': 'Bookmarks',
+        'submenu': [
+          {
+            'label': 'Bookmarks Toolbar',
+            'type': 'checkbox',
+            'checked': false
+          }
+        ]
+      }
+    ])
+
+    it('returns the new template when checked status is updated', function () {
+      const expectedTemplate = Immutable.fromJS([
+        {
+          'label': 'Bookmarks',
+          'submenu': [
+            {
+              'label': 'Bookmarks Toolbar',
+              'type': 'checkbox',
+              'checked': true
+            }
+          ]
+        }
+      ])
+      const newTemplate = menuUtil.setTemplateItemChecked(defaultTemplate, 'Bookmarks Toolbar', true)
+      assert.deepEqual(newTemplate.toJS(), expectedTemplate.toJS())
+    })
+    it('returns null when no change is made', function () {
+      const newTemplate = menuUtil.setTemplateItemChecked(defaultTemplate, 'Bookmarks Toolbar', false)
+      assert.equal(newTemplate, null)
     })
   })
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bbondy 

Since titlebar was released with 0.12.3, the checked state has not updating properly because appState doesn't receive the update.

Fixes https://github.com/brave/browser-laptop/issues/4810