### PR TITLE
Animate fadeIn of titlebar buttons

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -749,7 +749,9 @@
   }
 
   &:not(.titleMode) {
-    .urlbarForm, .browserButton, .bookmarkButtonContainer {
+    .urlbarForm,
+    .bookmarkButtonContainer,
+    span[class$="Button"] {
       animation: fadeIn .6s;
       opacity: 0;
       animation-fill-mode: forwards;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Make sure "Always show the URL bar" is turned off in preferences.
2. Also make sure "Show Home button on URL bar" is turned on in Preferences.
2. Open a new tab and navigate to any site.
3. Hover over the titlebar.
4. Make sure the reload button and home button fade in with the urlbar.

Fixes #5664