### PR TITLE
default browser check should run only on release build

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -444,9 +444,18 @@ app.on('ready', () => {
     }
     process.emit(messages.APP_INITIALIZED)
 
-    // Default browser checking
-    let isDefaultBrowser = defaultProtocols.every(p => app.isDefaultProtocolClient(p))
-    appActions.changeSetting(settings.IS_DEFAULT_BROWSER, isDefaultBrowser)
+    if (process.env.BRAVE_IS_DEFAULT_BROWSER !== undefined) {
+      if (process.env.BRAVE_IS_DEFAULT_BROWSER === 'true') {
+        appActions.changeSetting(settings.IS_DEFAULT_BROWSER, true)
+      } else if (process.env.BRAVE_IS_DEFAULT_BROWSER === 'false') {
+        appActions.changeSetting(settings.IS_DEFAULT_BROWSER, false)
+      }
+    } else {
+      // Default browser checking
+      let isDefaultBrowser = ['development', 'test'].includes(process.env.NODE_ENV)
+        ? true : defaultProtocols.every(p => app.isDefaultProtocolClient(p))
+      appActions.changeSetting(settings.IS_DEFAULT_BROWSER, isDefaultBrowser)
+    }
 
     if (CmdLine.newWindowURL) {
       appActions.newWindow(Immutable.fromJS({


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #4958

Auditors: @bridiver, @bbondy

Test Plan:
1. Make sure there is no session data
2. npm run start/test should not popup the check default browser modal
and overrides brave as default browser.
3. BRAVE_IS_DEFAULT_BROWSER=true npm run start/test should not popup the check default browser modal
and overrides brave as default browser.
4. BRAVE_IS_DEFAULT_BROWSER=false npm run start/test should popup the check default browser modal
and overrides brave not be default browser.