### PR TITLE
Clear per-tab browserAction data when navigation happens

### DIFF
--- a/docs/windowActions.md
+++ b/docs/windowActions.md
@@ -48,7 +48,7 @@ Dispatches a message to the store to set the new URL.
 
 
 
-### setNavigated(location, key, isNavigatedInPage) 
+### setNavigated(location, key, isNavigatedInPage, tabId) 
 
 Dispatches a message to the store to let it know a page has been navigated.
 
@@ -59,6 +59,8 @@ Dispatches a message to the store to let it know a page has been navigated.
 **key**: `number`, The frame key to modify.
 
 **isNavigatedInPage**: `boolean`, true if it was a navigation within the same page.
+
+**tabId**: `number`, the tab id
 
 
 

--- a/js/actions/windowActions.js
+++ b/js/actions/windowActions.js
@@ -97,13 +97,15 @@ const windowActions = {
    * @param {string} location - The URL of the page that was navigated to.
    * @param {number} key - The frame key to modify.
    * @param {boolean} isNavigatedInPage - true if it was a navigation within the same page.
+   * @param {number} tabId - the tab id
    */
-  setNavigated: function (location, key, isNavigatedInPage) {
+  setNavigated: function (location, key, isNavigatedInPage, tabId) {
     dispatch({
       actionType: WindowConstants.WINDOW_SET_NAVIGATED,
       location,
       key,
-      isNavigatedInPage
+      isNavigatedInPage,
+      tabId
     })
   },
 

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -994,7 +994,7 @@ class Frame extends ImmutableComponent {
         windowActions.loadUrl(this.frame, 'about:error')
         appActions.removeSite(siteUtil.getDetailFromFrame(this.frame))
       } else if (provisionLoadFailure) {
-        windowActions.setNavigated(this.webview.getURL(), this.props.frameKey, true)
+        windowActions.setNavigated(this.webview.getURL(), this.props.frameKey, true, this.frame.get('tabId'))
       }
     }
     this.webview.addEventListener('load-commit', (e) => {
@@ -1018,7 +1018,7 @@ class Frame extends ImmutableComponent {
       if (this.props.isActive && this.webview.canGoBack() && document.activeElement !== this.webview) {
         this.webview.focus()
       }
-      windowActions.setNavigated(e.url, this.props.frameKey, false)
+      windowActions.setNavigated(e.url, this.props.frameKey, false, this.frame.get('tabId'))
       // force temporary url display for tabnapping protection
       windowActions.setMouseInTitlebar(true)
 
@@ -1059,7 +1059,7 @@ class Frame extends ImmutableComponent {
     })
     this.webview.addEventListener('did-navigate-in-page', (e) => {
       if (e.isMainFrame) {
-        windowActions.setNavigated(e.url, this.props.frameKey, true)
+        windowActions.setNavigated(e.url, this.props.frameKey, true, this.frame.get('tabId'))
         loadEnd(true)
       }
     })

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -788,6 +788,11 @@ const handleAppAction = (action) => {
     case WindowConstants.WINDOW_SET_FAVICON:
       appState = appState.set('sites', siteUtil.updateSiteFavicon(appState.get('sites'), action.frameProps.get('location'), action.favicon))
       break
+    case WindowConstants.WINDOW_SET_NAVIGATED:
+      if (!action.isNavigatedInPage) {
+        appState = extensionState.browserActionUpdated(appState, action)
+      }
+      break
     default:
   }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #5327

Auditors: @bridiver, @bbondy

Test Plan:
1. Go to about:preferences#advanced and enable pocket
2. Login pocket
3. Navigate to arbitrary page
4. Save page to pocket
5. Navigate to other page/refresh the page
6. The pocket icon should not be illuminated