### PR TITLE
Setting location for a frame will now set loading=true

### DIFF
--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -266,7 +266,8 @@ const doAction = (action) => {
             currentLocation.substring(0, 6).toLowerCase() !== 'about:') {
           windowState = windowState.mergeIn(frameStatePath(action.key), {
             activeShortcut: 'load-non-navigatable-url',
-            activeShortcutDetails: action.location
+            activeShortcutDetails: action.location,
+            loading: true
           })
         }
         updateNavBarInput(frame.get('location'), frameStatePath(action.key))
@@ -274,7 +275,8 @@ const doAction = (action) => {
         // reload if the url is unchanged
         windowState = windowState.mergeIn(frameStatePath(action.key), {
           audioPlaybackActive: false,
-          activeShortcut: 'reload'
+          activeShortcut: 'reload',
+          loading: true
         })
         windowState = windowState.mergeIn(tabStatePath(action.key), {
           audioPlaybackActive: false
@@ -292,7 +294,8 @@ const doAction = (action) => {
         windowState = windowState.mergeIn(frameStatePath(action.key), {
           src: action.location,
           location: action.location,
-          activeShortcut
+          activeShortcut,
+          loading: true
         })
         windowState = windowState.mergeIn(tabStatePath(action.key), {
           location: action.location


### PR DESCRIPTION
Follow up for https://github.com/brave/browser-laptop/pull/5498

## Problem
Being on a new tab and then loading a URL would return loading: false, even after the location is updated.

## Resolution
setting location for a frame will now set loading=true

Is this OK? Usually, it gets set to true in WindowStore:: WINDOW_WEBVIEW_LOAD_START
The only places I see this used are:
- navigationBar (which binds to urlBar, which then binds to urlBarIcon (where the problem is))
- tabs (used to show the loading spinner)

Auditors: @diracdeltas, @bridiver