### PR TITLE
bookmark icon not properly aligned on linux

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -25,6 +25,17 @@
                  - (@navbarBraveButtonWidth + 2 * @navbarButtonSpacing);
 }
 
+// Linux specific styles
+.platform--linux {
+  #navigator {
+    &:not(.titleMode) {
+      .bookmarkButtonContainer {
+        margin-top: 1px;
+      }
+    }
+  }
+}
+
 // Windows specific styles
 .platform--win32 {
   div#window.frameless:not(.isFullScreen):not(.isMaximized) {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5632

Auditors: @srirambv @bsclifton 

Test Plan:

Open Brave on Linux and make sure the bookmark star is aligned with the urlbar form. Screenshot below.

<img width="264" alt="screen shot 2016-11-15 at 11 17 35 am" src="https://cloud.githubusercontent.com/assets/490294/20313507/25865f3c-ab25-11e6-9196-7ceb3999d6e9.png">
