### PR TITLE
Implement hide-autofill-popup

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -804,8 +804,10 @@ class Frame extends ImmutableComponent {
       contextMenus.onShowAutofillMenu(e.suggestions, e.rect, this.frame)
     })
     this.webview.addEventListener('hide-autofill-popup', (e) => {
-      // TODO(Anthony): conflict with contextmenu
-      // windowActions.setContextMenuDetail()
+      let webContents = this.webview.getWebContents()
+      if (webContents && webContents.isFocused()) {
+        windowActions.setContextMenuDetail()
+      }
     })
     this.webview.addEventListener('ipc-message', (e) => {
       let method = () => {}


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #3816
fix #4540
fix #5023

Auditors: @bbondy

Test Plan:
1. Go to https://github.com/brave/browser-laptop/issues
2. In the filters textbox, start typing characters until autocomplete pops up
3. Push enter to submit
4. Scroll the page should dismiss the popup

1. Go to https://github.com/brave/browser-laptop/issues
2. In the filters textbox, start typing characters until autocomplete pops up
3. Push enter to submit
4. Popup should be dismissed