### PR TITLE
Add transition for new-tabbackground

### DIFF
--- a/less/about/newtab.less
+++ b/less/about/newtab.less
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+@import "../animations.less";
 @import "./common.less";
 
 * {
@@ -15,7 +16,13 @@ strong, div, span, li, em, p, a {
 }
 
 body {
-  background: @darkGray;
+  background: #fff;
+}
+
+body, .dynamicBackground, .gradient {
+  opacity: 0;
+  animation: fadeIn 200ms;
+  animation-fill-mode: forwards;
 }
 
 main,


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

to avoid flash of unstyled content

Auditors: @bsclifton

Closes #5309

Test Plan:
* Enable new tab page
* Open a new tab
* There should be a smooth transition between the moment page is opened and background is charged