### PR TITLE
Caption buttons are no longer tab focusable

### DIFF
--- a/app/renderer/components/windowCaptionButtons.js
+++ b/app/renderer/components/windowCaptionButtons.js
@@ -49,12 +49,15 @@ class WindowCaptionButtons extends ImmutableComponent {
   }
 
   render () {
+    const props = { tabIndex: -1 }
+
     return <div className={cx({
       fullscreen: this.props.windowMaximized,
       windowCaptionButtons: true
     })}>
       <div className='container'>
         <button
+          {...props}
           className={cx({
             fullscreen: this.props.windowMaximized,
             captionButton: true,
@@ -65,6 +68,7 @@ class WindowCaptionButtons extends ImmutableComponent {
           <div className='widget' />
         </button>
         <button
+          {...props}
           className={cx({
             fullscreen: this.props.windowMaximized,
             captionButton: true,
@@ -79,6 +83,7 @@ class WindowCaptionButtons extends ImmutableComponent {
           </div>
         </button>
         <button
+          {...props}
           className={cx({
             fullscreen: this.props.windowMaximized,
             captionButton: true,


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes https://github.com/brave/browser-laptop/issues/4846

Auditors: @bbondy

Test plan:
1. Launch Brave on Windows and set focus to URL bar
2. Press tab to move focus and hit enter
3. Window should not minimize, maximize, or close (focus should have went
to the page)