### PR TITLE
Make empty home page address to be about:blank

### DIFF
--- a/js/lib/appUrlUtil.js
+++ b/js/lib/appUrlUtil.js
@@ -161,7 +161,7 @@ module.exports.newFrameUrl = function () {
 
   switch (settingValue) {
     case newTabMode.HOMEPAGE:
-      return getSetting(settings.HOMEPAGE) || 'about:newtab'
+      return getSetting(settings.HOMEPAGE) || 'about:blank'
 
     case newTabMode.DEFAULT_SEARCH_ENGINE:
       const searchProviders = require('../data/searchProviders').providers


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bsclifton

Fix #5652

Test Plan:

* Go to about:preferences
* Under General tab, on `A new tab shows`, select `my home page`
* On `my home page is` field, leave it blank
* Open a new tab
* New tab should be `about:blank`