### PR TITLE
Filter the lastAccessTime == 0 in urlbar suggestions

### DIFF
--- a/js/components/urlBarSuggestions.js
+++ b/js/components/urlBarSuggestions.js
@@ -289,7 +289,8 @@ class UrlBarSuggestions extends ImmutableComponent {
       // status. If history is turned off, bookmarked sites will appear
       // in the bookmark section.
       return (title.toLowerCase().includes(urlLocationLower) ||
-              location.toLowerCase().includes(urlLocationLower))
+              location.toLowerCase().includes(urlLocationLower)) &&
+              site.get('lastAccessedTime')
     }
     var historySites = props.sites.filter(historyFilter)
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #5183

Auditors: @bbondy, @bsclifton

Test Plan:
1. Import bookmarks
2. They should not appear in urlbar suggestions until you visit them