### PR TITLE
New tab button can now show a dropdown

### DIFF
--- a/js/components/longPressButton.js
+++ b/js/components/longPressButton.js
@@ -19,11 +19,24 @@ class LongPressButton extends ImmutableComponent {
     if (e.target.attributes.getNamedItem('disabled')) {
       return
     }
+    if (e && e.preventDefault) {
+      e.preventDefault()
+    }
+    if (e && e.stopPropagation) {
+      e.stopPropagation()
+    }
 
     const self = this
     const target = e.target
     const LONG_PRESS_MILLISECONDS = 300
 
+    // Right click should immediately trigger the action
+    if (e.button === 2) {
+      self.props.onLongPress(target)
+      return
+    }
+
+    // Otherwise, it should wait before triggering
     this.longPressTimer = setTimeout(function () {
       self.isLocked = true
       self.props.onLongPress(target)
@@ -49,7 +62,9 @@ class LongPressButton extends ImmutableComponent {
       this.isLocked = false
       return
     }
-    this.props.onClick(e)
+    if (this.props.onClick) {
+      this.props.onClick(e)
+    }
   }
 
   render () {

--- a/js/components/tabs.js
+++ b/js/components/tabs.js
@@ -25,6 +25,8 @@ class Tabs extends ImmutableComponent {
     this.onDrop = this.onDrop.bind(this)
     this.onPrevPage = this.onPrevPage.bind(this)
     this.onNextPage = this.onNextPage.bind(this)
+    this.onNewTabLongPress = this.onNewTabLongPress.bind(this)
+    this.wasNewTabClicked = this.wasNewTabClicked.bind(this)
   }
 
   onPrevPage () {
@@ -83,15 +85,15 @@ class Tabs extends ImmutableComponent {
       e.preventDefault()
     }
   }
-
+  wasNewTabClicked (target) {
+    return target.className === this.refs.newTabButton.props.className
+  }
   newTab () {
     windowActions.newFrame()
   }
-
-  onNewTabLongPress (rect) {
-    contextMenus.onNewTabContextMenu(rect)
+  onNewTabLongPress (target) {
+    contextMenus.onNewTabContextMenu(target)
   }
-
   render () {
     this.tabRefs = []
     const index = this.props.previewTabPageIndex !== undefined
@@ -132,6 +134,7 @@ class Tabs extends ImmutableComponent {
         })()}
 
         <LongPressButton
+          ref='newTabButton'
           label='+'
           l10nId='newTabButton'
           className='browserButton navbutton newFrameButton'

--- a/js/components/tabs.js
+++ b/js/components/tabs.js
@@ -11,8 +11,9 @@ const windowActions = require('../actions/windowActions')
 const windowStore = require('../stores/windowStore')
 const dragTypes = require('../constants/dragTypes')
 const cx = require('../lib/classSet')
+const contextMenus = require('../contextMenus')
 
-const Button = require('./button')
+const LongPressButton = require('./longPressButton')
 const Tab = require('./tab')
 const dnd = require('../dnd')
 const dndData = require('../dndData')
@@ -87,6 +88,10 @@ class Tabs extends ImmutableComponent {
     windowActions.newFrame()
   }
 
+  onNewTabLongPress (rect) {
+    contextMenus.onNewTabContextMenu(rect)
+  }
+
   render () {
     this.tabRefs = []
     const index = this.props.previewTabPageIndex !== undefined
@@ -125,10 +130,15 @@ class Tabs extends ImmutableComponent {
               onClick={this.onNextPage} />
           }
         })()}
-        <Button label='+'
+
+        <LongPressButton
+          label='+'
           l10nId='newTabButton'
-          className='navbutton newFrameButton'
-          onClick={this.newTab} />
+          className='browserButton navbutton newFrameButton'
+          disabled={false}
+          onClick={this.newTab}
+          onLongPress={this.onNewTabLongPress}
+        />
       </span>
     </div>
   }

--- a/js/components/tabsToolbar.js
+++ b/js/components/tabsToolbar.js
@@ -26,6 +26,10 @@ class TabsToolbar extends ImmutableComponent {
   }
 
   onContextMenu (e) {
+    if (this.refs.tabs.wasNewTabClicked(e.target)) {
+      // Don't show the tabs menu if the new tab "+"" was clicked
+      return
+    }
     contextMenus.onTabsToolbarContextMenu(windowStore.getFrame(this.props.activeFrameKey), undefined, undefined, e)
   }
 
@@ -51,7 +55,9 @@ class TabsToolbar extends ImmutableComponent {
           />
         : null
       }
-      <Tabs tabs={unpinnedTabs}
+      <Tabs
+        ref='tabs'
+        tabs={unpinnedTabs}
         shouldAllowWindowDrag={this.props.shouldAllowWindowDrag}
         draggingOverData={this.props.draggingOverData}
         paintTabs={this.props.paintTabs}

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -611,15 +611,6 @@ function getMisspelledSuggestions (selection, isMisspelled, suggestions) {
   return items
 }
 
-function newTabMenuTemplateInit (location, e) {
-  const template = [
-    CommonMenu.newPrivateTabMenuItem(),
-    CommonMenu.newPartitionedTabMenuItem(),
-    CommonMenu.newWindowMenuItem()
-  ]
-  return template
-}
-
 function getEditableItems (selection, editFlags) {
   const hasSelection = selection.length > 0
   const hasClipboard = clipboard.readText().length > 0
@@ -1257,8 +1248,13 @@ function onTabContextMenu (frameProps, e) {
   tabMenu.destroy()
 }
 
-function onNewTabContextMenu (rect) {
-  const menuTemplate = newTabMenuTemplateInit(rect)
+function onNewTabContextMenu (target) {
+  const rect = target.getBoundingClientRect()
+  const menuTemplate = [
+    CommonMenu.newPrivateTabMenuItem(),
+    CommonMenu.newPartitionedTabMenuItem(),
+    CommonMenu.newWindowMenuItem()
+  ]
 
   windowActions.setContextMenuDetail(Immutable.fromJS({
     left: rect.left,

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -611,6 +611,15 @@ function getMisspelledSuggestions (selection, isMisspelled, suggestions) {
   return items
 }
 
+function newTabMenuTemplateInit (location, e) {
+  const template = [
+    CommonMenu.newPrivateTabMenuItem(),
+    CommonMenu.newPartitionedTabMenuItem(),
+    CommonMenu.newWindowMenuItem()
+  ]
+  return template
+}
+
 function getEditableItems (selection, editFlags) {
   const hasSelection = selection.length > 0
   const hasClipboard = clipboard.readText().length > 0
@@ -1248,6 +1257,16 @@ function onTabContextMenu (frameProps, e) {
   tabMenu.destroy()
 }
 
+function onNewTabContextMenu (rect) {
+  const menuTemplate = newTabMenuTemplateInit(rect)
+
+  windowActions.setContextMenuDetail(Immutable.fromJS({
+    left: rect.left,
+    top: rect.bottom + 2,
+    template: menuTemplate
+  }))
+}
+
 function onTabsToolbarContextMenu (activeFrame, closestDestinationDetail, isParent, e) {
   e.stopPropagation()
   const tabsToolbarMenu = Menu.buildFromTemplate(tabsToolbarTemplateInit(activeFrame, closestDestinationDetail, isParent))
@@ -1458,6 +1477,7 @@ module.exports = {
   onHamburgerMenu,
   onMainContextMenu,
   onTabContextMenu,
+  onNewTabContextMenu,
   onTabsToolbarContextMenu,
   onDownloadsToolbarContextMenu,
   onTabPageContextMenu,

--- a/test/about/braveTest.js
+++ b/test/about/braveTest.js
@@ -23,7 +23,6 @@ describe('about:brave tests', function () {
         .waitUntil(function () {
           return this.getText('table.sortableTable td[data-sort="Brave"]')
             .then((textValue) => {
-              console.log(textValue)
               return textValue && String(textValue).length > 0 && String(textValue) !== 'null'
             })
         })
@@ -33,7 +32,6 @@ describe('about:brave tests', function () {
         .waitUntil(function () {
           return this.getText('table.sortableTable td[data-sort="Muon"]')
             .then((textValue) => {
-              console.log(textValue)
               return textValue && String(textValue).length > 0 && String(textValue) !== 'null'
             })
         })
@@ -43,7 +41,6 @@ describe('about:brave tests', function () {
         .waitUntil(function () {
           return this.getText('table.sortableTable td[data-sort="Update Channel"]')
             .then((textValue) => {
-              console.log(textValue)
               return textValue && String(textValue).length > 0 && String(textValue) !== 'null'
             })
         })

--- a/test/components/tabTest.js
+++ b/test/components/tabTest.js
@@ -1,11 +1,11 @@
-/* global describe, it, before */
+/* global describe, it, before, beforeEach */
 
 const Brave = require('../lib/brave')
 const messages = require('../../js/constants/messages')
 const settings = require('../../js/constants/settings')
-const {urlInput, backButton, forwardButton, activeTabTitle} = require('../lib/selectors')
+const {urlInput, backButton, forwardButton, activeTabTitle, newFrameButton} = require('../lib/selectors')
 
-describe('tabs', function () {
+describe('tab tests', function () {
   function * setup (client) {
     yield client
       .waitForUrl(Brave.newTabUrl)
@@ -70,6 +70,31 @@ describe('tabs', function () {
     it('makes the non partitioned webview visible', function * () {
       yield this.app.client
         .waitForVisible('webview[partition="persist:default"]')
+    })
+  })
+
+  describe('new tab button', function () {
+    Brave.beforeEach(this)
+    beforeEach(function * () {
+      yield setup(this.app.client)
+    })
+
+    it('creates a new tab when clicked', function * () {
+      yield this.app.client
+        .click(newFrameButton)
+        .waitForExist('.tab[data-frame-key="2"]')
+    })
+    it('shows a context menu when long pressed (click and hold)', function * () {
+      yield this.app.client
+        .moveToObject(newFrameButton)
+        .buttonDown(0)
+        .waitForExist('.contextMenu .contextMenuItem .contextMenuItemText')
+        .buttonUp(0)
+    })
+    it('shows a context menu when right clicked', function * () {
+      yield this.app.client
+        .rightClick(newFrameButton)
+        .waitForExist('.contextMenu .contextMenuItem .contextMenuItemText')
     })
   })
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes #4398
Fixes #1594

Auditors: @lucidNTR, @cezaraugusto, @jkup

This PR was originally by @lucidNTR; I adjusted a few things and then also added right click as a way to trigger the long press button.  I went ahead and added webdriver tests for this functionality too.

## screenshot

Here's what the new menu looks like (you can click and hold on the + or right click it)
![screen shot 2016-11-16 at 4 31 20 pm](https://cloud.githubusercontent.com/assets/4733304/20370151/5f1d3bb2-ac1a-11e6-858d-cc756f698148.png)
 
Because the right-click change was made to the LongPressButton control, the back and forward buttons get this change for free (they were already triggerable by click and hold):
![screen shot 2016-11-16 at 4 31 42 pm](https://cloud.githubusercontent.com/assets/4733304/20370171/7f0dfeca-ac1a-11e6-85e7-ebdb59c52de1.png)

## test plan
1. Launch Brave and right click the new tab button "+"
2. Verify that it shows New Private / New Session / New Window
3. Cancel the menu and then click and hold the new tab button "+"
4. After ~300ms, the menu should show up
5. Cancel the menu again and navigate to Brave.com.
6. Follow a few links so that you have a history, then hit back button.
7. Confirm you can right click both the back/forward buttons to show the menu
8. Cancel the menu and then click and hold each button to confirm the existing behavior works