### PR TITLE
Navigation bar no longer centered

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -42,6 +42,8 @@
   }
 
   #navigator {
+    margin-right: 0px;
+
     .homeButton {
       margin: 0 0 3px 0;
     }
@@ -469,6 +471,8 @@
   @centerOffset: 2 * (@navbarButtonWidth + @navbarButtonSpacing) // width area on the left
                  - (@navbarBraveButtonWidth + 2 * @navbarButtonSpacing);
 
+  @rightMargin: @navbarLeftMarginDarwin / 2;
+
   display: flex;
 
   // Buttons on the left
@@ -498,6 +502,7 @@
     flex-grow: 1;
     min-width: 0%; // allow the navigator to shrink
     max-width: 900px;
+    margin-right: @rightMargin;
 
     &.titleMode {
       padding-right: @centerOffset;
@@ -552,10 +557,12 @@
       }
     }
 
-    .extraDragArea {
-      display: flex;
-      flex-grow: 0;
-      width: @navbarBraveButtonMarginLeft;
+    @media (max-width: @breakpointWideViewport) {
+      .extraDragArea {
+        display: flex;
+        flex-grow: 0;
+        width: @navbarBraveButtonMarginLeft;
+      }
     }
   }
 }
@@ -846,13 +853,6 @@
 
   > * {
     -webkit-app-region: no-drag;
-
-    &.endButtons {
-      margin-right: 20px;
-      @media (max-width: @breakpointNarrowViewport) {
-        margin-right: 0px;
-      }
-    }
   }
 
   .inputbar-wrapper {

--- a/less/variables.less
+++ b/less/variables.less
@@ -77,7 +77,7 @@
 @bookmarksFolderIconSize: 15px;
 
 @navbarButtonSpacing: 4px;
-@navbarButtonWidth: 30px;
+@navbarButtonWidth: 20px;
 @navbarBraveButtonWidth: 23px;
 @navbarBraveButtonMarginLeft: 80px;
 @navbarLeftMarginDarwin: 76px;
@@ -133,6 +133,7 @@
 @zindexWindowFullScreen: 4000;
 @zindexWindowFullScreenBanner: 4100;
 
+@breakpointWideViewport: 1000px;
 @breakpointNarrowViewport: 600px;
 @breakpointExtensionButtonPadding: 720px;
 @breakpointSmallWin32: 650px;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bsclifton @bradleyrichter 

Fix #5476

Test Plan:

1. Open Brave
2. Make sure urlbar and it's buttons are *almost* centered to the browser window.

Note* I realize there is a 5px difference or so because the left section is a bit smaller than the right but it should be good enough for now :)

