### PR TITLE
Fix default setting behavior for getSetting()

### DIFF
--- a/js/constants/settings.js
+++ b/js/constants/settings.js
@@ -68,7 +68,7 @@ const settings = {
   ONE_PASSWORD_ENABLED: 'security.passwords.one-password-enabled',
   DASHLANE_ENABLED: 'security.passwords.dashlane-enabled',
   LAST_PASS_ENABLED: 'security.passwords.last-pass-enabled',
-  // > phased out with 0.12.5
+  // > phased out with 0.12.6
   SHOW_BOOKMARKS_TOOLBAR_FAVICON: 'bookmarks.toolbar.showFavicon',
   SHOW_BOOKMARKS_TOOLBAR_ONLY_FAVICON: 'bookmarks.toolbar.showOnlyFavicon'
 }

--- a/js/settings.js
+++ b/js/settings.js
@@ -60,7 +60,7 @@ const resolveValue = (settingKey, settingsCollection) => {
 
 module.exports.getSetting = (settingKey, settingsCollection) => {
   const setting = resolveValue(settingKey, settingsCollection)
-  if (typeof setting !== 'undefined') return setting
+  if (typeof setting !== 'undefined' && setting !== null) return setting
   return getDefaultSetting(settingKey, settingsCollection)
 }
 


### PR DESCRIPTION
I accidently introduced the bug here (merged into 0.12.6):
https://github.com/brave/browser-laptop/commit/889757e1c94433594112efac5a4baf6f2f3026df#commitcomment-19471078

The fix by @darkdh is correct, except password manager defaults to a null value (not undefined)
https://github.com/brave/browser-laptop/commit/10927580f0865cab2a7a6b7620d52417b185a071

This fix checks against undefined and null

Auditors: @darkdh @bbondy

Test Plan: run unit tests (most PW manager ones were failing)