### PR TITLE
fix pinning topSites not respecting position

### DIFF
--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -66,7 +66,7 @@ class NewTabPage extends React.Component {
     return this.state.newTabData.getIn(['newTabDetail', 'sites']) || Immutable.List()
   }
   get pinnedTopSites () {
-    return this.state.newTabData.getIn(['newTabDetail', 'pinnedTopSites']) || Immutable.List().setSize(18)
+    return (this.state.newTabData.getIn(['newTabDetail', 'pinnedTopSites']) || Immutable.List()).setSize(18)
   }
   get ignoredTopSites () {
     return this.state.newTabData.getIn(['newTabDetail', 'ignoredTopSites']) || Immutable.List()


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bsclifton

fix #5337

Test Plan:

* Access new tab page;
* Access 4-6 websites;
* Pin the second and fourth site.;
* Pinning a site should add a Pin icon on top-right corner and be kept on its position (not jump);
* Access another website (i.e. https://brave.com) and get back to new tab. 
* Ensure that pinned topSites are still on their positions (2nd and 4th);
* Ensure that your latest accessed site is on first position;
* Ensure that other sites were pulled to right, but skipping pinned positions. 