### PR TITLE
Change hover of bookmark bar items

### DIFF
--- a/less/bookmarksToolbar.less
+++ b/less/bookmarksToolbar.less
@@ -57,7 +57,8 @@
     display: flex;
 
     &:hover {
-      background: lighten(@tabsBackground, 5%);
+      background: white;
+      box-shadow: 0px 1px 5px 0px rgba(0, 0, 0, 0.1);
     }
 
     &.draggingOverLeft {

--- a/less/bookmarksToolbar.less
+++ b/less/bookmarksToolbar.less
@@ -40,8 +40,8 @@
   }
 
   .bookmarkToolbarButton {
-    border-radius: @borderRadius;
-    color: black;
+    border-radius: 3px;
+    color: @mediumGray;
     cursor: default;
     font-size: 11px;
     line-height: 12px;
@@ -113,6 +113,7 @@
     .bookmarkFolderChevron {
       color: #676767;
       margin-left: var(--bookmark-item-chevron-margin);
+      font-size: 8px;
     }
   }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Open a new Brave window.
2. Make sure the bookmarks toolbar is visible (Menubar > Bookmarks > Bookmarks Toolbar).
3. Add a new bookmark to the bookmarks toolbar, if necessary.
4. Move the mouse pointer (hover) over the bookmark item.
5. Make sure it has a white background with a light gray shadow (like the back and reload buttons).

Fixes #5665.

This matches the hover appearance of the toolbar buttons. Feel free to close if a different appearance is desired.