### PR TITLE
Dropdown shown when long pressing new tab will now show "New Tab"

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -1251,6 +1251,7 @@ function onTabContextMenu (frameProps, e) {
 function onNewTabContextMenu (target) {
   const rect = target.getBoundingClientRect()
   const menuTemplate = [
+    CommonMenu.newTabMenuItem(),
     CommonMenu.newPrivateTabMenuItem(),
     CommonMenu.newPartitionedTabMenuItem(),
     CommonMenu.newWindowMenuItem()


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes https://github.com/brave/browser-laptop/issues/5703

Auditors: @bbondy

Test Plan:
1. Launch Brave and right click on the new tab button "+"
2. Click the "New Tab" item
3. Notice a new tab be created