### PR TITLE
payments advanced settings button hidden when payments disabled

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -1247,7 +1247,7 @@ class PaymentsTab extends ImmutableComponent {
             <span data-l10n-id='off' />
             <SettingCheckbox dataL10nId='on' prefKey={settings.PAYMENTS_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
           </div>
-          { this.props.ledgerData.get('created') ? <Button l10nId='advancedSettings' className='whiteButton inlineButton' onClick={this.props.showOverlay.bind(this, 'advancedSettings')} /> : null }
+          { this.props.ledgerData.get('created') && this.enabled ? <Button l10nId='advancedSettings' className='advancedSettings whiteButton inlineButton' onClick={this.props.showOverlay.bind(this, 'advancedSettings')} /> : null }
         </div>
       </div>
       {

--- a/test/components/ledgerPanelTest.js
+++ b/test/components/ledgerPanelTest.js
@@ -1,7 +1,7 @@
 /* global describe, it, beforeEach, before */
 
 const Brave = require('../lib/brave')
-const {urlInput, addFundsButton, paymentsStatus, paymentsWelcomePage, paymentsTab, walletSwitch, ledgerTable} = require('../lib/selectors')
+const {urlInput, advancedSettings, addFundsButton, paymentsStatus, paymentsWelcomePage, paymentsTab, walletSwitch, ledgerTable} = require('../lib/selectors')
 const assert = require('assert')
 
 const prefsUrl = 'about:preferences'
@@ -76,6 +76,29 @@ describe('Payments Panel', function () {
               val.value.settings['payments.notifications'] === false
           })
         }, ledgerAPIWaitTimeout)
+    })
+
+    it('advanced settings is hidden by default', function * () {
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(prefsUrl)
+        .waitForVisible(paymentsTab)
+        .click(paymentsTab)
+        .waitForVisible(paymentsWelcomePage)
+        .waitForVisible(walletSwitch)
+        .waitForVisible(advancedSettings, 100, true)
+    })
+
+    it('advanced settings is visible when payments are enabled', function * () {
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(prefsUrl)
+        .waitForVisible(paymentsTab)
+        .click(paymentsTab)
+        .waitForVisible(paymentsWelcomePage)
+        .waitForVisible(walletSwitch)
+        .click(walletSwitch)
+        .waitForVisible(advancedSettings, ledgerAPIWaitTimeout)
     })
 
     it('can create wallet', function * () {

--- a/test/lib/selectors.js
+++ b/test/lib/selectors.js
@@ -54,6 +54,7 @@ module.exports = {
   homepageInput: '[data-l10n-id="homepageInput"]',
   walletSwitch: '.enablePaymentsSwitch .switchBackground',
   addFundsButton: '.addFunds',
+  advancedSettings: '.advancedSettings',
   fundsSelectBox: '#fundsSelectBox',
   paymentsStatus: '#walletStatus',
   ledgerTable: '#ledgerTable',


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5384

Auditors @bbondy @bsclifton 

Test Plan:

1. Go to Preferences > Payments
2. You should *not* see the advanced settings button
3. Enable Payments
4. You should see the advanced settings button
5. Disable Payments
6. You should *not* see the button
