### PR TITLE
Fixing magic number bug in downloads bar

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -628,8 +628,11 @@ class Frame extends ImmutableComponent {
       e.stopPropagation()
     })
     this.webview.addEventListener('update-target-url', (e) => {
-      const downloadsBarHeight = 50
-      let nearBottom = e.y > (window.innerHeight - 150 - downloadsBarHeight) // todo: magic number
+      if (!this.root) {
+        this.root = window.getComputedStyle(document.querySelector(':root'))
+        this.downloadsBarHeight = Number.parseInt(this.root.getPropertyValue('--downloads-bar-height'), 10)
+      }
+      let nearBottom = e.y > (window.innerHeight - 150 - this.downloadsBarHeight)
       let mouseOnLeft = e.x < (window.innerWidth / 2)
       let showOnRight = nearBottom && mouseOnLeft
       windowActions.setLinkHoverPreview(e.url, showOnRight)

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -67,6 +67,11 @@ const addFolderMenuItem = (closestDestinationDetail, isParent) => {
   }
 }
 
+const getDownloadsBarHeight = () => {
+  const root = window.getComputedStyle(document.querySelector(':root'))
+  return Number.parseInt(root.getPropertyValue('--downloads-bar-height'), 10)
+}
+
 function tabPageTemplateInit (framePropsList) {
   return [{
     label: locale.translation('unmuteTabs'),
@@ -1201,8 +1206,7 @@ function onShowBookmarkFolderMenu (bookmarks, bookmark, activeFrame, e) {
  */
 function onShowUsernameMenu (usernames, origin, action, boundingRect,
                                     topOffset) {
-  // TODO: magic number
-  const downloadsBarOffset = windowStore.getState().getIn(['ui', 'downloadsToolbar', 'isVisible']) ? 50 : 0
+  const downloadsBarOffset = windowStore.getState().getIn(['ui', 'downloadsToolbar', 'isVisible']) ? getDownloadsBarHeight() : 0
   const menuTemplate = usernameTemplateInit(usernames, origin, action)
   windowActions.setContextMenuDetail(Immutable.fromJS({
     left: boundingRect.left,
@@ -1213,8 +1217,7 @@ function onShowUsernameMenu (usernames, origin, action, boundingRect,
 
 function onShowAutofillMenu (suggestions, boundingRect, frame) {
   const menuTemplate = autofillTemplateInit(suggestions, frame)
-  // TODO: magic number
-  const downloadsBarOffset = windowStore.getState().getIn(['ui', 'downloadsToolbar', 'isVisible']) ? 50 : 0
+  const downloadsBarOffset = windowStore.getState().getIn(['ui', 'downloadsToolbar', 'isVisible']) ? getDownloadsBarHeight() : 0
   const offset = {
     x: (window.innerWidth - boundingRect.clientWidth),
     y: (window.innerHeight - boundingRect.clientHeight)

--- a/less/downloadBar.less
+++ b/less/downloadBar.less
@@ -19,7 +19,7 @@
   border-top: 1px solid #888;
   color: black;
   display: flex;
-  height: 50px;
+  height: @downloadsBarHeight;
   padding: 5px var(--download-bar-padding);
   width: 100%;
   z-index: @zindexDownloadsBar;

--- a/less/variables.less
+++ b/less/variables.less
@@ -63,6 +63,7 @@
 @switchNubShadow: 1px 1px 5px -2px black;
 
 @navbarHeight: 36px;
+@downloadsBarHeight: 50px;
 @tabsToolbarHeight: 23px;
 @tabPagesHeight: 12px;
 @bookmarksToolbarHeight: 24px;
@@ -144,4 +145,5 @@
 
 :root {
   --navbar-height: @navbarHeight;
+  --downloads-bar-height: @downloadsBarHeight;
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

Fixes #3604 

Added a new variable for downloads bar height in variables.less and consumed this across the codebase where 50px was hardcoded for this.

Auditors: @bsclifton 

