### PR TITLE
Unhighlight search terms on findbar clear

### DIFF
--- a/js/components/findbar.js
+++ b/js/components/findbar.js
@@ -11,6 +11,7 @@ const SwitchControl = require('../components/switchControl')
 const windowActions = require('../actions/windowActions')
 const windowStore = require('../stores/windowStore')
 const {getTextColorForBackground} = require('../lib/color')
+const webviewActions = require('../actions/webviewActions')
 
 class FindBar extends ImmutableComponent {
   constructor () {
@@ -106,6 +107,7 @@ class FindBar extends ImmutableComponent {
   }
 
   onClear () {
+    webviewActions.stopFindInPage()
     this.searchInput.value = ''
     this.focus()
   }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Open the findbar and type in a search term on the current page.
2. Look at the term that is highlighted somewhere on the page.
3. Click the findbar clear button.
4. Make sure the term is not highlighted anymore.

Fixes #5110