### PR TITLE
Aligned Flash info icons

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -1584,24 +1584,29 @@ class SecurityTab extends ImmutableComponent {
       <div className='sectionTitle' data-l10n-id='pluginSettings' />
       <SettingsList>
         <SettingCheckbox checked={this.props.flashInstalled ? this.props.braveryDefaults.get('flash') : false} dataL10nId='enableFlash' onChange={this.onToggleFlash} disabled={!this.props.flashInstalled} />
-        <span className='subtext'>
-          <span className='fa fa-info-circle' id='flashInfoIcon' />
+        <div className='subtext flashText'>
           {
             isDarwin || isWindows
-              ? <span><span data-l10n-id='enableFlashSubtext' />&nbsp;
+              ? <div>
+                <span className='fa fa-info-circle' id='flashInfoIcon' />
+                <span data-l10n-id='enableFlashSubtext' />&nbsp;
                 <span className='linkText' onClick={aboutActions.newFrame.bind(null, {
                   location: appConfig.flash.installUrl
-                }, true)}>{'Adobe'}</span>.</span>
-              : <span data-l10n-id='enableFlashSubtextLinux' />
+                }, true)}>{'Adobe'}</span>.
+                </div>
+              : <div>
+                <span className='fa fa-info-circle' id='flashInfoIcon' />
+                <span data-l10n-id='enableFlashSubtextLinux' />
+              </div>
           }
           <div>
             <span className='fa fa-info-circle' id='flashInfoIcon' />
-            <span><span data-l10n-id='flashTroubleshooting' />&nbsp;
-              <span className='linkText' onClick={aboutActions.newFrame.bind(null, {
-                location: 'https://github.com/brave/browser-laptop/wiki/Flash-Support-Deprecation-Proposal#troubleshooting-flash-issues'
-              }, true)}>{'wiki'}</span>.</span>
+            <span data-l10n-id='flashTroubleshooting' />&nbsp;
+            <span className='linkText' onClick={aboutActions.newFrame.bind(null, {
+              location: 'https://github.com/brave/browser-laptop/wiki/Flash-Support-Deprecation-Proposal#troubleshooting-flash-issues'
+            }, true)}>{'wiki'}</span>.
           </div>
-        </span>
+        </div>
       </SettingsList>
       { !isLinux
       ? <div>

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -333,6 +333,16 @@ a {
   margin: 1.2em 2px 7px;
 }
 
+.settingsList .subtext {
+  &.flashText {
+    margin-top: 0;
+
+    #flashInfoIcon {
+      padding: 5px 5px 5px 0;
+    }
+  }
+}
+
 .settingsListCopy {
   color: @braveOrange;
   cursor: pointer;
@@ -1000,10 +1010,6 @@ div.nextPaymentSubmission {
   .spaceAround {
     margin: 50px auto;
   }
-}
-
-#flashInfoIcon {
-  padding: 5px 5px 5px 0;
 }
 
 .widevineInfoIcon {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes #5760

Auditors: @bbondy

Test Plan: Open about:preferences#security and make sure the info icons are aligned