### PR TITLE
Fix Brave crashing on confirm bug

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -368,6 +368,7 @@ app.on('ready', () => {
     }
     buttons = ['OK']
     message = message ? message.toString() : ''
+    title = title ? title.toString() : ''
     dialog.showMessageBox(BrowserWindow.getFocusedWindow(), {
       message: message,
       title: title,
@@ -384,6 +385,7 @@ app.on('ready', () => {
     }
     buttons = ['OK', 'Cancel']
     message = message ? message.toString() : ''
+    title = title ? title.toString() : ''
     cancelId = 1
     event.returnValue = !dialog.showMessageBox(BrowserWindow.getFocusedWindow(), {
       message: message,

--- a/app/index.js
+++ b/app/index.js
@@ -363,9 +363,7 @@ app.on('ready', () => {
   ipcMain.removeAllListeners('window-alert')
   ipcMain.on('window-alert', function (event, message, title) {
     var buttons
-    if (title == null) {
-      title = ''
-    }
+
     buttons = ['OK']
     message = message ? message.toString() : ''
     title = title ? title.toString() : ''
@@ -380,9 +378,7 @@ app.on('ready', () => {
   ipcMain.removeAllListeners('window-confirm')
   ipcMain.on('window-confirm', function (event, message, title) {
     var buttons, cancelId
-    if (title == null) {
-      title = ''
-    }
+
     buttons = ['OK', 'Cancel']
     message = message ? message.toString() : ''
     title = title ? title.toString() : ''

--- a/app/index.js
+++ b/app/index.js
@@ -383,6 +383,7 @@ app.on('ready', () => {
       title = ''
     }
     buttons = ['OK', 'Cancel']
+    message = message ? message.toString() : ''
     cancelId = 1
     event.returnValue = !dialog.showMessageBox(BrowserWindow.getFocusedWindow(), {
       message: message,


### PR DESCRIPTION
(Realized that this can be solved with exactly what @bridiver did for alerts in #4798, just copied for confirm dialog, so replacing previous PR I had with @bridiver's sol'n)

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist. #4883 
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Open Brave
2. Visit http://pentesting.x10host.com (entire page content is: `<script>confirm(1)</script>`, so can test with `data:text/html,<script>confirm(1)</script>` as well)
3. Observe that Brave does not crash, and confirm dialog with message content "1" is displayed.

Fix:
- `dialog.showMessageBox` requires that the message and title arguments are strings
- make sure that when `message` is a  number (or other non-string type) it is coerced to a string
- exact same change as what @bridiver did for alerts in #4798, but for confirm dialog

fixes #4883