### PR TITLE
Fix alignment of home button between tab with content and about:newtab

### DIFF
--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -115,7 +115,7 @@ class NavigationBar extends ImmutableComponent {
       <div className='startButtons'>
         {
           isSourceAboutUrl(this.props.location) || this.titleMode
-          ? <span className='browserButton' />
+          ? <span className='browserButton hidden-button fa fa-repeat' />
           : this.loading
             ? <Button iconClass='fa-times'
               l10nId='stopButton'

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -619,6 +619,10 @@
 
   &:not(.titleMode) {
     .urlbarForm, .browserButton {
+      &.hidden-button {
+        animation: none;
+        animation-fill-mode: none;
+      }
       animation: fadeIn .6s;
       opacity: 0;
       animation-fill-mode: forwards;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes https://github.com/brave/browser-laptop/issues/4854

Auditors: @jkup @bbondy 

@jkup this is a proposed fix which has the same symptom as the favorites button you had adjusted with https://github.com/brave/browser-laptop/pull/4726.  This PR should fix it too- basically, it's putting a placeholder button in place (which has opacity 0) which causes the flexbox to adjust it's bounds properly. I'm curious if there's a better solution, but I would need to dig in more (I don't have enough CSS knowledge at the moment to know an alternative)

Test plan:
1. Launch Brave and open https://brave.com and also a new tab
2. Open preferences, enable home button
3. switch between brave.com and the new tab screen. home icon should not move