### PR TITLE
"Other Bookmarks" folder no longer shows delete in context menu

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -217,7 +217,7 @@ function siteDetailTemplateInit (siteDetail, activeFrame) {
   let isHistoryEntry = false
   let isHistoryEntries = false
   let isFolder = false
-  let isRootFolder = false
+  let isSystemFolder = false
   let deleteLabel
   let deleteTag
 
@@ -226,7 +226,8 @@ function siteDetailTemplateInit (siteDetail, activeFrame) {
     deleteTag = siteTags.BOOKMARK
   } else if (siteUtil.isFolder(siteDetail)) {
     isFolder = true
-    isRootFolder = siteDetail.get('folderId') === 0
+    isSystemFolder = siteDetail.get('folderId') === 0 ||
+      siteDetail.get('folderId') === -1
     deleteLabel = 'deleteFolder'
     deleteTag = siteTags.BOOKMARK_FOLDER
   } else if (siteUtil.isHistoryEntry(siteDetail)) {
@@ -271,7 +272,7 @@ function siteDetailTemplateInit (siteDetail, activeFrame) {
       CommonMenu.separatorMenuItem)
   }
 
-  if (!isRootFolder) {
+  if (!isSystemFolder) {
     // History can be deleted but not edited
     // Picking this menu item pops up the AddEditBookmark modal
     if (!isHistoryEntry && !isHistoryEntries) {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

"Other Bookmarks" folder no longer shows delete in context menu

Fixes https://github.com/brave/browser-laptop/issues/4836

Auditors: @bbondy

Test Plan:
1) Launch Brave and open about:bookmarks
2) Right click "Other Bookmarks" folder
3) Notice delete and edit are no longer shown