### PR TITLE
show about:blank in urlbar

### DIFF
--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -336,7 +336,7 @@ const UrlUtil = {
    * @return {string}
    */
   getDisplayLocation: function (url, pdfjsEnabled) {
-    if (!url || ['about:blank', 'about:newtab'].includes(url)) {
+    if (!url || url === 'about:newtab') {
       return ''
     }
     const parsed = urlParse(pdfjsEnabled ? this.getLocationIfPDF(url) : url)

--- a/test/components/navigationBarTest.js
+++ b/test/components/navigationBarTest.js
@@ -739,14 +739,22 @@ describe('navigationBar', function () {
       before(function * () {
         yield setup(this.app.client)
         yield this.app.client.waitForExist(urlInput)
-        yield this.app.client.keys('about:blank')
-        // hit enter
-        yield this.app.client.keys('\uE007')
       })
-      it('hides the url', function * () {
-        yield this.app.client.waitUntil(function () {
-          return this.getValue(urlInput).then((val) => val === '')
-        })
+      it('hides about:newtab', function * () {
+        yield this.app.client
+          .tabByUrl(this.newTabUrl)
+          .windowByUrl(Brave.browserWindowUrl)
+          .waitUntil(function () {
+            return this.getValue(urlInput).then((val) => val === '')
+          })
+      })
+      it('shows about:blank', function * () {
+        yield this.app.client
+          .keys('about:blank')
+          .keys('\uE007')
+          .waitUntil(function () {
+            return this.getValue(urlInput).then((val) => val === 'about:blank')
+          })
       })
     })
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #5209

Auditors: @bbondy

Test Plan:
1. go to about:blank, observe that it is shown in the urlbar
2. highlight urlbar and go to about:newtab, observe that it is now empty