### PR TITLE
Made every place of buttons on the navigation bar clickable

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -481,19 +481,9 @@
 
     .backButton,
     .forwardButton {
-    width: 20px;
-    margin-top: 5px;
+      width: 100%;
     }
 
-    .backButton {
-    padding-right:4px;
-    margin-left: 4px;
-    }
-
-    .forwardButton {
-    padding-left: 4px;
-    margin-left: 6px;
-    }
   }
 
   // Navigation bar at the center
@@ -532,10 +522,10 @@
 
     .extensionButton {
       -webkit-app-region: no-drag;
-    background-size: contain;
-    height: 17px;
-    margin: 4px 4px 0 0;
-    opacity: 0.85;
+      background-size: contain;
+      height: 17px;
+      margin: 4px 4px 0 0;
+      opacity: 0.85;
     }
 
     .braveMenu {
@@ -581,11 +571,11 @@
   width: 26px;
   margin-left: -3px;
   margin-right: 6px;
-    
+
   &.nav {
-  margin-left: 4px;
-  margin-right: 1px;
-  width: 34px;
+    margin-left: 4px;
+    margin-right: 1px;
+    width: 34px;
   }
 
   &:last-child {
@@ -600,44 +590,44 @@
 
 .backButton,
 .forwardButton {
-  height: 15px;
+  height: 24px;
   width: 30px;
-  margin-top: 5px;
+  margin: 0;
 }
 
 .backButton {
   background: url('../img/toolbar/back_btn.svg') center no-repeat;
-  margin-left: 4px;
+  background-size: 15px 15px;
 }
 
 .forwardButton {
   background: url('../img/toolbar/forward_btn.svg') center no-repeat;
-  margin-left: 4px;
+  background-size: 15px 15px;
 }
 
 #navigator {
+  .stopButton,
+  .reloadButton,
+  .homeButton {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    height: 100%;
+  }
+
   .stopButton {
     background: url('../img/toolbar/stoploading_btn.svg') center no-repeat;
-    margin: 0 3px 3px 3px;
-    padding: 0 6px;
-    height: 12px;
-    position: relative;
-    top: 3px;
+    background-size: 12px 12px;
   }
 
   .reloadButton {
     background: url('../img/toolbar/reload_btn.svg') center no-repeat;
-    margin: 0 3px -1px 3px;
-    padding: 0 4px;
-    position: relative;
+    background-size: 15px 15px;
   }
 
   .homeButton {
     background: url('../img/toolbar/home_btn.svg') center no-repeat;
-    width: 14px;
-    height: 13px;
-    padding: 0 6px;
-    position: relative;
+    background-size: 18px 18px;
   }
 
   .bookmarkButton {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Made every place of buttons on the navigation bar (backButton, forwardButton, stopButton, reloadButton and homeButton) clickable.

The commit of this PR makes the all area inside the button clickable by removing the margin and padding around the icon, which has been only clickable, and setting the size of the svg icons with ``background-size``.

Fixes #5679

Auditors: @bradleyrichter (Especially I'd love to hear your feedback on the sizes of the buttons. Please have a look at background-size properties, thanks.)

Test Plan:
1. Enable Home Button
2. Open some pages in the same tab to enable backButton and forwardButton
3. Make sure every place of the buttons are clickable
4. Make sure height and width of the buttons remain the same (34x24, 26x24)
5. Make sure stopButton is centered

Image 1
<img width="364" alt="screenshot 2016-11-19 17 14 45" src="https://cloud.githubusercontent.com/assets/3362943/20454198/bbe72c18-ae7c-11e6-9908-2eb102d494c9.png">

Image 2
<img width="147" alt="screenshot 2016-11-19 17 15 44" src="https://cloud.githubusercontent.com/assets/3362943/20454197/bbe3a6ba-ae7c-11e6-90fe-a8467a0f02f7.png">

Image 3
<img width="34" alt="screenshot 2016-11-19 21 42 51" src="https://cloud.githubusercontent.com/assets/3362943/20455521/28795b16-aea1-11e6-8d74-47969a2f935c.png">


#5526 