### PR TITLE
English locale will now show a smaller version of AM/PM

### DIFF
--- a/js/about/newTabComponents/clock.js
+++ b/js/about/newTabComponents/clock.js
@@ -8,7 +8,8 @@ class Clock extends React.Component {
   constructor () {
     super()
     this.state = {
-      currentTime: this.currentTime
+      time: this.formattedTime,
+      timePeriod: this.formattedTimePeriod
     }
   }
   get currentTime () {
@@ -16,9 +17,20 @@ class Clock extends React.Component {
     const timeOptions = {hour: '2-digit', minute: '2-digit'}
     return date.toLocaleTimeString([], timeOptions)
   }
+  get formattedTime () {
+    const time = this.currentTime
+    return time.replace(' AM', '').replace(' PM', '')
+  }
+  get formattedTimePeriod () {
+    const time = this.currentTime
+    if (time.toUpperCase().indexOf(' AM') > -1) return 'AM'
+    if (time.toUpperCase().indexOf(' PM') > -1) return 'PM'
+    return ''
+  }
   updateClock () {
     this.setState({
-      currentTime: this.currentTime
+      time: this.formattedTime,
+      timePeriod: this.formattedTimePeriod
     })
   }
   componentDidMount () {
@@ -26,7 +38,7 @@ class Clock extends React.Component {
   }
   render () {
     return <div className='clock'>
-      <span className='time'>{this.state.currentTime}</span>
+      <span className='time'>{this.state.time}</span><span className='timePeriod'>{this.state.timePeriod}</span>
     </div>
   }
 }

--- a/less/about/newtab.less
+++ b/less/about/newtab.less
@@ -138,6 +138,15 @@ ul {
         color: #fff;
       }
 
+      .timePeriod {
+        color: #fff;
+        display: inline-block;
+        font-size: 20px;
+        font-weight: 400;
+        margin-top: 6px;
+        vertical-align: top;
+      }
+
       .dayTime {
         font-size: 51px;
         color: #fff;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

**NOTE**: _Ready for merge after 0.12.9 moves to dev-channel_ :smile: 

Fixes https://github.com/brave/browser-laptop/issues/5381

Auditors: @cezaraugusto

## Test Plan
1. Set your locale in Preferences to be English (U.S.)
2. Visit about:newtab; AM/PM (if shown for you) should be smaller than the font-size used for the hour/minute

## Screenshots
**Japanese (24 hour time; no AM/PM shown)**
![screen shot 2016-11-09 at 2 49 06 pm](https://cloud.githubusercontent.com/assets/4733304/20156215/ab90602a-a68c-11e6-810b-ec7f226af815.png)

**English (US; shows AM/PM smaller, vertically aligned to top)** 
![screen shot 2016-11-09 at 2 50 43 pm](https://cloud.githubusercontent.com/assets/4733304/20156221/af6807b6-a68c-11e6-8747-afb8f74ee15b.png)
