### PR TITLE
only set frame title when navigation is not renderer initiated

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -1007,10 +1007,13 @@ class Frame extends ImmutableComponent {
       // force temporary url display for tabnapping protection
       windowActions.setMouseInTitlebar(true)
 
-      // After navigating to the URL, set correct frame title
-      let webContents = this.webview.getWebContents()
-      let title = webContents.getTitleAtIndex(webContents.getCurrentEntryIndex())
-      windowActions.setFrameTitle(this.frame, title)
+      // After navigating to the URL via back/forward buttons, set correct frame title
+      if (!e.isRendererInitiated) {
+        let webContents = this.webview.getWebContents()
+        let index = webContents.getCurrentEntryIndex()
+        let title = webContents.getTitleAtIndex(index)
+        windowActions.setFrameTitle(this.frame, title)
+      }
     })
     this.webview.addEventListener('crashed', (e) => {
       windowActions.setFrameError(this.frame, {

--- a/test/fixtures/spoof_content.html
+++ b/test/fixtures/spoof_content.html
@@ -1,0 +1,3 @@
+<title>fake page</title>
+<h1>fake page</h1>
+<script>location="http://google.com/";</script>

--- a/test/fixtures/spoof_opener.html
+++ b/test/fixtures/spoof_opener.html
@@ -1,0 +1,22 @@
+<script>
+function next()
+{
+	w.location.replace('http://google.com/?'+n);n++;
+	setTimeout("next();",15);
+	setTimeout("next();",25);
+}
+function f()
+{
+	w=window.open("spoof_content.html","_blank","width=500 height=500");
+    i=setInterval(() => {
+      try {
+        x=w.location.href;
+      } catch (e) {
+        clearInterval(i);
+        n=0;
+        next();
+      }
+    }, 5);
+}
+</script>
+<a href="#" onclick="f()">Google</a><br>


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. go to http://web.mit.edu/zyan/Public/googlespoof.html
2. click on the link
3. when the new window stops loading, the tab title should be the tab URL instead of 'fake'

partial fix for #4973. this prevents the page-that-is-being-spoofed from displaying the title from the spoofing page.

requires https://github.com/brave/electron/pull/83

auditors: @bbondy