### PR TITLE
Add "Search for" for selected text in input fields

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -995,6 +995,10 @@ function mainTemplateInit (nodeProps, frame) {
     if (editableItems.length > 0) {
       template.push(...editableItems, CommonMenu.separatorMenuItem)
     }
+
+    if (isTextSelected) {
+      template.push(searchSelectionMenuItem(nodeProps.selectionText), CommonMenu.separatorMenuItem)
+    }
   } else if (isTextSelected) {
     if (isDarwin) {
       template.push(showDefinitionMenuItem(nodeProps.selectionText),


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Open Brave and navigate to any site with an input field.
2. Type a word in the input field.
3. Select the word.
4. Right-click the selection.
5. There should be a menu item called "Search for…" in the context menu.
6. Click "Search for…".
7. A new tab should open with the default search engine, and the search term should be the selected text.

![image](https://cloud.githubusercontent.com/assets/19424103/20070038/8fdd4644-a4e4-11e6-9658-a2c94ce017a2.png)

Fixes #5465