### PR TITLE
Add tooltips to external links in the UI

### DIFF
--- a/app/renderer/components/widevineInfo.js
+++ b/app/renderer/components/widevineInfo.js
@@ -46,6 +46,7 @@ class WidevineInfo extends ImmutableComponent {
         <span style={widevineInfoIconStyle}
           className='fa fa-info-circle'
           onClick={this.onMoreInfo}
+          title={appConfig.widevine.moreInfoUrl}
         />
       </div>
       <div className='subtext'>
@@ -53,6 +54,7 @@ class WidevineInfo extends ImmutableComponent {
         <span style={widevineInfoIconStyle}
           className='fa fa-info-circle'
           onClick={this.onViewLicense}
+          title={appConfig.widevine.licenseUrl}
         />
       </div>
     </div>

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -1615,7 +1615,7 @@ class SecurityTab extends ImmutableComponent {
                 <span data-l10n-id='enableFlashSubtext' />&nbsp;
                 <span className='linkText' onClick={aboutActions.newFrame.bind(null, {
                   location: appConfig.flash.installUrl
-                }, true)}>{'Adobe'}</span>.
+                }, true)} title={appConfig.flash.installUrl}>{'Adobe'}</span>.
               </div>
               : <div>
                 <span className='fa fa-info-circle' id='flashInfoIcon' />
@@ -1627,7 +1627,7 @@ class SecurityTab extends ImmutableComponent {
             <span data-l10n-id='flashTroubleshooting' />&nbsp;
             <span className='linkText' onClick={aboutActions.newFrame.bind(null, {
               location: 'https://github.com/brave/browser-laptop/wiki/Flash-Support-Deprecation-Proposal#troubleshooting-flash-issues'
-            }, true)}>{'wiki'}</span>.
+            }, true)} title='https://github.com/brave/browser-laptop/wiki/Flash-Support-Deprecation-Proposal#troubleshooting-flash-issues'>{'wiki'}</span>.
           </div>
         </div>
       </SettingsList>

--- a/js/components/braveryPanel.js
+++ b/js/components/braveryPanel.js
@@ -304,7 +304,7 @@ class BraveryPanel extends ImmutableComponent {
                     <option data-l10n-id='block3rdPartyCookie' value='block3rdPartyCookie' />
                     <option data-l10n-id='allowAllCookies' value='allowAllCookies' />
                   </select>
-                  <SwitchControl onClick={this.onToggleFp} rightl10nId='fingerprintingProtection' checkedOn={fpEnabled} disabled={!shieldsUp} onInfoClick={this.onInfoClick} className='fingerprintingProtectionSwitch' />
+                  <SwitchControl onClick={this.onToggleFp} rightl10nId='fingerprintingProtection' checkedOn={fpEnabled} disabled={!shieldsUp} onInfoClick={this.onInfoClick} infoTitle={config.fingerprintingInfoUrl} className='fingerprintingProtectionSwitch' />
                   <SwitchControl onClick={this.onToggleSafeBrowsing} rightl10nId='safeBrowsing' checkedOn={this.props.braverySettings.safeBrowsing} disabled={!shieldsUp} />
                 </div>
               </div></span>

--- a/js/components/switchControl.js
+++ b/js/components/switchControl.js
@@ -57,7 +57,7 @@ class SwitchControl extends ImmutableComponent {
           ? <span className='switchControlRightText' data-l10n-id={this.props.rightl10nId} data-l10n-args={this.props.rightl10nArgs}>{this.props.rightText || ''}</span>
           : null}
           {(this.props.rightl10nId || this.props.rightText) && this.props.onInfoClick
-          ? <div className='switchControlRightText'><span data-l10n-id={this.props.rightl10nId} data-l10n-args={this.props.rightl10nArgs}>{this.props.rightText}</span><span className='fa fa-question-circle info clickable' onClick={this.props.onInfoClick} /></div>
+          ? <div className='switchControlRightText'><span data-l10n-id={this.props.rightl10nId} data-l10n-args={this.props.rightl10nArgs}>{this.props.rightText}</span><span className='fa fa-question-circle info clickable' onClick={this.props.onInfoClick} title={this.props.infoTitle} /></div>
           : null}
         </div>
       }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes #5759

Test Plan:
1. Open a Brave and open Preferences.
2. Open the Security section.
3. In the Plugin Settings section, move your mouse over the link `Adobe`.
4. Make sure it has a tooltip that matches screenshot 1 below.
5. Move your mouse over the link `wiki`.
6. Make sure it has a tooltip that matches screenshot 2 below.
7. In the Google Widevine Support section, move your mouse over the first info button (after the first paragraph).
8. Make sure it has a tooltip that matches screenshot 3 below.
9. Move your mouse over the second info button (after the second paragraph).
10. Make sure it has a tooltip that matches screenshot 4 below.
11. Open a new tab. Navigate to any site.
12. Open the Shields panel by clicking the Brave logo in the top right corner.
13. Mouse over the question mark button beside the `Fingerprinting Protection` switch.
14. Make sure it has a tooltip that matches screenshot 5 below.

Screenshot 1:
![image](https://cloud.githubusercontent.com/assets/19424103/20512377/8e744c42-b044-11e6-81e4-437ff8f90c42.png)
Screenshot 2:
![image](https://cloud.githubusercontent.com/assets/19424103/20512402/bc053090-b044-11e6-99d6-4ca6842f8da9.png)
Screenshot 3:
![image](https://cloud.githubusercontent.com/assets/19424103/20512417/de96d410-b044-11e6-8816-68cc3f135247.png)
Screenshot 4:
![image](https://cloud.githubusercontent.com/assets/19424103/20512443/006f487e-b045-11e6-877c-af3af6949597.png)
Screenshot 5:
![image](https://cloud.githubusercontent.com/assets/19424103/20512497/491a2710-b045-11e6-9e87-f3ae666684a1.png)
