### PR TITLE
Fix clearing the findbar

### DIFF
--- a/js/components/findbar.js
+++ b/js/components/findbar.js
@@ -11,7 +11,6 @@ const SwitchControl = require('../components/switchControl')
 const windowActions = require('../actions/windowActions')
 const windowStore = require('../stores/windowStore')
 const {getTextColorForBackground} = require('../lib/color')
-const webviewActions = require('../actions/webviewActions')
 
 class FindBar extends ImmutableComponent {
   constructor () {
@@ -107,8 +106,11 @@ class FindBar extends ImmutableComponent {
   }
 
   onClear () {
-    webviewActions.stopFindInPage()
     this.searchInput.value = ''
+    windowActions.setFindDetail(this.frame, Immutable.fromJS({
+      searchString: '',
+      caseSensitivity: this.isCaseSensitive
+    }))
     this.focus()
   }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Navigate to any page and open the findbar.
2. Type in any word on the current page.
3. Click the clear button.
4. Make sure 1) the text field is empty, 2) the number of matches is gone, and 3) the highlighted terms found on the page are gone.

Fixes #5247