### PR TITLE
Add mouse-over visual feedback to Preference tabs

### DIFF
--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -160,6 +160,7 @@ body {
     &:hover {
       .topBarButton.fa {
         background-color: @darkGray;
+        cursor: pointer;
       }
     }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Open Preferences menu
2. Mouse over menu items on the left
3. Pointer should display similarly to:

![cursor-pointer](https://cloud.githubusercontent.com/assets/460373/19674231/ac9da6e2-9a54-11e6-9ee0-e0b823128fa8.png)


Fixes #5112