### PR TITLE
Handle reload by setUrl in window store

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -458,8 +458,11 @@ class Frame extends ImmutableComponent {
         // In this case both the user display and the user think they're on this.props.location.
         if (this.webview.getURL() !== this.props.location && !this.isAboutPage()) {
           this.webview.loadURL(this.props.location)
-        } else if (this.isIntermediateAboutPage()) {
-          this.webview.loadURL(this.props.aboutDetails.get('url'))
+        } else if (this.isIntermediateAboutPage() &&
+          this.webview.getURL() !== this.props.location &&
+          this.webview.getURL() !== this.props.aboutDetails.get('url')) {
+          windowActions.setUrl(this.props.aboutDetails.get('url'),
+            this.props.aboutDetails.get('frameKey'))
         } else {
           this.webview.reload()
         }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #5177

Auditors: @bbondy

Test Plan:
1. Type brave.123 in navigation bar
2. After DNS error page is presented, click refresh button next to navigation bar
3. The error page refresh normally

1. Type brave.123 in navigation bar
2. After DNS error page is presented, click "Retry the URL" in error page
3. The error page refresh normally

1. Navigate to https://expired.badssl.com/
2. After cert error page is presented, click refresh button next to navigation bar
3. The error page refresh normally

1. Navigate to https://expired.badssl.com/
2. After cert error page is presented, click "Retry the URL" in error page
3. The error page refresh normally

1. Make network unavailable
2. Type anything in navigation bar
3. After connection error page is presented, click refresh button next to navigation bar
4. The error page refresh normally

1. Make network unavailable
2. Type anything in navigation bar
3. After connection error page is presented, click "Retry the URL" in error page
4. The error page refresh normally

1. Make network unavailable
2. Type anything in navigation bar
3. After connection error page is presented, make network available
4. Click refresh button next to navigation bar
5. The original page should load

1. Make network unavailable
2. Type anything in navigation bar
3. After connection error page is presented, make network available
4. Click "Retry the URL" in error page
5. The original page should load