### PR TITLE
Fix about:brave; version information is always set (regardless of errors)

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -349,6 +349,34 @@ module.exports.cleanSessionDataOnShutdown = () => {
 }
 
 /**
+ * version information (shown on about:brave)
+ */
+const setVersionInformation = (data) => {
+  try {
+    const os = require('os')
+    const versionInformation = [
+      {name: 'Brave', version: app.getVersion()},
+      {name: 'Muon', version: process.versions['atom-shell']},
+      {name: 'libchromiumcontent', version: process.versions['chrome']},
+      {name: 'V8', version: process.versions.v8},
+      {name: 'Node.js', version: process.versions.node},
+      {name: 'Update Channel', version: Channel.channel()},
+      {name: 'os.platform', version: os.platform()},
+      {name: 'os.release', version: os.release()},
+      {name: 'os.arch', version: os.arch()}
+      // TODO(bsclifton): read the latest commit hash from a file, etc.
+    ]
+    data.about = data.about || {}
+    data.about.brave = {
+      versionInformation: versionInformation
+    }
+  } catch (e) {
+    console.log('ERROR calling sessionStore::setVersionInformation(): ', e)
+  }
+  return data
+}
+
+/**
  * Loads the browser state from storage.
  *
  * @return a promise which resolves with the immutable browser state or
@@ -434,30 +462,13 @@ module.exports.loadAppState = () => {
           return
         }
       }
-
-      // version information (shown on about:brave)
-      const os = require('os')
-      const versionInformation = [
-        {name: 'Brave', version: app.getVersion()},
-        {name: 'Muon', version: process.versions['atom-shell']},
-        {name: 'libchromiumcontent', version: process.versions['chrome']},
-        {name: 'V8', version: process.versions.v8},
-        {name: 'Node.js', version: process.versions.node},
-        {name: 'Update Channel', version: Channel.channel()},
-        {name: 'os.platform', version: os.platform()},
-        {name: 'os.release', version: os.release()},
-        {name: 'os.arch', version: os.arch()}
-        // TODO(bsclifton): read the latest commit hash from a file, etc.
-      ]
-      data.about = data.about || {}
-      data.about.brave = {
-        versionInformation: versionInformation
-      }
+      data = setVersionInformation(data)
     } catch (e) {
       // TODO: Session state is corrupted, maybe we should backup this
       // corrupted value for people to report into support.
       console.log('could not parse data: ', data)
       data = exports.defaultAppState()
+      data = setVersionInformation(data)
     }
     locale.init(data.settings[settings.LANGUAGE]).then((locale) => {
       app.setLocale(locale)

--- a/test/about/braveTest.js
+++ b/test/about/braveTest.js
@@ -1,0 +1,52 @@
+/* global describe, it, before */
+
+const Brave = require('../lib/brave')
+const {urlInput} = require('../lib/selectors')
+const {getTargetAboutUrl} = require('../../js/lib/appUrlUtil')
+
+describe('about:brave tests', function () {
+  Brave.beforeAll(this)
+  before(function * () {
+    const url = getTargetAboutUrl('about:brave')
+    yield this.app.client
+      .waitForUrl(Brave.newTabUrl)
+      .waitForBrowserWindow()
+      .waitForVisible(urlInput)
+      .waitForExist('.tab[data-frame-key="1"]')
+      .tabByIndex(0)
+      .loadUrl(url)
+  })
+
+  describe('when showing versions', function () {
+    it('lists Brave', function * () {
+      yield this.app.client
+        .waitUntil(function () {
+          return this.getText('table.sortableTable td[data-sort="Brave"]')
+            .then((textValue) => {
+              console.log(textValue)
+              return textValue && String(textValue).length > 0 && String(textValue) !== 'null'
+            })
+        })
+    })
+    it('lists Muon', function * () {
+      yield this.app.client
+        .waitUntil(function () {
+          return this.getText('table.sortableTable td[data-sort="Muon"]')
+            .then((textValue) => {
+              console.log(textValue)
+              return textValue && String(textValue).length > 0 && String(textValue) !== 'null'
+            })
+        })
+    })
+    it('lists Update Channel', function * () {
+      yield this.app.client
+        .waitUntil(function () {
+          return this.getText('table.sortableTable td[data-sort="Update Channel"]')
+            .then((textValue) => {
+              console.log(textValue)
+              return textValue && String(textValue).length > 0 && String(textValue) !== 'null'
+            })
+        })
+    })
+  })
+})


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Version information is always set (regardless of errors). 

Code itself is now fault tolerant as well. Includes tests.

Fixes: https://github.com/brave/browser-laptop/issues/5633

Auditors: @jonathansampson, @bbondy

Manual test plan:
1. Move your session out of the way (or do a fresh install)
2. Launch Brave
3. Go to about:brave
4. Notice version shows as expected

Automated test plan:
run `npm run test -- --grep="about:brave tests"`