### PR TITLE
minimum visits and minduration not persisting when changed

### DIFF
--- a/app/ledger.js
+++ b/app/ledger.js
@@ -145,7 +145,7 @@ const doAction = (action) => {
         case settings.MINIMUM_VISIT_TIME:
           if (action.value <= 0) break
 
-          synopsis.options.minDuration = action.value * 1000
+          synopsis.options.minDuration = action.value
           updatePublisherInfo()
           break
 
@@ -580,10 +580,11 @@ var enable = (paymentsEnabled) => {
       // cf., the `Synopsis` constructor, https://github.com/brave/ledger-publisher/blob/master/index.js#L167
       value = getSetting(settings.MINIMUM_VISIT_TIME)
       if (!value) {
-        value = 8
+        value = 8 * 1000
         appActions.changeSetting(settings.MINIMUM_VISIT_TIME, value)
       }
-      if (value > 0) synopsis.options.minDuration = value * 1000
+      // for earlier versions of the code...
+      if ((value > 0) && (value < 1000)) synopsis.options.minDuration = value * 1000
 
       value = getSetting(settings.MINIMUM_VISITS)
       if (!value) {
@@ -1225,9 +1226,6 @@ var getStateInfo = (state) => {
 
   ledgerInfo.paymentId = state.properties.wallet.paymentId
   ledgerInfo.passphrase = state.properties.wallet.keychains.passphrase
-
-  ledgerInfo.minDuration = synopsis.options.minDuration
-  ledgerInfo.minPublisherVisits = synopsis.options.minPublisherVisits
 
   ledgerInfo.created = !!state.properties.wallet
   ledgerInfo.creating = !ledgerInfo.created

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -1014,8 +1014,8 @@ class PaymentsTab extends ImmutableComponent {
   }
 
   get advancedSettingsContent () {
-    const minDuration = this.props.ledgerData.get('minDuration')
-    const minPublisherVisits = this.props.ledgerData.get('minPublisherVisits')
+    const minDuration = this.props.ledgerData.getIn(['synopsisOptions', 'minDuration'])
+    const minPublisherVisits = this.props.ledgerData.getIn(['synopsisOptions', 'minPublisherVisits'])
 
     return <div className='board'>
       <div className='panel advancedSettings'>
@@ -1025,11 +1025,11 @@ class PaymentsTab extends ImmutableComponent {
             <SettingItem>
               <select
                 className='form-control'
-                defaultValue={minDuration || 8}
+                defaultValue={minDuration || 8000}
                 onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.MINIMUM_VISIT_TIME)}>>
-                <option value='5'>5 seconds</option>
-                <option value='8'>8 seconds</option>
-                <option value='60'>1 minute</option>
+                <option value='5000'>5 seconds</option>
+                <option value='8000'>8 seconds</option>
+                <option value='60000'>1 minute</option>
               </select>
             </SettingItem>
           </SettingsList>


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #4822

Auditors @mrose17 @bsclifton 

Two things here. One, we were multiplying by 1000 before storing the value but that causes a bug when the (now * 1000) value gets back to the UI. So instead, let's just keep the values in milliseconds.

The second thing is we initially store the minDuration and minimumVisits in ledgerData at the root but then we were saving it to ledgerData.synopsisOptions when it changed so the UI was grabbing the old value!

@bsclifton can you think of a good automated test for this? I know we chatted about it yesterday  but I was struggling to implement something that makes sense!

## Test Plan
1. Start Brave
2. Go to Preferences > Payments
3. Click on Advanced Settings
4. Change Minimum Duration to any new value
5. Close and re-open the Advanced Settings modal
6. Make sure the new value persists
7. Do 4-6 with minimum visits as well