### PR TITLE
Do not use default setting when value is false

### DIFF
--- a/js/settings.js
+++ b/js/settings.js
@@ -60,7 +60,7 @@ const resolveValue = (settingKey, settingsCollection) => {
 
 module.exports.getSetting = (settingKey, settingsCollection) => {
   const setting = resolveValue(settingKey, settingsCollection)
-  if (setting) return setting
+  if (typeof setting !== 'undefined') return setting
   return getDefaultSetting(settingKey, settingsCollection)
 }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #4903

Auditors: @bbondy

Test Plan:
1. Turn on/off "Always show the URL bar" in about:preferences#general
2. The title mode should work as expected