### PR TITLE
Add F6 shortcut for focusing the URL bar

### DIFF
--- a/app/localShortcuts.js
+++ b/app/localShortcuts.js
@@ -14,6 +14,7 @@ module.exports.register = (win) => {
   // the URL bar.  In those cases it's acceptable for the individual components to
   // listen to the events.
   const simpleWebContentEvents = [
+    ['F6', messages.SHORTCUT_FOCUS_URL],
     ['CmdOrCtrl+Shift+]', messages.SHORTCUT_NEXT_TAB],
     ['CmdOrCtrl+Shift+[', messages.SHORTCUT_PREV_TAB],
     ['CmdOrCtrl+Alt+Right', messages.SHORTCUT_NEXT_TAB],


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

Fix #4464
Test plan:
Open browser
Hit F6
URL bar should get focus