### PR TITLE
Retrieve Transifex language resources using lower case

### DIFF
--- a/tools/downloadLanguages.js
+++ b/tools/downloadLanguages.js
@@ -63,7 +63,7 @@ if (process.env.RESOURCE) {
 languages.forEach(function (languageCode) {
   resources.forEach(function (resource) {
     // Build the URI
-    var URI = TEMPLATE.replace('RESOURCE_SLUG', resource + 'properties')
+    var URI = TEMPLATE.replace('RESOURCE_SLUG', resource.toLowerCase() + 'properties')
     URI = URI.replace('LANG_CODE', languageCode)
 
     // Authorize and request the translation file

--- a/tools/downloadLanguages.js
+++ b/tools/downloadLanguages.js
@@ -5,10 +5,11 @@
 /*
   Environment Variables
 
-  USERNAME        - valid Transifex user name with read privileges
-  PASSWORD        - password for above username
+  USERNAME            - valid Transifex user name with read privileges
+  PASSWORD            - password for above username
 
-  LANG [optional] - single language code to retrieve in xx-XX format (I.e. en-US)
+  LANG [optional]     - single language code to retrieve in xx-XX format (I.e. en-US)
+  RESOURCE [optional] - single file name to retrieve (I.e. app)
 */
 
 'use strict'
@@ -53,6 +54,11 @@ var resources = fs.readdirSync(path.join(__dirname, '..', 'app', 'extensions', '
   return language.split(/\./)[0]
 })
 
+// allow download of a single resource
+if (process.env.RESOURCE) {
+  resources = [process.env.RESOURCE]
+}
+
 // For each language / resource combination
 languages.forEach(function (languageCode) {
   resources.forEach(function (resource) {
@@ -94,7 +100,11 @@ languages.forEach(function (languageCode) {
         if (process.env.TEST) {
           console.log(body)
         } else {
-          fs.writeFileSync(filename, body)
+          if (body === 'Not Found') {
+            console.log('  *** WARNING - empty file contents for ' + resource + '. Not writing. ***')
+          } else {
+            fs.writeFileSync(filename, body)
+          }
         }
       }
     })


### PR DESCRIPTION
Test Plan:

`npm run download-languages` should run without displaying warning for all resources including those with mixed capitalization.

