### PR TITLE
"Add funds" notification: Reduce nag level and add button to "Turn off notifications"

### DIFF
--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -168,6 +168,7 @@ flashSubtext=from {{source}} on {{site}}.
 flashExpirationText=Approvals reset 7 days after last visit.
 addFundsNotification=Your Brave Payments account is waiting for a deposit.
 reconciliationNotification=Good news! Brave will pay your favorite publisher sites in less than 24 hours.
+turnOffNotifications=Turn off notifications
 reviewSites=Review your chosen sites
 dismiss=Dismiss
 addFunds=Add funds

--- a/app/ledger.js
+++ b/app/ledger.js
@@ -1494,29 +1494,43 @@ const showDisabledNotifications = () => {
 */
 const showEnabledNotifications = () => {
   const reconcileStamp = ledgerInfo.reconcileStamp
-  const balance = Number(ledgerInfo.balance || 0)
-  const unconfirmed = Number(ledgerInfo.unconfirmed || 0)
-
   if (reconcileStamp && reconcileStamp - underscore.now() < msecs.day) {
-    if (ledgerInfo.btc &&
-        balance + unconfirmed < 0.9 * Number(ledgerInfo.btc)) {
-      addFundsMessage = addFundsMessage || locale.translation('addFundsNotification')
-      appActions.showMessageBox({
-        greeting: locale.translation('updateHello'),
-        message: addFundsMessage,
-        buttons: [
-          {text: locale.translation('updateLater')},
-          {text: locale.translation('addFunds'), className: 'primary'}
-        ],
-        options: {
-          style: 'greetingStyle',
-          persist: false
-        }
-      })
+    if (shouldShowNotificationAddFunds()) {
+      showNotificationAddFunds()
     } else if (shouldShowNotificationReviewPublishers()) {
       showNotificationReviewPublishers()
     }
   }
+}
+
+const shouldShowNotificationAddFunds = () => {
+  const balance = Number(ledgerInfo.balance || 0)
+  const unconfirmed = Number(ledgerInfo.unconfirmed || 0)
+  const nextTime = getSetting(settings.PAYMENTS_NOTIFICATION_ADD_FUNDS_TIMESTAMP)
+  if (nextTime && (nextTime > underscore.now())) {
+    return false
+  }
+  return ledgerInfo.btc &&
+         (balance + unconfirmed < 0.9 * Number(ledgerInfo.btc))
+}
+
+const showNotificationAddFunds = () => {
+  const nextTime = underscore.now() + 3 * msecs.day
+  appActions.changeSetting(settings.PAYMENTS_NOTIFICATION_ADD_FUNDS_TIMESTAMP, nextTime)
+
+  addFundsMessage = addFundsMessage || locale.translation('addFundsNotification')
+  appActions.showMessageBox({
+    greeting: locale.translation('updateHello'),
+    message: addFundsMessage,
+    buttons: [
+      {text: locale.translation('updateLater')},
+      {text: locale.translation('addFunds'), className: 'primary'}
+    ],
+    options: {
+      style: 'greetingStyle',
+      persist: false
+    }
+  })
 }
 
 const shouldShowNotificationReviewPublishers = () => {

--- a/app/ledger.js
+++ b/app/ledger.js
@@ -324,7 +324,6 @@ if (ipc) {
       // buttonIndex === 1 is "Later"; the timestamp until which to delay is set
       // in showNotificationAddFunds() when triggering this notification.
       if (buttonIndex === 0) {
-        // Turn off notifications
         appActions.changeSetting(settings.PAYMENTS_NOTIFICATIONS, false)
       } else if (buttonIndex === 2) {
         // Add funds: Open payments panel
@@ -336,12 +335,17 @@ if (ipc) {
     } else if (message === reconciliationMessage) {
       appActions.hideMessageBox(message)
       // buttonIndex === 1 is Dismiss
-      if (buttonIndex === 0 && win) {
+      if (buttonIndex === 0) {
+        appActions.changeSetting(settings.PAYMENTS_NOTIFICATIONS, false)
+      } else if (buttonIndex === 2 && win) {
         win.webContents.send(messages.SHORTCUT_NEW_FRAME,
           'about:preferences#payments', { singleFrame: true })
       }
     } else if (message === notificationPaymentDoneMessage) {
       appActions.hideMessageBox(message)
+      if (buttonIndex === 0) {
+        appActions.changeSetting(settings.PAYMENTS_NOTIFICATIONS, false)
+      }
     } else if (message === notificationTryPaymentsMessage) {
       appActions.hideMessageBox(message)
       if (buttonIndex === 1 && win) {
@@ -1553,8 +1557,9 @@ const showNotificationReviewPublishers = () => {
     greeting: locale.translation('updateHello'),
     message: reconciliationMessage,
     buttons: [
-      {text: locale.translation('reviewSites'), className: 'primary'},
-      {text: locale.translation('dismiss')}
+      {text: locale.translation('turnOffNotifications')},
+      {text: locale.translation('dismiss')},
+      {text: locale.translation('reviewSites'), className: 'primary'}
     ],
     options: {
       style: 'greetingStyle',
@@ -1574,6 +1579,7 @@ const showNotificationPaymentDone = (transactionContributionFiat) => {
     greeting: locale.translation('updateHello'),
     message: notificationPaymentDoneMessage,
     buttons: [
+      {text: locale.translation('turnOffNotifications')},
       {text: locale.translation('Ok'), className: 'primary'}
     ],
     options: {

--- a/app/locale.js
+++ b/app/locale.js
@@ -193,6 +193,7 @@ var rendererIdentifiers = function () {
     'reconciliationNotification',
     'reviewSites',
     'addFunds',
+    'turnOffNotifications',
     'copyToClipboard',
     'smartphoneTitle',
     'displayQRCode',

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -120,6 +120,8 @@ module.exports = {
     'bookmarks.toolbar.showOnlyFavicon': false,
     'payments.enabled': false,
     'payments.notifications': false,
+    // "Add funds to your wallet" -- Limit to once every n days to reduce nagging.
+    'payments.notification-add-funds-timestamp': null,
     // "Out of money, pls add" / "In 24h we'll pay publishers [Review]"
     // After shown, set timestamp to next reconcile time - 1 day.
     'payments.notification-reconcile-soon-timestamp': null,

--- a/js/constants/settings.js
+++ b/js/constants/settings.js
@@ -46,6 +46,7 @@ const settings = {
   // Payments Tab
   PAYMENTS_ENABLED: 'payments.enabled',
   PAYMENTS_NOTIFICATIONS: 'payments.notifications',
+  PAYMENTS_NOTIFICATION_ADD_FUNDS_TIMESTAMP: 'notification-add-funds-timestamp',
   PAYMENTS_NOTIFICATION_RECONCILE_SOON_TIMESTAMP: 'notification-reconcile-soon-timestamp',
   PAYMENTS_NOTIFICATION_TRY_PAYMENTS_DISMISSED: 'payments.notificationTryPaymentsDismissed',
   PAYMENTS_CONTRIBUTION_AMOUNT: 'payments.contribution-amount',

--- a/less/notificationBar.less
+++ b/less/notificationBar.less
@@ -27,7 +27,7 @@
         font-size: 14px;
         height: 25px;
         line-height: 27px;
-        margin: auto 4px;
+        margin: auto 0 auto 4px;
         padding: 0px 25px;
         width: auto;
 


### PR DESCRIPTION
Fix #5418
Fix #5299

Auditors: @bsclifton

Test Plan / Quieter notification:
1. Trigger the "Add funds" notification.
  a. Update reconcileStamp to <24 hours from now (or a few days in the past)
  b. Ensure not enough balance
2. Change startup notification delay in ledger.js L484 from 15m to 5s
3. Open Brave and observe notification. Click Later.
4. Close Brave and reopen. Notification should not reappear.
(Next Add funds notification timestamp is set in Application Support/brave-development/session-store-1 `notification-add-funds-timestamp`)

Test Plan / Turn off button:
5. Trigger the Add funds notification again by closing Brave and editing session-store-1 `notification-add-funds-timestamp` to the past.
6. Open Brave, and when the notification appears choose Turn off.
7. Open Preferences > Payments and click Advanced Settings... and observe notifications are disabled.

Image / Before
<img width="1058" alt="screen shot 2016-11-07 at 12 22 25" src="https://cloud.githubusercontent.com/assets/521861/20076580/cc6deb5a-a4ed-11e6-9cbe-e92fd20d159f.png">

Image / After
![screen shot 2016-11-08 at 14 30 38](https://cloud.githubusercontent.com/assets/521861/20120031/f80a1766-a5bf-11e6-9aff-4a56a891c90c.png)


Image 2 / After
![screen shot 2016-11-08 at 14 19 39](https://cloud.githubusercontent.com/assets/521861/20120001/d338dcec-a5bf-11e6-84b6-03bf8d119481.png)


cc @bbondy @bradleyrichter 
