### PR TITLE
Allow about pages to reload and clone

### DIFF
--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -130,7 +130,7 @@ class NavigationBar extends ImmutableComponent {
         }
       <div className='startButtons'>
         {
-          isSourceAboutUrl(this.props.location) || this.titleMode
+          this.titleMode
           ? null
           : this.loading
             ? <Button iconClass='fa-times'

--- a/js/state/frameStateUtil.js
+++ b/js/state/frameStateUtil.js
@@ -246,6 +246,7 @@ function cloneFrame (frameOpts, guestInstanceId) {
   clone.location = 'about:blank'
   clone.src = 'about:blank'
   clone.parentFrameKey = frameOpts.key
+  clone.aboutDetails = frameOpts.aboutDetails
   return clone
 }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #2826

Auditors: @bridiver, @bbondy

Test Plan:
1. Generate any error pages(connection error, cert error, ...)
2. Clone/Reload should work properly

1. Go to any about pages
2. Clone/Reload should work properly