### PR TITLE
Change sites from List to Map

### DIFF
--- a/app/common/state/aboutNewTabState.js
+++ b/app/common/state/aboutNewTabState.js
@@ -10,14 +10,6 @@ const excludeSiteDetail = (siteDetail) => {
   return !siteUtil.isBookmark(siteDetail) && !siteUtil.isHistoryEntry(siteDetail)
 }
 
-const removeDuplicateSites = (sites) => {
-  // Filter out duplicate entries by location
-  return sites.filter((element, index, list) => {
-    if (!element) return false
-    return index === list.findIndex((site) => site && site.get('location') === element.get('location'))
-  })
-}
-
 const aboutNewTabState = {
   mergeDetails: (state, props) => {
     state = makeImmutable(state)
@@ -46,8 +38,6 @@ const aboutNewTabState = {
 
     // Keep track of the last 18 visited sites
     let sites = state.getIn(['about', 'newtab', 'sites']) || new Immutable.List()
-    sites = sites.unshift(siteDetail)
-    sites = removeDuplicateSites(sites)
     sites = sites.take(18)
     // TODO(cezaraugusto): Sort should respect unshift and don't prioritize bookmarks
     // |

--- a/app/common/state/aboutNewTabState.js
+++ b/app/common/state/aboutNewTabState.js
@@ -37,7 +37,7 @@ const aboutNewTabState = {
     }
 
     // Keep track of the last 18 visited sites
-    let sites = state.getIn(['about', 'newtab', 'sites']) || new Immutable.List()
+    let sites = state.getIn(['about', 'newtab', 'sites']) || new Immutable.Map()
     sites = sites.take(18)
     // TODO(cezaraugusto): Sort should respect unshift and don't prioritize bookmarks
     // |

--- a/app/importer.js
+++ b/app/importer.js
@@ -23,6 +23,7 @@ const locale = require('./locale')
 var isMergeFavorites = false
 var isImportingBookmarks = false
 var hasBookmarks
+var importedSites
 
 exports.init = () => {
   importer.initialize()
@@ -171,6 +172,7 @@ importer.on('add-bookmarks', (e, bookmarks, topLevelFolder) => {
       sites.push(site)
     }
   }
+  importedSites = Immutable.fromJS(sites)
   appActions.addSite(Immutable.fromJS(sites))
 })
 
@@ -187,7 +189,7 @@ importer.on('add-favicons', (e, detail) => {
       }
     }
   })
-  let sites = AppStore.getState().get('sites')
+  let sites = importedSites
   sites = sites.map((site) => {
     if ((site.get('favicon') === undefined && site.get('location') !== undefined &&
       faviconMap[site.get('location')] !== undefined) ||

--- a/app/renderer/components/bookmarksToolbar.js
+++ b/app/renderer/components/bookmarksToolbar.js
@@ -319,17 +319,18 @@ class BookmarksToolbar extends ImmutableComponent {
 
     // Loop through until we fill up the entire bookmark toolbar width
     let i
-    for (i = 0; i < noParentItems.size; i++) {
+    let noParentItemsList = noParentItems.toList()
+    for (i = 0; i < noParentItemsList.size; i++) {
       let iconWidth = props.showFavicon ? iconSize : 0
       // font-awesome file icons are 3px smaller
-      if (props.showFavicon && !noParentItems.getIn([i, 'folderId']) && !noParentItems.getIn([i, 'favicon'])) {
+      if (props.showFavicon && !noParentItemsList.getIn([i, 'folderId']) && !noParentItemsList.getIn([i, 'favicon'])) {
         iconWidth -= 3
       }
-      const chevronWidth = props.showFavicon && noParentItems.getIn([i, 'folderId']) ? this.chevronWidth : 0
+      const chevronWidth = props.showFavicon && noParentItemsList.getIn([i, 'folderId']) ? this.chevronWidth : 0
       if (props.showFavicon && props.showOnlyFavicon) {
         widthAccountedFor += this.padding + iconWidth + chevronWidth
       } else {
-        const text = noParentItems.getIn([i, 'customTitle']) || noParentItems.getIn([i, 'title']) || noParentItems.getIn([i, 'location'])
+        const text = noParentItemsList.getIn([i, 'customTitle']) || noParentItemsList.getIn([i, 'title']) || noParentItemsList.getIn([i, 'location'])
         widthAccountedFor += Math.min(calculateTextWidth(text, `${this.fontSize} ${this.fontFamily}`) + this.padding + iconWidth + chevronWidth, this.maxWidth)
       }
       widthAccountedFor += margin
@@ -337,9 +338,18 @@ class BookmarksToolbar extends ImmutableComponent {
         break
       }
     }
-    this.bookmarksForToolbar = noParentItems.take(i)
+    const bookmarkSort = (x, y) => {
+      if (x.get('order') < y.get('order')) {
+        return -1
+      } else if (x.get('order') > y.get('order')) {
+        return 1
+      } else {
+        return 0
+      }
+    }
+    this.bookmarksForToolbar = noParentItems.take(i).sort(bookmarkSort)
     // Show at most 100 items in the overflow menu
-    this.overflowBookmarkItems = noParentItems.skip(i).take(100)
+    this.overflowBookmarkItems = noParentItems.skip(i).take(100).sort(bookmarkSort)
   }
   componentWillMount () {
     this.updateBookmarkData(this.props)

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -436,7 +436,7 @@ module.exports.loadAppState = () => {
       if (Array.isArray(data.sites) && data.sites.length) {
         let sites = {}
         data.sites.forEach((site) => {
-          let key = siteUtil.getSiteKey(Immutable.fromJS(site), site.tags)
+          let key = siteUtil.getSiteKey(Immutable.fromJS(site))
           sites[key] = site
         })
         data.sites = sites
@@ -446,7 +446,7 @@ module.exports.loadAppState = () => {
           let sites = {}
           data.about.newtab.sites.forEach((site) => {
             if (site) {
-              let key = siteUtil.getSiteKey(Immutable.fromJS(site), site.tags)
+              let key = siteUtil.getSiteKey(Immutable.fromJS(site))
               sites[key] = site
             }
           })

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -441,6 +441,18 @@ module.exports.loadAppState = () => {
         })
         data.sites = sites
       }
+      if (data.about && data.about.newtab && data.about.newtab.sites) {
+        if (Array.isArray(data.about.newtab.sites) && data.about.newtab.sites.length) {
+          let sites = {}
+          data.about.newtab.sites.forEach((site) => {
+            if (site) {
+              let key = siteUtil.getSiteKey(Immutable.fromJS(site), site.tags)
+              sites[key] = site
+            }
+          })
+          data.about.newtab.sites = sites
+        }
+      }
 
       // version information (shown on about:brave)
       const os = require('os')

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -432,6 +432,16 @@ module.exports.loadAppState = () => {
         }
       }
 
+      // sites refactoring migration
+      if (Array.isArray(data.sites) && data.sites.length) {
+        let sites = {}
+        data.sites.forEach((site) => {
+          let key = siteUtil.getSiteKey(Immutable.fromJS(site), site.tags)
+          sites[key] = site
+        })
+        data.sites = sites
+      }
+
       // version information (shown on about:brave)
       const os = require('os')
       const versionInformation = [
@@ -466,7 +476,7 @@ module.exports.loadAppState = () => {
 module.exports.defaultAppState = () => {
   return {
     firstRunTimestamp: new Date().getTime(),
-    sites: [],
+    sites: {},
     tabs: [],
     extensions: {},
     visits: [],

--- a/docs/state.md
+++ b/docs/state.md
@@ -35,7 +35,7 @@ AppStore
     }
   },
   sites: {
-  [siteKey]: { // Calculated by siteUtil.getSiteKey()
+  [siteKey]: { // folder: folderId; bookmark/history: location + partitionNumber + parentFolderId
     location: string,
     title: string,
     customTitle: string, // User provided title for bookmark; overrides title

--- a/docs/state.md
+++ b/docs/state.md
@@ -34,7 +34,8 @@ AppStore
       }
     }
   },
-  sites: [{
+  sites: {
+  [siteKey]: { // Calculated by siteUtil.getSiteKey()
     location: string,
     title: string,
     customTitle: string, // User provided title for bookmark; overrides title
@@ -46,7 +47,7 @@ AppStore
     partitionNumber: number, // Optionally specifies a specific session
     folderId: number, // Set for bookmark folders only
     parentFolderId: number // Set for bookmarks and bookmark folders only
-  }],
+  }},
   downloads: [{
     [downloadId]: {
       startTime: number, // datetime.getTime()

--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -105,7 +105,7 @@ class NewTabPage extends React.Component {
 
     const getUnpinned = () => {
       const firstSite = unpinnedTopSites.first()
-      unpinnedTopSites = unpinnedTopSites.shift()
+      unpinnedTopSites = unpinnedTopSites.slice(1)
       return firstSite
     }
 

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -25,22 +25,20 @@ const isBookmarkFolder = (tags) => {
     tags && typeof tags !== 'string' && tags.includes(siteTags.BOOKMARK_FOLDER)
 }
 
-/**
- * Obtains the index of the location in sites
- *
- * @param sites The application state's Immutable sites list
- * @param siteDetail The siteDetails entry to get the index of
- * @param tags Tag for siteDetail (ex: bookmark). Folders are searched differently than other entries
- * @return index of the siteDetail or -1 if not found.
- */
-module.exports.getSiteIndex = function (sites, siteDetail, tags) {
-  if (!sites || !siteDetail) {
-    return -1
+module.exports.getSiteKey = function (siteDetail, tags) {
+  if (!siteDetail) {
+    return null
   }
-  if (isBookmarkFolder(tags)) {
-    return sites.findIndex((site) => isBookmarkFolder(site.get('tags')) && site.get('folderId') === siteDetail.get('folderId'))
+  const folderId = siteDetail.get('folderId')
+  const location = siteDetail.get('location')
+  if (isBookmarkFolder(tags) && folderId) {
+    return folderId.toString()
+  } else if (location) {
+    return location +
+      (siteDetail.get('partitionNumber') || 0) +
+      (siteDetail.get('parentFolderId') || 0)
   }
-  return sites.findIndex((site) => site.get('location') === siteDetail.get('location') && (site.get('partitionNumber') || 0) === (siteDetail.get('partitionNumber') || 0))
+  return null
 }
 
 /**
@@ -51,11 +49,14 @@ module.exports.getSiteIndex = function (sites, siteDetail, tags) {
  * @return true if the location is already bookmarked
  */
 module.exports.isSiteBookmarked = function (sites, siteDetail) {
-  const index = module.exports.getSiteIndex(sites, siteDetail, siteTags.BOOKMARK)
-  if (index === -1) {
+  if (!sites) {
     return false
   }
-  return isBookmark(sites.get(index).get('tags'))
+  const key = module.exports.getSiteKey(siteDetail, siteTags.BOOKMARK)
+  if (key === null) {
+    return false
+  }
+  return isBookmark(sites.getIn([key, 'tags']))
 }
 
 const getNextFolderIdItem = (sites) =>
@@ -85,7 +86,7 @@ module.exports.getNextFolderId = (sites) => {
 
 // Some details can be copied from the existing siteDetail if null
 // ex: parentFolderId, partitionNumber, and favicon
-const mergeSiteDetails = (oldSiteDetail, newSiteDetail, tag, folderId) => {
+const mergeSiteDetails = (oldSiteDetail, newSiteDetail, tag, folderId, order) => {
   let tags = oldSiteDetail && oldSiteDetail.get('tags') || new Immutable.List()
   if (tag) {
     tags = tags.toSet().add(tag).toList()
@@ -105,8 +106,13 @@ const mergeSiteDetails = (oldSiteDetail, newSiteDetail, tag, folderId) => {
   let site = Immutable.fromJS({
     lastAccessedTime: lastAccessedTime,
     tags,
-    title: newSiteDetail.get('title')
+    title: newSiteDetail.get('title'),
+    order
   })
+
+  if (oldSiteDetail && oldSiteDetail.get('order') !== undefined) {
+    site = site.set('order', oldSiteDetail.get('order'))
+  }
 
   if (newSiteDetail.get('location')) {
     site = site.set('location', newSiteDetail.get('location'))
@@ -162,8 +168,13 @@ module.exports.addSite = function (sites, siteDetail, tag, originalSiteDetail) {
     tag = siteDetail.getIn(['tags', 0])
   }
 
-  const index = module.exports.getSiteIndex(sites, originalSiteDetail || siteDetail, tag)
-  const oldSite = index !== -1 ? sites.getIn([index]) : null
+  let originalSiteKey
+  if (originalSiteDetail) {
+    originalSiteKey = module.exports.getSiteKey(originalSiteDetail, originalSiteDetail.get('tags'))
+  }
+
+  const oldKey = originalSiteKey || module.exports.getSiteKey(siteDetail, tag)
+  const oldSite = oldKey !== null ? sites.get(oldKey) : null
   let folderId = siteDetail.get('folderId')
 
   if (tag === siteTags.BOOKMARK_FOLDER) {
@@ -173,7 +184,7 @@ module.exports.addSite = function (sites, siteDetail, tag, originalSiteDetail) {
         site.get('parentFolderId') === siteDetail.get('parentFolderId') &&
         site.get('customTitle') === siteDetail.get('customTitle'))
       if (dupFolder) {
-        sites = module.exports.removeSite(sites, dupFolder, siteTags.BOOKMARK_FOLDER)
+        sites = module.exports.removeSite(sites, dupFolder, siteTags.BOOKMARK_FOLDER, true)
       }
     } else if (!folderId) {
       // Assign an id if this is a new folder
@@ -181,13 +192,13 @@ module.exports.addSite = function (sites, siteDetail, tag, originalSiteDetail) {
     }
   }
 
-  let site = mergeSiteDetails(oldSite, siteDetail, tag, folderId)
-  if (index === -1) {
-    // Insert new entry
-    return sites.push(site)
+  let site = mergeSiteDetails(oldSite, siteDetail, tag, folderId, sites.size)
+
+  const key = originalSiteKey || module.exports.getSiteKey(site, tag)
+  if (key === null) {
+    return sites
   }
-  // Update existing entry
-  return sites.setIn([index], site)
+  return sites.set(key, site)
 }
 
 /**
@@ -197,36 +208,32 @@ module.exports.addSite = function (sites, siteDetail, tag, originalSiteDetail) {
  * @param siteDetail The siteDetail to remove a tag from
  * @return The new sites Immutable object
  */
-module.exports.removeSite = function (sites, siteDetail, tag) {
-  const index = module.exports.getSiteIndex(sites, siteDetail, tag)
-  if (index === -1) {
-    return sites
-  }
+module.exports.removeSite = function (sites, siteDetail, tag, reorder) {
+  const key = module.exports.getSiteKey(siteDetail, tag)
 
-  const tags = sites.getIn([index, 'tags'])
+  const tags = sites.getIn([key, 'tags'])
   if (isBookmarkFolder(tags)) {
-    const folderId = sites.getIn([index, 'folderId'])
+    const folderId = sites.getIn([key, 'folderId'])
     const childSites = sites.filter((site) => site.get('parentFolderId') === folderId)
     childSites.forEach((site) => {
       const tags = site.get('tags')
       tags.forEach((tag) => {
-        sites = module.exports.removeSite(sites, site, tag)
+        sites = module.exports.removeSite(sites, site, tag, false)
       })
     })
   }
-  if (tags.size === 0 && !tag) {
-    // If called without tags and entry has no tags, remove the entry
-    return sites.splice(index, 1)
-  } else if (tags.size > 0 && !tag) {
-    // If called without tags BUT entry has tags, null out lastAccessedTime.
-    // This is a bookmark entry that we want to clear history for (but NOT delete/untag bookmark)
-    return sites.setIn([index, 'lastAccessedTime'], null)
+  if (reorder) {
+    const order = sites.getIn([key, 'order'])
+    sites = sites.map((site) => {
+      const siteOrder = site.get('order')
+      if (siteOrder > order) {
+        return site.set('order', siteOrder - 1)
+      }
+      return site
+    })
   }
-  // Else, remove the specified tag
-  return sites
-    .setIn([index, 'parentFolderId'], 0)
-    .deleteIn([index, 'customTitle'])
-    .setIn([index, 'tags'], tags.toSet().remove(tag).toList())
+
+  return sites.delete(key)
 }
 
 /**
@@ -277,28 +284,40 @@ module.exports.isMoveAllowed = (sites, sourceDetail, destinationDetail) => {
  * @param disallowReparent If set to true, parent folder will not be set
  * @return The new sites Immutable object
  */
-module.exports.moveSite = function (sites, sourceDetail, destinationDetail, prepend, destinationIsParent, disallowReparent) {
+module.exports.moveSite = function (sites, sourceDetail, destinationDetail, prepend,
+  destinationIsParent, disallowReparent) {
   if (!module.exports.isMoveAllowed(sites, sourceDetail, destinationDetail)) {
     return sites
   }
 
-  const sourceSiteIndex = module.exports.getSiteIndex(sites, sourceDetail, sourceDetail.get('tags'))
+  let sourceKey = module.exports.getSiteKey(sourceDetail, sourceDetail.get('tags'))
+  let destinationKey = module.exports.getSiteKey(destinationDetail, destinationDetail.get('tags'))
+
+  const sourceSiteIndex = sites.getIn([sourceKey, 'order'])
   let destinationSiteIndex
   if (destinationIsParent) {
     // When the destination is the parent we want to put it at the end
     destinationSiteIndex = sites.size - 1
     prepend = false
   } else {
-    destinationSiteIndex = module.exports.getSiteIndex(sites, destinationDetail, destinationDetail.get('tags'))
+    destinationSiteIndex = sites.getIn([destinationKey, 'order'])
   }
 
   let newIndex = destinationSiteIndex + (prepend ? 0 : 1)
-  let sourceSite = sites.get(sourceSiteIndex)
-  let destinationSite = sites.get(destinationSiteIndex)
-  sites = sites.splice(sourceSiteIndex, 1)
+  let sourceSite = sites.get(sourceKey)
+  let destinationSite = sites.get(destinationKey)
+  sites = sites.delete(sourceKey)
+  sites = sites.map((site) => {
+    const siteOrder = site.get('order')
+    if (siteOrder > sourceSiteIndex) {
+      return site.set('order', siteOrder - 1)
+    }
+    return site
+  })
   if (newIndex > sourceSiteIndex) {
     newIndex--
   }
+  sourceSite = sourceSite.set('order', newIndex)
 
   if (!disallowReparent) {
     if (destinationIsParent && destinationDetail.get('folderId') !== sourceSite.get('folderId')) {
@@ -309,7 +328,8 @@ module.exports.moveSite = function (sites, sourceDetail, destinationDetail, prep
       sourceSite = sourceSite.set('parentFolderId', destinationSite.get('parentFolderId'))
     }
   }
-  return sites.splice(newIndex, 0, sourceSite)
+  sourceKey = module.exports.getSiteKey(sourceSite, sourceSite.get('tags'))
+  return sites.set(sourceKey, sourceSite)
 }
 
 module.exports.getDetailFromFrame = function (frame, tag) {

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -439,10 +439,15 @@ const handleAppAction = (action) => {
           appState = appState.set('sites', siteUtil.addSite(appState.get('sites'), s, action.tag))
         })
       } else {
-        appState = appState.set('sites', siteUtil.addSite(appState.get('sites'), action.siteDetail, action.tag, action.originalSiteDetail))
+        let sites = appState.get('sites')
+        if (!action.siteDetail.get('folderId')) {
+          action.siteDetail = action.siteDetail.set('folderId', siteUtil.getNextFolderId(sites))
+        }
+        appState = appState.set('sites', siteUtil.addSite(sites, action.siteDetail, action.tag))
       }
       if (action.destinationDetail) {
-        appState = appState.set('sites', siteUtil.moveSite(appState.get('sites'), action.siteDetail, action.destinationDetail, false, false, true))
+        appState = appState.set('sites', siteUtil.moveSite(appState.get('sites'),
+          action.siteDetail, action.destinationDetail, false, false, true))
       }
       // If there was an item added then clear out the old history entries
       if (oldSiteSize !== appState.get('sites').size) {
@@ -451,12 +456,18 @@ const handleAppAction = (action) => {
       appState = aboutNewTabState.addSite(appState, action)
       break
     case AppConstants.APP_REMOVE_SITE:
-      appState = appState.set('sites', siteUtil.removeSite(appState.get('sites'), action.siteDetail, action.tag))
-      appState = aboutNewTabState.removeSite(appState, action)
-      break
+      {
+        appState = appState.set('sites', siteUtil.removeSite(appState.get('sites'), action.siteDetail, action.tag, true))
+        appState = aboutNewTabState.removeSite(appState, action)
+        break
+      }
     case AppConstants.APP_MOVE_SITE:
-      appState = appState.set('sites', siteUtil.moveSite(appState.get('sites'), action.sourceDetail, action.destinationDetail, action.prepend, action.destinationIsParent, false))
-      break
+      {
+        appState = appState.set('sites', siteUtil.moveSite(appState.get('sites'),
+          action.sourceDetail, action.destinationDetail, action.prepend,
+          action.destinationIsParent, false))
+        break
+      }
     case AppConstants.APP_MERGE_DOWNLOAD_DETAIL:
       if (action.downloadDetail) {
         appState = appState.mergeIn(['downloads', action.downloadId], action.downloadDetail)

--- a/test/unit/common/state/aboutNewTabStateTest.js
+++ b/test/unit/common/state/aboutNewTabStateTest.js
@@ -3,12 +3,13 @@ const aboutNewTabState = require('../../../../app/common/state/aboutNewTabState'
 const Immutable = require('immutable')
 const assert = require('assert')
 const siteTags = require('../../../../js/constants/siteTags')
+const siteUtil = require('../../../../js/state/siteUtil')
 
 const defaultAppState = Immutable.fromJS({
   about: {
     newtab: {
       gridLayoutSize: 'large',
-      sites: [],
+      sites: {},
       ignoredTopSites: [],
       pinnedTopSites: [],
       updatedStamp: undefined
@@ -110,14 +111,16 @@ describe('aboutNewTabState', function () {
 
     it('adds the entry into the sites list', function () {
       const state = aboutNewTabState.addSite(defaultAppState, bookmarkAction)
-      const updatedValue = state.getIn(['about', 'newtab', 'sites', 0, 'location'])
+      const key = siteUtil.getSiteKey(Immutable.fromJS(bookmarkAction.siteDetail))
+      const updatedValue = state.getIn(['about', 'newtab', 'sites', key, 'location'])
       assert.equal(updatedValue, bookmarkAction.siteDetail.location)
     })
 
     it('will add lastAccessedTime to the siteDetail if missing from history entry', function () {
       const action = {siteDetail: {location: 'https://brave.com'}}
       const state = aboutNewTabState.addSite(defaultAppState, action)
-      const updatedValue = state.getIn(['about', 'newtab', 'sites', 0, 'lastAccessedTime'])
+      const key = siteUtil.getSiteKey(Immutable.fromJS(action.siteDetail))
+      const updatedValue = state.getIn(['about', 'newtab', 'sites', key, 'lastAccessedTime'])
       assert.equal(typeof updatedValue === 'number' && updatedValue > arbitraryTimeInThePast, true)
     })
   })
@@ -182,12 +185,14 @@ describe('aboutNewTabState', function () {
 
     it('updates the entry into the sites list', function () {
       let state = aboutNewTabState.addSite(defaultAppState, bookmarkAction)
-      let favicon = state.getIn(['about', 'newtab', 'sites', 0, 'favicon'])
+      let key = siteUtil.getSiteKey(Immutable.fromJS(bookmarkAction.siteDetail))
+      let favicon = state.getIn(['about', 'newtab', 'sites', key, 'favicon'])
       assert.equal(favicon, undefined)
 
       const action = {frameProps: {location: 'https://brave.com'}, favicon: 'https://brave.com/favicon.ico'}
       state = aboutNewTabState.updateSiteFavicon(state, action)
-      favicon = state.getIn(['about', 'newtab', 'sites', 0, 'favicon'])
+      key = siteUtil.getSiteKey(Immutable.fromJS({location: 'https://brave.com'}))
+      favicon = state.getIn(['about', 'newtab', 'sites', key, 'favicon'])
       assert.equal(favicon, action.favicon)
     })
   })

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -34,7 +34,7 @@ describe('siteUtil', function () {
 
   describe('getSiteKey', function () {
     it('returns null if siteDetail is falsey', function () {
-      const key = siteUtil.getSiteKey(null, siteTags.BOOKMARK_FOLDER)
+      const key = siteUtil.getSiteKey(null)
       assert.equal(key, null)
     })
     describe('matching `BOOKMARK_FOLDER`', function () {
@@ -42,12 +42,12 @@ describe('siteUtil', function () {
         const siteDetail = Immutable.fromJS({
           folderId: 1
         })
-        const key = siteUtil.getSiteKey(siteDetail, siteTags.BOOKMARK_FOLDER)
+        const key = siteUtil.getSiteKey(siteDetail)
         assert.equal(key, 1)
       })
       it('returns null if folderId is missing', function () {
         const siteDetail = new Immutable.Map()
-        const key = siteUtil.getSiteKey(siteDetail, siteTags.BOOKMARK_FOLDER)
+        const key = siteUtil.getSiteKey(siteDetail)
         assert.equal(key, null)
       })
     })
@@ -57,19 +57,19 @@ describe('siteUtil', function () {
           location: testUrl1,
           partitionNumber: 0
         })
-        const key = siteUtil.getSiteKey(siteDetail, siteTags.BOOKMARK)
+        const key = siteUtil.getSiteKey(siteDetail)
         assert.equal(key, testUrl1 + '00')
       })
       it('returns key if location matches and partitionNumber is NOT present', function () {
         const siteDetail = Immutable.fromJS({
           location: testUrl1
         })
-        const key = siteUtil.getSiteKey(siteDetail, siteTags.BOOKMARK)
+        const key = siteUtil.getSiteKey(siteDetail)
         assert.equal(key, testUrl1 + '00')
       })
       it('returns null if location is missing', function () {
         const siteDetail = new Immutable.Map()
-        const key = siteUtil.getSiteKey(siteDetail, siteTags.BOOKMARK)
+        const key = siteUtil.getSiteKey(siteDetail)
         assert.equal(key, null)
       })
     })
@@ -82,7 +82,7 @@ describe('siteUtil', function () {
         tags: [siteTags.BOOKMARK]
       }
       const siteDetail = Immutable.fromJS(site)
-      const key = siteUtil.getSiteKey(siteDetail, siteTags.BOOKMARK)
+      const key = siteUtil.getSiteKey(siteDetail)
       const sites = {}
       sites[key] = site
       const result = siteUtil.isSiteBookmarked(Immutable.fromJS(sites), siteDetail)
@@ -93,7 +93,7 @@ describe('siteUtil', function () {
         location: testUrl2,
         tags: [siteTags.BOOKMARK]
       }
-      const key = siteUtil.getSiteKey(Immutable.fromJS(site), siteTags.BOOKMARK)
+      const key = siteUtil.getSiteKey(Immutable.fromJS(site))
       const sites = {}
       sites[key] = site
       const result = siteUtil.isSiteBookmarked(Immutable.fromJS(sites), Immutable.fromJS({
@@ -108,7 +108,7 @@ describe('siteUtil', function () {
         tags: [siteTags.BOOKMARK_FOLDER]
       }
       const siteDetail = Immutable.fromJS(site)
-      const key = siteUtil.getSiteKey(siteDetail, siteTags.BOOKMARK_FOLDER)
+      const key = siteUtil.getSiteKey(siteDetail)
       const sites = {}
       sites[key] = site
       const result = siteUtil.isSiteBookmarked(Immutable.fromJS(sites), siteDetail)
@@ -135,7 +135,7 @@ describe('siteUtil', function () {
   describe('addSite', function () {
     it('gets the tag from siteDetail if not provided', function () {
       const processedSites = siteUtil.addSite(emptySites, bookmarkAllFields)
-      const processedKey = siteUtil.getSiteKey(bookmarkAllFields, bookmarkAllFields.tags)
+      const processedKey = siteUtil.getSiteKey(bookmarkAllFields)
       const expectedSites = Immutable.fromJS([bookmarkAllFields])
       assert.deepEqual(processedSites.getIn([processedKey, 'tags']), expectedSites.getIn([0, 'tags']))
     })
@@ -156,7 +156,7 @@ describe('siteUtil', function () {
       describe('when adding bookmark', function () {
         it('preserves existing siteDetail fields', function () {
           const processedSites = siteUtil.addSite(emptySites, bookmarkAllFields, siteTags.BOOKMARK)
-          const processedKey = siteUtil.getSiteKey(bookmarkAllFields, siteTags.BOOKMARK)
+          const processedKey = siteUtil.getSiteKey(bookmarkAllFields)
           let sites = {}
           sites[processedKey] = bookmarkAllFields.set('order', 0).toJS()
           const expectedSites = Immutable.fromJS(sites)
@@ -164,7 +164,7 @@ describe('siteUtil', function () {
         })
         it('sets 0 for lastAccessedTime if not specified', function () {
           const processedSites = siteUtil.addSite(emptySites, bookmarkMinFields, siteTags.BOOKMARK)
-          const processedKey = siteUtil.getSiteKey(bookmarkMinFields, siteTags.BOOKMARK)
+          const processedKey = siteUtil.getSiteKey(bookmarkMinFields)
           assert.equal(processedSites.getIn([processedKey, 'lastAccessedTime']), 0)
           assert.deepEqual(processedSites.getIn([processedKey, 'tags']).toJS(), [siteTags.BOOKMARK])
         })
@@ -173,7 +173,7 @@ describe('siteUtil', function () {
         it('assigns a folderId', function () {
           const processedSites = siteUtil.addSite(emptySites, folderMinFields)
           const folderMinFieldsWithId = folderMinFields.set('folderId', 1)
-          const processedKey = siteUtil.getSiteKey(folderMinFieldsWithId, folderMinFieldsWithId.get('tags'))
+          const processedKey = siteUtil.getSiteKey(folderMinFieldsWithId)
           const folderId = processedSites.getIn([processedKey, 'folderId'])
           assert.equal(folderId, 1)
         })
@@ -181,7 +181,7 @@ describe('siteUtil', function () {
           // Add a new bookmark folder
           let processedSites = siteUtil.addSite(emptySites, folderMinFields)
           const folderMinFieldsWithId1 = folderMinFields.set('folderId', 1)
-          const processedKey1 = siteUtil.getSiteKey(folderMinFieldsWithId1, folderMinFieldsWithId1.get('tags'))
+          const processedKey1 = siteUtil.getSiteKey(folderMinFieldsWithId1)
           const folderId = processedSites.getIn([processedKey1, 'folderId'])
           const bookmark = Immutable.fromJS({
             lastAccessedTime: 123,
@@ -192,14 +192,14 @@ describe('siteUtil', function () {
           })
           // Add a bookmark into that folder
           processedSites = siteUtil.addSite(processedSites, bookmark)
-          const processedKey2 = siteUtil.getSiteKey(bookmark, bookmark.get('tags'))
+          const processedKey2 = siteUtil.getSiteKey(bookmark)
           assert.equal(processedSites.size, 2)
           assert.equal(processedSites.getIn([processedKey2, 'parentFolderId']), folderId)
 
           // Add another bookmark folder with the same name / parentFolderId
           processedSites = siteUtil.addSite(processedSites, folderMinFields)
           const folderMinFieldsWithId2 = folderMinFields.set('folderId', 2)
-          const processedKey3 = siteUtil.getSiteKey(folderMinFieldsWithId2, folderMinFieldsWithId2.get('tags'))
+          const processedKey3 = siteUtil.getSiteKey(folderMinFieldsWithId2)
           assert.equal(processedSites.size, 3)
           const folderId2 = processedSites.getIn([processedKey3, 'folderId'])
           assert.equal(folderId === folderId2, false)
@@ -245,10 +245,10 @@ describe('siteUtil', function () {
             order: 3,
             tags: [siteTags.BOOKMARK]
           }
-          const siteKey1 = siteUtil.getSiteKey(Immutable.fromJS(site1), site1.tags)
-          const siteKey2 = siteUtil.getSiteKey(Immutable.fromJS(site2), site2.tags)
-          const siteKey3 = siteUtil.getSiteKey(Immutable.fromJS(site3), site3.tags)
-          const siteKey4 = siteUtil.getSiteKey(Immutable.fromJS(site4), site4.tags)
+          const siteKey1 = siteUtil.getSiteKey(Immutable.fromJS(site1))
+          const siteKey2 = siteUtil.getSiteKey(Immutable.fromJS(site2))
+          const siteKey3 = siteUtil.getSiteKey(Immutable.fromJS(site3))
+          const siteKey4 = siteUtil.getSiteKey(Immutable.fromJS(site4))
           sites[siteKey1] = site1
           sites[siteKey2] = site2
           sites[siteKey3] = site3
@@ -283,7 +283,7 @@ describe('siteUtil', function () {
           order: 0,
           favicon: 'https://brave.com/favicon.ico'
         })
-        const oldSiteKey = siteUtil.getSiteKey(oldSiteDetail, oldSiteDetail.get('tags'))
+        const oldSiteKey = siteUtil.getSiteKey(oldSiteDetail)
         const newSiteDetail = Immutable.fromJS({
           lastAccessedTime: 456,
           tags: [siteTags.BOOKMARK],
@@ -304,7 +304,7 @@ describe('siteUtil', function () {
         let sites = {}
         sites[oldSiteKey] = oldSiteDetail.toJS()
         const processedSites = siteUtil.addSite(Immutable.fromJS(sites), newSiteDetail, siteTags.BOOKMARK, oldSiteDetail)
-        const expectedSiteKey = siteUtil.getSiteKey(expectedSiteDetail, expectedSiteDetail.get('tags'))
+        const expectedSiteKey = siteUtil.getSiteKey(expectedSiteDetail)
         let expectedSites = {}
         expectedSites[expectedSiteKey] = expectedSiteDetail.toJS()
         assert.deepEqual(processedSites.toJS(), expectedSites)
@@ -318,7 +318,7 @@ describe('siteUtil', function () {
           order: 0,
           customTitle: 'old customTitle'
         })
-        const oldSiteKey = siteUtil.getSiteKey(oldSiteDetail, oldSiteDetail.get('tags'))
+        const oldSiteKey = siteUtil.getSiteKey(oldSiteDetail)
         const newSiteDetail = Immutable.fromJS({
           lastAccessedTime: 456,
           tags: [siteTags.BOOKMARK],
@@ -330,7 +330,7 @@ describe('siteUtil', function () {
         sites[oldSiteKey] = oldSiteDetail.toJS()
         const processedSites = siteUtil.addSite(Immutable.fromJS(sites), newSiteDetail, siteTags.BOOKMARK, oldSiteDetail)
         const expectedSites = {}
-        const expectedSiteKey = siteUtil.getSiteKey(newSiteDetail, newSiteDetail.get('tags'))
+        const expectedSiteKey = siteUtil.getSiteKey(newSiteDetail)
         expectedSites[expectedSiteKey] = newSiteDetail.set('order', 0).toJS()
         assert.deepEqual(processedSites.toJS(), expectedSites)
       })
@@ -344,7 +344,7 @@ describe('siteUtil', function () {
           tags: [siteTags.BOOKMARK],
           location: testUrl1
         }
-        const siteKey = siteUtil.getSiteKey(Immutable.fromJS(siteDetail), siteDetail.tags)
+        const siteKey = siteUtil.getSiteKey(Immutable.fromJS(siteDetail))
         let sites = {}
         sites[siteKey] = siteDetail
         const processedSites = siteUtil.removeSite(Immutable.fromJS(sites), Immutable.fromJS(siteDetail), siteTags.BOOKMARK)
@@ -377,10 +377,10 @@ describe('siteUtil', function () {
           order: 3,
           tags: [siteTags.BOOKMARK]
         }
-        const siteKey1 = siteUtil.getSiteKey(Immutable.fromJS(site1), site1.tags)
-        const siteKey2 = siteUtil.getSiteKey(Immutable.fromJS(site2), site2.tags)
-        const siteKey3 = siteUtil.getSiteKey(Immutable.fromJS(site3), site3.tags)
-        const siteKey4 = siteUtil.getSiteKey(Immutable.fromJS(site4), site4.tags)
+        const siteKey1 = siteUtil.getSiteKey(Immutable.fromJS(site1))
+        const siteKey2 = siteUtil.getSiteKey(Immutable.fromJS(site2))
+        const siteKey3 = siteUtil.getSiteKey(Immutable.fromJS(site3))
+        const siteKey4 = siteUtil.getSiteKey(Immutable.fromJS(site4))
         sites[siteKey1] = site1
         sites[siteKey2] = site2
         sites[siteKey3] = site3
@@ -394,6 +394,59 @@ describe('siteUtil', function () {
         const expectedSites = new Immutable.Map()
         assert.deepEqual(processedSites, expectedSites)
       })
+      it('removes with reorder', function () {
+        let sites = {}
+        let expectedSites = {}
+        const site1 = {
+          folderId: 1,
+          parentFolderId: 0,
+          order: 0,
+          tags: [siteTags.BOOKMARK_FOLDER]
+        }
+        const site2 = {
+          folderId: 2,
+          parentFolderId: 1,
+          order: 1,
+          tags: [siteTags.BOOKMARK_FOLDER]
+        }
+        const site3 = {
+          parentFolderId: 1,
+          location: testUrl1,
+          order: 2,
+          tags: [siteTags.BOOKMARK]
+        }
+        const site4 = {
+          parentFolderId: 2,
+          location: testUrl2,
+          order: 3,
+          tags: [siteTags.BOOKMARK]
+        }
+        const expectedSite4 = {
+          parentFolderId: 2,
+          location: testUrl2,
+          order: 2,
+          tags: [siteTags.BOOKMARK]
+        }
+        const siteKey1 = siteUtil.getSiteKey(Immutable.fromJS(site1))
+        const siteKey2 = siteUtil.getSiteKey(Immutable.fromJS(site2))
+        const siteKey3 = siteUtil.getSiteKey(Immutable.fromJS(site3))
+        const siteKey4 = siteUtil.getSiteKey(Immutable.fromJS(site4))
+        sites[siteKey1] = site1
+        sites[siteKey2] = site2
+        sites[siteKey3] = site3
+        sites[siteKey4] = site4
+        expectedSites[siteKey1] = site1
+        expectedSites[siteKey2] = site2
+        expectedSites[siteKey4] = expectedSite4
+        const siteDetail = {
+          parentFolderId: 1,
+          location: testUrl1,
+          tags: [siteTags.BOOKMARK]
+        }
+        const processedSites = siteUtil.removeSite(Immutable.fromJS(sites), Immutable.fromJS(siteDetail),
+          siteTags.BOOKMARK_FOLDER)
+        assert.deepEqual(processedSites.toJS(), expectedSites)
+      })
     })
     describe('tag=falsey', function () {
       it('deletes a history entry (has no tags)', function () {
@@ -401,7 +454,7 @@ describe('siteUtil', function () {
           tags: [],
           location: testUrl1
         }
-        const siteKey = siteUtil.getSiteKey(Immutable.fromJS(siteDetail), siteDetail.tags)
+        const siteKey = siteUtil.getSiteKey(Immutable.fromJS(siteDetail))
         let sites = {}
         sites[siteKey] = siteDetail
         const processedSites = siteUtil.removeSite(Immutable.fromJS(sites), Immutable.fromJS(siteDetail))
@@ -416,7 +469,7 @@ describe('siteUtil', function () {
       // Add a new bookmark folder
       let processedSites = siteUtil.addSite(emptySites, folderMinFields)
       const folderMinFieldsWithId = folderMinFields.set('folderId', 1)
-      const processedKey = siteUtil.getSiteKey(folderMinFieldsWithId, folderMinFieldsWithId.get('tags'))
+      const processedKey = siteUtil.getSiteKey(folderMinFieldsWithId)
       const folderId = processedSites.getIn([processedKey, 'folderId'])
       // Add a bookmark into that folder
       processedSites = siteUtil.addSite(processedSites, bookmarkAllFields.set('parentFolderId', folderId))
@@ -428,17 +481,17 @@ describe('siteUtil', function () {
       // Add a new bookmark folder
       let processedSites = siteUtil.addSite(emptySites, folderMinFields)
       const folderMinFieldsWithId1 = folderMinFields.set('folderId', 1)
-      const processedKey1 = siteUtil.getSiteKey(folderMinFieldsWithId1, folderMinFieldsWithId1.get('tags'))
+      const processedKey1 = siteUtil.getSiteKey(folderMinFieldsWithId1)
       const folderId1 = processedSites.getIn([processedKey1, 'folderId'])
       // Add a child below that folder
       processedSites = siteUtil.addSite(processedSites, folderMinFields.set('parentFolderId', folderId1))
       const folderMinFieldsWithId2 = folderMinFields.set('folderId', 2)
-      const processedKey2 = siteUtil.getSiteKey(folderMinFieldsWithId2, folderMinFieldsWithId2.get('tags'))
+      const processedKey2 = siteUtil.getSiteKey(folderMinFieldsWithId2)
       const folderId2 = processedSites.getIn([processedKey2, 'folderId'])
       // Add a folder below the previous child
       processedSites = siteUtil.addSite(processedSites, folderMinFields.set('parentFolderId', folderId2))
       const folderMinFieldsWithId3 = folderMinFields.set('folderId', 3)
-      const processedKey3 = siteUtil.getSiteKey(folderMinFieldsWithId3, folderMinFieldsWithId3.get('tags'))
+      const processedKey3 = siteUtil.getSiteKey(folderMinFieldsWithId3)
       const bookmarkFolder1 = processedSites.get(processedKey1)
       const bookmarkFolder3 = processedSites.get(processedKey3)
       // Should NOT be able to move grandparent folder into its grandchild


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

fix #4879

Auditors: @bbondy, @bsclifton, @cezaraugusto

Test Plan:
Performance:
1. Import bulk bookmarks (4000+) from other browsers (Don't merge into toolbar)
2. The process should finish instantly
3. Delete Import from XXX folder
4. The process should finish instantly

Migration:
1. Make sure session-store-1 contains the sites data before 0.12.10
2. Lauch Brave and Close
3. sites of session-store-1 should change from [] tp {}