### PR TITLE
Aligned the bookmark icon on the navbar

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -560,7 +560,7 @@
     left: 37px;
 
     &.withHomeButton {
-      left: 67px;
+      left: 61px;
     }
   }
 

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -564,8 +564,8 @@
 .navigationButton {
   background-color: @buttonColor;
   display: inline-block;
-  width: 12px;
-  height: 14px;
+  width: 100%;
+  height: 100%;
   margin: 0 7px 0 0;
 }
 
@@ -645,13 +645,17 @@
   .bookmarkButton {
     background: url('../img/toolbar/bookmark_btn.svg') center no-repeat;
     -webkit-mask-repeat: no-repeat;
+    background-size: 14px 14px;
+    margin: 0;
+    height: 0;
     width: 14px;
     height: 14px;
-    margin-bottom: 2px;
-    margin-left: 6px;
+    position: relative;
+    left: 5px;
 
     &.removeBookmarkButton {
       background: url('../img/toolbar/bookmark_marked.svg') center no-repeat;
+      background-size: 14px 14px;
     }
   }
 }
@@ -766,10 +770,9 @@
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
       box-sizing: border-box;
+      display: block;
       height: 25px;
-      line-height: 25px;
-      margin-right: -2px;
-      display: inline-block;
+      width: 25px;
     }
   }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

This PR addresses the issue which was caused by introducing SVG toolbar icons and placing them with pixels, by removing margins around the bookmark icon and setting `background-size`.

Fixes #5632

Auditors: @bradleyrichter

Test Plan: make sure the bookmark icon is properly aligned on each platforms

Image 1: on Ubuntu
![pasted image at 2016_11_03 01_37 pm](https://cloud.githubusercontent.com/assets/3362943/20455330/b76a0456-ae9c-11e6-8589-36a09b232a03.png)

Image 2: on macOS
<img width="193" alt="screenshot 2016-11-19 21 12 26" src="https://cloud.githubusercontent.com/assets/3362943/20455350/01976c80-ae9d-11e6-8933-826a22121091.png">

Related: #5173 #4852