### PR TITLE
Add fallback when a topSite doesn't have favicon

### DIFF
--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -15,6 +15,7 @@ const SiteRemovalNotification = require('./newTabComponents/siteRemovalNotificat
 const FooterInfo = require('./newTabComponents/footerInfo')
 const aboutActions = require('./aboutActions')
 const siteUtil = require('../state/siteUtil')
+const urlutils = require('../lib/urlutil')
 const siteTags = require('../constants/siteTags')
 const cx = require('../lib/classSet.js')
 const config = require('../constants/config')
@@ -264,6 +265,12 @@ class NewTabPage extends React.Component {
     const gridLayoutSize = this.gridLayoutSize
     const gridLayout = this.gridLayout
 
+    const getLetterFromUrl = (url) => {
+      const hostname = urlutils.getHostname(url.get('location'), true)
+      const name = url.get('title') || hostname || '?'
+      return name.charAt(0).toUpperCase()
+    }
+
     return <div className='dynamicBackground' style={this.state.backgroundImage.style}>
       {
         this.state.backgroundImage
@@ -297,9 +304,7 @@ class NewTabPage extends React.Component {
                     href={site.get('location')}
                     favicon={
                       site.get('favicon') == null
-                      ? site.get('title')
-                        ? site.get('title').charAt(0).toUpperCase()
-                        : '?'
+                      ? getLetterFromUrl(site)
                       : <img src={site.get('favicon')} />
                     }
                     style={{backgroundColor: site.get('themeColor')}}


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

Auditors: @bsclifton

Fix #5332

Test Plan:
* Inside [`getLetterFromUrl`](https://github.com/brave/browser-laptop/compare/master...cezaraugusto:feature/newtab/5332?expand=1#diff-dbb992f7cd2508b46d5cd98e609be5a5R268) function, change `site.get('title')` to something else. i.e. `site.get('titlenator')`
* On topSites grid, sites' tile should fallback to location's first letter
* Change url.get('location') to something else. i.e. `url.get('locationizer')`
* On topSites grid, sites' tile should fallback to `?` string