### PR TITLE
Disable option to add a bookmark without location and a folder without a title.

### DIFF
--- a/js/components/addEditBookmark.js
+++ b/js/components/addEditBookmark.js
@@ -36,8 +36,9 @@ class AddEditBookmark extends ImmutableComponent {
     const title = this.props.currentDetail.get('title') || this.props.currentDetail.get('customTitle')
     const location = this.props.currentDetail.get('location')
 
-    return (typeof title === 'string' && title.trim().length > 0) ||
-      (!this.isFolder && typeof location === 'string' && location.trim().length > 0)
+    return this.isFolder
+      ? (typeof title === 'string' && title.trim().length > 0)
+      : (typeof title === 'string' && location.trim().length > 0)
   }
 
   get isFolder () {

--- a/less/button.less
+++ b/less/button.less
@@ -41,8 +41,10 @@ span.browserButton,
   }
 
   &[disabled] {
-    opacity: .25;
     pointer-events: none;
+    // prevent titleMode animation from overriding opacity
+    animation: none !important;
+    opacity: .25 !important;
   }
 
   &.smallButton {


### PR DESCRIPTION
Fix #5010

Auditors: @bsclifton

Test Plan:

1) Add a bookmark
2) Edit bookmark removing its location
3) "Done" button should be disabled

and:

1) Add a bookmark folder
2) Remove folder's title
3) "Done" button should be disabled
