### PR TITLE
align percentage column in ledger payments

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -287,7 +287,7 @@ class LedgerTable extends ImmutableComponent {
         headings={['rank', 'publisher', 'include', 'views', 'timeSpent', 'percentage']}
         defaultHeading='rank'
         overrideDefaultStyle
-        columnClassNames={['alignRight', '', '', 'alignRight', 'alignRight', '']}
+        columnClassNames={['alignRight', '', '', 'alignRight', 'alignRight', 'alignRight']}
         rowClassNames={
           this.synopsis.map((item) =>
             this.enabledForSite(item) ? '' : 'paymentsDisabled').toJS()


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5402

Auditors @bradleyrichter @srirambv 

Test Plan:

1. Open Preferences > Payments
2. Enable Payments
3. Browse websites until you have entries in the ledger table
4. Make sure the % column items are right aligned

![screen shot 2016-11-04 at 12 36 39 pm](https://cloud.githubusercontent.com/assets/490294/20019878/9c4cfccc-a28b-11e6-93d0-e3ceeeac1547.png)

