### PR TITLE
fix syncing between react and DOM urlbar focus/select

### DIFF
--- a/js/components/urlBar.js
+++ b/js/components/urlBar.js
@@ -69,8 +69,8 @@ class UrlBar extends ImmutableComponent {
     return this.props.urlbar.get('focused')
   }
 
-  updateDOMInputFocus (focused) {
-    if (this.urlInput && focused) {
+  updateDOMInputFocus () {
+    if (this.urlInput && this.isFocused()) {
       this.focus()
     }
   }
@@ -146,7 +146,7 @@ class UrlBar extends ImmutableComponent {
           }
           // this can't go through appActions for some reason
           // or the whole window will reload on the first page request
-          this.updateDOMInputFocus(false)
+          this.updateDOMInputFocus()
           this.clearSearchEngine()
         }
         windowActions.setRenderUrlBarSuggestions(false)
@@ -371,12 +371,16 @@ class UrlBar extends ImmutableComponent {
         }
       }
     }
+    // Manually sync some react state with DOM state
     if (this.isFocused() !== prevProps.urlbar.get('focused')) {
       this.updateDOMInputFocus()
     }
     if (this.isSelected() !== prevProps.urlbar.get('selected')) {
-      this.select()
-      windowActions.setUrlBarSelected(false)
+      const selected = this.isSelected()
+      if (selected) {
+        this.select()
+      }
+      windowActions.setUrlBarSelected(selected)
     }
   }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

previously it seems that the urlbar was getting selected
every time the react select state was updated; yet then the
react selected state would be updated to false.

this may fix https://github.com/brave/browser-laptop/issues/5529

Auditors: @bbondy

Test Plan:
follow Alex's test steps in https://github.com/brave/browser-laptop/issues/5529
and check that the first character is not deleted.