### PR TITLE
Reposition Brave Lion on Windows

### DIFF
--- a/app/renderer/components/windowCaptionButtons.js
+++ b/app/renderer/components/windowCaptionButtons.js
@@ -53,7 +53,8 @@ class WindowCaptionButtons extends ImmutableComponent {
 
     return <div className={cx({
       fullscreen: this.props.windowMaximized,
-      windowCaptionButtons: true
+      windowCaptionButtons: true,
+      verticallyCenter: this.props.verticallyCenter
     })}>
       <div className='container'>
         <button

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -909,6 +909,7 @@ class Main extends ImmutableComponent {
                     contextMenuDetail={this.props.windowState.get('contextMenuDetail')}
                     autohide={getSetting(settings.AUTO_HIDE_MENU)}
                     lastFocusedSelector={customTitlebar.lastFocusedSelector} />
+                  <WindowCaptionButtons windowMaximized={customTitlebar.isMaximized} />
                 </div>
                 : null
             }
@@ -969,7 +970,7 @@ class Main extends ImmutableComponent {
               />
               <div className='topLevelEndButtons'>
                 <div className={cx({
-                  extraDragArea: true,
+                  extraDragArea: !customTitlebar.menubarVisible,
                   allowDragging: shouldAllowWindowDrag
                 })} />
                 {
@@ -980,15 +981,21 @@ class Main extends ImmutableComponent {
                   className={cx({
                     navbutton: true,
                     braveShieldsDisabled,
-                    braveShieldsDown: !braverySettings.shieldsUp
+                    braveShieldsDown: !braverySettings.shieldsUp,
+                    leftOfCaptionButton: customTitlebar.captionButtonsVisible && !customTitlebar.menubarVisible
                   })}
                   onClick={this.onBraveMenu} />
+                {
+                  customTitlebar.captionButtonsVisible && !customTitlebar.menubarVisible
+                  ? <span className='buttonSeparator' />
+                  : null
+                }
               </div>
             </div>
           </div>
           {
-            customTitlebar.captionButtonsVisible
-              ? <WindowCaptionButtons windowMaximized={customTitlebar.isMaximized} />
+            customTitlebar.captionButtonsVisible && !customTitlebar.menubarVisible
+              ? <WindowCaptionButtons windowMaximized={customTitlebar.isMaximized} verticallyCenter='true' />
               : null
           }
         </div>

--- a/less/button.less
+++ b/less/button.less
@@ -15,7 +15,7 @@
 
 span.buttonSeparator {
   width: 1px;
-  border-left: 1px solid @gray;
+  border-left: 1px solid #e2e2e2;
   margin: 4px 3px 4px 3px;
 }
 

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -232,6 +232,9 @@
         }
       }
     }
+    .verticallyCenter {
+      justify-content: center;
+    }
   }
 
   // Windows 10 specific styles
@@ -243,16 +246,29 @@
       border: 1px solid #2283d3;
     }
     .windowCaptionButtons {
+      &.verticallyCenter {
+        > .container {
+          height: 100%;
+        }
+      }
+      &:not(.verticallyCenter) {
+        > .container {
+          button.captionButton {
+            height: 29px;
+            &.fullscreen {
+              height: 21px;
+            }
+          }
+        }
+      }
+
       > .container {
         button.captionButton {
           width: 45px;
-          height: 29px;
           border: 0;
           background-color: transparent;
 
-          &.fullscreen {
-            height:21px;
-          }
+          &.fullscreen { }
 
           &.minimize {
             &:hover {
@@ -350,6 +366,9 @@
         }
       }
     }
+    .verticallyCenter {
+      justify-content: center;
+    }
   }
 }
 
@@ -414,8 +433,9 @@
     display: flex;
     cursor: default;
     -webkit-user-select: none;
-    flex-grow: 0;
+    flex-grow: 1;
     margin-top: 2px;
+    height: 19px;
 
     .menubarItem {
       color: black;
@@ -435,6 +455,10 @@
       background-color: #cce8ff !important;
       border: 1px solid #99d1ff !important;
     }
+  }
+
+  .windowCaptionButtons {
+    flex-grow: 0;
   }
 }
 
@@ -499,6 +523,7 @@
   .topLevelEndButtons {
     display: flex;
     flex-direction: row;
+    margin-left: 3px;
 
     .extensionButton {
       -webkit-app-region: no-drag;
@@ -521,6 +546,9 @@
       &.braveShieldsDisabled {
         -webkit-filter: grayscale(100%);
         opacity: 0.4;
+      }
+      &.leftOfCaptionButton {
+        margin-right: 1px;
       }
     }
 
@@ -812,7 +840,7 @@
     &.endButtons {
       margin-right: 20px;
       @media (max-width: @breakpointNarrowViewport) {
-        margin-right: -5px;
+        margin-right: 0px;
       }
     }
   }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes https://github.com/brave/browser-laptop/issues/5069 (Refine the Brave button (look, positioning, feel) on Windows)
Fixes https://github.com/brave/browser-laptop/issues/5383 (Brave Logo Slides Beneath URL Bar)

Also includes (no issue):
Hide extra drag area when menu is showing

**NOTE**: _I've only manually tested on Windows 10. Still needs to be manually tested on Windows 7 before being accepted. Any help there is appreciated_ :smile:

Auditors: @jonathansampson, @bbondy

## Test Plan
should be executed on Windows 10 and Windows 7

1. Launch Brave
2. Have menu hidden and always show URL bar to true
3. Lion should have an extra separator next to the right of it and caption
buttons should be center aligned. Compare against mockup.
4. Make window really skinny (width-wise)
5. Brave lion or extension icons should NOT go under URL bar
6. Disable "auto-hide menu" so that menu is always showing
7. Lion should now be under the caption buttons and there should be no
grab area to the left of it (except for where the noscript icon goes, but
that wasn't changed and isn't draggable)

## screenshots
![screen shot 2016-11-07 at 3 53 15 pm](https://cloud.githubusercontent.com/assets/4733304/20090733/2e9557e2-a54c-11e6-9423-6651219a50f5.png)

![screen shot 2016-11-08 at 12 28 32 am](https://cloud.githubusercontent.com/assets/4733304/20090740/372c3434-a54c-11e6-88e3-999371289915.png)

![screen shot 2016-11-08 at 12 29 25 am](https://cloud.githubusercontent.com/assets/4733304/20090745/3fc1fc64-a54c-11e6-818e-a2435779354e.png)
