### PR TITLE
Move bookmark hanger arrow now that reload is on about pages

### DIFF
--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -122,9 +122,7 @@ class NavigationBar extends ImmutableComponent {
           originalDetail={this.props.bookmarkDetail.get('originalDetail')}
           destinationDetail={this.props.bookmarkDetail.get('destinationDetail')}
           shouldShowLocation={this.props.bookmarkDetail.get('shouldShowLocation')}
-          withStopButton={!isSourceAboutUrl(this.props.location)}
           withHomeButton={getSetting(settings.SHOW_HOME_BUTTON)}
-          withoutButtons={isSourceAboutUrl(this.props.location) && !getSetting(settings.SHOW_HOME_BUTTON)}
           />
         : null
         }
@@ -155,9 +153,7 @@ class NavigationBar extends ImmutableComponent {
             navbutton: true,
             bookmarkButton: true,
             removeBookmarkButton: this.bookmarked,
-            withStopButton: !isSourceAboutUrl(this.props.location),
-            withHomeButton: getSetting(settings.SHOW_HOME_BUTTON),
-            withoutButtons: isSourceAboutUrl(this.props.location) && !getSetting(settings.SHOW_HOME_BUTTON)
+            withHomeButton: getSetting(settings.SHOW_HOME_BUTTON)
           })}
           l10nId={this.bookmarked ? 'removeBookmarkButton' : 'addBookmarkButton'}
           onClick={this.onToggleBookmark} />

--- a/less/forms.less
+++ b/less/forms.less
@@ -429,14 +429,8 @@
       bottom: 10px;
       left: 37px;
 
-      &.withoutButtons {
-        left: 6px;
-      }
-
-      &.withStopButton {
-        &.withHomeButton {
-          left: 67px;
-        }
+      &.withHomeButton {
+        left: 67px;
       }
     }
 

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -641,10 +641,6 @@
       line-height: 25px;
       margin-top: 2px;
       margin-right: -2px;
-
-      &.withoutButtons {
-        margin-bottom: 2px;
-      }
     }
   }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #4923

Auditors @bsclifton @darkdh 

Test Plan:

Make sure the new bookmark UI's arrow on the top lines up with the star in all situations.

