### PR TITLE
Fix drag and drop for about:newtab (and other fixes)

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -224,7 +224,8 @@ AppStore
       gridLayoutSize: string, // 'small', 'medium', 'large'
       sites: [string], // List of sites to be used on gridLayout
       ignoredTopSites: [string], // List of ignored sites
-      pinnedTopSites: [string] // List of pinned sites
+      pinnedTopSites: [string], // List of pinned sites
+      updatedStamp: number // timestamp for when the data was last updated
     }
   },
   menu: {

--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -31,10 +31,36 @@ class NewTabPage extends React.Component {
     this.state = {
       showSiteRemovalNotification: false,
       backgroundImage: this.randomBackgroundImage,
-      imageLoadFailed: false
+      imageLoadFailed: false,
+      updatedStamp: undefined
     }
     ipc.on(messages.NEWTAB_DATA_UPDATED, (e, newTabData) => {
-      this.setState({ newTabData: Immutable.fromJS(newTabData || {}) })
+      this.sanitize(newTabData)
+    })
+  }
+  sanitize (newTabData) {
+    let sanitizedData = Immutable.fromJS(newTabData || {})
+    const updatedStamp = sanitizedData.getIn(['newTabDetail', 'updatedStamp'])
+
+    // Only update if the data has changed.
+    // console.log(updatedStamp + ']DATA_TS==LAST_TS[' + this.state.updatedStamp)
+    if (updatedStamp === this.state.updatedStamp) {
+      return
+    }
+
+    // Ensure top sites only has unique values
+    const pinnedTopSites = sanitizedData.getIn(['newTabDetail', 'pinnedTopSites'])
+    if (pinnedTopSites) {
+      const uniqueValues = pinnedTopSites.filter((element, index, list) => {
+        if (!element) return false
+        return index === list.findIndex((site) => site && site.get('location') === element.get('location'))
+      })
+      sanitizedData = sanitizedData.setIn(['newTabDetail', 'pinnedTopSites'], uniqueValues)
+    }
+
+    this.setState({
+      newTabData: sanitizedData,
+      updatedStamp: updatedStamp
     })
   }
 
@@ -171,7 +197,14 @@ class NewTabPage extends React.Component {
       newTabState.pinnedTopSites = pinnedTopSites
     }
     newTabState.sites = gridSites
-    aboutActions.setNewTabDetail(newTabState)
+
+    // Only update if there was an actual change
+    const stateDiff = Immutable.fromJS(newTabState)
+    const existingState = this.state.newTabData || Immutable.fromJS({})
+    const proposedState = existingState.mergeIn(['newTabDetail'], stateDiff)
+    if (!proposedState.isSubset(existingState)) {
+      aboutActions.setNewTabDetail(stateDiff)
+    }
   }
 
   onToggleBookmark (siteProps) {
@@ -278,7 +311,9 @@ class NewTabPage extends React.Component {
                     href={site.get('location')}
                     favicon={
                       site.get('favicon') == null
-                      ? site.get('title').charAt(0).toUpperCase()
+                      ? site.get('title')
+                        ? site.get('title').charAt(0).toUpperCase()
+                        : '?'
                       : <img src={site.get('favicon')} />
                     }
                     style={{backgroundColor: site.get('themeColor')}}

--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -113,20 +113,11 @@ class NewTabPage extends React.Component {
 
     // We need to know which sites are pinned first, so we can skip them while populating
     gridSites = gridSites.push.apply(pinnedTopSites, gridSites)
-
-    for (let i = 0; i < gridSites.size; i++) {
-      // skip pinnedTopSites while populating
-      if (!this.isPinned(i)) {
-        gridSites = gridSites.set(i, sites.first())
-        sites = sites.shift()
-      }
-    }
+    gridSites = gridSites.map((item, i) => item == null ? sites.get(i) : item)
 
     // Remove from grid all ignored sites
     gridSites = gridSites.filter((site) => ignoredTopSites.indexOf(site) === -1)
 
-    // Filter duplicated and remove null
-    gridSites = gridSites.toSet().toList()
     gridSites = gridSites.filter(site => site != null)
 
     return gridSites


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix drag-n-drop for topSites grid
Fixes #5336

Also includes optimizations / small bug fixes:
- Remove duplicates from pinned sites before binding to state (corrupt state could cause a problem)
- Prevent unnecessary state updates (frame.js => newtab.js and while dragging)
- handle null sites array (default to new list)
- updated the unique detecting logic for newVisitedSites

Auditors: @cezaraugusto @bbondy