### PR TITLE
Add default icon for url that has a broken file

### DIFF
--- a/js/about/bookmarks.js
+++ b/js/about/bookmarks.js
@@ -210,9 +210,8 @@ class BookmarkTitleHeader extends ImmutableComponent {
 class BookmarkTitleCell extends ImmutableComponent {
   render () {
     let iconStyle
-    let showingFavicon = false
+    const icon = this.props.siteDetail.get('favicon')
     if (!siteUtil.isFolder(this.props.siteDetail)) {
-      const icon = this.props.siteDetail.get('favicon')
       if (icon) {
         iconStyle = {
           minWidth: iconSize,
@@ -221,16 +220,23 @@ class BookmarkTitleCell extends ImmutableComponent {
           backgroundSize: iconSize,
           height: iconSize
         }
-        showingFavicon = true
       }
     }
 
     const bookmarkTitle = this.props.siteDetail.get('customTitle') || this.props.siteDetail.get('title')
     const bookmarkLocation = this.props.siteDetail.get('location')
+    const defaultIcon = 'fa fa-file-o'
 
     return <div>
       {
-        showingFavicon ? <span className='bookmarkFavicon' style={iconStyle} /> : null
+        <span
+          className={cx({
+            bookmarkFavicon: true,
+            bookmarkFile: !icon,
+            [defaultIcon]: !icon
+          })}
+          style={iconStyle}
+        />
       }
       <span>{bookmarkTitle || bookmarkLocation}</span>
       {

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -34,6 +34,7 @@ const windowStore = require('../stores/windowStore')
 const appStoreRenderer = require('../stores/appStoreRenderer')
 const siteSettings = require('../state/siteSettings')
 const {newTabMode} = require('../../app/common/constants/settingsEnums')
+const imageUtil = require('../lib/imageUtil')
 
 const WEBRTC_DEFAULT = 'default'
 const WEBRTC_DISABLE_NON_PROXY = 'disable_non_proxied_udp'
@@ -819,7 +820,9 @@ class Frame extends ImmutableComponent {
     })
     this.webview.addEventListener('page-favicon-updated', (e) => {
       if (e.favicons && e.favicons.length > 0) {
-        windowActions.setFavicon(this.frame, e.favicons[0])
+        imageUtil.getWorkingImageUrl(e.favicons[0], (imageFound) => {
+          windowActions.setFavicon(this.frame, imageFound ? e.favicons[0] : null)
+        })
       }
     })
     this.webview.addEventListener('page-title-updated', ({title}) => {

--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -159,6 +159,8 @@ class Tab extends ImmutableComponent {
     }
 
     const icon = this.props.tab.get('icon')
+    const defaultIcon = 'fa fa-file-o'
+
     if (!this.loading && icon) {
       iconStyle = Object.assign(iconStyle, {
         backgroundImage: `url(${icon})`,
@@ -225,6 +227,8 @@ class Tab extends ImmutableComponent {
           locationHasFavicon
           ? <div className={cx({
             tabIcon: true,
+            bookmarkFile: !icon,
+            [defaultIcon]: !icon,
             'fa fa-circle-o-notch fa-spin': this.loading
           })}
             style={iconStyle} />

--- a/js/lib/imageUtil.js
+++ b/js/lib/imageUtil.js
@@ -19,3 +19,10 @@ module.exports.getBase64FromImageUrl = (url) => {
     img.src = url
   })
 }
+
+module.exports.getWorkingImageUrl = (url, cb) => {
+  const img = new window.Image()
+  img.onload = () => cb(true)
+  img.onerror = () => cb(false)
+  img.src = url
+}

--- a/test/about/newTabTest.js
+++ b/test/about/newTabTest.js
@@ -224,6 +224,37 @@ describe('about:newtab tests', function () {
         yield this.app.client
           .waitForExist('.topSitesElementFavicon', 3000, true)
       })
+
+      it('shows favicon image for topSites', function * () {
+        const pageWithFavicon = Brave.server.url('favicon.html')
+
+        yield this.app.client
+          .tabByUrl(Brave.newTabUrl)
+          .url(pageWithFavicon)
+          .waitForUrl(pageWithFavicon)
+          .windowParentByUrl(pageWithFavicon)
+
+        yield reloadNewTab(this.app.client)
+
+        yield this.app.client
+          .waitForVisible('.topSitesElementFavicon img').should.eventually.be.true
+      })
+
+      it('replace topSites favicon images with a letter when no icon is found', function * () {
+        const pageWithoutFavicon = Brave.server.url('page_favicon_not_found.html')
+
+        yield this.app.client
+          .tabByUrl(Brave.newTabUrl)
+          .url(pageWithoutFavicon)
+          .waitForUrl(pageWithoutFavicon)
+          .windowParentByUrl(pageWithoutFavicon)
+
+        yield reloadNewTab(this.app.client)
+
+        yield this.app.client
+          .waitForVisible('.topSitesElementFavicon')
+          .getText('.topSitesElementFavicon').should.eventually.be.equal('F')
+      })
     })
   })
 })

--- a/test/components/bookmarksToolbarTest.js
+++ b/test/components/bookmarksToolbarTest.js
@@ -150,4 +150,57 @@ describe('bookmarksToolbar', function () {
         .waitForVisible('.contextMenuItemText', 1000, true)
     })
   })
+
+  describe('display favicon on bookmarks toolbar', function () {
+    Brave.beforeEach(this)
+    beforeEach(function * () {
+      yield setup(this.app.client)
+    })
+
+    it('display bookmark favicon for url that has it', function * () {
+      const pageWithFavicon = Brave.server.url('favicon.html')
+
+      yield this.app.client
+        .changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, true)
+        .changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR_FAVICON, true)
+        .waitForVisible(bookmarksToolbar)
+        .waitForUrl(Brave.newTabUrl)
+        .loadUrl(pageWithFavicon)
+        .windowParentByUrl(pageWithFavicon)
+        .waitForVisible(navigator)
+        .moveToObject(navigator)
+        .waitForVisible(navigatorNotBookmarked)
+        .click(navigatorNotBookmarked)
+        .waitForVisible(doneButton)
+        .click(doneButton)
+
+      yield this.app.client.waitUntil(() =>
+        this.app.client.getCssProperty('.bookmarkFavicon', 'background-image').then((backgroundImage) =>
+          backgroundImage.value === `url("${Brave.server.url('img/test.ico')}")`
+      ))
+    })
+
+    it('fallback to default bookmark icon when url has no favicon', function * () {
+      const pageWithoutFavicon = Brave.server.url('page_favicon_not_found.html')
+
+      yield this.app.client
+        .changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, true)
+        .changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR_FAVICON, true)
+        .waitForVisible(bookmarksToolbar)
+        .waitForUrl(Brave.newTabUrl)
+        .loadUrl(pageWithoutFavicon)
+        .windowParentByUrl(pageWithoutFavicon)
+        .waitForVisible(navigator)
+        .moveToObject(navigator)
+        .waitForVisible(navigatorNotBookmarked)
+        .click(navigatorNotBookmarked)
+        .waitForVisible(doneButton)
+        .click(doneButton)
+
+      yield this.app.client.waitUntil(() =>
+        this.app.client.getAttribute('.bookmarkFavicon', 'class').then((className) =>
+          className === 'bookmarkFavicon bookmarkFile fa fa-file-o'
+      ))
+    })
+  })
 })

--- a/test/components/navigationBarTest.js
+++ b/test/components/navigationBarTest.js
@@ -398,6 +398,15 @@ describe('navigationBar tests', function () {
           backgroundImage.value === `url("${Brave.server.url('img/test.ico')}")`
       ))
     })
+
+    it('Fallback to default icon when no one is specified', function * () {
+      const pageWithNoFavicon = Brave.server.url('page_no_favicon.html')
+      yield this.app.client.tabByUrl(Brave.newTabUrl).url(pageWithNoFavicon).waitForUrl(pageWithNoFavicon).windowParentByUrl(pageWithNoFavicon)
+      yield this.app.client.waitUntil(() =>
+        this.app.client.getAttribute(activeTabFavicon, 'class').then((className) =>
+          className === 'tabIcon bookmarkFile fa fa-file-o'
+      ))
+    })
   })
 
   describe('lockIcon', function () {

--- a/test/fixtures/page_favicon_not_found.html
+++ b/test/fixtures/page_favicon_not_found.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Favicon is not found page</title>
+  <link rel="shortcut icon" type="image/x-icon" href="img/notfound.ico">
+</head>
+<body>
+  Favicon is declared but not found!
+</body>
+</html>


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bsclifton
/cc @bbondy

Fix #5455

Also fixes:
https://github.com/brave/browser-laptop/issues/2075 (bookmark is invisible if favicon.ico is not found)
https://github.com/brave/browser-laptop/issues/3648 (Favicons Only Behavior Now Leaves Blanks when there is no favicon)

## Test Plan:
* Automated tests must pass (see below)
  **For bookmarks toolbar**
  `npm run test -- --grep="display favicon on bookmarks toolbar"` 

  **For bookmarks manager**
  `npm run test -- --grep="display favicon on bookmarks manager"` 

  **For tabs**
  `npm run test -- --grep="Fallback to default icon when no one is specified"` 

  **For new tab page** 
  `npm run test -- --grep="shows favicon image for topSites"` 
  `npm run test -- --grep="replace topSites favicon images with a letter when no icon is found"` 

* Manual tests (results can be compared to 0.12.10 to confirm fix):
  - Test adding page which doesn't have favicon
    - navigate to https://www.oediscountparts.com/
    - bookmark page
    - notice page has the default document icon
  - Test favicon only mode
    - bookmark a few sites
    - visit https://www.oediscountparts.com/ (which doesn't have a favicon) and bookmark the site
    - Go to `about:preferences` and set `Bookmarks Bar` to the value `Favicons only`