### PR TITLE
Bookmark Icon position in title mode looks bad

### DIFF
--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -148,15 +148,19 @@ class NavigationBar extends ImmutableComponent {
             onClick={this.onHome} />
           : null
         }
-        <Button iconClass={this.bookmarked ? 'fa-star' : 'fa-star-o'}
-          className={cx({
-            navbutton: true,
-            bookmarkButton: true,
-            removeBookmarkButton: this.bookmarked,
-            withHomeButton: getSetting(settings.SHOW_HOME_BUTTON)
-          })}
-          l10nId={this.bookmarked ? 'removeBookmarkButton' : 'addBookmarkButton'}
-          onClick={this.onToggleBookmark} />
+        {
+          !this.titleMode
+          ? <Button iconClass={this.bookmarked ? 'fa-star' : 'fa-star-o'}
+            className={cx({
+              navbutton: true,
+              bookmarkButton: true,
+              removeBookmarkButton: this.bookmarked,
+              withHomeButton: getSetting(settings.SHOW_HOME_BUTTON)
+            })}
+            l10nId={this.bookmarked ? 'removeBookmarkButton' : 'addBookmarkButton'}
+            onClick={this.onToggleBookmark} />
+          : null
+        }
       </div>
       <UrlBar ref='urlBar'
         sites={this.props.sites}


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #4985

Auditors @bradleyrichter @bsclifton 

Test Plan:
<img width="159" alt="screen shot 2016-10-21 at 4 28 48 pm" src="https://cloud.githubusercontent.com/assets/490294/19614579/7df9d578-97ab-11e6-8291-f72215f51cb4.png">
<img width="395" alt="screen shot 2016-10-21 at 4 28 52 pm" src="https://cloud.githubusercontent.com/assets/490294/19614580/7dfba416-97ab-11e6-9fef-d7ddd321bbaf.png">

We decided just to hide the bookmark star on titlemode for now. It should show while editing and hide when you click away.

