### PR TITLE
Disable save button when no detail present

### DIFF
--- a/js/components/autofillAddressPanel.js
+++ b/js/components/autofillAddressPanel.js
@@ -88,6 +88,16 @@ class AutofillAddressPanel extends ImmutableComponent {
   onClick (e) {
     e.stopPropagation()
   }
+  get disableSaveButton () {
+    let currentDetail = this.props.currentDetail
+    if (!currentDetail.size) return true
+    if (!currentDetail.get('name') && !currentDetail.get('organization') &&
+      !currentDetail.get('streetAddress') && !currentDetail.get('city') &&
+      !currentDetail.get('state') && !currentDetail.get('country') &&
+      !currentDetail.get('phone') && !currentDetail.get('email')) return true
+    return false
+  }
+
   render () {
     return <Dialog onHide={this.props.onHide} className='manageAutofillDataPanel autofillAddressPanel' isClickDismiss>
       <div className='genericForm manageAutofillData' onClick={this.onClick}>
@@ -141,7 +151,8 @@ class AutofillAddressPanel extends ImmutableComponent {
           </div>
           <div className='formRow manageAutofillDataButtons'>
             <Button l10nId='cancel' className='secondaryAltButton' onClick={this.props.onHide} />
-            <Button l10nId='save' className='primaryButton saveAddressButton' onClick={this.onSave} />
+            <Button l10nId='save' className='primaryButton saveAddressButton' onClick={this.onSave}
+              disabled={this.disableSaveButton} />
           </div>
         </div>
       </div>

--- a/js/components/autofillCreditCardPanel.js
+++ b/js/components/autofillCreditCardPanel.js
@@ -58,6 +58,12 @@ class AutofillCreditCardPanel extends ImmutableComponent {
   onClick (e) {
     e.stopPropagation()
   }
+  get disableSaveButton () {
+    let currentDetail = this.props.currentDetail
+    if (!currentDetail.size) return true
+    if (!currentDetail.get('name') && !currentDetail.get('card')) return true
+    return false
+  }
   render () {
     var ExpMonth = []
     for (let i = 1; i <= 12; ++i) {
@@ -98,7 +104,8 @@ class AutofillCreditCardPanel extends ImmutableComponent {
           </div>
           <div className='formRow manageAutofillDataButtons'>
             <Button l10nId='cancel' className='secondaryAltButton' onClick={this.props.onHide} />
-            <Button l10nId='save' className='primaryButton saveCreditCardButton' onClick={this.onSave} />
+            <Button l10nId='save' className='primaryButton saveCreditCardButton' onClick={this.onSave}
+              disabled={this.disableSaveButton} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #4855

Auditors: @bbondy

Test Plan:
1. Open "about:autofill"
2. Click "Add Address"
3. The save button should be disabled
4. Enter the detail of form, the save button should be enabled
5. Remove all detail of form, the save button should be disabled

1. Open "about:autofill"
2. Click "Add Credit Card"
3. The save button should be disabled
4. Enter the detail of form, the save button should be enabled (Name, Card Number)
5. Remove all detail of form, the save button should be disabled (Name, Card Number)

1. Open "about:autofill"
2. Add address entry
3. Edit the address entry
4. Remove all detail of form, the save button should be disabled

1. Open "about:autofill"
2. Add credit card entry
3. Edit the credit card entry
4. Remove all detail of form, the save button should be disabled (Name, Card Number)