### PR TITLE
Fixed edit bookmark hanger showing when adding bookmark

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -53,7 +53,7 @@ const addBookmarkMenuItem = (label, siteDetail, closestDestinationDetail, isPare
       if (isParent) {
         siteDetail = siteDetail.set('parentFolderId', closestDestinationDetail && (closestDestinationDetail.get('folderId') || closestDestinationDetail.get('parentFolderId')))
       }
-      windowActions.setBookmarkDetail(siteDetail, siteDetail, closestDestinationDetail, true)
+      windowActions.setBookmarkDetail(siteDetail, siteDetail, closestDestinationDetail, false, true)
     }
   }
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5508 

Auditors @bbondy @bsclifton 

Test Plan:

1. Open Brave
2. Go to any site you don't currently have bookmarked
3. Right click on the page
4. Click 'Add Bookmark'
6. Make sure the "Bookmark Added" text shows, not the "Edit Bookmark"