### PR TITLE
Handle different protocol prefixes in auto-suggest

### DIFF
--- a/app/renderer/lib/suggestion.js
+++ b/app/renderer/lib/suggestion.js
@@ -107,5 +107,8 @@ module.exports.simpleDomainNameValue = (site) => {
  *
  */
 module.exports.normalizeLocation = (location) => {
-  return location.replace(/www\./, '')
+  location = location.replace(/www\./, '')
+  location = location.replace(/^http:\/\//, '')
+  location = location.replace(/^https:\/\//, '')
+  return location
 }

--- a/js/constants/config.js
+++ b/js/constants/config.js
@@ -26,10 +26,10 @@ module.exports = {
   urlBarSuggestions: {
     maxOpenedFrames: 2,
     maxBookmarkSites: 2,
-    maxHistorySites: 2,
+    maxHistorySites: 3,
     maxAboutPages: 2,
     maxSearch: 3,
-    maxTopSites: 5
+    maxTopSites: 3
   },
   navigationBar: {
     defaultSearchSuggestions: false,

--- a/test/unit/lib/urlSuggestionTest.js
+++ b/test/unit/lib/urlSuggestionTest.js
@@ -9,8 +9,8 @@ const AGE_DECAY = 50
 
 describe('suggestion', function () {
   it('normalizes location', function () {
-    assert.ok(suggestion.normalizeLocation('https://www.site.com') === 'https://site.com', 'www. prefix removed')
-    assert.ok(suggestion.normalizeLocation('http://site.com') === 'http://site.com', 'location not modified')
+    assert.ok(suggestion.normalizeLocation('https://www.site.com') === 'site.com', 'www. prefix removed')
+    assert.ok(suggestion.normalizeLocation('http://site.com') === 'site.com', 'location not modified')
   })
 
   it('sorts sites correctly', function () {


### PR DESCRIPTION
- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Ran `git rebase -i` to squash commits (if needed).

  * Remove http and https from URLs when sorting
  * Increase history limit to 3, suggested to 3
  * Update unit tests

Auditors: @bbondy

Test Plan:

  1. Visit a mixture of sites that have a similar name (twitter.com, twilio.com) but have a different protocol prefix (http, https)
  2. Ensure that history sorting is entirely based on count and frequency
  3. Ensure that a maximum of 3 history items and 3 suggested sites are shown (so as not to overflow the space available and cause a scrollbar to appear)

Fixes: #5091