### PR TITLE
Insert virtual history items for sites like www.google.ca in auto-suggestion url

### DIFF
--- a/js/components/urlBarSuggestions.js
+++ b/js/components/urlBarSuggestions.js
@@ -281,10 +281,26 @@ class UrlBarSuggestions extends ImmutableComponent {
       }
     }
 
+    const historyFilter = (site) => {
+      const title = site.get('title') || ''
+      const location = site.get('location') || ''
+      // Note: Bookmark sites are now included in history. This will allow
+      // sites to appear in the auto-complete regardless of their bookmark
+      // status. If history is turned off, bookmarked sites will appear
+      // in the bookmark section.
+      return (title.toLowerCase().includes(urlLocationLower) ||
+              location.toLowerCase().includes(urlLocationLower))
+    }
+    var historySites = props.sites.filter(historyFilter)
+
+    // potentially append virtual history items (such as www.google.com when
+    // searches have been made but the root site has not been visited)
+    historySites = historySites.concat(suggestion.createVirtualHistoryItems(historySites))
+
     // history
     if (getSetting(settings.HISTORY_SUGGESTIONS)) {
       suggestions = suggestions.concat(mapListToElements({
-        data: props.sites,
+        data: historySites,
         maxResults: config.urlBarSuggestions.maxHistorySites,
         type: suggestionTypes.HISTORY,
         clickHandler: navigateClickHandler((site) => {
@@ -293,16 +309,7 @@ class UrlBarSuggestions extends ImmutableComponent {
         sortHandler: sortBasedOnLocationPos,
         formatTitle: (site) => site.get('title'),
         formatUrl: (site) => site.get('location'),
-        filterValue: (site) => {
-          const title = site.get('title') || ''
-          const location = site.get('location') || ''
-          return (title.toLowerCase().includes(urlLocationLower) ||
-                  location.toLowerCase().includes(urlLocationLower))
-          // Note: Bookmkark sites are now included in history. This will allow
-          // sites to appear in the auto-complete regardless of their bookmark
-          // status. If history is turned off, bookmarked sites will appear
-          // in the bookmark section.
-        }
+        filterValue: historyFilter
       }))
     }
 

--- a/test/unit/lib/urlSuggestionTest.js
+++ b/test/unit/lib/urlSuggestionTest.js
@@ -26,3 +26,38 @@ describe('suggestion', function () {
     assert.ok(suggestion.simpleDomainNameValue(siteComplex) === 0, 'complex site returns 0')
   })
 })
+
+const site1 = Immutable.Map({
+  location: 'http://www.foo.com/1',
+  count: 0,
+  lastAccessedTime: 0,
+  title: 'www.foo/com/1'
+})
+
+const site2 = Immutable.Map({
+  location: 'http://www.foo.com/2',
+  count: 0,
+  lastAccessedTime: 0,
+  title: 'www.foo/com/2'
+})
+
+const site3 = Immutable.Map({
+  location: 'http://www.foo.com/3',
+  count: 0,
+  lastAccessedTime: 0,
+  title: 'www.foo/com/3'
+})
+
+describe('suggestion', function () {
+  it('shows virtual history item', function () {
+    var history = Immutable.List([site1, site2, site3])
+    var virtual = suggestion.createVirtualHistoryItems(history)
+    assert.ok(virtual.length > 0, 'virtual location created')
+    assert.ok(virtual[0].get('location') === 'http://www.foo.com')
+    assert.ok(virtual[0].get('title') === 'www.foo.com')
+    assert.ok(virtual[0].get('lastAccessedTime') > 0)
+    history = Immutable.List([site1, site2])
+    virtual = suggestion.createVirtualHistoryItems(history)
+    assert.ok(virtual.length === 0, 'virtual location not created')
+  })
+})


### PR DESCRIPTION
- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Ran `git rebase -i` to squash commits (if needed).

When a site is visted for a deep linked page or with parameters
the history item is stored with the complete parameters and links.
Often after a user visits the site a number of times, the expectation
shifts such that the simple domain should be the first suggestion
in the url bar suggestion list. The canonical example is when a
user searches Google a number of times via the url bar. After three
searches www.google.com will be added as a virtual history item in the
search results.

Auditors: @bbondy, @bradrichter

Test Plan:
1. Clear history
2. End three searchs from the url bar without accessing www.google.com
3. Open a new tab and type goog - ensure a history item for www.google.com is displayed

Fixes: #5067
