### PR TITLE
Don't toggle menu unless ALT was the last key pressed

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -104,6 +104,7 @@ class Main extends ImmutableComponent {
     this.onFind = this.onFind.bind(this)
     this.onFindHide = this.onFindHide.bind(this)
     this.checkForTitleMode = debounce(this.checkForTitleMode.bind(this), 20)
+    this.lastKeyPressed = undefined
   }
   registerWindowLevelShortcuts () {
     // For window level shortcuts that don't work as local shortcuts
@@ -129,6 +130,8 @@ class Main extends ImmutableComponent {
           }
           break
       }
+
+      this.lastKeyPressed = e.which
     })
   }
 
@@ -143,16 +146,20 @@ class Main extends ImmutableComponent {
               break
             }
 
-            e.preventDefault()
+            // Only show/hide the menu if last key pressed was ALT
+            // (typing ALT codes should not toggle menu)
+            if (this.lastKeyPressed === keyCodes.ALT) {
+              e.preventDefault()
 
-            if (getSetting(settings.AUTO_HIDE_MENU)) {
-              windowActions.toggleMenubarVisible(null)
-            } else {
-              if (customTitlebar.menubarSelectedIndex) {
-                windowActions.setSubmenuSelectedIndex()
-                windowActions.setContextMenuDetail()
+              if (getSetting(settings.AUTO_HIDE_MENU)) {
+                windowActions.toggleMenubarVisible(null)
               } else {
-                windowActions.setSubmenuSelectedIndex([0])
+                if (customTitlebar.menubarSelectedIndex) {
+                  windowActions.setSubmenuSelectedIndex()
+                  windowActions.setContextMenuDetail()
+                } else {
+                  windowActions.setSubmenuSelectedIndex([0])
+                }
               }
             }
             break


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Don't toggle menu unless ALT was the last key pressed
This prevents ALT codes from toggling menu

Fixes https://github.com/brave/browser-laptop/issues/4295

Auditors: @jonathansampson, @BrendanEich

Test Plan:
1. Launch Brave on Windows and go to http://jsbin.com
2. Click inside a text area and type a few letters
3. Push ALT (left) and release to confirm menu shows and do same to hide it
4. Push and hold ALT (left), key in 0133, then let go of ALT
5. The ellipsis should be typed out and the menu should NOT have been toggled