### PR TITLE
extend blue outline in URL bar to include bookmark button

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -556,10 +556,10 @@
     border-bottom: 10px solid #FFFFFF;
     position: relative;
     bottom: 10px;
-    left: 37px;
+    left: 62px;
 
     &.withHomeButton {
-      left: 67px;
+      left: 100px;
     }
   }
 

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -639,8 +639,10 @@
     -webkit-mask-repeat: no-repeat;
     width: 14px;
     height: 14px;
-    margin-bottom: 2px;
-    margin-left: 6px;
+    margin: 0;
+    position: absolute;
+    top: 4px;
+    left: 4px;
 
     &.removeBookmarkButton {
       background: url('../img/toolbar/bookmark_marked.svg') center no-repeat;
@@ -714,8 +716,6 @@
   #navigator:not(.titleMode) & {
     background: white;
     border-radius: @borderRadiusURL;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
     box-shadow: inset 0 0 0 1px rgba(0,0,0,0.1), inset 0 1px 0 rgba(0,0,0,0.05), inset 0 1px 1px rgba(0,0,0,0.1);
     color: @chromeText;
   }
@@ -751,17 +751,20 @@
       animation-fill-mode: forwards;
     }
 
+    .startButtons {
+      position: relative;
+      z-index: 999;
+    }
+
     .bookmarkButtonContainer {
-      border: 1px solid #CBCBCB;
-      border-radius: @borderRadius;
-      border-right: none;
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
+      background-color: #f7f7f7;
       box-sizing: border-box;
-      height: 25px;
-      line-height: 25px;
-      margin-right: -2px;
+      height: 21px;
+      width: 23px;
       display: inline-block;
+      position: relative;
+      left: 25px;
+      top: 2px;
     }
   }
 
@@ -893,6 +896,7 @@
     color: @siteSecureColor;
     left: 14px;
     margin-top: 1px;
+    padding-left: 20px;
     font-size: 13px;
     min-height: 10px;
     min-width: 16px;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5439

Auditors @bsclifton @bradleyrichter 

@bradleyrichter this ticket presents a little bit of a tough problem.

The bookmark star needs to have a gray background but also needs to be positioned over the white urlbar. The only problem is if the width and height of the bookmark star background are 100% of the urlbar then the glow won't show up.

What I've done so far is made the grey background 1px smaller than the urlbar on all sides so technically there is a tiny white space in between but I think it looks alright.

Here are some screenshots of what I've come up with so far: let me know what you think!
![screen shot 2016-11-09 at 6 45 50 pm](https://cloud.githubusercontent.com/assets/490294/20162977/a25b6858-a6ad-11e6-846e-41d0960b648a.png)
![screen shot 2016-11-09 at 6 45 54 pm](https://cloud.githubusercontent.com/assets/490294/20162976/a258f064-a6ad-11e6-8b79-1cc7e9c585c6.png)
![screen shot 2016-11-09 at 6 45 57 pm](https://cloud.githubusercontent.com/assets/490294/20162978/a25d5e9c-a6ad-11e6-81aa-c95bd3ed4244.png)


Test Plan:

I'm making sure this looks ok on Windows right now and then I'll remove WiP and update testing notes.

