### PR TITLE
Update frameKey in aboutDetails when clone about pages

### DIFF
--- a/js/state/frameStateUtil.js
+++ b/js/state/frameStateUtil.js
@@ -221,7 +221,7 @@ function getPartition (frameOpts) {
   return partition
 }
 
-function cloneFrame (frameOpts, guestInstanceId) {
+function cloneFrame (frameOpts, guestInstanceId, key) {
   const cloneableAttributes = [
     'audioMuted',
     'canGoBack',
@@ -246,7 +246,10 @@ function cloneFrame (frameOpts, guestInstanceId) {
   clone.location = 'about:blank'
   clone.src = 'about:blank'
   clone.parentFrameKey = frameOpts.key
-  clone.aboutDetails = frameOpts.aboutDetails
+  if (frameOpts.aboutDetails !== undefined) {
+    clone.aboutDetails = frameOpts.aboutDetails
+    clone.aboutDetails.frameKey = key
+  }
   return clone
 }
 

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -162,7 +162,7 @@ const addToHistory = (frameProps) => {
   return history.slice(-10)
 }
 
-const newFrame = (frameOpts, openInForeground, insertionIndex) => {
+const newFrame = (frameOpts, openInForeground, insertionIndex, nextKey) => {
   const frames = windowState.get('frames')
 
   if (frameOpts === undefined) {
@@ -187,7 +187,9 @@ const newFrame = (frameOpts, openInForeground, insertionIndex) => {
     }
   }
 
-  const nextKey = incrementNextKey()
+  if (nextKey === undefined) {
+    nextKey = incrementNextKey()
+  }
   let nextPartitionNumber = 0
   if (frameOpts.partitionNumber) {
     nextPartitionNumber = frameOpts.partitionNumber
@@ -434,9 +436,13 @@ const doAction = (action) => {
       newFrame(action.frameOpts, action.openInForeground)
       break
     case WindowConstants.WINDOW_CLONE_FRAME:
-      let insertionIndex = FrameStateUtil.findIndexForFrameKey(windowState.get('frames'), action.frameOpts.key) + 1
-      newFrame(FrameStateUtil.cloneFrame(action.frameOpts, action.guestInstanceId), action.openInForeground, insertionIndex)
-      break
+      {
+        let insertionIndex = FrameStateUtil.findIndexForFrameKey(windowState.get('frames'), action.frameOpts.key) + 1
+        const nextKey = incrementNextKey()
+        newFrame(FrameStateUtil.cloneFrame(action.frameOpts, action.guestInstanceId, nextKey),
+          action.openInForeground, insertionIndex, nextKey)
+        break
+      }
     case WindowConstants.WINDOW_CLOSE_FRAME:
       // Use the frameProps we passed in, or default to the active frame
       const frameProps = action.frameProps || FrameStateUtil.getActiveFrame(windowState)

--- a/test/unit/state/frameStateUtilTest.js
+++ b/test/unit/state/frameStateUtilTest.js
@@ -35,7 +35,16 @@ describe('frameStateUtil', function () {
         history: ['http://brave.com'],
         location: 'http://brave.com/about'
       }
+      this.aboutFrameOpts = {}
+      Object.assign(this.aboutFrameOpts, this.frameOpts)
+      this.aboutFrameOpts['aboutDetails'] =
+      {
+        errorCode: -1,
+        frameKey: 1
+      }
       this.clonedFrame = frameStateUtil.cloneFrame(this.frameOpts, 4)
+      this.key = 6
+      this.aboutClonedFrame = frameStateUtil.cloneFrame(this.aboutFrameOpts, 5, this.key)
     })
 
     it('does not copy the key', function () {
@@ -82,6 +91,15 @@ describe('frameStateUtil', function () {
       assert.equal(this.clonedFrame.computedThemeColor, 'aaaaaa')
       assert.deepEqual(this.clonedFrame.history, ['http://brave.com'])
       assert(this.clonedFrame.history !== this.frameOpts.history)
+    })
+
+    it('clone without aboutDetails', function () {
+      assert.equal(this.clonedFrame.aboutDetails, undefined)
+    })
+
+    it('copies aboutDetails with key', function () {
+      assert.equal(this.aboutClonedFrame.aboutDetails.errorCode, this.aboutFrameOpts.aboutDetails.errorCode)
+      assert.equal(this.aboutClonedFrame.aboutDetails.frameKey, this.key)
     })
   })
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #4984

Auditors: @bsclifton

Test Plan:
1. generate error page (ex. connection lost)
2. clone the error tab
3. retry on the cloned tab of step2
4. reload should happen on the cloned tab