### PR TITLE
Bug fixes for about:bookmarks

### DIFF
--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -99,7 +99,7 @@ module.exports = {
     'general.language': null, // null means to use the OS lang
     'general.startup-mode': 'lastTime',
     'general.homepage': 'https://www.brave.com',
-    'general.newtab-mode-TEMP': 'blank',
+    'general.newtab-mode-TEMP': process.env.NODE_ENV === 'test' ? 'newTabPage' : 'blank',
     'general.show-home-button': false,
     'general.useragent.value': null, // Set at runtime
     'general.autohide-menu': true,

--- a/test/about/bookmarksManagerTest.js
+++ b/test/about/bookmarksManagerTest.js
@@ -188,5 +188,16 @@ describe('about:bookmarks', function () {
         .keys(Brave.keys.SHIFT)
         .click('table.sortableTable td.title[data-sort="Brave"]')
     })
+    it('deselects everything if something other than a row is clicked', function * () {
+      yield this.app.client
+        .tabByUrl(aboutBookmarksUrl)
+        .loadUrl(aboutBookmarksUrl)
+        // Click one bookmark, to select it
+        .click('table.sortableTable td.title[data-sort="Brave"]')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="Brave"]')
+        // Click the header; this should dismiss and release selection
+        .click('table.sortableTable th')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="Brave"]', 5000, true)
+    })
   })
 })


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Bug fixes for about:bookmarks:
- clear selection when click is outside of table
- clear selection when any element is dragged

Fixes https://github.com/brave/browser-laptop/issues/5223
Fixes https://github.com/brave/browser-laptop/issues/5249

**NOTE: this updates appConfig to use about:newtab for new tabs if NODE_ENV=test, which is required for our tests to run. I had unintentionally broke those (because some tests rely on URL bar having focus) when submitting https://github.com/brave/browser-laptop/pull/5301**

Auditors: @darkdh @bbondy 

Test Plan:
1. Launch Brave and visit about:bookmarks
2. Import bookmarks or have bookmarks ready
3. Drag bookmarks from the view on the right over to a different folder
4. Observe that the selection is cleared
5. Use Ctrl or Cmd and select multiple items
6. Click below the table or click the header for the table
7. Notice the selection is cleared