### PR TITLE
Fix newtab's test "lets you pin a tile"

### DIFF
--- a/test/about/newTabTest.js
+++ b/test/about/newTabTest.js
@@ -129,7 +129,7 @@ describe('about:newtab tests', function () {
         .waitForVisible('.topSitesElementFavicon')
         .moveToObject('.topSitesElement')
         .waitForVisible('.topSitesActionContainer')
-        .click('.topSitesActionBtn')
+        .click('.topSitesActionBtn:first-child')
         .moveToObject('.timeSaved')
         .waitForVisible('.pinnedTopSite')
     })


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bbondy

Test Plan:

* Test `lets you pin a tile (and shows the pinned icon afterwards)` should pass