### PR TITLE
URL input field on the bookmark pulldown disappears

### DIFF
--- a/js/components/addEditBookmark.js
+++ b/js/components/addEditBookmark.js
@@ -86,11 +86,11 @@ class AddEditBookmark extends ImmutableComponent {
       currentDetail = currentDetail.set('customTitle', e.target.value)
     }
 
-    windowActions.setBookmarkDetail(currentDetail, this.props.originalDetail, this.props.destinationDetail)
+    windowActions.setBookmarkDetail(currentDetail, this.props.originalDetail, this.props.destinationDetail, this.props.shouldShowLocation)
   }
   onLocationChange (e) {
     const currentDetail = this.props.currentDetail.set('location', e.target.value)
-    windowActions.setBookmarkDetail(currentDetail, this.props.originalDetail, this.props.destinationDetail)
+    windowActions.setBookmarkDetail(currentDetail, this.props.originalDetail, this.props.destinationDetail, this.props.shouldShowLocation)
   }
   onParentFolderChange (e) {
     const currentDetail = this.props.currentDetail.set('parentFolderId', Number(e.target.value))


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #4897

Auditors @luixxiul @bbondy 

Test Plan:

To test, make sure that after clicking the star in the URLbar (both on a currently bookmarked and currently not bookmarked page) you can edit both the name and location without the form changing (i.e the location field disappearing)
