### PR TITLE
Make bookmarks fill toolbar container for any window width. fix #4116

### DIFF
--- a/app/renderer/components/bookmarksToolbar.js
+++ b/app/renderer/components/bookmarksToolbar.js
@@ -297,7 +297,7 @@ class BookmarksToolbar extends ImmutableComponent {
     const noParentItems = this.bookmarks
       .filter((bookmark) => !bookmark.get('parentFolderId'))
     let widthAccountedFor = 0
-    const overflowButtonWidth = 25
+    const overflowButtonWidth = 15
 
     // Dynamically calculate how many bookmark items should appear on the toolbar
     // before it is actually rendered.
@@ -305,8 +305,7 @@ class BookmarksToolbar extends ImmutableComponent {
       this.root = window.getComputedStyle(document.querySelector(':root'))
       this.maxWidth = Number.parseInt(this.root.getPropertyValue('--bookmark-item-max-width'), 10)
       this.padding = Number.parseInt(this.root.getPropertyValue('--bookmark-item-padding'), 10) * 2
-      // Toolbar padding is only on the left
-      this.toolbarPadding = Number.parseInt(this.root.getPropertyValue('--bookmarks-toolbar-padding'), 10)
+      this.toolbarPadding = Number.parseInt(this.root.getPropertyValue('--bookmarks-toolbar-padding'), 10) * 2
       this.bookmarkItemMargin = Number.parseInt(this.root.getPropertyValue('--bookmark-item-margin'), 10) * 2
       // No margin for show only favicons
       this.chevronMargin = Number.parseInt(this.root.getPropertyValue('--bookmark-item-chevron-margin'), 10)
@@ -319,7 +318,7 @@ class BookmarksToolbar extends ImmutableComponent {
 
     // Loop through until we fill up the entire bookmark toolbar width
     let i
-    for (i = 0; i < noParentItems.size; i++) {
+    for (i = 0; i < noParentItems.size; ++i) {
       let iconWidth = props.showFavicon ? iconSize : 0
       // font-awesome file icons are 3px smaller
       if (props.showFavicon && !noParentItems.getIn([i, 'folderId']) && !noParentItems.getIn([i, 'favicon'])) {

--- a/less/bookmarksToolbar.less
+++ b/less/bookmarksToolbar.less
@@ -11,6 +11,7 @@
   --bookmark-item-chevron-margin: 4px;
   --bookmark-item-font-size: 16px;
   --bookmarks-toolbar-padding: 10px;
+  --bookmark-item-show-only-favicon-max-width: 24px;
 }
 
 .bookmarksToolbar {
@@ -79,6 +80,7 @@
     &.showOnlyFavicon {
       padding: 2px 4px;
       margin: auto 0px;
+      max-width: var(--bookmark-item-show-only-favicon-max-width);
 
       .bookmarkFavicon, .bookmarkFile {
         margin-right: 0px;
@@ -127,11 +129,18 @@
   }
 
   .overflowIndicator {
-    padding-left: 6px;
-    padding-right: 11px;
+    padding-right: 3px;
     margin-left: auto;
     margin-right: 0;
     margin-bottom: auto;
     margin-top: auto;
+    display: flex;
+    flex-grow: 0.1;
+    justify-content: flex-end;
+  }
+
+  .showOnlyFavicon + .overflowIndicator {
+    // If we're seeing only favicons, add an extra gutter for our » arrow
+    padding-right: 12px;
   }
 }


### PR DESCRIPTION
Auditors: @bbondy 

Fix: #4116

Test Plan:
- Open Brave with Bookmarks toolbar enabled;
- Resize the window horizontally
- Check that our » (_view more_ bookmarks button) don't disappear;
- Check that bookmarks are added on blank spaces, as window gets wider;
- Check that there's shouldn't have any UI breaks/unaligned items;
- They should work flawlessly with our three options for bookmarks:
  - No favicons
  - With favicons
  - Only favicons
