### PR TITLE
Removed draggable style from URL bar (was causing maximize w/ double …

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -617,11 +617,7 @@
   z-index: @zindexNavigationBar;
 
   form {
-    -webkit-app-region: drag;
-    // Disable window dragging so that selecting text and dragging the favicon is possible.
-    input, .urlbarIcon {
-      -webkit-app-region: no-drag;
-    }
+    -webkit-app-region: no-drag;
   }
 
   &:not(.titleMode) {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Removed draggable style from URL bar (was causing maximize w/ double click on Windows)

Fixes https://github.com/brave/browser-laptop/issues/4922

Auditors: @bbondy

Test plan:
1. Launch Brave on Windows and double click inside URL bar (ex: to left of
lock icon or on the time loaded)
2. Window should no longer maximize.
3. Lock icon is still drag/droppable onto bookmarks toolbar, etc.