### PR TITLE
Change order of topSites actions to PIN-BM-CLOSE

### DIFF
--- a/app/common/state/aboutNewTabState.js
+++ b/app/common/state/aboutNewTabState.js
@@ -44,10 +44,6 @@ const aboutNewTabState = {
       return state
     }
 
-    // Remove tags since we've verified this is a bookmark/history item
-    // NOTE: siteUtil.removeSite won't delete the entry unless tags are missing
-    siteDetail = siteDetail.delete('tags')
-
     // Keep track of the last 18 visited sites
     let sites = state.getIn(['about', 'newtab', 'sites']) || new Immutable.List()
     sites = sites.unshift(siteDetail)
@@ -57,7 +53,7 @@ const aboutNewTabState = {
     // |
     // V
     // .sort(suggestion.sortByAccessCountWithAgeDecay)
-    sites = siteUtil.addSite(sites, siteDetail, undefined, props.originalSiteDetail)
+    sites = siteUtil.addSite(sites, siteDetail, props.tag, props.originalSiteDetail)
     state = state.setIn(['about', 'newtab', 'sites'], sites)
     return state.setIn(['about', 'newtab', 'updatedStamp'], new Date().getTime())
   },
@@ -74,9 +70,11 @@ const aboutNewTabState = {
       return state
     }
 
-    // Remove tags since we've verified this is a bookmark/history item
+    // Remove tags if this is a history item.
     // NOTE: siteUtil.removeSite won't delete the entry unless tags are missing
-    siteDetail = siteDetail.delete('tags')
+    if (siteDetail.get('tags') && siteDetail.get('tags').size === 0) {
+      siteDetail = siteDetail.delete('tags')
+    }
 
     const sites = state.getIn(['about', 'newtab', 'sites'])
     state = state.setIn(['about', 'newtab', 'sites'], siteUtil.removeSite(sites, siteDetail, undefined))

--- a/js/about/newTabComponents/block.js
+++ b/js/about/newTabComponents/block.js
@@ -80,19 +80,19 @@ class Block extends ImmutableComponent {
               className={cx({
                 topSitesActionBtn: true,
                 fa: true,
-                [starIcon]: true
+                [pinIcon]: true
               })}
-              onClick={onToggleBookmark}
-              data-l10n-id={isBookmarked ? 'removeBookmarkButton' : 'addBookmarkButton'}
+              onClick={onPinnedTopSite}
+              data-l10n-id={isPinned ? 'pinTopSiteButton' : 'unpinTopSiteButton'}
             />
             <button
               className={cx({
                 topSitesActionBtn: true,
                 fa: true,
-                [pinIcon]: true
+                [starIcon]: true
               })}
-              onClick={onPinnedTopSite}
-              data-l10n-id={isPinned ? 'pinTopSiteButton' : 'unpinTopSiteButton'}
+              onClick={onToggleBookmark}
+              data-l10n-id={isBookmarked ? 'removeBookmarkButton' : 'addBookmarkButton'}
             />
             <button
               className='topSitesActionBtn fa fa-close'

--- a/less/about/newtab.less
+++ b/less/about/newtab.less
@@ -249,7 +249,7 @@ ul {
             visibility: visible;
             position: absolute;
             top: 4px;
-            right: 4px;
+            left: 4px;
             width: 20px;
             height: 20px;
             background-color: @gray25;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

Auditors: @bsclifton

Fix #5380

Test Plan:

* hover over any topSites tile
* order should be PIN-BOOKMARK-CLOSE
* pinning a tile should have its indicator on the left