### PR TITLE
Fix regression caused by removing drag from URL bar element

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -618,7 +618,11 @@
   z-index: @zindexNavigationBar;
 
   form {
-    -webkit-app-region: no-drag;
+    -webkit-app-region: drag;
+    // Disable window dragging so that selecting text and dragging the favicon is possible.
+    input, .urlbarIcon {
+      -webkit-app-region: no-drag;
+    }
   }
 
   &:not(.titleMode) {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

Fix regression caused by removing drag from URL bar element
Fixes https://github.com/brave/browser-laptop/issues/5225
Unfixes (breaks) https://github.com/brave/browser-laptop/issues/4922 (I manually reopened)

Auditors: @bbondy

Test Plan:
1. Launch Brave and make the window smaller in size (800x600 for example)
2. make sure you can drag the window by the top area (all 6 pixels for macOS)