### PR TITLE
Normalize the location string for a history item by removing the www. before sorting

### DIFF
--- a/app/renderer/lib/suggestion.js
+++ b/app/renderer/lib/suggestion.js
@@ -99,3 +99,13 @@ module.exports.simpleDomainNameValue = (site) => {
     return 0
   }
 }
+
+/*
+ * Normalize a location for url suggestion sorting
+ *
+ * @param {string} location - history item location
+ *
+ */
+module.exports.normalizeLocation = (location) => {
+  return location.replace(/www\./, '')
+}

--- a/js/components/urlBarSuggestions.js
+++ b/js/components/urlBarSuggestions.js
@@ -248,8 +248,10 @@ class UrlBarSuggestions extends ImmutableComponent {
       })
 
     const sortBasedOnLocationPos = (s1, s2) => {
-      const pos1 = s1.get('location').indexOf(urlLocationLower)
-      const pos2 = s2.get('location').indexOf(urlLocationLower)
+      const location1 = suggestion.normalizeLocation(s1.get('location'))
+      const location2 = suggestion.normalizeLocation(s2.get('location'))
+      const pos1 = location1.indexOf(urlLocationLower)
+      const pos2 = location2.indexOf(urlLocationLower)
       if (pos1 === -1 && pos2 === -1) {
         return 0
       } else if (pos1 === -1) {

--- a/test/unit/lib/urlSuggestionTest.js
+++ b/test/unit/lib/urlSuggestionTest.js
@@ -8,6 +8,11 @@ require('../braveUnit')
 const AGE_DECAY = 50
 
 describe('suggestion', function () {
+  it('normalizes location', function () {
+    assert.ok(suggestion.normalizeLocation('https://www.site.com') === 'https://site.com', 'www. prefix removed')
+    assert.ok(suggestion.normalizeLocation('http://site.com') === 'http://site.com', 'location not modified')
+  })
+
   it('sorts sites correctly', function () {
     assert.ok(suggestion.sortingPriority(10, 100, 50, AGE_DECAY) > suggestion.sortingPriority(10, 100, 40, AGE_DECAY), 'newer sites with equal access counts sort earlier')
     assert.ok(suggestion.sortingPriority(10, 100, 50, AGE_DECAY) < suggestion.sortingPriority(11, 100, 40, AGE_DECAY), 'Sites with higher access counts sort earlier (unless time delay overriden)')
@@ -21,4 +26,3 @@ describe('suggestion', function () {
     assert.ok(suggestion.simpleDomainNameValue(siteComplex) === 0, 'complex site returns 0')
   })
 })
-


### PR DESCRIPTION
- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bbondy

Test Plan:

  1. Clear session file
  2. Visit twitter.com once
  3. Visit twilio.com once
  4. Close both tabs
  5. Open a new tab and enter the string 'twi'
  6. Ensure www.twilio.com is the first entry (as it was visited most recently and has the same visit count value)

Fixes: #4955