### PR TITLE
Don't show HTTP icon while site is loading (since it may be HTTPS)

### DIFF
--- a/app/renderer/components/urlBarIcon.js
+++ b/app/renderer/components/urlBarIcon.js
@@ -1,0 +1,104 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const React = require('react')
+const ImmutableComponent = require('../../../js/components/immutableComponent')
+const windowActions = require('../../../js/actions/windowActions')
+const cx = require('../../../js/lib/classSet')
+const dragTypes = require('../../../js/constants/dragTypes')
+const dndData = require('../../../js/dndData')
+const {isSourceAboutUrl} = require('../../../js/lib/appUrlUtil')
+const searchIconSize = 16
+
+class UrlBarIcon extends ImmutableComponent {
+  constructor () {
+    super()
+    this.onClick = this.onClick.bind(this)
+    this.onDragStart = this.onDragStart.bind(this)
+  }
+  get isSecure () {
+    return this.props.isHTTPPage &&
+           this.props.isSecure &&
+           !this.props.active
+  }
+  /**
+   * insecure icon does not show when:
+   * - loading
+   * - in title mode
+   * - urlbar is active (ex: you can type)
+   */
+  get isInsecure () {
+    return this.props.isHTTPPage &&
+           !this.props.isSecure &&
+           !this.props.active &&
+           this.props.loading === false &&
+           !this.props.titleMode
+  }
+  /**
+   * search icon:
+   * - does not show when loading
+   * - does not show when in title mode
+   * - shows when urlbar is active (ex: you can type)
+   * - is a catch-all for: about pages, files, etc
+   */
+  get isSearch () {
+    const showSearch = this.props.active &&
+                       this.props.loading === false
+
+    const defaultToSearch = (!this.isSecure && !this.isInsecure && !showSearch) &&
+                            !this.props.titleMode &&
+                            this.props.loading === false
+
+    return showSearch || defaultToSearch
+  }
+  get iconClasses () {
+    if (this.props.activateSearchEngine) {
+      return cx({urlbarIcon: true})
+    }
+
+    return cx({
+      urlbarIcon: true,
+      'fa': true,
+      // NOTE: EV style not approved yet; see discussion at https://github.com/brave/browser-laptop/issues/791
+      'fa-lock': this.isSecure,
+      'fa-exclamation-triangle': this.isInsecure,
+      'fa fa-search': this.isSearch
+    })
+  }
+  get iconStyles () {
+    if (!this.props.activateSearchEngine) {
+      return {}
+    }
+
+    return {
+      backgroundImage: `url(${this.props.searchSelectEntry.image})`,
+      minWidth: searchIconSize,
+      width: searchIconSize,
+      backgroundSize: searchIconSize,
+      height: searchIconSize,
+      marginTop: '3px',
+      marginRight: '3px'
+    }
+  }
+  onClick () {
+    if (isSourceAboutUrl(this.props.location)) {
+      return
+    }
+    windowActions.setSiteInfoVisible(true)
+  }
+  onDragStart (e) {
+    dndData.setupDataTransferURL(e.dataTransfer, this.props.location, this.props.title)
+    dndData.setupDataTransferBraveData(e.dataTransfer, dragTypes.TAB, this.activeFrame)
+  }
+  render () {
+    return <span
+      onDragStart={this.onDragStart}
+      draggable
+      onClick={this.onClick}
+      className={this.iconClasses}
+      style={this.iconStyles} />
+  }
+}
+
+module.exports = UrlBarIcon


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Don't show HTTP icon while site is loading (since it may be HTTPS)

Fixes https://github.com/brave/browser-laptop/issues/5490

Includes breaking the urlbar icon into it's own control (along with click/drag events)

Auditors: @diracdeltas, @jkup, @bbondy

Test Plan:
1. Launch Brave and open a new tab
2. Type in "https://twitter.com" and get really close to your screen
3. Hit enter and notice you do not see the yellow triangle at any time