### PR TITLE
[WIP] Use Electron event to set urlbar security state

### DIFF
--- a/app/renderer/components/urlBarIcon.js
+++ b/app/renderer/components/urlBarIcon.js
@@ -30,9 +30,8 @@ class UrlBarIcon extends ImmutableComponent {
    */
   get isInsecure () {
     return this.props.isHTTPPage &&
-           !this.props.isSecure &&
+           this.props.isSecure === false &&
            !this.props.active &&
-           this.props.loading === false &&
            !this.props.titleMode
   }
   /**
@@ -63,7 +62,7 @@ class UrlBarIcon extends ImmutableComponent {
       // NOTE: EV style not approved yet; see discussion at https://github.com/brave/browser-laptop/issues/791
       'fa-lock': this.isSecure,
       'fa-exclamation-triangle': this.isInsecure,
-      'fa fa-search': this.isSearch
+      'fa-search': this.isSearch
     })
   }
   get iconStyles () {

--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -471,7 +471,6 @@ class UrlBar extends ImmutableComponent {
           onContextMenu={this.onContextMenu}
           data-l10n-id='urlbar'
           className={cx({
-            insecure: !this.props.isSecure && this.props.loading === false && !this.isHTTPPage,
             private: this.private,
             testHookLoadDone: !this.props.loading
           })}


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).


Requires https://github.com/brave/electron/pull/90
Fix https://github.com/brave/browser-laptop/issues/5238

Auditors: @bsclifton @darkdh

Test Plan:
1. go to http://dev.ruby.sh/bpoc.html and it should not show up as secure

TODO: add automated test for the hackerone issue