### PR TITLE
Import favicon fix:

### DIFF
--- a/app/importer.js
+++ b/app/importer.js
@@ -171,16 +171,21 @@ importer.on('add-bookmarks', (e, bookmarks, topLevelFolder) => {
 importer.on('add-favicons', (e, detail) => {
   let faviconMap = {}
   detail.forEach((entry) => {
-    if (entry.favicon_url.startsWith('made-up-favicon:')) {
-      faviconMap[entry.urls[0]] = entry.png_data
+    if (entry.favicon_url.includes('made-up-favicon')) {
+      for (let url of entry.urls) {
+        faviconMap[url] = entry.png_data
+      }
     } else {
-      faviconMap[entry.urls[0]] = entry.favicon_url
+      for (let url of entry.urls) {
+        faviconMap[url] = entry.favicon_url
+      }
     }
   })
   let sites = AppStore.getState().get('sites')
   sites = sites.map((site) => {
-    if (site.get('favicon') === undefined && site.get('location') !== undefined &&
-      faviconMap[site.get('location')] !== undefined) {
+    if ((site.get('favicon') === undefined && site.get('location') !== undefined &&
+      faviconMap[site.get('location')] !== undefined) ||
+      (site.get('favicon') !== undefined && site.get('favicon').includes('made-up-favicon'))) {
       return site.set('favicon', faviconMap[site.get('location')])
     } else {
       return site


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

1. Iterate all urls using the favicon
2. Adjust made-up-favicon condition and override old made-up-favicon url

fix #4882

Auditors: @bridiver, @bbondy

Test Plan:
1. Import bookmarks from firefox on brave 0.12.3
2. Import bookmarks from firefox on brave contains this commit
3. The bookmarks under "Mozilla Firefox" should have favicons

1. Import bookmarks from any browsers
2. The imported bookmarks should have favicons

1. Import bookmarks from html bookmarks file
2. The imported bookmarks should have favicons