### PR TITLE
Add "Import recovery keys" button to Payments->Advanced->Recover

### DIFF
--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -160,6 +160,7 @@ backupLedger=Backup your wallet
 balanceRecovered={{balance}} BTC was recovered and transferred to your Brave wallet.
 recoverLedger=Recover your wallet
 recover=Recover
+recoverFromFile=Import recovery keys
 printKeys=Print keys
 saveRecoveryFile=Save recovery file...
 advancedPrivacySettings=Advanced Privacy Settings:

--- a/app/filtering.js
+++ b/app/filtering.js
@@ -487,12 +487,14 @@ function registerForDownloadListener (session) {
     }
 
     const defaultPath = path.join(getSetting(settings.DEFAULT_DOWNLOAD_SAVE_PATH) || app.getPath('downloads'), itemFilename)
-    const savePath = dialog.showSaveDialog(win, { defaultPath })
+    const savePath = (process.env.SPECTRON ? defaultPath : dialog.showSaveDialog(win, { defaultPath }))
+
     // User cancelled out of save dialog prompt
     if (!savePath) {
       event.preventDefault()
       return
     }
+
     item.setSavePath(savePath)
     appActions.changeSetting(settings.DEFAULT_DOWNLOAD_SAVE_PATH, path.dirname(savePath))
 

--- a/docs/appActions.md
+++ b/docs/appActions.md
@@ -146,13 +146,13 @@ Dispatches a message to clear all completed downloads
 
 ### ledgerRecoverySucceeded() 
 
-Dispatches a message to clear all completed downloads
+Dispatches a message indicating ledger recovery succeeded
 
 
 
 ### ledgerRecoveryFailed() 
 
-Dispatches a message to clear all completed downloads
+Dispatches a message indicating ledger recovery failed
 
 
 

--- a/js/about/aboutActions.js
+++ b/js/about/aboutActions.js
@@ -108,6 +108,13 @@ const aboutActions = {
     })
   },
 
+  ledgerRecoverWalletFromFile: function () {
+    aboutActions.dispatchAction({
+      actionType: appConstants.APP_RECOVER_WALLET,
+      useRecoveryKeyFile: true
+    })
+  },
+
   /**
    * Clear wallet recovery status
    */

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -901,6 +901,10 @@ class PaymentsTab extends ImmutableComponent {
     aboutActions.ledgerRecoverWallet(this.state.FirstRecoveryKey, this.state.SecondRecoveryKey)
   }
 
+  recoverWalletFromFile () {
+    aboutActions.ledgerRecoverWalletFromFile()
+  }
+
   copyToClipboard (text) {
     aboutActions.setClipboard(text)
   }
@@ -911,6 +915,7 @@ class PaymentsTab extends ImmutableComponent {
 
   clearRecoveryStatus () {
     aboutActions.clearRecoveryStatus()
+    this.props.hideAdvancedOverlays()
   }
 
   printKeys () {
@@ -1143,23 +1148,26 @@ class PaymentsTab extends ImmutableComponent {
   }
 
   get ledgerRecoveryContent () {
+    let balance = this.props.ledgerData.get('balance')
+
     const l10nDataArgs = {
-      balance: this.props.ledgerData.get('balance')
+      balance: (!balance ? '0.00' : balance)
     }
+
     return <div className='board'>
       {
         this.props.ledgerData.get('recoverySucceeded') === true
         ? <div className='recoveryOverlay'>
           <h1>Success!</h1>
           <p className='spaceAround' data-l10n-id='balanceRecovered' data-l10n-args={JSON.stringify(l10nDataArgs)} />
-          <Button l10nId='ok' className='whiteButton inlineButton' onClick={this.clearRecoveryStatus} />
+          <Button l10nId='ok' className='whiteButton inlineButton' onClick={this.clearRecoveryStatus.bind(this)} />
         </div>
         : null
       }
       {
         this.props.ledgerData.get('recoverySucceeded') === false
         ? <div className='recoveryOverlay'>
-          <h1>Recovery failed</h1>
+          <h1 className='recoveryError'>Recovery failed</h1>
           <p className='spaceAround'>Please re-enter keys or try different keys.</p>
           <Button l10nId='ok' className='whiteButton inlineButton' onClick={this.clearRecoveryStatus} />
         </div>
@@ -1184,6 +1192,7 @@ class PaymentsTab extends ImmutableComponent {
     return <div className='panel advancedSettingsFooter'>
       <div className='recoveryFooterButtons'>
         <Button l10nId='recover' className='primaryButton' onClick={this.recoverWallet} />
+        <Button l10nId='recoverFromFile' className='primaryButton' onClick={this.recoverWalletFromFile} />
         <Button l10nId='cancel' className='whiteButton' onClick={this.props.hideOverlay.bind(this, 'ledgerRecovery')} />
       </div>
     </div>
@@ -1841,6 +1850,15 @@ class AboutPreferences extends React.Component {
     this.updateTabFromAnchor = this.updateTabFromAnchor.bind(this)
   }
 
+  hideAdvancedOverlays () {
+    this.setState({
+      advancedSettingsOverlayVisible: false,
+      ledgerBackupOverlayVisible: false,
+      ledgerRecoveryOverlayVisible: false
+    })
+    this.forceUpdate()
+  }
+
   componentDidMount () {
     window.addEventListener('popstate', this.updateTabFromAnchor)
   }
@@ -1966,7 +1984,8 @@ class AboutPreferences extends React.Component {
           ledgerRecoveryOverlayVisible={this.state.ledgerRecoveryOverlayVisible}
           addFundsOverlayVisible={this.state.addFundsOverlayVisible}
           showOverlay={this.setOverlayVisible.bind(this, true)}
-          hideOverlay={this.setOverlayVisible.bind(this, false)} />
+          hideOverlay={this.setOverlayVisible.bind(this, false)}
+          hideAdvancedOverlays={this.hideAdvancedOverlays.bind(this)} />
         break
       case preferenceTabs.SECURITY:
         tab = <SecurityTab settings={settings} siteSettings={siteSettings} braveryDefaults={braveryDefaults} onChangeSetting={this.onChangeSetting} />

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -192,7 +192,7 @@ const appActions = {
   },
 
   /**
-   * Dispatches a message to clear all completed downloads
+   * Dispatches a message indicating ledger recovery succeeded
    */
   ledgerRecoverySucceeded: function () {
     AppDispatcher.dispatch({
@@ -201,7 +201,7 @@ const appActions = {
   },
 
   /**
-   * Dispatches a message to clear all completed downloads
+   * Dispatches a message indicating ledger recovery failed
    */
   ledgerRecoveryFailed: function () {
     AppDispatcher.dispatch({

--- a/test/components/ledgerPanelAdvancedPanelTest.js
+++ b/test/components/ledgerPanelAdvancedPanelTest.js
@@ -1,0 +1,225 @@
+/* global describe, it, beforeEach */
+
+const Brave = require('../lib/brave')
+const {urlInput, paymentsWelcomePage, paymentsTab, walletSwitch, backupWallet, recoverWallet, saveWalletFile, advancedSettingsButton, recoverWalletFromFileButton, balanceRecovered, balanceNotRecovered, recoveryOverlayOkButton} = require('../lib/selectors')
+const messages = require('../../js/constants/messages')
+
+const assert = require('assert')
+
+const prefsUrl = 'about:preferences'
+const ledgerAPIWaitTimeout = 60000
+
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const urlParse = require('url').parse
+const uuid = require('uuid')
+
+const WALLET_RECOVERY_FILE_BASENAME = 'brave_wallet_recovery.txt'
+const PAYMENT_ID_TRANSLATION_KEY = 'ledgerBackupText3'
+const PASSPHRASE_TRANSLATION_KEY = 'ledgerBackupText4'
+
+const moment = require('moment')
+
+let translationsCache = null
+
+function setup (client) {
+  return client
+    .translations().then(function (translations) {
+      if (translations && translations.value) {
+        translationsCache = translations.value
+      }
+      return this
+    })
+    .waitForBrowserWindow()
+    .waitForVisible(urlInput)
+}
+
+function* setupPaymentsTabAndOpenAdvancedSettings (client, tabAlreadyLoaded) {
+  yield client
+    .tabByIndex(0)
+
+  if (!tabAlreadyLoaded) {
+    yield client
+      .loadUrl(prefsUrl)
+      .waitForVisible(paymentsTab)
+      .click(paymentsTab)
+      .waitForVisible(paymentsWelcomePage)
+      .waitForVisible(walletSwitch)
+      .click(walletSwitch)
+      .waitForVisible(advancedSettingsButton, ledgerAPIWaitTimeout)
+  }
+
+  yield client.click(advancedSettingsButton)
+}
+
+function validateRecoveryFile (recoveryFileContents) {
+  const UUID_LENGTH = 36
+  const RECOVERY_FILE_EXPECTED_NUM_LINES = 7
+
+  assert.equal(typeof recoveryFileContents, 'string', 'recovery file should contain a string')
+
+  let messageLines = recoveryFileContents.split(os.EOL)
+
+  assert.equal(messageLines.length, RECOVERY_FILE_EXPECTED_NUM_LINES, 'recovery file should have the expected number of lines')
+
+  const paymentIdPrefixText = translationsCache[PAYMENT_ID_TRANSLATION_KEY]
+  assert.equal(typeof paymentIdPrefixText, 'string', `payment ID prefix text ("${PAYMENT_ID_TRANSLATION_KEY}") should exist in translation cache`)
+
+  const passphrasePrefixText = translationsCache[PASSPHRASE_TRANSLATION_KEY]
+  assert.equal(typeof passphrasePrefixText, 'string', `passphrase prefix text ("${PASSPHRASE_TRANSLATION_KEY}") should exist in translation cache`)
+
+  let paymentIdLine = '' || messageLines[3]
+  assert.equal(typeof paymentIdLine === 'string' && paymentIdLine.length >= paymentIdPrefixText.length + UUID_LENGTH, true)
+
+  let passphraseLine = '' || messageLines[4]
+  assert.equal(typeof passphraseLine === 'string' && passphraseLine.length >= passphrasePrefixText.length + UUID_LENGTH, true)
+
+  const paymentIdPattern = new RegExp([paymentIdPrefixText, '([^ ]+)'].join(' '))
+  const paymentId = (paymentIdLine.match(paymentIdPattern) || [])[1]
+  assert.ok(paymentId)
+  assert.equal(typeof paymentId, 'string')
+  console.log(`recovered paymentId: ${paymentId}`)
+
+  const passphrasePattern = new RegExp([passphrasePrefixText, '(.+)$'].join(' '))
+  const passphrase = (passphraseLine.match(passphrasePattern) || [])[1]
+  assert.ok(passphrase)
+  assert.equal(typeof passphrase, 'string')
+  console.log(`recovered passphrase: ${passphrase}`)
+
+  // validate that paymentId and passphrase are uuids here
+  const UUID_REGEX = /^[0-9a-z]{8}\-[0-9a-z]{4}\-[0-9a-z]{4}\-[0-9a-z]{4}\-[0-9a-z]{12}$/
+  assert.ok(paymentId.match(UUID_REGEX), 'paymentId should be a valid UUID')
+  assert.ok(passphrase.match(UUID_REGEX), 'passphrase should be a valid UUID')
+
+  return true
+}
+
+let recoverWalletFromFile = function * (client) {
+  yield setupPaymentsTabAndOpenAdvancedSettings(client, true)
+
+  // open "Recover your wallet" submodal and click "Import recovery keys"
+  yield client
+    .waitForVisible(recoverWallet, ledgerAPIWaitTimeout)
+    .click(recoverWallet)
+    .waitForVisible(recoverWalletFromFileButton, ledgerAPIWaitTimeout)
+    .click(recoverWalletFromFileButton)
+}
+
+let generateAndSaveRecoveryFile = function (recoveryFilePath, paymentId, passphrase) {
+  let recoveryFileContents = ''
+
+  if (typeof paymentId === 'string' || typeof passphrase === 'string') {
+    const date = moment().format('L')
+
+    const messageLines = [
+      translationsCache['ledgerBackupText1'],
+      [translationsCache['ledgerBackupText2'], date].join(' '),
+      '',
+      [translationsCache['ledgerBackupText3'], paymentId].join(' '),
+      [translationsCache['ledgerBackupText4'], passphrase].join(' '),
+      '',
+      translationsCache['ledgerBackupText5']
+    ]
+
+    recoveryFileContents = messageLines.join(os.EOL)
+  }
+
+  fs.writeFileSync(recoveryFilePath, recoveryFileContents)
+
+  return
+}
+
+describe('Payments Panel -> Advanced Panel', function () {
+  let context = this
+  Brave.beforeEach(this)
+
+  beforeEach(function * () {
+    yield setup(this.app.client)
+  })
+
+  it('can backup wallet to file', function * () {
+    context.cleanSessionStoreAfterEach = false
+
+    yield setupPaymentsTabAndOpenAdvancedSettings(this.app.client)
+
+    // open "Backup your wallet" sub-modal and click "Save recovery file..."
+    yield this.app.client
+      .waitForVisible(backupWallet, ledgerAPIWaitTimeout)
+      .click(backupWallet)
+      .waitForVisible(saveWalletFile, ledgerAPIWaitTimeout)
+      .click(saveWalletFile)
+
+    const windowHandlesResponse = yield this.app.client.windowHandles()
+    const windowHandles = windowHandlesResponse.value
+
+    // confirm the saved backup file is opened in a new tab
+    yield this.app.client.window(windowHandles[0])
+      .ipcSend('shortcut-focus-url')
+      .waitForElementFocus(urlInput, ledgerAPIWaitTimeout)
+      .waitUntil(function () {
+        return this.getValue(urlInput)
+          .then(function (urlString) {
+            // VERIFY that the downloaded recovery file is opened in new tab
+            assert.equal(typeof urlString, 'string')
+            let urlObj = urlParse(urlString)
+            assert.ok(urlObj)
+            assert.equal(urlObj.protocol, 'file:')
+            assert.equal(path.basename(urlObj.pathname), WALLET_RECOVERY_FILE_BASENAME)
+
+            // VERIFY contents of downloaded recovery file
+            let pathname = urlObj.pathname
+            // this is a test, so OK to throw exception in here
+            let recoveryFileContents = fs.readFileSync(pathname).toString()
+
+            context.recoveryFilePathname = pathname
+
+            return validateRecoveryFile(recoveryFileContents)
+          })
+      })
+      .pause(1000)
+      .ipcSend(messages.SHORTCUT_CLOSE_FRAME, 2)
+      .pause(1000)
+      .ipcSend('shortcut-focus-url')
+  })
+
+  it('can recover wallet from file', function * () {
+    yield recoverWalletFromFile(this.app.client)
+
+    yield this.app.client
+      .waitForVisible(balanceRecovered, ledgerAPIWaitTimeout)
+      .waitForVisible(recoveryOverlayOkButton, ledgerAPIWaitTimeout)
+      .click(recoveryOverlayOkButton)
+      .pause(1000)
+  })
+
+  let randomPaymentId = uuid.v4().toLowerCase()
+
+  it('shows an error popover if one recovery key is missing', function * () {
+    generateAndSaveRecoveryFile(context.recoveryFilePathname, randomPaymentId, '')
+    yield recoverWalletFromFile(this.app.client)
+    yield this.app.client
+      .waitForVisible(balanceNotRecovered, ledgerAPIWaitTimeout)
+  })
+
+  it('shows an error popover if a recovery key is not a UUID', function * () {
+    generateAndSaveRecoveryFile(context.recoveryFilePathname, randomPaymentId, 'not-a-uuid')
+    yield recoverWalletFromFile(this.app.client)
+    yield this.app.client
+      .waitForVisible(balanceNotRecovered, ledgerAPIWaitTimeout)
+  })
+
+  it('shows an error popover if both recovery keys are missing', function * () {
+    generateAndSaveRecoveryFile(context.recoveryFilePathname, '', '')
+    yield recoverWalletFromFile(this.app.client)
+    yield this.app.client
+      .waitForVisible(balanceNotRecovered, ledgerAPIWaitTimeout)
+  })
+
+  it('shows an error popover if the file is empty', function * () {
+    generateAndSaveRecoveryFile(context.recoveryFilePathname)
+    yield recoverWalletFromFile(this.app.client)
+    yield this.app.client
+      .waitForVisible(balanceNotRecovered, ledgerAPIWaitTimeout)
+  })
+})

--- a/test/components/ledgerPanelTest.js
+++ b/test/components/ledgerPanelTest.js
@@ -5,7 +5,7 @@ const {urlInput, advancedSettings, addFundsButton, paymentsStatus, paymentsWelco
 const assert = require('assert')
 
 const prefsUrl = 'about:preferences'
-const ledgerAPIWaitTimeout = 10000
+const ledgerAPIWaitTimeout = 20000
 
 function * setup (client) {
   yield client

--- a/test/lib/selectors.js
+++ b/test/lib/selectors.js
@@ -65,6 +65,14 @@ module.exports = {
   siteSettingItem: '.siteSettingItem',
   ledgerTable: '.ledgerTable',
   bitcoinDashboard: '.bitcoinDashboard',
+  advancedSettingsButton: '[data-l10n-id="advancedSettings"]',
+  backupWallet: '[data-l10n-id="backupLedger"]',
+  recoverWallet: '[data-l10n-id="recoverLedger"]',
+  recoverWalletFromFileButton: '[data-l10n-id="recoverFromFile"]',
+  recoveryOverlayOkButton: '.recoveryOverlay [data-l10n-id="ok"]',
+  saveWalletFile: '[data-l10n-id="saveRecoveryFile"]',
+  balanceRecovered: '[data-l10n-id="balanceRecovered"]',
+  balanceNotRecovered: '.recoveryError',
   modalCloseButton: 'button.close',
   coinbaseBuyButton: '[data-l10n-id="add"]',
   paymentQRCode: '[title="Brave wallet QR code"]',
@@ -79,5 +87,6 @@ module.exports = {
   dismissDenyRunInsecureContentButton: '.dismissDenyRunInsecureContentButton',
   tabsToolbar: '.tabsToolbar',
   hamburgerMenu: '.menuButton',
-  contextMenu: '.contextMenu'
+  contextMenu: '.contextMenu',
+  okButton: '[data-l10n-id="ok"]'
 }


### PR DESCRIPTION
Add "Import recovery keys" button that opens a file chooser dialog

fixes #4806
fixes #6263

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist. (issue #4806)
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed). 

## Test Plan:
1. Open Preferences->Payments

-- backup your wallet to a file  --
2. Click "Advanced Settings..."
3. Click "Backup your wallet"
4. Click "Save recovery file..."
5. Choose a location / filename for your backup from the File Chooser dialog

-- recover your wallet from file --
6. Return to Preferences -> Payments (Close all modals)
7. Open "Advanced Settings..."
8. Click "Recover your wallet"
9. Click "Import recovery keys"
10. Use File Chooser dialog to select the backup file created previously (step 5)
11. Observe "Success" screen

## Automated test plan
```bash
# window 1
npm run watch-test
#window 2
npm run uitest -- --grep="Payments Panel -> Advanced Panel"
```