### PR TITLE
Font-size of select element inside braveryControlGroup was set to 13px

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -447,6 +447,7 @@
         }
 
         select {
+          font-size: 13px;
           margin-bottom: 25px;
         }
       }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Closes #5772

Auditors: @bradleyrichter

Test Plan:
1. Open the bravery panel
2. Make sure that the font-size of select element inside braveryControlGroup was set to 13px