### PR TITLE
Disable autofill management button when autofill is disabled

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -1528,7 +1528,7 @@ class SecurityTab extends ImmutableComponent {
         <Button l10nId='manageAutofillData' className='primaryButton manageAutofillDataButton'
           onClick={aboutActions.newFrame.bind(null, {
             location: 'about:autofill'
-          }, true)} />
+          }, true)} disabled={!getSetting(settings.AUTOFILL_ENABLED, this.props.settings)} />
       </SettingsList>
       <div className='sectionTitle' data-l10n-id='doNotTrackTitle' />
       <SettingsList>


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).


fix #5146

Auditors: @bsclifton

Test Plan:
1. Go to about:preferences#security
2. Toggle "Enable Autofill" off
3. Manage Autofill Data button should be disabled