### PR TITLE
Removed "inlineButton" from Cancel button on Brave wallet recovery dialog

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -1147,7 +1147,7 @@ class PaymentsTab extends ImmutableComponent {
     return <div className='panel advancedSettingsFooter'>
       <div className='recoveryFooterButtons'>
         <Button l10nId='recover' className='primaryButton' onClick={this.recoverWallet} />
-        <Button l10nId='cancel' className='whiteButton inlineButton' onClick={this.props.hideOverlay.bind(this, 'ledgerRecovery')} />
+        <Button l10nId='cancel' className='whiteButton' onClick={this.props.hideOverlay.bind(this, 'ledgerRecovery')} />
       </div>
     </div>
   }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5804 into
<img width="243" alt="screenshot 2016-11-23 13 17 04" src="https://cloud.githubusercontent.com/assets/3362943/20551052/3ac6dfb0-b17f-11e6-8674-28e7564b1e88.png">


Auditors: @bbondy

Test Plan:
1. Open about:preferences#payments
2. Click "Recover your wallet"