### PR TITLE
Add new "automatically send usage stats" setting under advanced settings

### DIFF
--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -246,3 +246,4 @@ importBrowserData=Import Browser Data
 importNow=Import now…
 clearAll=Clear all
 sendCrashReports=Send anonymous crash reports to Brave (requires browser restart)
+sendUsageStatistics=Automatically send usage statistics to Brave

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -1501,6 +1501,7 @@ class AdvancedTab extends ImmutableComponent {
         <SettingCheckbox dataL10nId='usePDFJS' prefKey={settings.PDFJS_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
         <SettingCheckbox dataL10nId='useSmoothScroll' prefKey={settings.SMOOTH_SCROLL_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
         <SettingCheckbox dataL10nId='sendCrashReports' prefKey={settings.SEND_CRASH_REPORTS} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
+        <SettingCheckbox dataL10nId='sendUsageStatistics' prefKey={settings.SEND_USAGE_STATISTICS} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
       </SettingsList>
     </div>
   }

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -125,6 +125,7 @@ module.exports = {
     'advanced.pdfjs-enabled': true,
     'advanced.smooth-scroll-enabled': false,
     'advanced.send-crash-reports': true,
+    'advanced.send-usage-statistics': false,
     'advanced.minimum-visit-time': 8,
     'advanced.minimum-visits': 5,
     'shutdown.clear-history': false,

--- a/js/constants/settings.js
+++ b/js/constants/settings.js
@@ -58,6 +58,7 @@ const settings = {
   DEFAULT_ZOOM_LEVEL: 'advanced.default-zoom-level',
   SMOOTH_SCROLL_ENABLED: 'advanced.smooth-scroll-enabled',
   SEND_CRASH_REPORTS: 'advanced.send-crash-reports',
+  SEND_USAGE_STATISTICS: 'advanced.send-usage-statistics',
   ADBLOCK_CUSTOM_RULES: 'adblock.customRules',
   MINIMUM_VISIT_TIME: 'advanced.minimum-visit-time',
   MINIMUM_VISTS: 'advanced.minimum-visits'


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests). **N/A**
- [x] Ran `git rebase -i` to squash commits (if needed).

Add new "automatically send usage stats" setting under advanced settings

Currently, nothing uses this new setting. But now that it's there, it can be used by future changes.

Fixes https://github.com/brave/browser-laptop/issues/4691

Auditors: @aekeus @bradleyrichter

Test Plan:
1. Open Brave and launch preferences
2. Go under advanced and see new setting

![screen shot 2016-10-16 at 10 02 06 am](https://cloud.githubusercontent.com/assets/4733304/19419358/b57da3fa-938a-11e6-8f0c-b009f2e1260c.png)
