### PR TITLE
Add user-friendly title for about:blank

### DIFF
--- a/app/extensions/brave/about-blank.html
+++ b/app/extensions/brave/about-blank.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="availableLanguages" content="">
+    <meta name="defaultLanguage" content="en-US">
+    <title data-l10n-id="aboutBlank"></title>
+    <script src='js/about.js'></script>
+    <script src="ext/l20n.min.js" async></script>
+    <link rel="localization" href="locales/{locale}/preferences.properties">
+  </head>
+  <body />
+</html>

--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -106,6 +106,7 @@ startsWithOptionHomePage=my home page
 startsWithOptionNewTabPage=the new tab page
 newTabMode=A new tab shows
 newTabBlank=blank
+aboutBlank=about:blank
 newTabNewTabPage=the new tab page
 newTabHomePage=my home page
 newTabDefaultSearchEngine=default search engine


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

Auditors: @bsclifton, @bradleyrichter, @srirambv

Fix #5764

Test Plan:

* Set new tab opens with my homepage
* Clear the homepage field
* Open a new tab
* New tab title must be about:blank
* Navigate to a site on that tab and long press the back navigation button. 
* Title inside history's contextMenu should be "about:blank"