### PR TITLE
Make tab close button respect tab's container

### DIFF
--- a/less/tabs.less
+++ b/less/tabs.less
@@ -42,8 +42,8 @@
 }
 
 .tab {
-  // background: rgba(222, 222, 222, 0.6);
-    background: linear-gradient(to bottom, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0.1));
+  position: relative;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.4), rgba(255, 255, 255, 0.1));
   border-radius: @borderRadiusTabs @borderRadiusTabs 0px 0px;
   border-width: 1px 1px 0;
   box-sizing: border-box;
@@ -157,13 +157,24 @@
   }
 
   .closeTab {
+    transition: opacity 100ms linear;
     opacity: 0;
     text-align: center;
     width: 16px;
     height: 16px;
     margin-left: 4px;
     margin-right: 4px;
-
+    @media (max-width: @breakpointTabsTextTrim) {
+      position: absolute;
+      width: 100%;
+      margin: 0;
+      background: #fff;
+      border-radius: 0;
+      height: 100%;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+    }
     &:hover {
       opacity: 1;
     }

--- a/less/variables.less
+++ b/less/variables.less
@@ -135,6 +135,7 @@
 
 @breakpointWideViewport: 1000px;
 @breakpointNarrowViewport: 600px;
+@breakpointTabsTextTrim: 770px;
 @breakpointExtensionButtonPadding: 720px;
 @breakpointSmallWin32: 650px;
 @breakpointTinyWin32: 500px;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5431

Auditors: @bbondy, @bsclifton

Note:

This change fixed the issue, but affected tab icons on small windows (now being overflowed in a different way). Doesn't look weird imo but can be improved per team's request.

Test Plan:

* Reduce window's width checking for close button on tabs
* Close button should not overflow tab container on narrow views, avoiding UI mismatch