### PR TITLE
Fix search icon overlapping custom search engine icon

### DIFF
--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -455,6 +455,7 @@ class UrlBar extends ImmutableComponent {
     const showIconSecure = !this.activateSearchEngine && this.isHTTPPage && this.props.isSecure && !this.props.urlbar.get('active')
     const showIconInsecure = !this.activateSearchEngine && this.isHTTPPage && !this.props.isSecure && !this.props.urlbar.get('active') && !this.props.titleMode
     const showIconSearch = !this.activateSearchEngine && this.props.urlbar.get('active') && this.props.loading === false
+    const showSearchByDefault = !this.activateSearchEngine && !showIconSecure && !showIconInsecure && !showIconSearch && !this.props.titleMode
     return <form
       className='urlbarForm'
       action='#'
@@ -469,7 +470,7 @@ class UrlBar extends ImmutableComponent {
           'fa': !this.activateSearchEngine,
           'fa-lock': showIconSecure,
           'fa-exclamation-triangle': showIconInsecure,
-          'fa fa-search': showIconSearch || (!showIconSecure && !showIconInsecure && !showIconSearch && !this.props.titleMode),
+          'fa fa-search': showIconSearch || showSearchByDefault,
           extendedValidation: this.extendedValidationSSL
         })}
         style={

--- a/test/components/navigationBarTest.js
+++ b/test/components/navigationBarTest.js
@@ -1015,6 +1015,10 @@ describe('navigationBar', function () {
                 .then((backgroundImage) => backgroundImage.value === `url("${entry.image}")`)
             })
         })
+
+        it('does not show the default icon (search)', function * () {
+          yield this.app.client.waitForExist('.urlbarIcon.fa-search', 1500, true)
+        })
       })
     })
   })


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix search icon overlapping custom search engine icon

- Fixes https://github.com/brave/browser-laptop/issues/5477
- Accidental regression caused by https://github.com/brave/browser-laptop/pull/5449
- Includes webdriver test to enforce the expected behavior

Auditors: @bbondy

Test Plan:
1. Launch Brave and open a new tab
2. Confirm that magnifying glass shows
3. Type into URL bar, confirm it stays as magnifying glass
4. Use a search shortcut, like :m, and type this into the URL bar. For example `:m date`
5. magnifying glass should disappear and it should show the MDN icon