### PR TITLE
Remove row control for topSites on new tab page

### DIFF
--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -17,7 +17,6 @@ const aboutActions = require('./aboutActions')
 const siteUtil = require('../state/siteUtil')
 const urlutils = require('../lib/urlutil')
 const siteTags = require('../constants/siteTags')
-const cx = require('../lib/classSet.js')
 const config = require('../constants/config')
 const backgrounds = require('../data/backgrounds')
 
@@ -262,7 +261,6 @@ class NewTabPage extends React.Component {
       return null
     }
 
-    const gridLayoutSize = this.gridLayoutSize
     const gridLayout = this.gridLayout
 
     const getLetterFromUrl = (url) => {
@@ -285,15 +283,6 @@ class NewTabPage extends React.Component {
             <Clock />
           </div>
           <div className='topSitesContainer'>
-            <button
-              className={cx({
-                toggleTopSitesGridIcon: true,
-                hasThreeRows: gridLayoutSize === 'large',
-                hasTwoRows: gridLayoutSize === 'medium',
-                hasOneRow: gridLayoutSize === 'small'
-              })}
-              onClick={this.onChangeGridLayout.bind(this)}
-            />
             <nav className='topSitesGrid'>
               {
                 gridLayout.map((site) =>


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

fix #5482

Auditors: @bbondy

Test Plan:

* there should be no row control for topSites