### PR TITLE
Fix padding issue on preferences > home page input

### DIFF
--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -450,7 +450,6 @@ span.browserButton.primaryButton {
 input:not([type="checkbox"]), select {
   &.form-control {
     box-sizing: border-box;
-    padding-left: 2px;
     width: 280px;
   }
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

This value was used before but it ended up overriding the new styles laid down with https://github.com/brave/browser-laptop/pull/5442/

Fixes https://github.com/brave/browser-laptop/issues/5680

Auditors: @jkup

Test Plan:
1. Launch Brave and open Preferences
2. Look at padding next to the text inside the "My homepage is" textbox