### PR TITLE
Allow back/forward nav buttons to be draggable when disabled

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -535,15 +535,16 @@
     transition: margin @transitionDuration ease-in-out;
 
     span {
-      -webkit-app-region: no-drag;
       -webkit-user-select: none;
       color: @buttonColor;
+      cursor: default;
       border-radius: 4px;
       font-weight: 300;
       opacity: 0.2;
 
       &:not([disabled]) {
         opacity: 0.85;
+        -webkit-app-region: no-drag;
       }
 
       &:not([disabled]):hover {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Allow back/forward nav buttons to be draggable when disabled
Also fixes cursor when clicking and dragging when active (was showing text
selection cursor before)

Fixes https://github.com/brave/browser-laptop/issues/5044

Auditors: @bradleyrichter

Test Plan:
1. Launch Brave and open a new tab
2. Confirm you can drag window anywhere inside the back and forward buttons
3. Visit brave.com (back button becomes active)
4. Visit github.com and then hit the back button (forward button becomes active)
5. Confirm you cannot drag window by either back or forward button
6. Confirm this change does not interfere with the long press button (which shows history)
7. When doing steps 5/6, make sure cursor stays the default pointer and
doesn't change into the text selection cursor.