### PR TITLE
about:newtab - Update the unpinned site list to only show one result per domain

### DIFF
--- a/app/common/state/aboutNewTabState.js
+++ b/app/common/state/aboutNewTabState.js
@@ -29,7 +29,21 @@ const sortCountDescending = (left, right) => {
   if (left.get('count') > right.get('count')) return -1
   return 0
 }
-
+const removeDuplicateDomains = (list) => {
+  const siteDomains = new Set()
+  return list.filter((site) => {
+    try {
+      const hostname = require('url').parse(site.get('location')).hostname
+      if (!siteDomains.has(hostname)) {
+        siteDomains.add(hostname)
+        return true
+      }
+    } catch (e) {
+      console.log('Error parsing hostname: ', e)
+    }
+    return false
+  })
+}
 /**
  * topSites are defined by users. Pinned sites are attached to their positions
  * in the grid, and the non pinned indexes are populated with newly accessed sites
@@ -43,9 +57,7 @@ const getTopSites = (state) => {
 
   // Filter out pinned and ignored sites
   let unpinnedSites = sites.filter((site) => !(isPinned(state, site) || isIgnored(state, site)))
-
-  // TODO(bsclifton): de-dupe here
-  // ..
+  unpinnedSites = removeDuplicateDomains(unpinnedSites)
 
   // Merge the pinned and unpinned lists together
   // Pinned items have priority because the position is important

--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -181,9 +181,6 @@ class NewTabPage extends React.Component {
       const currentPositionIndex = gridSites.indexOf(currentPosition)
       const pinnedTopSites = this.pinnedTopSites.splice(currentPositionIndex, 1, null)
       newTabState.pinnedTopSites = pinnedTopSites
-
-      // TODO: ignoring an item sometimes was removing a pin for a different site
-      // I think the merge is not working properly.
     }
 
     newTabState.ignoredTopSites = this.ignoredTopSites.push(siteProps)


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

about:newtab - Update the unpinned site list to only show one result per domain

Fixes https://github.com/brave/browser-laptop/issues/5565

Auditors: @bbondy