### PR TITLE
Show bookmarks in history auto-complete

### DIFF
--- a/js/components/urlBarSuggestions.js
+++ b/js/components/urlBarSuggestions.js
@@ -297,8 +297,11 @@ class UrlBarSuggestions extends ImmutableComponent {
           const title = site.get('title') || ''
           const location = site.get('location') || ''
           return (title.toLowerCase().includes(urlLocationLower) ||
-            location.toLowerCase().includes(urlLocationLower)) &&
-            (!site.get('tags') || site.get('tags').size === 0)
+                  location.toLowerCase().includes(urlLocationLower))
+          // Note: Bookmkark sites are now included in history. This will allow
+          // sites to appear in the auto-complete regardless of their bookmark
+          // status. If history is turned off, bookmarked sites will appear
+          // in the bookmark section.
         }
       }))
     }


### PR DESCRIPTION
- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [X] Ran `git rebase -i` to squash commits (if needed).

Bookmark sites are by definition also history items. Removing them from the
history section of the auto-complete causes them not to be selected when
a matching auto-complete term is entered.

This commit fixes that behaviour.

Auditors: @bbondy
cc @bradleyrichter 

Test Plan: (Courtesy of @Sh1d0w)

  * Visit github.com several times and confirm it appears under History section in url bar suggestions
  * Bookmark it and confirm it properly appears under bookmarks section in url bar suggestions
  * Now from settings disable "Show bookmarks suggestions" for the autocomplete
  * Type github.com in the url bar and ensure it appears under history section as it should

Fixes: #5024