### PR TITLE
Work-around for console error during history filtering 

### DIFF
--- a/js/components/urlBarSuggestions.js
+++ b/js/components/urlBarSuggestions.js
@@ -282,6 +282,9 @@ class UrlBarSuggestions extends ImmutableComponent {
     }
 
     const historyFilter = (site) => {
+      if (!site) {
+        return false
+      }
       const title = site.get('title') || ''
       const location = site.get('location') || ''
       // Note: Bookmark sites are now included in history. This will allow


### PR DESCRIPTION
Work-around for error where history filtering using Immutable.Map() was occasionally passing "undefined" to the filter function.

With the error in place, it didn't seem to break functionality, it just logged the error.

Auditors: @diracdeltas

Test Plan:
1. Launch Brave and open a new tab
2. Push Shift+F8 to open console for browser
3. Put focus back onto webview
4. Click inside the URL bar and then type some chars
5. Notice there is no error anymore :)