### PR TITLE
History page now properly opens new tab w/ link that was clicked

### DIFF
--- a/js/about/history.js
+++ b/js/about/history.js
@@ -55,8 +55,8 @@ class HistoryTimeCell extends ImmutableComponent {
 class HistoryDay extends ImmutableComponent {
   navigate (entry) {
     aboutActions.newFrame({
-      location: entry.location,
-      partitionNumber: entry.partitionNumber
+      location: entry.get('location'),
+      partitionNumber: entry.get('partitionNumber')
     })
   }
   render () {

--- a/test/about/historyTest.js
+++ b/test/about/historyTest.js
@@ -9,11 +9,14 @@ describe('about:history', function () {
   Brave.beforeAll(this)
 
   before(function * () {
+    const page1 = Brave.server.url('page1.html')
+
     yield this.app.client
       .waitForUrl(Brave.newTabUrl)
       .waitForBrowserWindow()
       .waitForVisible(urlInput)
       .windowByUrl(Brave.browserWindowUrl)
+      .addSite({ location: page1, title: 'Page 1' })
       .addSite({ location: 'https://brave.com', title: 'Brave' })
       .addSite({ location: 'https://brave.com/test', customTitle: 'customTest' })
       .addSite({ location: 'https://www.youtube.com' })
@@ -39,79 +42,99 @@ describe('about:history', function () {
       .waitForVisible('table.sortableTable thead tr th.sort-up div[data-l10n-id="time"]')
   })
 
-  // Multi Select
-  it('Simulate cmd/control click behavior', function * () {
-    yield this.app.client
-      .tabByUrl(aboutHistoryUrl)
-      .click('table.sortableTable td.title[data-sort="Brave"]')
-      .isDarwin().then((val) => {
-        if (val === true) {
-          return this.app.client.keys(Brave.keys.COMMAND)
-        } else {
-          return this.app.client.keys(Brave.keys.CONTROL)
-        }
-      })
-      .click('table.sortableTable td.title[data-sort="https://www.youtube.com"]')
-      .waitForVisible('table.sortableTable tr.selected td.title[data-sort="Brave"]')
-      .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://www.youtube.com"]')
-      .waitForVisible('table.sortableTable td.title[data-sort="https://brave.com/test"]')
-      // key depressed
-      .isDarwin().then((val) => {
-        if (val === true) {
-          return this.app.client.keys(Brave.keys.COMMAND)
-        } else {
-          return this.app.client.keys(Brave.keys.CONTROL)
-        }
-      })
-      .click('table.sortableTable td.title[data-sort="https://www.facebook.com"]')
-      .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://www.facebook.com"]')
-      .waitForVisible('table.sortableTable td.title[data-sort="https://brave.com/test"]')
-      .waitForVisible('table.sortableTable td.title[data-sort="Brave"]')
-      .waitForVisible('table.sortableTable td.title[data-sort="https://www.youtube.com"]')
-      // reset state
-      .click('table.sortableTable td.title[data-sort="https://www.facebook.com"]')
-      .waitForVisible('table.sortableTable td.title[data-sort="https://www.facebook.com"]')
+  describe('double click', function () {
+    it('opens a new tab with the location of the entry when double clicked', function * () {
+      const page1 = Brave.server.url('page1.html')
+
+      yield this.app.client
+        .tabByUrl(aboutHistoryUrl)
+        .doubleClick('table.sortableTable td.title[data-sort="Page 1"]')
+        .waitUntil(function () {
+          return this.getTabCount().then((count) => {
+            return count === 2
+          })
+        })
+        .waitForUrl(page1)
+        .tabByIndex(0)
+    })
   })
-  it('Simulate shift click behavior', function * () {
-    yield this.app.client
-      .tabByUrl(aboutHistoryUrl)
-      .click('table.sortableTable td.title[data-sort="Brave"]')
-      .keys(Brave.keys.SHIFT)
-      .click('table.sortableTable td.title[data-sort="https://www.youtube.com"]')
-      .waitForVisible('table.sortableTable tr.selected td.title[data-sort="Brave"]')
-      .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://www.youtube.com"]')
-      .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://brave.com/test"]')
-      .waitForVisible('table.sortableTable td.title[data-sort="https://www.facebook.com"]')
-      // key depressed
-      .keys(Brave.keys.SHIFT)
-      .click('table.sortableTable td.title[data-sort="https://www.facebook.com"]')
-      .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://www.facebook.com"]')
-      .isDarwin().then((val) => {
-        if (val === true) {
-          return this.app.client.keys(Brave.keys.COMMAND)
-        } else {
-          return this.app.client.keys(Brave.keys.CONTROL)
-        }
-      })
-      .click('table.sortableTable td.title[data-sort="https://www.youtube.com"]')
-      .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://www.youtube.com"]')
-      // key depressed
-      .isDarwin().then((val) => {
-        if (val === true) {
-          return this.app.client.keys(Brave.keys.COMMAND)
-        } else {
-          return this.app.client.keys(Brave.keys.CONTROL)
-        }
-      })
-      .keys(Brave.keys.SHIFT)
-      .click('table.sortableTable td.title[data-sort="Brave"]')
-      .waitForVisible('table.sortableTable tr.selected td.title[data-sort="Brave"]')
-      .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://www.youtube.com"]')
-      .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://brave.com/test"]')
-      .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://www.facebook.com"]')
-      // reset state
-      // key depressed
-      .keys(Brave.keys.SHIFT)
-      .click('table.sortableTable td.title[data-sort="Brave"]')
+
+  describe('multi-select', function () {
+    it('selects multiple rows when clicked with cmd/control', function * () {
+      yield this.app.client
+        .tabByUrl(aboutHistoryUrl)
+        .loadUrl(aboutHistoryUrl)
+        .click('table.sortableTable td.title[data-sort="Brave"]')
+        .isDarwin().then((val) => {
+          if (val === true) {
+            return this.app.client.keys(Brave.keys.COMMAND)
+          } else {
+            return this.app.client.keys(Brave.keys.CONTROL)
+          }
+        })
+        .click('table.sortableTable td.title[data-sort="https://www.youtube.com"]')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="Brave"]')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://www.youtube.com"]')
+        .waitForVisible('table.sortableTable td.title[data-sort="https://brave.com/test"]')
+        // key depressed
+        .isDarwin().then((val) => {
+          if (val === true) {
+            return this.app.client.keys(Brave.keys.COMMAND)
+          } else {
+            return this.app.client.keys(Brave.keys.CONTROL)
+          }
+        })
+        .click('table.sortableTable td.title[data-sort="https://www.facebook.com"]')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://www.facebook.com"]')
+        .waitForVisible('table.sortableTable td.title[data-sort="https://brave.com/test"]')
+        .waitForVisible('table.sortableTable td.title[data-sort="Brave"]')
+        .waitForVisible('table.sortableTable td.title[data-sort="https://www.youtube.com"]')
+        // reset state
+        .click('table.sortableTable td.title[data-sort="https://www.facebook.com"]')
+        .waitForVisible('table.sortableTable td.title[data-sort="https://www.facebook.com"]')
+    })
+    it('selects multiple contiguous rows when shift clicked', function * () {
+      yield this.app.client
+        .tabByUrl(aboutHistoryUrl)
+        .loadUrl(aboutHistoryUrl)
+        .click('table.sortableTable td.title[data-sort="Brave"]')
+        .keys(Brave.keys.SHIFT)
+        .click('table.sortableTable td.title[data-sort="https://www.youtube.com"]')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="Brave"]')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://www.youtube.com"]')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://brave.com/test"]')
+        .waitForVisible('table.sortableTable td.title[data-sort="https://www.facebook.com"]')
+        // key depressed
+        .keys(Brave.keys.SHIFT)
+        .click('table.sortableTable td.title[data-sort="https://www.facebook.com"]')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://www.facebook.com"]')
+        .isDarwin().then((val) => {
+          if (val === true) {
+            return this.app.client.keys(Brave.keys.COMMAND)
+          } else {
+            return this.app.client.keys(Brave.keys.CONTROL)
+          }
+        })
+        .click('table.sortableTable td.title[data-sort="https://www.youtube.com"]')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://www.youtube.com"]')
+        // key depressed
+        .isDarwin().then((val) => {
+          if (val === true) {
+            return this.app.client.keys(Brave.keys.COMMAND)
+          } else {
+            return this.app.client.keys(Brave.keys.CONTROL)
+          }
+        })
+        .keys(Brave.keys.SHIFT)
+        .click('table.sortableTable td.title[data-sort="Brave"]')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="Brave"]')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://www.youtube.com"]')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://brave.com/test"]')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="https://www.facebook.com"]')
+        // reset state
+        // key depressed
+        .keys(Brave.keys.SHIFT)
+        .click('table.sortableTable td.title[data-sort="Brave"]')
+    })
   })
 })


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes https://github.com/brave/browser-laptop/issues/4909

Auditors: @darkdh

Test Plan:
1. Launch Brave and visit a few sites
2. Visit about:history
3. Double click one of the entries and confirm it opens the location in a new tab