### PR TITLE
Added safe wrapper for toLocateDate() to handle null/invalid dates an…

### DIFF
--- a/app/common/lib/formatUtil.js
+++ b/app/common/lib/formatUtil.js
@@ -84,6 +84,20 @@ module.exports.formatAccelerator = (accelerator) => {
   return result
 }
 
+module.exports.toLocaleString = (epoch, defaultValue) => {
+  if (epoch && typeof epoch === 'number') {
+    try {
+      const date = new Date(epoch).toLocaleString()
+      if (date !== 'Invalid Date') {
+        return date
+      }
+    } catch (e) {
+      console.log('Error parsing date: ', e)
+    }
+  }
+  return defaultValue || ''
+}
+
 /**
  * Clamp values down to a given range (min/max).
  * Value is wrapped when out of bounds. ex:

--- a/js/about/bookmarks.js
+++ b/js/about/bookmarks.js
@@ -14,6 +14,7 @@ const dndData = require('../dndData')
 const cx = require('../lib/classSet')
 const SortableTable = require('../components/sortableTable')
 const siteUtil = require('../state/siteUtil')
+const formatUtil = require('../../app/common/lib/formatUtil')
 const iconSize = require('../../app/common/lib/faviconUtil').iconSize
 
 const ipc = window.chrome.ipc
@@ -340,8 +341,8 @@ class BookmarksList extends ImmutableComponent {
             value: entry.get('customTitle') || entry.get('title') || entry.get('location')
           },
           {
-            html: new Date(entry.get('lastAccessedTime')).toLocaleString(),
-            value: entry.get('lastAccessedTime')
+            html: formatUtil.toLocaleString(entry.get('lastAccessedTime'), ''),
+            value: entry.get('lastAccessedTime') || 0
           }
         ])}
         rowObjects={this.props.bookmarks}

--- a/test/unit/lib/formatUtilTest.js
+++ b/test/unit/lib/formatUtilTest.js
@@ -47,6 +47,30 @@ describe('formatUtil', function () {
     })
   })
 
+  describe('toLocaleString', function () {
+    it('formats the date as a string', function () {
+      const result = formatUtil.toLocaleString(1479159834005)
+      assert.equal(typeof result, 'string')
+      assert.equal(result.length > 0, true)
+    })
+    it('falls back to provided default value if epoch is falsey', function () {
+      const result = formatUtil.toLocaleString(null, 'abc')
+      assert.equal(result, 'abc')
+    })
+    it('falls back to empty string if no default provided and epoch is falsey', function () {
+      const result = formatUtil.toLocaleString()
+      assert.equal(result, '')
+    })
+    it('falls back to default value if invalid date is passed', function () {
+      const result = formatUtil.toLocaleString(NaN, 'def')
+      assert.equal(result, 'def')
+    })
+    it('falls back to default value if a non-number is passed', function () {
+      const result = formatUtil.toLocaleString('this is not a number', 'ghi')
+      assert.equal(result, 'ghi')
+    })
+  })
+
   describe('wrappingClamp', function () {
     it('does not change value if within bounds', function () {
       assert.equal(formatUtil.wrappingClamp(5, 1, 10), 5)


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

@bbondy: ** Would be great if this could make it into 0.12.9, but can be pushed to 0.12.10.  I'll tentatively mark it as 0.12.9 and let you choose while merging** :smile: 

…d updated code on Bookmark Manager.

Fixes https://github.com/brave/browser-laptop/issues/5576

Auditors: @bbondy

Test Plan:
1. Launch Brave and open Bookmarks Manager
2. Click the import button and import a file as html
3. View the bookmarks in bookmarks manager. Notice the date is now empty (and not the epoch)