### PR TITLE
[Proposal] CSS in JS documentation

### DIFF
--- a/docs/style.md
+++ b/docs/style.md
@@ -1,0 +1,141 @@
+# Overview
+
+All applicable styles should be colocated with their corresponding JavaScript component using [Aphrodite](https://github.com/Khan/aphrodite).
+
+## Legacy
+
+All legacy styles are processed with [Less](http://lesscss.org/) and can be found in the /less directory. These should still be maintained but all future CSS should be written in JavaScript and kept inside the appropriate component file.
+
+## Example
+
+Here is an example of a React component styled with Aphrodite.
+
+Aphrodite will automatically create a single `<style>` tag in the document `<head>` to put its generated styles in.
+
+```jsx
+const React = require('react')
+const ImmutableComponent = require('./immutableComponent')
+const {StyleSheet, css} = require('aphrodite')
+
+class Button extends ImmutableComponent {
+  render () {
+    return <span className={css(styles.browserButton)} 
+      disabled={this.props.disabled}
+      data-l10n-id={this.props.l10nId}
+      data-button-value={this.props.dataButtonValue}
+      onClick={this.props.onClick} />
+  }
+}
+
+const styles = StyleSheet.create({
+  browserButton: {
+    cursor: 'default',
+    display: 'inline-block',
+    lineHeight: '25px',
+    width: '25px',
+    height: '25px',
+
+    ':hover': {
+      color: 'black'
+    },
+
+    '@media (min-width: 500px)': {
+      width: '100px'
+    }
+  }
+})
+
+module.exports = Button
+```
+
+A few things to note:
+
+1. All multi-word properties become camel cased (lineHeight instead of line-height).
+2. Pseudo selectors and media queries can be given their own class or be nested within a selector.
+
+## Sharing Styles
+
+Shared styles go in the `app/styles` directory. For example, we could create a Buttons.js file in `app/styles` with something like:
+
+```jsx
+import { StyleSheet } from 'aphrodite'
+
+export default StyleSheet.create({
+  Button: {
+    background: 'red'
+  }
+})
+```
+
+And then in a component file we could:
+
+```jsx
+import ButtonStyles from './styles/Buttons'
+
+...
+
+<button className={css(ButtonStyles.Button)}>Click Me</button>
+```
+
+
+### Passing Styles to Child Components
+
+Alternatively, styles can be treated as props and passed down from parent to child. Here is an example:
+
+```jsx
+// addEditBookmarkHanger.js
+
+const React = require('react')
+const ImmutableComponent = require('../../../js/components/immutableComponent')
+const Button = require('../../../js/components/button')
+const {StyleSheet, css} = require('aphrodite')
+
+class AddEditBookmarkHanger extends ImmutableComponent {
+  render () {
+    <Button styles={[styles.hangerButton, styles.hangerText]} />
+  }
+}
+
+const styles = StyleSheet.create({
+  hangerButton: {
+    width: '50px',
+    height: '25px',
+
+    ':hover': {
+      color: orange
+    }
+  },
+
+  hangerText: {
+    fontSize: '20px'
+  }
+})
+
+// button.js
+
+const React = require('react')
+const ImmutableComponent = require('./immutableComponent')
+const {StyleSheet, css} = require('aphrodite')
+
+class Button extends ImmutableComponent {
+  render () {
+    return <span className={css(this.props.styles)} />
+  }
+}
+```
+
+## Testing
+
+As styles are converted from LESS to Aphrodite, we will lose the ability to control the generated class names. This means for our webdriver tests will no longer be able to use class names as selectors. Instead we will be adding the attribute `data-test-id` to elements. This approach gives us the added benefit of differentiating between code meant for presentation and code meant for testing.
+
+An example would be moving:
+
+```jsx
+<Button className='paymentHistoryButton' l10nId={buttonText} onClick={onButtonClick.bind(this)} />
+```
+
+to:
+
+```jsx
+<Button className={css(paymentButton)} data-test-id='paymentHistoryButton' l10nId={buttonText} onClick={onButtonClick.bind(this)} />
+```

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   "dependencies": {
     "abp-filter-parser-cpp": "1.2.x",
     "acorn": "3.2.0",
+    "aphrodite": "^1.0.0",
     "async": "^2.0.1",
     "electron-localshortcut": "^0.6.0",
     "electron-prebuilt": "brave/electron-prebuilt",


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5204

I've been talking with @bbondy and @bsclifton for a while about refactoring the CSS in browser-laptop. I think that a modular, component based approach would suit us well. This PR is a proposal for adding [Aphrodite](https://github.com/Khan/aphrodite) to our codebase and moving in the direction of writing our CSS in JavaScript.

Attached is the dependency and a rough draft with my thoughts around adopting Aphrodite. Some things that would be great to discuss in this PR:
- [ ] Are there other approaches people prefer? [Radium](https://github.com/FormidableLabs/radium)? [PostCSS](https://github.com/postcss/postcss)?,  Sticking with SASS/LESS?
- [ ] The big win here is lightweight colocation of our CSS and JS. This comes at the cost of some nice to haves like global variables and some nice tools like [Stylelint](http://stylelint.io/) (which only works with PostCSS)
- [ ] How should we go about implementing? It makes sense to me to just take an incremental approach. The only downside here is there could be conflicts between the generated styles and the ones inherited from classNames.
- [ ] Anything else I'm missing!
## Migration

I think the best way to migrate would be one component at a time. Basically since Aphrodite uses className we would just have components the _either_ use CSS classes or Aphrodite classes, never both.

There is a small issue of collisions. Aphrodite generates unique classes so we won't have collisions that way but we still have lots of element based styling (.SettingsItem span {}) so even with removing classNames elements might still be inheriting styles from our .less files.
## Shared Styles

I really like the approach @bbondy outlined of making a styles folder with some shared.js files that just export styles. So we could have dialog.js which just exports all shared dialog styles and then require it in each dialog component (overriding specifics if needed).
## Sizing units

I think the best approach moving forward would be to use relative sizing units instead of pixels.
### Text

I really like the approach that [CSS-Tricks](https://css-tricks.com/rems-ems/) takes which is to use px at the document level, em's for all text elements (h2, p, etc), and rem for actual components (sortableTable, navigation, etc). That would look something like this:

``` css
html {
  font-size: 14px;
}

.sortableTable {
  /* Components are relative to the document size */
  font-size: 1.2rem;
}

.sortableTable h2 {
  /* Specific text elements, if necessary, are styled relative to their component */
  font-size: 1.4em;
}
```
### Elements

Beyond font sizes, I'm still trying to figure out best approach for width and height of elements. You can use relative sizes like em's but I'm not sure if that's confusing or helpful.
## Aphrodite vs. inline style objects

With React, you can simply pass JavaScript objects into the style attribute of any JSX element. There are two big advantages to Aphrodite over this approach.
1. Generated classes allow much easier debugging with devtools over pure inline styles.
2. Aphrodite allows for media queries, pseudo selectors and hover/visited state.

## Extra Reading

In case it helps, I wrote [a blog post](https://codeplanet.io/sharing-styles-react-aphrodite/) describing how we could share styles and made [a demo project](https://github.com/jkup/aphrodite-react) in case anyone wants to mess around with Aphrodite!
