### PR TITLE
Removed "blank" option (about:blank !== about:newtab)

### DIFF
--- a/app/common/constants/settingsEnums.js
+++ b/app/common/constants/settingsEnums.js
@@ -9,7 +9,6 @@ const startsWithOption = {
 }
 
 const newTabMode = {
-  BLANK: 'blank',
   NEW_TAB_PAGE: 'newTabPage',
   HOMEPAGE: 'homePage',
   DEFAULT_SEARCH_ENGINE: 'defaultSearchEngine'

--- a/docs/state.md
+++ b/docs/state.md
@@ -161,7 +161,7 @@ AppStore
     // See defaults in js/constants/appConfig.js
     'general.startup-mode': string, // One of: lastTime, homePage, newTabPage
     'general.homepage': string, // URL of the user's homepage
-    'general.newtab-mode-TEMP': string,  // One of: blank, newTabPage, homePage, defaultSearchEngine
+    'general.newtab-mode': string,  // One of: newTabPage, homePage, defaultSearchEngine
     'general.show-home-button': boolean, // true if the home button should be shown
     'general.useragent.value': (undefined|string), // custom user agent value
     'general.downloads.default-save-path': string, // default path for saving files

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -655,7 +655,6 @@ class GeneralTab extends ImmutableComponent {
         <SettingItem dataL10nId='newTabMode'>
           <select value={getSetting(settings.NEWTAB_MODE, this.props.settings)}
             onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.NEWTAB_MODE)} >
-            <option data-l10n-id='newTabBlank' value={newTabMode.BLANK} />
             <option data-l10n-id='newTabNewTabPage' value={newTabMode.NEW_TAB_PAGE} />
             <option data-l10n-id='newTabHomePage' value={newTabMode.HOMEPAGE} />
             <option data-l10n-id='newTabDefaultSearchEngine' value={newTabMode.DEFAULT_SEARCH_ENGINE} />

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -99,7 +99,7 @@ module.exports = {
     'general.language': null, // null means to use the OS lang
     'general.startup-mode': 'lastTime',
     'general.homepage': 'https://www.brave.com',
-    'general.newtab-mode-TEMP': process.env.NODE_ENV === 'test' ? 'newTabPage' : 'blank',
+    'general.newtab-mode': 'newTabPage',
     'general.show-home-button': false,
     'general.useragent.value': null, // Set at runtime
     'general.autohide-menu': true,

--- a/js/constants/settings.js
+++ b/js/constants/settings.js
@@ -6,7 +6,7 @@ const settings = {
   // General tab
   STARTUP_MODE: 'general.startup-mode',
   HOMEPAGE: 'general.homepage',
-  NEWTAB_MODE: 'general.newtab-mode-TEMP',
+  NEWTAB_MODE: 'general.newtab-mode',
   SHOW_HOME_BUTTON: 'general.show-home-button',
   USERAGENT: 'general.useragent.value',
   DEFAULT_DOWNLOAD_SAVE_PATH: 'general.downloads.default-save-path',

--- a/js/lib/appUrlUtil.js
+++ b/js/lib/appUrlUtil.js
@@ -159,11 +159,8 @@ module.exports.newFrameUrl = function () {
   const {newTabMode} = require('../../app/common/constants/settingsEnums')
 
   switch (settingValue) {
-    case newTabMode.NEW_TAB_PAGE:
-      return 'about:newtab'
-
     case newTabMode.HOMEPAGE:
-      return getSetting(settings.HOMEPAGE) || 'about:blank'
+      return getSetting(settings.HOMEPAGE) || 'about:newtab'
 
     case newTabMode.DEFAULT_SEARCH_ENGINE:
       const searchProviders = require('../data/searchProviders').providers
@@ -173,7 +170,8 @@ module.exports.newFrameUrl = function () {
       })
       return defaultSearchEngineSettings[0].base
 
+    case newTabMode.NEW_TAB_PAGE:
     default:
-      return 'about:blank'
+      return 'about:newtab'
   }
 }


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/5334

Definitely my mistake folks- I had forgotten about the URL bar getting focus and didn't consider that the change broke tests also :frowning_face: 

This change:
- finalizes the name of the setting (the previous one had "TEST" in it)
- defaults unknown URLs to about:newtab (which makes sense, since those have URL bar focus)
- removes blank as an option (since it was going to be removed when we shipped)

If we need to disable the NEW about:newtab screen for 0.12.8, we can just return an empty div in `js/about/newtab.js`

Auditors: @diracdeltas, @bbondy

Test Plan:
1. Launch Brave and open a new tab
2. New tab should be about:newtab
3. Preferences > General should no longer show "blank"
4. Tests should work again