### PR TITLE
make panel wider to fit strings better, and fix missing class for popup

### DIFF
--- a/js/components/braveryPanel.js
+++ b/js/components/braveryPanel.js
@@ -300,7 +300,7 @@ class BraveryPanel extends ImmutableComponent {
                     braverySelectTitle: true,
                     disabled: !shieldsUp
                   })} data-l10n-id='cookieControl' />
-                  <select value={this.props.braverySettings.cookieControl} onChange={this.onToggleCookieControl} disabled={!shieldsUp}>
+                  <select className='form-control' value={this.props.braverySettings.cookieControl} onChange={this.onToggleCookieControl} disabled={!shieldsUp}>
                     <option data-l10n-id='block3rdPartyCookie' value='block3rdPartyCookie' />
                     <option data-l10n-id='allowAllCookies' value='allowAllCookies' />
                   </select>

--- a/less/forms.less
+++ b/less/forms.less
@@ -319,7 +319,7 @@
     border-radius: @borderRadius;
     padding: 0;
     text-align: left;
-    width: 473px;
+    width: 500px;
     right: 20px;
     -webkit-user-select: none;
     cursor: default;
@@ -428,6 +428,7 @@
         .braveryAdvancedIndicator {
           margin-left: 5px;
           margin-right: 5px;
+          margin-top: 2px;
         }
       }
 


### PR DESCRIPTION
auditors: @bsclifton @luixxiul 


fixes: #5715

![image](https://cloud.githubusercontent.com/assets/13509546/20417950/21822b3e-acfe-11e6-892b-21f9113671d7.png)



now looks like this:
![image](https://cloud.githubusercontent.com/assets/13509546/20417992/7eb1b86a-acfe-11e6-9222-094be06da0a5.png)
