### PR TITLE
Context menu now works on sortableTable with no selection

### DIFF
--- a/app/renderer/components/addEditBookmarkHanger.js
+++ b/app/renderer/components/addEditBookmarkHanger.js
@@ -55,6 +55,10 @@ class AddEditBookmarkHanger extends ImmutableComponent {
   get isFolder () {
     return siteUtil.isFolder(this.props.currentDetail)
   }
+  setDefaultFocus () {
+    this.bookmarkName.select()
+    this.bookmarkName.focus()
+  }
   updateFolders (props) {
     this.folders = siteUtil.getFolders(this.props.sites, props.currentDetail.get('folderId'))
   }
@@ -71,8 +75,7 @@ class AddEditBookmarkHanger extends ImmutableComponent {
     if (!this.props.isModal && !this.props.shouldShowLocation) {
       this.onSave(false)
     }
-    this.bookmarkName.select()
-    this.bookmarkName.focus()
+    this.setDefaultFocus()
   }
   onKeyDown (e) {
     switch (e.keyCode) {

--- a/js/components/addEditBookmark.js
+++ b/js/components/addEditBookmark.js
@@ -16,9 +16,13 @@ class AddEditBookmark extends ImmutableComponent {
   onClose () {
     windowActions.setBookmarkDetail()
   }
+  componentDidMount () {
+    this.refs.bookmarkHanger.setDefaultFocus()
+  }
   render () {
     return <Dialog onHide={this.onClose} isClickDismiss>
       <AddEditBookmarkHanger
+        ref='bookmarkHanger'
         isModal
         sites={this.props.sites}
         currentDetail={this.props.currentDetail}

--- a/js/components/sortableTable.js
+++ b/js/components/sortableTable.js
@@ -43,6 +43,11 @@ class SortableTable extends React.Component {
         : this
       : this
   }
+  get nullSelection () {
+    return this.props.multiSelect
+      ? this.stateOwner.state.selection.size === 0
+      : false
+  }
   get multipleItemsSelected () {
     return this.props.multiSelect
       ? this.stateOwner.state.selection.size > 1
@@ -261,9 +266,17 @@ class SortableTable extends React.Component {
 
     // Bindings for multi-select-specific event handlers
     if (this.props.multiSelect) {
-      rowAttributes.onContextMenu = this.onContextMenu
+      // Table supports multi-select
       rowAttributes.onClick = this.onClick
+      if (this.nullSelection && this.hasContextMenu) {
+        // If nothing is selected yet, offer a default per-item context menu
+        rowAttributes.onContextMenu = this.props.onContextMenu.bind(this, handlerInput, this.props.contextMenuName)
+      } else {
+        // If items are selected we must use the multiple item handler
+        rowAttributes.onContextMenu = this.onContextMenu
+      }
     } else {
+      // Table does not support multi-select
       if (this.hasContextMenu) {
         rowAttributes.onContextMenu = this.props.onContextMenu.bind(this, handlerInput, this.props.contextMenuName)
       }

--- a/js/components/sortableTable.js
+++ b/js/components/sortableTable.js
@@ -253,7 +253,9 @@ class SortableTable extends React.Component {
       (this.props.rowObjects.size > 0 || this.props.rowObjects.length > 0)
       ? (typeof this.props.rowObjects.toJS === 'function'
         ? this.props.rowObjects.get(index).toJS()
-        : this.props.rowObjects[index])
+        : (typeof this.props.rowObjects[index].toJS === 'function'
+          ? this.props.rowObjects[index].toJS()
+          : this.props.rowObjects[index]))
       : row
 
     // Allow parent control to optionally specify context

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -255,6 +255,8 @@ function siteDetailTemplateInit (siteDetail, activeFrame) {
     } else if (multipleHistoryEntries) {
       deleteLabel = 'deleteHistoryEntries'
     }
+  } else {
+    deleteLabel = ''
   }
 
   const template = []


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Context menu now works on sortableTable with no selection
Also fixes: focus for new folder / edit folder / new bookmark now set properly

Fixes #5202

Auditors: @darkdh

Test plan:
1. Launch Brave and go to about:bookmarks
2. Without selecting an item, right click on any entry to bring up context menu
3. Confirm you see the context menu for a single item
4. Visit about:history
5. without selecting an item, right click on any entry to bring up context menu
6. Confirm you see the context menu for a single item