### PR TITLE
Stats on about:newtab are now selectable :)

### DIFF
--- a/less/about/newtab.less
+++ b/less/about/newtab.less
@@ -25,7 +25,6 @@ body, .dynamicBackground, .gradient {
   animation-fill-mode: forwards;
 }
 
-main,
 .copyrightNotice {
   -webkit-user-select: none;
   cursor: default;
@@ -131,6 +130,8 @@ ul {
 
     .clock {
       line-height: 1;
+      -webkit-user-select: none;
+      cursor: default;
 
       .time {
         font-size: 75px;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

Fixes https://github.com/brave/browser-laptop/issues/5666

Auditors: @cezaraugusto, @luixxiul

Test Plan:
1. Launch Brave and visit about:newtab
2. Click and drag to select your stats
3. Copy/paste your adblock stats to share with friends :)