### PR TITLE
Re-introduce bookmark modal

### DIFF
--- a/app/renderer/components/addEditBookmarkHanger.js
+++ b/app/renderer/components/addEditBookmarkHanger.js
@@ -1,0 +1,207 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const React = require('react')
+const ImmutableComponent = require('../../../js/components/immutableComponent')
+const Button = require('../../../js/components/button')
+const cx = require('../../../js/lib/classSet')
+const windowActions = require('../../../js/actions/windowActions')
+const appActions = require('../../../js/actions/appActions')
+const KeyCodes = require('../../common/constants/keyCodes')
+const siteTags = require('../../../js/constants/siteTags')
+const settings = require('../../../js/constants/settings')
+const siteUtil = require('../../../js/state/siteUtil')
+const getSetting = require('../../../js/settings').getSetting
+
+class AddEditBookmarkHanger extends ImmutableComponent {
+  constructor () {
+    super()
+    this.onNameChange = this.onNameChange.bind(this)
+    this.onLocationChange = this.onLocationChange.bind(this)
+    this.onParentFolderChange = this.onParentFolderChange.bind(this)
+    this.onKeyDown = this.onKeyDown.bind(this)
+    this.onClose = this.onClose.bind(this)
+    this.onClick = this.onClick.bind(this)
+    this.onSave = this.onSave.bind(this)
+    this.onViewBookmarks = this.onViewBookmarks.bind(this)
+    this.onRemoveBookmark = this.onRemoveBookmark.bind(this)
+  }
+  get bookmarkNameValid () {
+    const title = this.props.currentDetail.get('title') || this.props.currentDetail.get('customTitle')
+    const location = this.props.currentDetail.get('location')
+    return this.isFolder
+      ? (typeof title === 'string' && title.trim().length > 0)
+      : (typeof location === 'string' && location.trim().length > 0)
+  }
+  get displayBookmarkName () {
+    if (this.props.currentDetail.get('customTitle') !== undefined) {
+      return this.props.currentDetail.get('customTitle')
+    }
+    return this.props.currentDetail.get('title') || ''
+  }
+  get heading () {
+    if (this.isFolder) {
+      return this.props.shouldShowLocation
+        ? 'bookmarkFolderEditing'
+        : 'bookmarkFolderAdding'
+    }
+    return this.props.shouldShowLocation
+      ? (!this.props.originalDetail || !this.props.originalDetail.has('location'))
+        ? 'bookmarkCreateNew'
+        : 'bookmarkEdit'
+      : 'bookmarkAdded'
+  }
+  get isFolder () {
+    return siteUtil.isFolder(this.props.currentDetail)
+  }
+  updateFolders (props) {
+    this.folders = siteUtil.getFolders(this.props.sites, props.currentDetail.get('folderId'))
+  }
+  componentWillMount () {
+    this.updateFolders(this.props)
+  }
+  componentWillUpdate (nextProps) {
+    if (this.props.sites !== nextProps.sites) {
+      this.updateFolders(nextProps)
+    }
+  }
+  componentDidMount () {
+    // Automatically save if this is triggered by the url star
+    if (!this.props.isModal && !this.props.shouldShowLocation) {
+      this.onSave(false)
+    }
+    this.bookmarkName.select()
+    this.bookmarkName.focus()
+  }
+  onKeyDown (e) {
+    switch (e.keyCode) {
+      case KeyCodes.ENTER:
+        this.onSave()
+        break
+      case KeyCodes.ESC:
+        this.onClose()
+        break
+    }
+  }
+  onClose () {
+    windowActions.setBookmarkDetail()
+  }
+  onClick (e) {
+    e.stopPropagation()
+  }
+  onNameChange (e) {
+    let currentDetail = this.props.currentDetail
+    if (currentDetail.get('title') === e.target.value && e.target.value) {
+      currentDetail = currentDetail.delete('customTitle')
+    } else {
+      currentDetail = currentDetail.set('customTitle', e.target.value)
+    }
+    windowActions.setBookmarkDetail(currentDetail, this.props.originalDetail, this.props.destinationDetail, this.props.shouldShowLocation, !this.props.isModal)
+  }
+  onLocationChange (e) {
+    const currentDetail = this.props.currentDetail.set('location', e.target.value)
+    windowActions.setBookmarkDetail(currentDetail, this.props.originalDetail, this.props.destinationDetail, this.props.shouldShowLocation, !this.props.isModal)
+  }
+  onParentFolderChange (e) {
+    const currentDetail = this.props.currentDetail.set('parentFolderId', Number(e.target.value))
+    windowActions.setBookmarkDetail(currentDetail, this.props.originalDetail, this.props.destinationDetail, undefined, !this.props.isModal)
+  }
+  showToolbarOnFirstBookmark () {
+    const hasBookmarks = this.props.sites.find(
+      (site) => siteUtil.isBookmark(site) || siteUtil.isFolder(site)
+    )
+    if (!hasBookmarks && !getSetting(settings.SHOW_BOOKMARKS_TOOLBAR)) {
+      appActions.changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, true)
+    }
+  }
+  onSave (closeDialog = true) {
+    // First check if the title of the currentDetail is set
+    if (!this.bookmarkNameValid) {
+      return false
+    }
+    this.showToolbarOnFirstBookmark()
+    const tag = this.isFolder ? siteTags.BOOKMARK_FOLDER : siteTags.BOOKMARK
+    appActions.addSite(this.props.currentDetail, tag, this.props.originalDetail, this.props.destinationDetail)
+    if (closeDialog) {
+      this.onClose()
+    }
+  }
+  onRemoveBookmark () {
+    const tag = this.isFolder ? siteTags.BOOKMARK_FOLDER : siteTags.BOOKMARK
+    appActions.removeSite(this.props.currentDetail, tag)
+    this.onClose()
+  }
+  onViewBookmarks () {
+    this.onClose()
+    windowActions.newFrame({location: 'about:bookmarks'}, true)
+  }
+  render () {
+    const props = this.props.isModal
+      ? {
+        className: 'fa fa-close',
+        onClick: this.onClose
+      }
+      : {
+        className: cx({
+          arrowUp: true,
+          withStopButton: this.props.withStopButton,
+          withHomeButton: this.props.withHomeButton,
+          withoutButtons: this.props.withoutButtons
+        })
+      }
+    return <div className={cx({
+      bookmarkDialog: this.props.isModal,
+      bookmarkHanger: !this.props.isModal
+    })}>
+      <div className='bookmarkForm' onClick={this.onClick}>
+        <div {...props} />
+
+        <div className='bookmarkFormInner'>
+          <h2 data-l10n-id={this.heading} />
+          <div className='bookmarkFormTable'>
+            <div id='bookmarkName' className='bookmarkFormRow'>
+              <label data-l10n-id='nameField' htmlFor='bookmarkName' />
+              <input spellCheck='false' onKeyDown={this.onKeyDown} onChange={this.onNameChange} value={this.displayBookmarkName} ref={(bookmarkName) => { this.bookmarkName = bookmarkName }} />
+            </div>
+            {
+              !this.isFolder && this.props.shouldShowLocation
+              ? <div id='bookmarkLocation' className='bookmarkFormRow'>
+                <label data-l10n-id='locationField' htmlFor='bookmarkLocation' />
+                <input spellCheck='false' onKeyDown={this.onKeyDown} onChange={this.onLocationChange} value={this.props.currentDetail.get('location')} />
+              </div>
+              : null
+            }
+            <div id='bookmarkParentFolder' className='bookmarkFormRow'>
+              <label data-l10n-id='parentFolderField' htmlFor='bookmarkParentFolder' />
+              <select value={this.props.currentDetail.get('parentFolderId')}
+                onChange={this.onParentFolderChange} >
+                <option value='0' data-l10n-id='bookmarksToolbar' />
+                {
+                  this.folders.map((folder) => <option value={folder.folderId}>{folder.label}</option>)
+                }
+              </select>
+            </div>
+            <div className='bookmarkButtons'>
+              {
+                this.props.originalDetail
+                ? <Button l10nId='remove' className='primaryButton whiteButton inlineButton' onClick={this.onRemoveBookmark} />
+                : null
+              }
+              <Button l10nId='done' disabled={!this.bookmarkNameValid} className='primaryButton' onClick={this.onSave} />
+            </div>
+          </div>
+        </div>
+        {
+          !this.props.isModal
+            ? <div className='bookmarkFormFooter'>
+              <Button l10nId='viewBookmarks' onClick={this.onViewBookmarks} />
+            </div>
+            : null
+        }
+      </div>
+    </div>
+  }
+}
+
+module.exports = AddEditBookmarkHanger

--- a/docs/windowActions.md
+++ b/docs/windowActions.md
@@ -467,7 +467,7 @@ Dispatches a message to set the find-in-page details.
 
 
 
-### setBookmarkDetail(currentDetail, originalDetail, destinationDetail, shouldShowLocation) 
+### setBookmarkDetail(currentDetail, originalDetail, destinationDetail, shouldShowLocation, isBookmarkHanger) 
 
 Dispatches a message to set add/edit bookmark details
 If set, also indicates that add/edit is shown
@@ -480,7 +480,9 @@ If set, also indicates that add/edit is shown
 
 **destinationDetail**: `Object`, Will move the added bookmark to the specified position
 
-**shouldShowLocation**: `Object`, Whether or not to show the URL input
+**shouldShowLocation**: `boolean`, Whether or not to show the URL input
+
+**isBookmarkHanger**: `boolean`, true if triggered from star icon in nav bar
 
 
 

--- a/js/about/history.js
+++ b/js/about/history.js
@@ -21,7 +21,7 @@ const ipc = window.chrome.ipc
 require('../../less/about/history.less')
 require('../../node_modules/font-awesome/css/font-awesome.css')
 
-// BSCTODO: this button is currently hidden (along with column icon)
+// TODO(bsclifton): this button is currently hidden (along with column icon)
 // When ready, this can be shown again (by updating style in history.less)
 // When that happens, be sure to also show the ::before (which has trash can icon)
 class DeleteHistoryEntryButton extends ImmutableComponent {
@@ -34,7 +34,7 @@ class DeleteHistoryEntryButton extends ImmutableComponent {
     if (e && e.preventDefault) {
       e.preventDefault()
     }
-    // BSCTODO: delete the selected entry
+    // TODO(bsclifton): delete the selected entry
   }
 
   render () {

--- a/js/actions/windowActions.js
+++ b/js/actions/windowActions.js
@@ -655,15 +655,17 @@ const windowActions = {
    * @param {Object} currentDetail - Properties of the bookmark to change to
    * @param {Object} originalDetail - Properties of the bookmark to edit
    * @param {Object} destinationDetail - Will move the added bookmark to the specified position
-   * @param {Object} shouldShowLocation - Whether or not to show the URL input
+   * @param {boolean} shouldShowLocation - Whether or not to show the URL input
+   * @param {boolean} isBookmarkHanger - true if triggered from star icon in nav bar
    */
-  setBookmarkDetail: function (currentDetail, originalDetail, destinationDetail, shouldShowLocation) {
+  setBookmarkDetail: function (currentDetail, originalDetail, destinationDetail, shouldShowLocation, isBookmarkHanger) {
     dispatch({
       actionType: WindowConstants.WINDOW_SET_BOOKMARK_DETAIL,
       currentDetail,
       originalDetail,
       destinationDetail,
-      shouldShowLocation
+      shouldShowLocation,
+      isBookmarkHanger
     })
   },
 

--- a/js/components/addEditBookmark.js
+++ b/js/components/addEditBookmark.js
@@ -4,196 +4,29 @@
 
 const React = require('react')
 const ImmutableComponent = require('./immutableComponent')
-const Button = require('./button')
-const cx = require('../lib/classSet')
+const Dialog = require('./dialog')
 const windowActions = require('../actions/windowActions')
-const appActions = require('../actions/appActions')
-const KeyCodes = require('../../app/common/constants/keyCodes')
-const siteTags = require('../constants/siteTags')
-const settings = require('../constants/settings')
-const siteUtil = require('../state/siteUtil')
-const getSetting = require('../settings').getSetting
+const AddEditBookmarkHanger = require('../../app/renderer/components/addEditBookmarkHanger')
 
 class AddEditBookmark extends ImmutableComponent {
   constructor () {
     super()
-    this.onNameChange = this.onNameChange.bind(this)
-    this.onLocationChange = this.onLocationChange.bind(this)
-    this.onParentFolderChange = this.onParentFolderChange.bind(this)
-    this.onKeyDown = this.onKeyDown.bind(this)
     this.onClose = this.onClose.bind(this)
-    this.onClick = this.onClick.bind(this)
-    this.onSave = this.onSave.bind(this)
-    this.onViewBookmarks = this.onViewBookmarks.bind(this)
-    this.onRemoveBookmark = this.onRemoveBookmark.bind(this)
-  }
-
-  get isBlankTab () {
-    return ['about:blank', 'about:newtab'].includes(this.props.currentDetail.get('location'))
-  }
-
-  get bookmarkNameValid () {
-    const title = this.props.currentDetail.get('title') || this.props.currentDetail.get('customTitle')
-    const location = this.props.currentDetail.get('location')
-
-    return this.isFolder
-      ? (typeof title === 'string' && title.trim().length > 0)
-      : (typeof location === 'string' && location.trim().length > 0)
-  }
-
-  get isFolder () {
-    return siteUtil.isFolder(this.props.currentDetail)
-  }
-  get heading () {
-    if (this.isFolder) {
-      return this.props.shouldShowLocation
-        ? 'bookmarkFolderEditing'
-        : 'bookmarkFolderAdding'
-    }
-    return this.props.shouldShowLocation
-      ? (!this.props.originalDetail || !this.props.originalDetail.has('location'))
-        ? 'bookmarkCreateNew'
-        : 'bookmarkEdit'
-      : 'bookmarkAdded'
-  }
-  updateFolders (props) {
-    this.folders = siteUtil.getFolders(this.props.sites, props.currentDetail.get('folderId'))
-  }
-  componentWillMount () {
-    this.updateFolders(this.props)
-  }
-  componentWillUpdate (nextProps) {
-    if (this.props.sites !== nextProps.sites) {
-      this.updateFolders(nextProps)
-    }
-  }
-  componentDidMount () {
-    // Automatically save if this is triggered by the url star
-    if (!this.props.shouldShowLocation) {
-      this.onSave(false)
-    }
-    this.bookmarkName.select()
-    this.bookmarkName.focus()
-  }
-  onKeyDown (e) {
-    switch (e.keyCode) {
-      case KeyCodes.ENTER:
-        this.onSave()
-        break
-      case KeyCodes.ESC:
-        this.onClose()
-        break
-    }
   }
   onClose () {
     windowActions.setBookmarkDetail()
   }
-  onClick (e) {
-    e.stopPropagation()
-  }
-  onNameChange (e) {
-    let currentDetail = this.props.currentDetail
-    if (currentDetail.get('title') === e.target.value && e.target.value) {
-      currentDetail = currentDetail.delete('customTitle')
-    } else {
-      currentDetail = currentDetail.set('customTitle', e.target.value)
-    }
-
-    windowActions.setBookmarkDetail(currentDetail, this.props.originalDetail, this.props.destinationDetail, this.props.shouldShowLocation)
-  }
-  onLocationChange (e) {
-    const currentDetail = this.props.currentDetail.set('location', e.target.value)
-    windowActions.setBookmarkDetail(currentDetail, this.props.originalDetail, this.props.destinationDetail, this.props.shouldShowLocation)
-  }
-  onParentFolderChange (e) {
-    const currentDetail = this.props.currentDetail.set('parentFolderId', Number(e.target.value))
-    windowActions.setBookmarkDetail(currentDetail, this.props.originalDetail, this.props.destinationDetail)
-  }
-  showToolbarOnFirstBookmark () {
-    const hasBookmarks = this.props.sites.find(
-      (site) => siteUtil.isBookmark(site) || siteUtil.isFolder(site)
-    )
-    if (!hasBookmarks && !getSetting(settings.SHOW_BOOKMARKS_TOOLBAR)) {
-      appActions.changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, true)
-    }
-  }
-  onSave (closeDialog = true) {
-    // First check if the title of the currentDetail is set
-    if (!this.bookmarkNameValid) {
-      return false
-    }
-
-    this.showToolbarOnFirstBookmark()
-    const tag = this.isFolder ? siteTags.BOOKMARK_FOLDER : siteTags.BOOKMARK
-    appActions.addSite(this.props.currentDetail, tag, this.props.originalDetail, this.props.destinationDetail)
-    if (closeDialog) {
-      this.onClose()
-    }
-  }
-  onRemoveBookmark () {
-    const tag = this.isFolder ? siteTags.BOOKMARK_FOLDER : siteTags.BOOKMARK
-    appActions.removeSite(this.props.currentDetail, tag)
-    this.onClose()
-  }
-  onViewBookmarks () {
-    this.onClose()
-    windowActions.newFrame({location: 'about:bookmarks'}, true)
-  }
-  get displayBookmarkName () {
-    if (this.props.currentDetail.get('customTitle') !== undefined) {
-      return this.props.currentDetail.get('customTitle')
-    }
-    return this.props.currentDetail.get('title') || ''
-  }
   render () {
-    return <div className='bookmarkDialog'>
-      <div className='bookmarkForm' onClick={this.onClick}>
-        <div className={cx({
-          arrowUp: true,
-          withStopButton: this.props.withStopButton,
-          withHomeButton: this.props.withHomeButton,
-          withoutButtons: this.props.withoutButtons
-        })} />
-        <div className='bookmarkFormInner'>
-          <h2 data-l10n-id={this.heading} />
-          <div className='bookmarkFormTable'>
-            <div id='bookmarkName' className='bookmarkFormRow'>
-              <label data-l10n-id='nameField' htmlFor='bookmarkName' />
-              <input spellCheck='false' onKeyDown={this.onKeyDown} onChange={this.onNameChange} value={this.displayBookmarkName} ref={(bookmarkName) => { this.bookmarkName = bookmarkName }} />
-            </div>
-            {
-              !this.isFolder && this.props.shouldShowLocation
-              ? <div id='bookmarkLocation' className='bookmarkFormRow'>
-                <label data-l10n-id='locationField' htmlFor='bookmarkLocation' />
-                <input spellCheck='false' onKeyDown={this.onKeyDown} onChange={this.onLocationChange} value={this.props.currentDetail.get('location')} />
-              </div>
-              : null
-            }
-            <div id='bookmarkParentFolder' className='bookmarkFormRow'>
-              <label data-l10n-id='parentFolderField' htmlFor='bookmarkParentFolder' />
-              <select value={this.props.currentDetail.get('parentFolderId')}
-                onChange={this.onParentFolderChange} >
-                <option value='0' data-l10n-id='bookmarksToolbar' />
-                {
-                  this.folders.map((folder) => <option value={folder.folderId}>{folder.label}</option>)
-                }
-              </select>
-            </div>
-            <div className='bookmarkButtons'>
-              {
-                this.props.originalDetail
-                ? <Button l10nId='remove' className='primaryButton whiteButton inlineButton' onClick={this.onRemoveBookmark} />
-                : null
-              }
-              <Button l10nId='done' disabled={!this.bookmarkNameValid} className='primaryButton' onClick={this.onSave} />
-            </div>
-          </div>
-        </div>
-        <div className='bookmarkFormFooter'>
-          <Button l10nId='viewBookmarks' onClick={this.onViewBookmarks} />
-        </div>
-      </div>
-    </div>
+    return <Dialog onHide={this.onClose} isClickDismiss>
+      <AddEditBookmarkHanger
+        isModal
+        sites={this.props.sites}
+        currentDetail={this.props.currentDetail}
+        originalDetail={this.props.originalDetail}
+        destinationDetail={this.props.destinationDetail}
+        shouldShowLocation={this.props.shouldShowLocation}
+      />
+    </Dialog>
   }
 }
 

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -32,6 +32,7 @@ const ClearBrowsingDataPanel = require('./clearBrowsingDataPanel')
 const ImportBrowserDataPanel = require('../../app/renderer/components/importBrowserDataPanel')
 const AutofillAddressPanel = require('./autofillAddressPanel')
 const AutofillCreditCardPanel = require('./autofillCreditCardPanel')
+const AddEditBookmark = require('./addEditBookmark')
 const LoginRequired = require('./loginRequired')
 const ReleaseNotes = require('./releaseNotes')
 const BookmarksToolbar = require('../../app/renderer/components/bookmarksToolbar')
@@ -666,7 +667,7 @@ class Main extends ImmutableComponent {
   }
 
   onMouseDown (e) {
-    // BSCTODO: update this to use eventUtil.eventElHasAncestorWithClasses
+    // TODO(bsclifton): update this to use eventUtil.eventElHasAncestorWithClasses
     let node = e.target
     while (node) {
       if (node.classList &&
@@ -674,7 +675,7 @@ class Main extends ImmutableComponent {
             node.classList.contains('contextMenu') ||
             node.classList.contains('extensionButton') ||
             node.classList.contains('menubarItem') ||
-            node.classList.contains('bookmarkForm'))) {
+            node.classList.contains('bookmarkHanger'))) {
         // Middle click (on context menu) needs to fire the click event.
         // We need to prevent the default "Auto-Scrolling" behavior.
         if (node.classList.contains('contextMenu') && e.button === 1) {
@@ -1013,6 +1014,15 @@ class Main extends ImmutableComponent {
           loginRequiredDetail
             ? <LoginRequired loginRequiredDetail={loginRequiredDetail} tabId={activeFrame.get('tabId')} />
             : null
+        }
+        {
+          this.props.windowState.get('bookmarkDetail') && !this.props.windowState.getIn(['bookmarkDetail', 'isBookmarkHanger'])
+          ? <AddEditBookmark sites={this.props.appState.get('sites')}
+            currentDetail={this.props.windowState.getIn(['bookmarkDetail', 'currentDetail'])}
+            originalDetail={this.props.windowState.getIn(['bookmarkDetail', 'originalDetail'])}
+            destinationDetail={this.props.windowState.getIn(['bookmarkDetail', 'destinationDetail'])}
+            shouldShowLocation={this.props.windowState.getIn(['bookmarkDetail', 'shouldShowLocation'])} />
+          : null
         }
         {
           noScriptIsVisible

--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -15,7 +15,7 @@ const messages = require('../constants/messages')
 const settings = require('../constants/settings')
 const ipc = global.require('electron').ipcRenderer
 const {isSourceAboutUrl} = require('../lib/appUrlUtil')
-const AddEditBookmark = require('./addEditBookmark')
+const AddEditBookmarkHanger = require('../../app/renderer/components/addEditBookmarkHanger')
 const siteUtil = require('../state/siteUtil')
 const eventUtil = require('../lib/eventUtil')
 const getSetting = require('../settings').getSetting
@@ -40,9 +40,9 @@ class NavigationBar extends ImmutableComponent {
 
   onToggleBookmark () {
     const editing = this.bookmarked
-    // trigger the AddEditBookmark modal; saving/deleting takes place there
+    // show the AddEditBookmarkHanger control; saving/deleting takes place there
     const siteDetail = siteUtil.getDetailFromFrame(this.activeFrame, siteTags.BOOKMARK)
-    windowActions.setBookmarkDetail(siteDetail, siteDetail, null, editing)
+    windowActions.setBookmarkDetail(siteDetail, siteDetail, null, editing, true)
   }
 
   onReload (e) {
@@ -116,8 +116,8 @@ class NavigationBar extends ImmutableComponent {
         titleMode: this.titleMode
       })}>
       {
-        this.props.bookmarkDetail
-        ? <AddEditBookmark sites={this.props.sites}
+        this.props.bookmarkDetail && this.props.bookmarkDetail.get('isBookmarkHanger')
+        ? <AddEditBookmarkHanger sites={this.props.sites}
           currentDetail={this.props.bookmarkDetail.get('currentDetail')}
           originalDetail={this.props.bookmarkDetail.get('originalDetail')}
           destinationDetail={this.props.bookmarkDetail.get('destinationDetail')}

--- a/js/constants/windowConstants.js
+++ b/js/constants/windowConstants.js
@@ -47,7 +47,7 @@ const windowConstants = {
   WINDOW_SET_BOOKMARK_DETAIL: _, // If set, also indicates that add/edit is shown
   WINDOW_SET_CONTEXT_MENU_DETAIL: _, // If set, also indicates that the context menu is shown
   WINDOW_SET_POPUP_WINDOW_DETAIL: _, // If set, also indicates that the popup window is shown
-  WINDOW_TOGGLE_BOOKMARK_HANGER: _,
+  WINDOW_HIDE_BOOKMARK_HANGER: _,
   WINDOW_SET_AUDIO_MUTED: _,
   WINDOW_SET_AUDIO_PLAYBACK_ACTIVE: _,
   WINDOW_SET_FAVICON: _,

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -228,7 +228,7 @@ function siteDetailTemplateInit (siteDetail, activeFrame) {
   let deleteLabel
   let deleteTag
 
-  // BSCTODO: pull this out to a method
+  // TODO(bsclifton): pull this out to a method
   if (siteUtil.isBookmark(siteDetail) && activeFrame) {
     deleteLabel = 'deleteBookmark'
     deleteTag = siteTags.BOOKMARK

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -620,7 +620,8 @@ const doAction = (action) => {
           currentDetail: action.currentDetail,
           originalDetail: action.originalDetail,
           destinationDetail: action.destinationDetail,
-          shouldShowLocation: action.shouldShowLocation
+          shouldShowLocation: action.shouldShowLocation,
+          isBookmarkHanger: action.isBookmarkHanger
         })
       }
       // Since the input values of bookmarks are bound, we need to notify the controls sync.
@@ -832,12 +833,15 @@ const doAction = (action) => {
         windowState = windowState.setIn(['ui', 'menubar', 'isVisible'], newVisibleStatus)
       }
       break
-    case WindowConstants.WINDOW_TOGGLE_BOOKMARK_HANGER:
-      windowState = windowState.delete('bookmarkDetail')
+    case WindowConstants.WINDOW_HIDE_BOOKMARK_HANGER:
+      const hangerShowing = windowState.getIn(['bookmarkDetail', 'isBookmarkHanger'])
+      if (hangerShowing) {
+        windowState = windowState.delete('bookmarkDetail')
+      }
       break
     case WindowConstants.WINDOW_RESET_MENU_STATE:
       doAction({actionType: WindowConstants.WINDOW_SET_POPUP_WINDOW_DETAIL})
-      doAction({actionType: WindowConstants.WINDOW_TOGGLE_BOOKMARK_HANGER})
+      doAction({actionType: WindowConstants.WINDOW_HIDE_BOOKMARK_HANGER})
       if (getSetting(settings.AUTO_HIDE_MENU)) {
         doAction({actionType: WindowConstants.WINDOW_TOGGLE_MENUBAR_VISIBLE, isVisible: false})
       } else {
@@ -845,7 +849,6 @@ const doAction = (action) => {
       }
       doAction({actionType: WindowConstants.WINDOW_SET_SUBMENU_SELECTED_INDEX})
       doAction({actionType: WindowConstants.WINDOW_SET_BOOKMARKS_TOOLBAR_SELECTED_FOLDER_ID})
-      windowState = windowState.setIn(['ui', 'bookmarksToolbar', 'selectedFolderId'], null)
       break
     case WindowConstants.WINDOW_SET_SUBMENU_SELECTED_INDEX:
       windowState = windowState.setIn(['ui', 'menubar', 'selectedIndex'],

--- a/less/forms.less
+++ b/less/forms.less
@@ -464,89 +464,104 @@
   text-overflow: ellipsis;
 }
 
-.dialog.bookmarkDialog {
-  justify-content: initial;
-  padding-left: 7px;
+.dialog > .bookmarkDialog {
+  width: 350px;
+  position: absolute;
+  top: 30px;
 }
 
-#navigator {
-  .bookmarkForm {
-    .genericForm;
-    background: linear-gradient(#FFFFFF, #DEDEDE);
-    margin-top: 10px;
-    padding: 0;
+.dialog > .bookmarkDialog > .bookmarkForm {
+  width: 350px;
+}
 
-    .arrowUp {
-      width: 0;
-      height: 0;
-      border-left: 10px solid transparent;
-      border-right: 10px solid transparent;
-      border-bottom: 10px solid #FFFFFF;
-      position: relative;
-      bottom: 10px;
-      left: 37px;
+.dialog > .bookmarkDialog .fa-close {
+  color: #999;
+  font-size: 16px;
+  float: right;
+  margin-top: 7px;
+  margin-right: 10px;
+}
 
-      &.withHomeButton {
-        left: 67px;
-      }
-    }
+.bookmarkForm {
+  .genericForm;
+  background: linear-gradient(#FFFFFF, #DEDEDE);
+  margin-top: 10px;
+  padding: 0;
 
-    .bookmarkFormRow {
-      margin-bottom: 10px;
-    }
+  .arrowUp {
+    width: 0;
+    height: 0;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+    border-bottom: 10px solid #FFFFFF;
+    position: relative;
+    bottom: 10px;
+    left: 37px;
 
-    .bookmarkButtons {
-      margin: 20px 0 10px 0;
-    }
-
-    .bookmarkFormInner {
-      padding: 10px 30px;
-    }
-
-    label {
-      color: @darkGray;
-      margin-left: 5px;
-    }
-
-    h2 {
-      color: @braveOrange;
-      font-weight: normal;
-      font-size: 16px;
-    }
-
-    input,
-    select {
-      display: block;
-      width: 100%;
-      max-width: 250px;
-      height: 25px;
-      border-radius: 5px;
-      padding: 0 5px;
-      margin: 5px 0 5px 0;
-      font-size: 0.9em;
-      border: solid 1px #ececec;
-      background: white;
-      color: #444444;
-      outline: none;
-    }
-
-    input {
-      box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
-    }
-
-    select {
-      box-shadow: 0px 1px 5px -1px rgba(0, 0, 0, 0.8);
+    &.withHomeButton {
+      left: 67px;
     }
   }
 
-  .bookmarkFormFooter {
-    background: @gray;
-    padding: 10px 30px;
+  .bookmarkFormRow {
+    margin-bottom: 10px;
+  }
 
-    span {
-      font-size: 12px;
-      text-align: left;
+  .bookmarkButtons {
+    margin: 20px 0 10px 0;
+  }
+
+  .bookmarkFormInner {
+    padding: 10px 30px;
+    h2 {
+      -webkit-user-select: none;
+      cursor: default;
     }
+  }
+
+  label {
+    color: @darkGray;
+    margin-left: 5px;
+  }
+
+  h2 {
+    color: @braveOrange;
+    font-weight: normal;
+    font-size: 16px;
+  }
+
+  input,
+  select {
+    display: block;
+    width: 100%;
+    max-width: 250px;
+    height: 25px;
+    border-radius: 5px;
+    padding: 0 5px;
+    margin: 5px 0 5px 0;
+    font-size: 0.9em;
+    border: solid 1px #ececec;
+    background: white;
+    color: #444444;
+    outline: none;
+  }
+
+  input {
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  }
+
+  select {
+    box-shadow: 0px 1px 5px -1px rgba(0, 0, 0, 0.8);
+  }
+}
+
+.bookmarkFormFooter {
+  background: @gray;
+  padding: 10px 30px;
+
+  span {
+    font-size: 12px;
+    text-align: left;
   }
 }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Re-introduce bookmark modal

- add/edit current site uses the bookmark hanger
- all other cases use a new control which wraps a modal around a slightly different
  version of the bookmark hanger.

Fixes https://github.com/brave/browser-laptop/issues/5103

Auditors: @jkup, @bbondy