### PR TITLE
Split apart "always show bookmarks toolbar" and the bookmarks toolbar display mode

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -616,7 +616,6 @@ class GeneralTab extends ImmutableComponent {
     const homepageValue = getSetting(settings.HOMEPAGE, this.props.settings)
     const homepage = homepageValue && homepageValue.trim()
     const disableShowHomeButton = !homepage || !homepage.length
-    const disableBookmarksBarSelect = !getSetting(settings.SHOW_BOOKMARKS_TOOLBAR, this.props.settings)
     const defaultLanguage = this.props.languageCodes.find((lang) => lang.includes(navigator.language)) || 'en-US'
     const defaultBrowser = getSetting(settings.IS_DEFAULT_BROWSER, this.props.settings)
       ? <div className='sectionTitle' data-l10n-id='defaultBrowser' />
@@ -652,7 +651,6 @@ class GeneralTab extends ImmutableComponent {
         <SettingCheckbox dataL10nId='disableTitleMode' prefKey={settings.DISABLE_TITLE_MODE} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
         <SettingItem dataL10nId='bookmarkToolbarSettings'>
           <select id='bookmarksBarSelect' value={getSetting(settings.BOOKMARKS_TOOLBAR_MODE, this.props.settings)}
-            disabled={disableBookmarksBarSelect}
             onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.BOOKMARKS_TOOLBAR_MODE)} >
             <option data-l10n-id='bookmarksBarTextOnly' value={bookmarksToolbarMode.TEXT_ONLY} />
             <option data-l10n-id='bookmarksBarTextAndFavicon' value={bookmarksToolbarMode.TEXT_AND_FAVICONS} />


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Split apart "always show bookmarks toolbar" and the bookmarks toolbar display mode

Fixes https://github.com/brave/browser-laptop/issues/4936

Auditors: @bbondy

Test Plan:
1. Launch Brave and open Preferences
2. Verify you can toggle "always show bookmarks toolbar" and not have the drop down above be affected