### PR TITLE
Set extension icon in context menu

### DIFF
--- a/app/browser/extensions/contextMenus.js
+++ b/app/browser/extensions/contextMenus.js
@@ -7,9 +7,9 @@ const contextMenus = {
         extensionActions.contextMenuAllRemoved(extensionId)
       })
     })
-    process.on('chrome-context-menus-create', (extensionId, menuItemId, properties) => {
+    process.on('chrome-context-menus-create', (extensionId, menuItemId, properties, icon) => {
       setImmediate(() => {
-        extensionActions.contextMenuCreated(extensionId, menuItemId, properties)
+        extensionActions.contextMenuCreated(extensionId, menuItemId, properties, icon)
       })
     })
   }

--- a/app/common/actions/extensionActions.js
+++ b/app/common/actions/extensionActions.js
@@ -85,13 +85,15 @@ const extensionActions = {
    * @param {string} extensionId - the extension id
    * @param {string} menuItemId - the id of the menu item that was clicked
    * @param {object} properties - createProperties of chrome.contextMenus.create
+   * @param {string} icon - 16x16 extension icon
    */
-  contextMenuCreated: function (extensionId, menuItemId, properties) {
+  contextMenuCreated: function (extensionId, menuItemId, properties, icon) {
     AppDispatcher.dispatch({
       actionType: ExtensionConstants.CONTEXT_MENU_CREATED,
       extensionId,
       menuItemId,
-      properties
+      properties,
+      icon
     })
   },
 

--- a/app/common/state/extensionState.js
+++ b/app/common/state/extensionState.js
@@ -142,11 +142,15 @@ const extensionState = {
         state = state.setIn(['extensions', action.get('extensionId'), 'contextMenus'], new Immutable.List())
       }
       let contextMenus = state.getIn(['extensions', action.get('extensionId'), 'contextMenus'])
+      let basePath = state.getIn(['extensions', action.get('extensionId'), 'base_path'])
+      basePath = decodeURI(basePath)
+      basePath = basePath.replace('file://', '')
       return state.setIn(['extensions', action.get('extensionId'), 'contextMenus'],
         contextMenus.push({
           extensionId: action.get('extensionId'),
           menuItemId: action.get('menuItemId'),
-          properties: action.get('properties').toJS()
+          properties: action.get('properties').toJS(),
+          icon: basePath + '/' + action.get('icon')
         }))
     } else {
       return state

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -1172,7 +1172,8 @@ function mainTemplateInit (nodeProps, frame) {
                   extensionActions.contextMenuClicked(
                     extensionContextMenu.extensionId, frame.get('tabId'), info)
                 }
-              }
+              },
+              icon: extensionContextMenu.icon
             })
           templateMap[extensionContextMenu.menuItemId] = template[template.length - 1]
         }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

requires https://github.com/brave/electron/pull/86
fix #5292

Auditors: @bridiver, @bbondy

Test Plan:
1. Enable pocket
2. right click to popup context menu
3. Save to pocket should have icon