### PR TITLE
svg buttons alignment on tabsbar

### DIFF
--- a/less/button.less
+++ b/less/button.less
@@ -20,12 +20,19 @@ span.buttonSeparator {
 }
 
 span.menuButton {
-  background: url('../img/toolbar/menu_btn.svg') center no-repeat;
+  background-color: @buttonColor;
   display: inline-block;
   width: 20px;
   height: 12px;
-  margin: 6px 4px 0 0;
+  margin: 8px 4px 0 0;
   cursor: default;
+  -webkit-mask-image: url('../img/toolbar/menu_btn.svg');
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+
+  &:hover {
+    background-color: black;
+  }
 }
 
 a.browserButton,


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5456

Auditors @bsclifton @luixxiul 

Test Plan:

1. Open Brave
2. Create new tabs until you've filled up the tabs row
3. Make sure the + for the new tab button lines up with the kabob three dots for menu.
4. Three dots should be dark gray and turn black on hover.

Screenshots for @bradleyrichter's approval

![screen shot 2016-11-07 at 12 01 54 pm](https://cloud.githubusercontent.com/assets/490294/20073761/5add1462-a4e2-11e6-8529-e2b35f969e77.png)

and hover

![screen shot 2016-11-07 at 12 02 00 pm](https://cloud.githubusercontent.com/assets/490294/20073767/5f9133da-a4e2-11e6-920c-e5a0fbe6e244.png)


