### PR TITLE
Remove Open in new tab from context menu while in a private browsing tab

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -902,7 +902,10 @@ function mainTemplateInit (nodeProps, frame) {
   const isAboutPage = aboutUrls.has(frame.get('location'))
 
   if (isLink) {
-    template.push(openInNewTabMenuItem(nodeProps.linkURL, frame.get('isPrivate'), frame.get('partitionNumber'), frame.get('key')),
+    if (!frame.get('isPrivate')) {
+      template.push(openInNewTabMenuItem(nodeProps.linkURL, frame.get('isPrivate'), frame.get('partitionNumber'), frame.get('key')))
+    }
+    template.push(
       openInNewPrivateTabMenuItem(nodeProps.linkURL, frame.get('key')),
       openInNewWindowMenuItem(nodeProps.linkURL, frame.get('isPrivate'), frame.get('partitionNumber')),
       CommonMenu.separatorMenuItem,


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5610

Test Plan:
Open a private tab and browse somewhere. 
Right click on a link, only "New Private Tab" and "New Window" should display. 

