### PR TITLE
Update default for magic titlebar on Windows/Linux; add favicon for about pages

### DIFF
--- a/app/extensions/brave/about-autofill.html
+++ b/app/extensions/brave/about-autofill.html
@@ -8,6 +8,7 @@
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
     <meta name='theme-color' content='#ff5000'>
+    <link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,">
     <title data-l10n-id="autofillTitle"></title>
     <script src='js/about.js'></script>
     <script src="ext/l20n.min.js" async></script>

--- a/app/extensions/brave/about-passwords.html
+++ b/app/extensions/brave/about-passwords.html
@@ -8,6 +8,7 @@
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
     <meta name='theme-color' content='#ff5000'>
+    <link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,">
     <title data-l10n-id="passwordsTitle"></title>
     <script src='js/about.js'></script>
     <script src="ext/l20n.min.js" async></script>

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -133,7 +133,7 @@ module.exports = {
     'security.passwords.dashlane-enabled': false,
     'security.passwords.last-pass-enabled': false,
     'general.downloads.default-save-path': null,
-    'general.disable-title-mode': process.platform === 'win32',
+    'general.disable-title-mode': process.platform === 'linux',
     'advanced.hardware-acceleration-enabled': true,
     'advanced.default-zoom-level': null,
     'advanced.pdfjs-enabled': true,


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

- Update default value for magic titlebar
  - false for Linux (ex: always show URL bar)
  - true for Windows (ex: use magic titlebar)

- add favicon for about pages for which it was missing
  - about:autofill
  - about:passwords

Auditors: @bradrichter, @darkdh

## Fixes https://github.com/brave/browser-laptop/issues/5416 (URL bar duplicates the title bar)

part 1: linux
1. Install Brave (fresh install or move session folder) on Linux
2. Launch Brave and visit brave.com
3. URL bar should always be showing
4. Go to about:preferences and ensure "Always show URL bar" is enabled

part 2: windows
1. Install Brave (fresh install or move session folder) on Windows
2. Launch Brave and visit brave.com
3. URL bar should be hidden unless mouse is in there
4. Go to about:preferences and ensure "Always show URL bar" is disabled

**NOTE:** _this PR does NOT fix https://github.com/brave/browser-laptop/issues/2301; keep that in mind when testing. Windows may have the correct setting, but still show the URL bar_ :frowning_face: 

## Fixes https://github.com/brave/browser-laptop/issues/5398 (about:autofill missing Brave favicon)

1. Launch Brave and visit about:about
2. Click about:passwords and notice the favicon now shows up
3. Click about:autofill and notice the favicon now shows up