### PR TITLE
fix Brave crash on confirm bug

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -384,6 +384,15 @@ app.on('ready', () => {
     }
     buttons = ['OK', 'Cancel']
     cancelId = 1
+
+    if (typeof message === 'number') {
+      message = '' + message
+    }
+
+    if (typeof title === 'number') {
+      title = '' + title
+    }
+
     event.returnValue = !dialog.showMessageBox(BrowserWindow.getFocusedWindow(), {
       message: message,
       title: title,


### PR DESCRIPTION
for your consideration, just one way to fix this

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist. #4883 
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Open Brave
2. Visit http://pentesting.x10host.com (entire page content is: `<script>confirm(1)</script>`)
3. Observe that Brave does not crash, and confirm dialog with message content "1" is displayed.

Fix:
- `dialog.showMessageBox` requires that the message and title arguments are strings
- if they are numbers instead, they're now coerced to strings before passing them to `showMessageBox`