### PR TITLE
Improve UX of default browser check and Manage Adblock Setting button

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -618,12 +618,11 @@ class GeneralTab extends ImmutableComponent {
     const disableShowHomeButton = !homepage || !homepage.length
     const defaultLanguage = this.props.languageCodes.find((lang) => lang.includes(navigator.language)) || 'en-US'
     const defaultBrowser = getSetting(settings.IS_DEFAULT_BROWSER, this.props.settings)
-      ? <div className='sectionTitle' data-l10n-id='defaultBrowser' />
-      : <div>
-        <div className='sectionTitle' data-l10n-id='notDefaultBrowser' />
+      ? <SettingItem dataL10nId='defaultBrowser' />
+      : <SettingItem dataL10nId='notDefaultBrowser' >
         <Button l10nId='setAsDefault' className='primaryButton setAsDefaultButton'
           onClick={this.setAsDefaultBrowser} />
-      </div>
+      </SettingItem>
 
     return <SettingsList>
       <div className='sectionTitle' data-l10n-id='generalSettings' />
@@ -670,11 +669,11 @@ class GeneralTab extends ImmutableComponent {
           <Button l10nId='importNow' className='primaryButton importNowButton'
             onClick={this.importBrowserDataNow} />
         </SettingItem>
-      </SettingsList>
-      <SettingsList>
         {defaultBrowser}
-        <SettingCheckbox dataL10nId='checkDefaultOnStartup' prefKey={settings.CHECK_DEFAULT_ON_STARTUP}
-          settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
+        <SettingItem>
+          <SettingCheckbox dataL10nId='checkDefaultOnStartup' prefKey={settings.CHECK_DEFAULT_ON_STARTUP}
+            settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
+        </SettingItem>
       </SettingsList>
     </SettingsList>
   }

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -372,6 +372,8 @@ span.browserButton.primaryButton {
 
   &.clearBrowsingDataButton,
   &.importNowButton,
+  &.setAsDefaultButton,
+  &.manageAdblockSettings,
   &.manageAutofillDataButton {
     font-size: 0.9em;
     margin-top: 20px;
@@ -379,6 +381,10 @@ span.browserButton.primaryButton {
   }
 
   &.importNowButton {
+    margin-top: 5px;
+  }
+
+  &.setAsDefaultButton {
     margin-top: 5px;
   }
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #4935

Auditors: @bbondy

Test Plan: N/A

Screen shots
---
![screen shot 2016-10-19 at 10 27 37](https://cloud.githubusercontent.com/assets/11330831/19522989/2052dafc-95e7-11e6-8e36-6a62e0d1f599.png)
![screen shot 2016-10-19 at 10 31 38](https://cloud.githubusercontent.com/assets/11330831/19523033/4608331e-95e7-11e6-972e-5f4bf5a72f1c.png)

![screen shot 2016-10-19 at 10 27 57](https://cloud.githubusercontent.com/assets/11330831/19522987/20379f62-95e7-11e6-9fcb-9a5eb9a8541c.png)
