### PR TITLE
Favicon is now updated in session after visiting site

### DIFF
--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -320,6 +320,36 @@ module.exports.getDetailFromFrame = function (frame, tag) {
 }
 
 /**
+ * Update the favicon URL for all entries in the sites list
+ * which match a given location. Currently, there should only be
+ * one match, but this will handle multiple.
+ *
+ * @param sites The application state's Immutable sites list
+ * @param location URL for the entry needing an update
+ * @param favicon favicon URL
+ */
+module.exports.updateSiteFavicon = function (sites, location, favicon) {
+  const matchingIndices = []
+
+  sites.filter((site, index) => {
+    if (site.get('location') === location) {
+      matchingIndices.push(index)
+      return true
+    }
+    return false
+  })
+
+  if (!matchingIndices.length) return sites
+
+  let updatedSites = sites
+  matchingIndices.forEach((index) => {
+    updatedSites = updatedSites.setIn([index, 'favicon'], favicon)
+  })
+
+  return updatedSites
+}
+
+/**
  * Converts a siteDetail to frameOpts format
  * @param {Object} siteDetail - A site detail as per app state
  * @return {Object} A frameOpts plain JS object, not ImmutableJS

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -770,6 +770,9 @@ const handleAppAction = (action) => {
     case AppConstants.APP_DEFAULT_BROWSER_CHECK_COMPLETE:
       appState = appState.set('defaultBrowserCheckComplete', {})
       break
+    case WindowConstants.WINDOW_SET_FAVICON:
+      appState = appState.set('sites', siteUtil.updateSiteFavicon(appState.get('sites'), action.frameProps.get('location'), action.favicon))
+      break
     default:
   }
 

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -470,6 +470,28 @@ describe('siteUtil', function () {
   describe('moveSite', function () {
   })
 
+  describe('updateSiteFavicon', function () {
+    it('updates the favicon for all matching entries', function () {
+      const siteDetail1 = Immutable.fromJS({
+        tags: [siteTags.BOOKMARK],
+        location: testUrl1,
+        title: 'bookmarked site'
+      })
+      const siteDetail2 = Immutable.fromJS({
+        tags: [],
+        location: testUrl1,
+        title: 'bookmarked site'
+      })
+      const sites = Immutable.fromJS([siteDetail1, siteDetail2])
+      const processedSites = siteUtil.updateSiteFavicon(sites, testUrl1, 'https://brave.com/favicon.ico')
+      const updatedSiteDetail1 = siteDetail1.set('favicon', 'https://brave.com/favicon.ico')
+      const updatedSiteDetail2 = siteDetail2.set('favicon', 'https://brave.com/favicon.ico')
+      const expectedSites = Immutable.fromJS([updatedSiteDetail1, updatedSiteDetail2])
+
+      assert.deepEqual(processedSites.toJS(), expectedSites.toJS())
+    })
+  })
+
   describe('getDetailFromFrame', function () {
     it('returns an Immutable object with all expected properties', function () {
       const frame = Immutable.fromJS({


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Required to make sure we get the latest favicons for the new about:newtab page,
our bookmarks toolbar, and also the about:bookmarks page. **Before, the favicon
was only being updated**:
- when site is bookmarked / rebookmarked
- when site is pinned

Auditors: @darkdh @cezaraugusto

Fixes https://github.com/brave/browser-laptop/issues/4860

Test Plan:
1. Import bookmarks from Chrome or HTML... OR manually create a new bookmark (from about:bookmarks)
2. Show the bookmarks toolbar and notice the favicon is not loaded
3. Load/visit one of the bookmarks which does NOT have a favicon yet
4. After visiting the page, notice that the favicon is updated

Fixes https://github.com/brave/browser-laptop/issues/2747

Test Plan:
1. Open a new tab
2. Per issue description, visit tokyo.cawaii.media/gisele/
3. Go back to the empty tab by pressing the back button
4. Press and hold the forward button to display the pulldown