### PR TITLE
Set preferences moment locale to navigator.language

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -27,8 +27,9 @@ const getSetting = require('../settings').getSetting
 const SortableTable = require('../components/sortableTable')
 const Button = require('../components/button')
 const searchProviders = require('../data/searchProviders')
-const moment = require('moment')
 const punycode = require('punycode')
+const moment = require('moment')
+moment.locale(navigator.language)
 
 const adblock = appConfig.resourceNames.ADBLOCK
 const cookieblock = appConfig.resourceNames.COOKIEBLOCK


### PR DESCRIPTION
Fix #4787

Auditors: @@luixxiul

Test Plan:
1. Set language to non English. restart if needed.
2. See Preferences > Payments, "Contribution due date: {due date}" due date should be localized
3. Try 1+2 for another language