### PR TITLE
Fix findbar background on sites with a translucent theme color

### DIFF
--- a/js/components/findbar.js
+++ b/js/components/findbar.js
@@ -199,10 +199,14 @@ class FindBar extends ImmutableComponent {
 
     const backgroundColor = this.backgroundColor
     let findBarStyle = {}
+    let findBarTextStyle = {}
 
     if (backgroundColor) {
       findBarStyle = {
         background: backgroundColor,
+        color: this.textColor
+      }
+      findBarTextStyle = {
         color: this.textColor
       }
     }
@@ -236,10 +240,10 @@ class FindBar extends ImmutableComponent {
           id='caseSensitivityCheckbox'
           checkedOn={this.isCaseSensitive}
           onClick={this.onCaseSensitivityChange} />
-        <label htmlFor='caseSensitivityCheckbox' data-l10n-id='caseSensitivity' style={findBarStyle} />
+        <label htmlFor='caseSensitivityCheckbox' data-l10n-id='caseSensitivity' style={findBarTextStyle} />
       </div>
       <span className='findButton closeButton'
-        style={findBarStyle}
+        style={findBarTextStyle}
         onClick={this.props.onFindHide}>+</span>
     </div>
   }

--- a/less/findbar.less
+++ b/less/findbar.less
@@ -23,6 +23,7 @@
 
   label {
     color: @mediumGray;
+    -webkit-user-select: none;
   }
 
   span.findButton {
@@ -48,6 +49,7 @@
     margin-right: 0;
     opacity: 0.5;
     transform: rotate(45deg);
+    -webkit-user-select: none;
   }
 
   .searchContainer {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
 - Go to a site with an rgba theme color (such as https://stackoverflow.com)
 - Press Ctrl-F
 - Note that "Match case" label and close button blend seamlessly into the rest of the findbar

Fixes #5742, #5744