### PR TITLE
browserActionBackgroundImage per-tab support

### DIFF
--- a/app/common/state/extensionState.js
+++ b/app/common/state/extensionState.js
@@ -74,11 +74,17 @@ const extensionState = {
     }
   },
 
-  browserActionBackgroundImage: (browserAction) => {
-    // TODO(bridiver) - handle icon single
-    if (browserAction.get('base_path') && browserAction.getIn(['path', '19']) && browserAction.getIn(['path', '38'])) {
-      return '-webkit-image-set(url(\'' + browserAction.get('base_path') + '/' + browserAction.getIn(['path', '19']) +
-                                          '\') 1x, url(\'' + browserAction.get('base_path') + '/' + browserAction.getIn(['path', '38']) + '\') 2x'
+  browserActionBackgroundImage: (browserAction, tabId) => {
+    tabId = tabId ? tabId.toString() : '-1'
+    if (browserAction.get('base_path')) {
+      if (browserAction.getIn(['tabs', tabId, 'path', '19']) && browserAction.getIn(['tabs', tabId, 'path', '38'])) {
+        return '-webkit-image-set(url(\'' + browserAction.get('base_path') + '/' + browserAction.getIn(['tabs', tabId, 'path', '19']) +
+          '\') 1x, url(\'' + browserAction.get('base_path') + '/' + browserAction.getIn(['tabs', tabId, 'path', '38']) + '\') 2x'
+      }
+      if (browserAction.getIn(['path', '19']) && browserAction.getIn(['path', '38'])) {
+        return '-webkit-image-set(url(\'' + browserAction.get('base_path') + '/' + browserAction.getIn(['path', '19']) +
+          '\') 1x, url(\'' + browserAction.get('base_path') + '/' + browserAction.getIn(['path', '38']) + '\') 2x'
+      }
     }
     return ''
   },

--- a/app/renderer/components/browserActionButton.js
+++ b/app/renderer/components/browserActionButton.js
@@ -40,7 +40,7 @@ class BrowserActionButton extends ImmutableComponent {
         extensionButton: true
       })}
       inlineStyles={{
-        backgroundImage: extensionState.browserActionBackgroundImage(this.props.browserAction),
+        backgroundImage: extensionState.browserActionBackgroundImage(this.props.browserAction, this.props.tabId),
         backgroundRepeat: 'no-repeat',
         backgroundPosition: 'center'
       }}


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

fix #4702

Auditors: @bridiver, @jonathansampson

Test Plan:
1. Make sure pocket logged in
2. Save page to pocket
3. Pocket icon should change