### PR TITLE
To "Review sites" notification add button to Dismiss

### DIFF
--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -169,6 +169,7 @@ flashExpirationText=Approvals reset 7 days after last visit.
 addFundsNotification=Your Brave Payments account is waiting for a deposit.
 reconciliationNotification=Good news! Brave will pay your favorite publisher sites in less than 24 hours.
 reviewSites=Review your chosen sites
+dismiss=Dismiss
 addFunds=Add funds
 notificationPasswordWithUserName=Would you like Brave to remember the password for {{username}} on {{origin}}?
 notificationPassword=Would you like Brave to remember your password on {{origin}}?

--- a/app/ledger.js
+++ b/app/ledger.js
@@ -333,7 +333,8 @@ if (ipc) {
       }
     } else if (message === reconciliationMessage) {
       appActions.hideMessageBox(message)
-      if (win) {
+      // buttonIndex === 1 is Dismiss
+      if (buttonIndex === 0 && win) {
         win.webContents.send(messages.SHORTCUT_NEW_FRAME,
           'about:preferences#payments', { singleFrame: true })
       }
@@ -1532,7 +1533,8 @@ const showNotificationReviewPublishers = () => {
     greeting: locale.translation('updateHello'),
     message: reconciliationMessage,
     buttons: [
-      {text: locale.translation('reviewSites'), className: 'primary'}
+      {text: locale.translation('reviewSites'), className: 'primary'},
+      {text: locale.translation('dismiss')}
     ],
     options: {
       style: 'greetingStyle',

--- a/app/locale.js
+++ b/app/locale.js
@@ -205,6 +205,7 @@ var rendererIdentifiers = function () {
     'notificationTryPayments',
     'notificationTryPaymentsYes',
     'prefsRestart',
+    'dismiss',
     'yes',
     'no',
     'noThanks',


### PR DESCRIPTION
Minor – adds a button to dismiss this notification.

Auditors: @bsclifton

Test Plan:
(Similar to plan for #5296)

1. Trigger the "Payment in 24 hours, please review" notification:
  a. Update reconcileStamp to <24 hours from now
  b. Update notification-reconcile-soon-timestamp to the past in Application Support/brave-development/session-store-1
  c. Change startup notification delay in ledger.js L484 from 15m to 5s
  d. Disable the sufficient funds conditional by adding false to ledger.js L1485 (showEnabledNotifications()) OR have sufficient funds
2. Open Brave and observe review sites notification
3. Click Dismiss to dismiss

Image / Before
<img width="1150" alt="screen shot 2016-11-07 at 13 28 03" src="https://cloud.githubusercontent.com/assets/521861/20078015/baf7a05e-a4f3-11e6-9682-d88bcb9732f1.png">

Image / After
<img width="1070" alt="screen shot 2016-11-07 at 14 09 16" src="https://cloud.githubusercontent.com/assets/521861/20078042/cce23a54-a4f3-11e6-853f-b2ded77878d0.png">