### PR TITLE
about:history - Clicking on something other than the table will clear any selections

### DIFF
--- a/js/about/bookmarks.js
+++ b/js/about/bookmarks.js
@@ -435,7 +435,7 @@ class AboutBookmarks extends React.Component {
     this.refs.bookmarkSearch.focus()
   }
   render () {
-    return <div className='siteDetailsPage'>
+    return <div className='siteDetailsPage' onClick={this.onClick}>
       <div className='siteDetailsPageHeader'>
         <div data-l10n-id='bookmarkManager' className='sectionTitle' />
         <div className='headerActions'>
@@ -450,7 +450,7 @@ class AboutBookmarks extends React.Component {
         </div>
       </div>
 
-      <div className='siteDetailsPageContent' onClick={this.onClick}>
+      <div className='siteDetailsPageContent'>
         <div className='folderView'>
           <div className='columnHeader'>
             <span data-l10n-id='folders' />

--- a/test/about/historyTest.js
+++ b/test/about/historyTest.js
@@ -168,5 +168,27 @@ describe('about:history', function () {
         .keys(Brave.keys.SHIFT)
         .click('table.sortableTable td.title[data-sort="Brave"]')
     })
+    it('deselects everything if something other than the table is clicked', function * () {
+      yield this.app.client
+        .tabByUrl(aboutHistoryUrl)
+        .loadUrl(aboutHistoryUrl)
+        // Click one bookmark, to select it
+        .click('table.sortableTable td.title[data-sort="Brave"]')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="Brave"]')
+        // Click the search box; this should dismiss and release selection
+        .click('input#historySearch')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="Brave"]', 5000, true)
+    })
+    it('does not lose selection if table is sorted', function * () {
+      yield this.app.client
+        .tabByUrl(aboutHistoryUrl)
+        .loadUrl(aboutHistoryUrl)
+        // Click one bookmark, to select it
+        .click('table.sortableTable td.title[data-sort="Brave"]')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="Brave"]')
+        // Click the "title" header; this sort the rows (but keep selection)
+        .click('table.sortableTable th')
+        .waitForVisible('table.sortableTable tr.selected td.title[data-sort="Brave"]')
+    })
   })
 })


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Clicking on something other than the table will clear any selections.  This had already been done for about:bookmarks.

Also, this PR updates the click area for about:bookmarks... expanding it to the whole page (instead of just the lower area).  See testing notes for more info.

Fixes https://github.com/brave/browser-laptop/issues/5458

Auditors: @darkdh

Test Plan:
1. Launch Brave and go to about:history
2. Select a few items (from multiple tables if possible)
3. Click one of the headers to sort; notice selection is not changed.
4. Click the search box (like you want to give it focus) and notice how selection is cleared.
5. Go to about:bookmarks
6. select a few items
7. Click in the search box (like you want to give it focus). Notice how selection is cleared. Before this PR, you couldn't click the page header (ex: the search box, the page title). Clicking elsewhere did work though.