### PR TITLE
display verified badge for verified publishers

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -213,6 +213,13 @@ class LedgerTable extends ImmutableComponent {
     return `https?://${synopsis.get('site')}`
   }
 
+  getVerifiedIcon (synopsis) {
+    return <span className='verified fa-stack'>
+      <i className='fa fa-circle fa-stack-2x' />
+      <i className='fa fa-check fa-stack-1x' />
+    </span>
+  }
+
   enabledForSite (synopsis) {
     const hostSettings = this.props.siteSettings.get(this.getHostPattern(synopsis))
     if (hostSettings) {
@@ -239,9 +246,10 @@ class LedgerTable extends ImmutableComponent {
     if (!synopsis || !synopsis.get || !this.shouldShow(synopsis)) {
       return []
     }
-    const faviconURL = synopsis.get('faviconURL') || appConfig.defaultFavicon
+    const faviconURL = synopsis.get('faviconURL')
     const rank = synopsis.get('rank')
     const views = synopsis.get('views')
+    const verified = synopsis.get('verified')
     const duration = synopsis.get('duration')
     const publisherURL = synopsis.get('publisherURL')
     const percentage = synopsis.get('percentage')
@@ -251,7 +259,7 @@ class LedgerTable extends ImmutableComponent {
     return [
       rank,
       {
-        html: <a href={publisherURL} target='_blank'><img src={faviconURL} alt={site} /><span>{site}</span></a>,
+        html: <a href={publisherURL} target='_blank'>{verified ? this.getVerifiedIcon() : null}{faviconURL ? <img src={faviconURL} alt={site} /> : <span className='fa fa-file-o' />}<span>{site}</span></a>,
         value: site
       },
       {

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -760,6 +760,7 @@ div.nextPaymentSubmission {
       -webkit-font-smoothing: antialiased;
       text-align: left;
       vertical-align: top;
+      position: relative;
 
       a {
         vertical-align: middle;
@@ -774,6 +775,27 @@ div.nextPaymentSubmission {
           height: 1.5em;
           margin-right: 6px;
           vertical-align: middle;
+        }
+      }
+
+      .fa-file-o {
+        font-size: 15px;
+        margin-right: 6px;
+        text-align: center;
+        width: 24px;
+      }
+
+      .verified{
+        left: -10px;
+        position: absolute;
+        font-size: 10px;
+
+        .fa-circle {
+          color: #67B640;
+        }
+
+        .fa-check {
+          color: white;
         }
       }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors @bbondy @bradleyrichter 

Fix #3467

Test Plan:

I don't have a real way to test this yet as the verified status isn't coming down from the ledger but ideally you'd visit a "verified" site like brianbondy.com and then when you look in the payments tab of settings you'll see a little green circle with a white checkbox in it.

If you'd like to test it you can just set verified to true in https://github.com/brave/browser-laptop/blob/verified-badge/js/about/preferences.js#L251 (then you'll see it for all publishers)

![screen shot 2016-10-24 at 8 56 32 pm](https://cloud.githubusercontent.com/assets/490294/19672541/60dd3c22-9a2c-11e6-9c10-964073f40995.png)