### PR TITLE
remove opacity from new tab button

### DIFF
--- a/less/button.less
+++ b/less/button.less
@@ -74,7 +74,6 @@ span.browserButton,
     font-size: 0px;
     width: 10px;
     max-height: 14px;
-    opacity: 0.5;
     position: relative;
     top: 8px;
     left: 2px;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5518

Test Plan:

Make sure the new tab button is dark enough to not look disabled. Like this screenshot:

![screen shot 2016-11-09 at 12 48 21 pm](https://cloud.githubusercontent.com/assets/490294/20154134/dbdcbbaa-a67a-11e6-9d4f-7d8daeb68b37.png)

instead of this:

![screen shot 2016-11-09 at 12 49 10 pm](https://cloud.githubusercontent.com/assets/490294/20154156/f064520e-a67a-11e6-81c3-f99210ac5bb8.png)


