### PR TITLE
Default window position now recorded and used for new windows

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -125,6 +125,7 @@ module.exports.cleanPerWindowData = (perWindowData, isShutdown) => {
     }
     frame.key = newKey
     // Full history is not saved yet
+    // TODO (bsclifton): remove this when https://github.com/brave/browser-laptop/issues/963 is complete
     frame.canGoBack = false
     frame.canGoForward = false
 
@@ -473,6 +474,7 @@ module.exports.defaultAppState = () => {
         ignoredTopSites: [],
         pinnedTopSites: []
       }
-    }
+    },
+    defaultWindowParams: {}
   }
 }

--- a/docs/appActions.md
+++ b/docs/appActions.md
@@ -116,13 +116,15 @@ Dispatches a message to clear all completed downloads
 
 
 
-### setDefaultWindowSize(size) 
+### defaultWindowParamsChanged(size, position) 
 
-Sets the default window size
+Sets the default window size / position
 
 **Parameters**
 
 **size**: `Array`, [width, height]
+
+**position**: `Array`, [x, y]
 
 
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -121,8 +121,14 @@ AppStore
     enabled: boolean, // true if widevine is installed and enabled
     ready: boolean // true if widevine is in a ready state
   },
-  defaultWindowHeight: number,
-  defaultWindowWidth: number,
+  defaultWindowHeight: number, // DEPRECATED (0.12.7); replaced w/ defaultWindowParams.height
+  defaultWindowWidth: number, // DEPRECATED (0.12.7); replaced w/ defaultWindowParams.width
+  defaultWindowParams: {
+    height: number,
+    width: number,
+    x: number,
+    y: number
+  },
   updates: {
     status: string, // UpdateStatus from js/constants/updateStatus.js
     metadata: {

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -145,13 +145,15 @@ const appActions = {
   },
 
   /**
-   * Sets the default window size
+   * Sets the default window size / position
    * @param {Array} size - [width, height]
+   * @param {Array} position - [x, y]
    */
-  setDefaultWindowSize: function (size) {
+  defaultWindowParamsChanged: function (size, position) {
     AppDispatcher.dispatch({
-      actionType: AppConstants.APP_SET_DEFAULT_WINDOW_SIZE,
-      size
+      actionType: AppConstants.APP_DEFAULT_WINDOW_PARAMS_CHANGED,
+      size,
+      position
     })
   },
 

--- a/js/constants/appConstants.js
+++ b/js/constants/appConstants.js
@@ -18,7 +18,7 @@ const AppConstants = {
   APP_ADD_PASSWORD: _, /** @param {Object} passwordDetail */
   APP_REMOVE_PASSWORD: _, /** @param {Object} passwordDetail */
   APP_CLEAR_PASSWORDS: _,
-  APP_SET_DEFAULT_WINDOW_SIZE: _,
+  APP_DEFAULT_WINDOW_PARAMS_CHANGED: _,
   APP_SET_DATA_FILE_ETAG: _,
   APP_SET_DATA_FILE_LAST_CHECK: _,
   APP_SET_RESOURCE_ENABLED: _,


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Default window position now recorded and used for new windows
- renamed setDefaultWindowSize => defaultWindowParamsChanged
- created new state (code will backfill value by trying to read the new value and if null, then try the old value)
- defaultWindowParamsChanged now saves x/y and uses when creating window
- consolidated duplicate BrowserWindow event handlers from `appStore.js` in `main.js`
- window resize handler now has a sliding 1 second timer to avoid spamming events (causing extreme slowness)

Fixes https://github.com/brave/browser-laptop/issues/3754
Fixes https://github.com/brave/browser-laptop/issues/3247
Fixes https://github.com/brave/browser-laptop/issues/586

Auditors: @bridiver, @bbondy
cc: @BrendanEich (I know this one has got you a few times- should be g2g after this!)

Test Plan:

for https://github.com/brave/browser-laptop/issues/3754
1. Launch Brave and go to Preferences
2. Set "Brave starts with" to "My homepage" and specify duckduckgo.com
3. Move window somewhere specific and resize it too
4. Close the browser
5. Launch browser and notice window size and position is correct (even though no window state was saved)

for https://github.com/brave/browser-laptop/issues/3247
6. Launch Brave on macOS
8. Only have one window open (close others; verify via the Window menu)
9. Move window somewhere specific and resize it to a weird (but memorable) size
10. Close the only window
11. Pick "New Window" from the file menu
12. Notice window goes to position of last window and assumes size of last window

for https://github.com/brave/browser-laptop/issues/586
13. Go to slashdot.org
14. Resize the window horizontally as fast as you possibly can!
15. Notice that while it could be better, it's MUCH faster than it is now
16. Move the window somewhere specific

Upgrade test plan:
1. Launch Brave (version 0.12.6) and go to Preferences
2. Set "Brave starts with" to "My homepage" and specify duckduckgo.com
3. Resize the window to a very specific size
4. Close the browser
5. Install Brave version 0.12.7
6. Launch Brave and notice that the window has the same dimensions as before (remember, position was not saved prior to this fix).