### PR TITLE
Properly display about:newtab when session is null

### DIFF
--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -35,21 +35,20 @@ class NewTabPage extends React.Component {
       updatedStamp: undefined
     }
     ipc.on(messages.NEWTAB_DATA_UPDATED, (e, newTabData) => {
-      this.sanitize(newTabData)
-    })
-  }
-  sanitize (newTabData) {
-    let sanitizedData = Immutable.fromJS(newTabData || {})
-    const updatedStamp = sanitizedData.getIn(['newTabDetail', 'updatedStamp'])
+      const data = Immutable.fromJS(newTabData || {})
+      const updatedStamp = data.getIn(['newTabDetail', 'updatedStamp'])
 
-    // Only update if the data has changed.
-    if (updatedStamp === this.state.updatedStamp) {
-      return
-    }
+      // Only update if the data has changed.
+      if (typeof updatedStamp === 'number' &&
+          typeof this.state.updatedStamp === 'number' &&
+          updatedStamp === this.state.updatedStamp) {
+        return
+      }
 
-    this.setState({
-      newTabData: sanitizedData,
-      updatedStamp: updatedStamp
+      this.setState({
+        newTabData: data,
+        updatedStamp: updatedStamp
+      })
     })
   }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Properly display about:newtab when session is null

Fixes https://github.com/brave/browser-laptop/issues/5379

Auditors: @cezaraugusto

cc: @bbondy, since this does fix the webdriver tests for about:newpage :D

Test Plan: 
1. Open two consoles, both open to the source
2. In first one, run `npm run watch-test`
3. In other, run `npm run test -- --grep="about:newtab"
4. Watch the tests pass :smile: