### PR TITLE
Refactor buttons on about:preferences#payments and bookmark dialog

### DIFF
--- a/app/renderer/components/addEditBookmarkHanger.js
+++ b/app/renderer/components/addEditBookmarkHanger.js
@@ -188,10 +188,10 @@ class AddEditBookmarkHanger extends ImmutableComponent {
             <div className='bookmarkButtons'>
               {
                 this.props.originalDetail
-                ? <Button l10nId='remove' className='primaryButton whiteButton inlineButton' onClick={this.onRemoveBookmark} />
+                ? <Button l10nId='remove' className='removeButton whiteButton' onClick={this.onRemoveBookmark} />
                 : null
               }
-              <Button l10nId='done' disabled={!this.bookmarkNameValid} className='primaryButton' onClick={this.onSave} />
+              <Button l10nId='done' disabled={!this.bookmarkNameValid} className='doneButton primaryButton' onClick={this.onSave} />
             </div>
           </div>
         </div>

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -1058,7 +1058,7 @@ class PaymentsTab extends ImmutableComponent {
         <span data-l10n-id='ledgerBackupContent' />
         <div className='copyKeyContainer'>
           <div className='copyContainer'>
-            <Button l10nId='copy' className='whiteButton inlineButton' onClick={this.copyToClipboard.bind(this, paymentId)} />
+            <Button l10nId='copy' className='copyButton whiteButton wideButton' onClick={this.copyToClipboard.bind(this, paymentId)} />
           </div>
           <div className='keyContainer'>
             <h3 data-l10n-id='firstKey' />
@@ -1067,7 +1067,7 @@ class PaymentsTab extends ImmutableComponent {
         </div>
         <div className='copyKeyContainer'>
           <div className='copyContainer'>
-            <Button l10nId='copy' className='whiteButton inlineButton' onClick={this.copyToClipboard.bind(this, passphrase)} />
+            <Button l10nId='copy' className='copyButton whiteButton wideButton' onClick={this.copyToClipboard.bind(this, passphrase)} />
           </div>
           <div className='keyContainer'>
             <h3 data-l10n-id='secondKey' />

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -1279,7 +1279,7 @@ class PaymentsTab extends ImmutableComponent {
             <span data-l10n-id='off' />
             <SettingCheckbox dataL10nId='on' prefKey={settings.PAYMENTS_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
           </div>
-          { this.props.ledgerData.get('created') && this.enabled ? <Button l10nId='advancedSettings' className='advancedSettings whiteButton inlineButton' onClick={this.props.showOverlay.bind(this, 'advancedSettings')} /> : null }
+          { this.props.ledgerData.get('created') && this.enabled ? <Button l10nId='advancedSettings' className='advancedSettings whiteButton inlineButton wideButton' onClick={this.props.showOverlay.bind(this, 'advancedSettings')} /> : null }
         </div>
       </div>
       {

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -904,7 +904,7 @@ div.nextPaymentSubmission {
       line-height: 1.3em;
     }
     span {
-      display: inline-block;
+      display: inline;
     }
     a {
       text-decoration: none;
@@ -949,15 +949,21 @@ div.nextPaymentSubmission {
 
     .copyKeyContainer {
       display: flex;
+      align-items: flex-end;
+      justify-content: space-between;
       width: 75%;
       margin: 20px auto;
 
       .copyContainer {
-        margin-top: 35px;
+        .copyButton {
+          font-size: 14px;
+          margin: 0;
+        }
+
       }
 
       .keyContainer {
-        margin-left: 75px;
+        margin-left: 1em;
 
         h3 {
           margin-bottom: 15px;

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -365,29 +365,35 @@ span.settingsListCopy {
   }
 }
 
-span.browserButton.primaryButton {
-  &.addFunds {
+span.browserButton {
+  &.advancedSettings {
     font-size: 0.9em;
-    margin-right: 50px;
   }
 
-  &.clearBrowsingDataButton,
-  &.importNowButton,
-  &.setAsDefaultButton,
-  &.manageAdblockSettings,
-  &.viewExtensionsInfo,
-  &.manageAutofillDataButton {
-    font-size: 0.9em;
-    margin-top: 20px;
-    padding: 5px 20px;
-  }
+  &.primaryButton {
+    &.addFunds {
+      font-size: 0.9em;
+      margin-right: 50px;
+    }
 
-  &.importNowButton {
-    margin-top: 5px;
-  }
+    &.clearBrowsingDataButton,
+    &.importNowButton,
+    &.setAsDefaultButton,
+    &.manageAdblockSettings,
+    &.viewExtensionsInfo,
+    &.manageAutofillDataButton {
+      font-size: 0.9em;
+      margin-top: 20px;
+      padding: 5px 20px;
+    }
 
-  &.setAsDefaultButton {
-    margin-top: 5px;
+    &.importNowButton {
+      margin-top: 5px;
+    }
+
+    &.setAsDefaultButton {
+      margin-top: 5px;
+    }
   }
 }
 
@@ -992,8 +998,11 @@ div.nextPaymentSubmission {
 }
 
 .advancedSettingsFooter {
-  padding: 20px 100px;
-  text-align: right;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 .recoveryOverlay {

--- a/less/button.less
+++ b/less/button.less
@@ -11,6 +11,7 @@
   line-height: 22px;
   margin: 5px 5px 0px 0px;
   padding: 0px 20px;
+  white-space: nowrap;
 }
 
 span.buttonSeparator {
@@ -35,8 +36,6 @@ span.menuButton {
   }
 }
 
-a.browserButton,
-span.browserButton,
 .browserButton {
   cursor: default;
   display: inline-block;
@@ -91,7 +90,8 @@ span.browserButton,
   &.wideButton,
   &.secondaryButton,
   &.secondaryAltButton,
-  &.subtleButton {
+  &.subtleButton,
+  &.whiteButton {
     .buttonCommon;
     width: auto;
     height: auto;
@@ -121,6 +121,8 @@ span.browserButton,
     display: block;
     margin-right: 0px;
     margin-left: 0px;
+    width: auto;
+    padding: 3px 35px;
   }
 
   &.whiteButton {
@@ -131,10 +133,7 @@ span.browserButton,
     display: block;
     font-weight: normal;
     font-style: normal;
-    font-size: 14px;
     color: @darkGray;
-    width: auto;
-    padding: 3px 35px;
   }
 
   &.inlineButton {

--- a/less/button.less
+++ b/less/button.less
@@ -130,7 +130,6 @@ span.menuButton {
     border: 2px solid white;
     box-shadow: @buttonShadow;
     cursor: pointer;
-    display: block;
     font-weight: normal;
     font-style: normal;
     color: @darkGray;

--- a/less/forms.less
+++ b/less/forms.less
@@ -569,6 +569,10 @@
 
   .bookmarkButtons {
     margin: 20px 0 10px 0;
+
+    .doneButton {
+      margin-right: 0;
+    }
   }
 
   .bookmarkFormInner {

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -610,6 +610,14 @@
 }
 
 #navigator {
+  .bookmarkButtons {
+    display: flex;
+
+    .removeButton {
+      flex-grow: 1;
+    }
+  }
+
   .stopButton,
   .reloadButton,
   .homeButton {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes #4786

- Moved paddings and width in "whiteButton" to "wideButton"
- Added "wideButton" to the advanced settings button on about:preferences#payments
- Added font-size to the button
- Added display:flex to footer of advanced settings
- Added white-space:nowrap to "buttonCommon" (buttons will not be wrapped by default)
- Removed redundant classes from bookmarkButtons to fix the size difference between "Remove" and "Done" buttons, which was introduced with the commit 85e428a
- Introduced new classes "removeButton" and "doneButton" inside bookmarkButtons to make the width of the row same as the other rows
- Introduced a new class "copyButton" to keep the font-size of the recovery key copy buttons to 14px
- Indroduced a flexbox to copyKeyContainer to keep the buttons aligned

Auditors: @jkup @bradleyrichter 

Test Plan: explained in messages of the commits 75a754a 23207ed