### PR TITLE
Add context menu to reload button

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -219,19 +219,9 @@ const createViewSubmenu = () => {
       click: function (item, focusedWindow) {
         CommonMenu.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_ACTIVE_FRAME_STOP])
       }
-    }, {
-      label: locale.translation('reloadPage'),
-      accelerator: 'CmdOrCtrl+R',
-      click: function (item, focusedWindow) {
-        CommonMenu.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_ACTIVE_FRAME_RELOAD])
-      }
-    }, {
-      label: locale.translation('cleanReload'),
-      accelerator: 'CmdOrCtrl+Shift+R',
-      click: function (item, focusedWindow) {
-        CommonMenu.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_ACTIVE_FRAME_CLEAN_RELOAD])
-      }
     },
+    CommonMenu.reloadPageMenuItem(),
+    CommonMenu.cleanReloadMenuItem(),
     CommonMenu.separatorMenuItem,
     /*
     {

--- a/app/common/commonMenu.js
+++ b/app/common/commonMenu.js
@@ -348,3 +348,23 @@ module.exports.braveryPaymentsMenuItem = () => {
     }
   }
 }
+
+module.exports.reloadPageMenuItem = () => {
+  return {
+    label: locale.translation('reloadPage'),
+    accelerator: 'CmdOrCtrl+R',
+    click: function (item, focusedWindow) {
+      module.exports.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_ACTIVE_FRAME_RELOAD])
+    }
+  }
+}
+
+module.exports.cleanReloadMenuItem = () => {
+  return {
+    label: locale.translation('cleanReload'),
+    accelerator: 'CmdOrCtrl+Shift+R',
+    click: function (item, focusedWindow) {
+      module.exports.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_ACTIVE_FRAME_CLEAN_RELOAD])
+    }
+  }
+}

--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -20,6 +20,8 @@ const siteUtil = require('../state/siteUtil')
 const eventUtil = require('../lib/eventUtil')
 const getSetting = require('../settings').getSetting
 const windowStore = require('../stores/windowStore')
+const contextMenus = require('../contextMenus')
+const LongPressButton = require('./longPressButton')
 
 class NavigationBar extends ImmutableComponent {
   constructor () {
@@ -27,6 +29,7 @@ class NavigationBar extends ImmutableComponent {
     this.onToggleBookmark = this.onToggleBookmark.bind(this)
     this.onStop = this.onStop.bind(this)
     this.onReload = this.onReload.bind(this)
+    this.onReloadLongPress = this.onReloadLongPress.bind(this)
     this.onNoScript = this.onNoScript.bind(this)
   }
 
@@ -51,6 +54,10 @@ class NavigationBar extends ImmutableComponent {
     } else {
       ipc.emit(messages.SHORTCUT_ACTIVE_FRAME_RELOAD)
     }
+  }
+
+  onReloadLongPress (target) {
+    contextMenus.onReloadContextMenu(target)
   }
 
   onHome () {
@@ -136,9 +143,11 @@ class NavigationBar extends ImmutableComponent {
               onClick={this.onStop} />
           </span>
           : <span className='navigationButtonContainer'>
-            <button data-l10n-id='reloadButton'
+            <LongPressButton
+              l10nId='reloadButton'
               className='navigationButton reloadButton'
-              onClick={this.onReload} />
+              onClick={this.onReload}
+              onLongPress={this.onReloadLongPress} />
           </span>
       }
       {

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -1482,6 +1482,20 @@ function onForwardButtonHistoryMenu (activeFrame, history, target) {
   }))
 }
 
+function onReloadContextMenu (target) {
+  const rect = target.getBoundingClientRect()
+  const menuTemplate = [
+    CommonMenu.reloadPageMenuItem(),
+    CommonMenu.cleanReloadMenuItem()
+  ]
+
+  windowActions.setContextMenuDetail(Immutable.fromJS({
+    left: rect.left,
+    top: rect.bottom + 2,
+    template: menuTemplate
+  }))
+}
+
 module.exports = {
   onHamburgerMenu,
   onMainContextMenu,
@@ -1498,5 +1512,6 @@ module.exports = {
   onShowAutofillMenu,
   onMoreBookmarksMenu,
   onBackButtonHistoryMenu,
-  onForwardButtonHistoryMenu
+  onForwardButtonHistoryMenu,
+  onReloadContextMenu
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes #5796

This enhancement takes advantage of `LongPressButton`, which has long press and right-click functionality out of the box. The context menu contains **Reload Page** and **Clean Reload**, the reload options currently implemented in Brave (from the View menu). Thus, Reload Page and Clean Reload have been moved to `CommonMenu`.

Test Plan:
1. Open a new Brave window.
2. Navigate to any site.
3. Right-click the reload button in the urlBar.
4. Make sure the context menu appears.
5. Click Reload Page.
6. Make sure the page is reloaded.
7. Right-click the reload button again.
8. Click Clean Reload.
9. Make sure the page is reloaded clean.
10. Long press the reload button.
11. Make sure the context menu also appears.

Screenshot (updated):
![image](https://cloud.githubusercontent.com/assets/19424103/20577150/a6205b0e-b186-11e6-99e7-6e60d6412c69.png)
