### PR TITLE
Updating icons in URL bar

### DIFF
--- a/js/components/siteInfo.js
+++ b/js/components/siteInfo.js
@@ -61,9 +61,9 @@ class SiteInfo extends ImmutableComponent {
           extendedValidation: this.isExtendedValidation
         })} /><span data-l10n-id='secureConnection' /></li>
     } else if (this.runInsecureContent) {
-      secureIcon = <li><span className='fa fa-unlock' /><span data-l10n-id='mixedConnection' /></li>
+      secureIcon = <li><span className='fa fa-exclamation-triangle' /><span data-l10n-id='mixedConnection' /></li>
     } else {
-      secureIcon = <li><span className='fa fa-unlock' /><span data-l10n-id='insecureConnection' data-l10n-args={JSON.stringify(l10nArgs)} /></li>
+      secureIcon = <li><span className='fa fa-exclamation-triangle' /><span data-l10n-id='insecureConnection' data-l10n-args={JSON.stringify(l10nArgs)} /></li>
     }
 
     // Figure out the partition info display

--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -409,6 +409,9 @@ class UrlBar extends ImmutableComponent {
   }
 
   render () {
+    const showIconSecure = !this.activateSearchEngine && this.isHTTPPage && this.props.isSecure && !this.props.urlbar.get('active')
+    const showIconInsecure = !this.activateSearchEngine && this.isHTTPPage && !this.props.isSecure && !this.props.urlbar.get('active') && !this.props.titleMode
+    const showIconSearch = !this.activateSearchEngine && this.props.urlbar.get('active') && this.props.loading === false
     const value = this.isActive || (!this.locationValue && this.isFocused())
       ? undefined
       : this.locationValue
@@ -424,9 +427,9 @@ class UrlBar extends ImmutableComponent {
         className={cx({
           urlbarIcon: true,
           'fa': !this.activateSearchEngine,
-          'fa-lock': !this.activateSearchEngine && this.isHTTPPage && this.props.isSecure && !this.props.urlbar.get('active'),
-          'fa-unlock': !this.activateSearchEngine && this.isHTTPPage && !this.props.isSecure && !this.props.urlbar.get('active') && !this.props.titleMode,
-          'fa fa-file': !this.activateSearchEngine && this.props.urlbar.get('active') && this.props.loading === false,
+          'fa-lock': showIconSecure,
+          'fa-exclamation-triangle': showIconInsecure,
+          'fa fa-search': showIconSearch || (!showIconSecure && !showIconInsecure && !showIconSearch),
           extendedValidation: this.extendedValidationSSL
         })}
         style={

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -769,7 +769,7 @@
   }
 
   .urlbarIcon {
-    color: @focusUrlbarOutline;
+    color: @siteSecureColor;
     left: 14px;
     margin-top: 1px;
     font-size: 13px;
@@ -777,19 +777,19 @@
     min-width: 16px;
 
     &.fa-lock,
-    &.fa-unlock {
+    &.fa-exclamation-triangle {
       margin-top: 1px;
       font-size: 16px;
       min-height: 10px;
       min-width: 16px;
     }
 
-    &.fa-unlock {
-        color: @gray;
+    &.fa-exclamation-triangle {
+        color: @siteInsecureColor;
     }
 
     &.extendedValidation {
-      color: green;
+      color: @siteEVColor;
     }
   }
 }

--- a/less/variables.less
+++ b/less/variables.less
@@ -38,6 +38,9 @@
 @contextMenuFontSize: 14px;
 @audioColor: @highlightBlue;
 @focusUrlbarOutline: @highlightBlue;
+@siteSecureColor: @highlightBlue;
+@siteInsecureColor: #FCBA00;
+@siteEVColor: green;
 @loadTimeColor: @highlightBlue;
 @activeTabDefaultColor: @chromePrimary;
 @buttonColor: #5a5a5a;

--- a/test/components/navigationBarTest.js
+++ b/test/components/navigationBarTest.js
@@ -332,7 +332,7 @@ describe('navigationBar', function () {
           .moveToObject(navigator)
           .waitForExist(urlbarIcon)
           .getAttribute(urlbarIcon, 'class').then((classes) =>
-            classes.includes('fa-unlock')
+            classes.includes('fa-exclamation-triangle')
         ))
         .windowByUrl(Brave.browserWindowUrl)
         .click(urlbarIcon)
@@ -791,6 +791,9 @@ describe('navigationBar', function () {
             return this.getValue(urlInput).then((val) => val === 'about:blank')
           })
       })
+      it('has the search icon', function * () {
+        yield this.app.client.waitForExist('.urlbarIcon.fa-search')
+      })
     })
 
     describe('page with focused form input', function () {
@@ -850,8 +853,8 @@ describe('navigationBar', function () {
         yield selectsText(this.app.client, 'brave.com')
       })
 
-      it('has the file icon', function * () {
-        yield this.app.client.waitForExist('.urlbarIcon.fa-file')
+      it('has the search icon', function * () {
+        yield this.app.client.waitForExist('.urlbarIcon.fa-search')
       })
     })
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Updating icons in URL bar

Fixes https://github.com/brave/browser-laptop/issues/5446
Fixes https://github.com/brave/browser-laptop/issues/4910

- includes updates to the webdriver tests (and adding new test case for this)
- colors for icon in URL bar pulled out into variables.less

Auditors: @diracdeltas, @bbondy

## Test Plan
1. Launch Brave and open a new tab
2. Notice that magnifying glass shows by default (with no text input yet)
3. Type some text and notice icon remains magnifying glass (no longer the document icon)
4. Visit http://mal-game.com
5. Notice the triangle exclamation icon is now showing, since connection is HTTP
6. Click the triangle in the URL bar and confirm you see the "insecure connection" modal
7. Visit https://mixed-script.badssl.com/
8. Click the lock icon in the URL bar
9. Secure connection modal comes up. Click "Load Unsafe Scripts"
10. Notice icon in URL bar is now the triangle
11. Click the triangle icon in the URL bar and confirm you see the "partially insecure connection" modal

## Screenshots
**HTTP shows yellow triangle now**
![screen shot 2016-11-07 at 1 54 26 am](https://cloud.githubusercontent.com/assets/4733304/20052726/8a3a64ee-a492-11e6-9b93-70c79336c7fe.png)

**Insecure/partially insecure modal uses triangle**
![screen shot 2016-11-07 at 1 54 46 am](https://cloud.githubusercontent.com/assets/4733304/20052751/a3c237b6-a492-11e6-8264-34b4d46249de.png)
![screen shot 2016-11-07 at 1 53 38 am](https://cloud.githubusercontent.com/assets/4733304/20052754/a7d20be2-a492-11e6-9c29-2ce9fbf59487.png)

**URL bar (when empty) now defaults to magnifying glass**
![screen shot 2016-11-07 at 2 00 48 am](https://cloud.githubusercontent.com/assets/4733304/20052780/c5cc7c22-a492-11e6-9198-dd977b146c48.png)

**when typing into URL bar, it shows magnifying glass instead of document**
![screen shot 2016-11-07 at 1 55 02 am](https://cloud.githubusercontent.com/assets/4733304/20052804/d8945140-a492-11e6-9066-797aed8eaaee.png)
