### PR TITLE
Fix caption button alignment on Windows 7

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -232,9 +232,6 @@
         }
       }
     }
-    .verticallyCenter {
-      justify-content: center;
-    }
   }
 
   // Windows 10 specific styles


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Properly fixes https://github.com/brave/browser-laptop/issues/5069
(help needed manually testing- my VM is having issues)

Auditors: @bbondy, @jonathansampson

Test Plan:
1. Launch Brave on Windows 7
2. Look at the caption buttons; verify positioning looks OK (there may be rendering bugs, but those already exist)
3. Maximize window and ensure positioning is staying correct