### PR TITLE
Delete "defaultBrowserCheckComplete" only when check on startup is on

### DIFF
--- a/app/renderer/components/checkDefaultBrowserDialog.js
+++ b/app/renderer/components/checkDefaultBrowserDialog.js
@@ -26,11 +26,13 @@ class CheckDefaultBrowserDialog extends ImmutableComponent {
     appActions.defaultBrowserUpdated(false)
     appActions.defaultBrowserCheckComplete()
     appActions.changeSetting(settings.CHECK_DEFAULT_ON_STARTUP, this.props.checkDefaultOnStartup)
+    this.props.onHide()
   }
   onUseBrave () {
     appActions.defaultBrowserUpdated(true)
     appActions.defaultBrowserCheckComplete()
     appActions.changeSetting(settings.CHECK_DEFAULT_ON_STARTUP, this.props.checkDefaultOnStartup)
+    this.props.onHide()
   }
   render () {
     return <Dialog className='checkDefaultBrowserDialog' >

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -234,8 +234,10 @@ module.exports.cleanAppData = (data, isShutdown) => {
   data.temporarySiteSettings = {}
   // Delete Flash state since this is checked on startup
   delete data.flashInitialized
-  // Delete defaultBrowserCheckComplete state since this is checked on startup
-  delete data.defaultBrowserCheckComplete
+  if (data.settings[settings.CHECK_DEFAULT_ON_STARTUP] === true) {
+    // Delete defaultBrowserCheckComplete state since this is checked on startup
+    delete data.defaultBrowserCheckComplete
+  }
   // Delete Recovery status on shut down
   try {
     delete data.ui.about.preferences.recoverySucceeded


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #4934

Auditors: @bbondy

Test Plan:
1. Turn off always check on startup
2. Close app
3. Open app
4. Go to preferences
5. Toggle the switch for always check on startup