### PR TITLE
Open bookmarks in new foreground tabs

### DIFF
--- a/js/actions/bookmarkActions.js
+++ b/js/actions/bookmarkActions.js
@@ -7,6 +7,8 @@
 const siteUtil = require('../state/siteUtil')
 const windowActions = require('./windowActions')
 const eventUtil = require('../lib/eventUtil')
+const {SWITCH_TO_NEW_TABS} = require('../constants/settings')
+const getSetting = require('../settings').getSetting
 
 const bookmarkActions = {
   openBookmarksInFolder: function (allBookmarkItems, folderDetail) {
@@ -17,7 +19,7 @@ const bookmarkActions = {
     // Only load the first 25 tabs as loaded
     bookmarks
       .forEach((bookmark, i) =>
-        windowActions.newFrame(Object.assign(siteUtil.toFrameOpts(bookmark), {unloaded: i > 25}), false))
+        windowActions.newFrame(Object.assign(siteUtil.toFrameOpts(bookmark), {unloaded: i > 25}), getSetting(SWITCH_TO_NEW_TABS)))
   },
 
   /**
@@ -31,7 +33,7 @@ const bookmarkActions = {
         windowActions.newFrame({
           location: bookmarkItem.get('location'),
           partitionNumber: bookmarkItem && bookmarkItem.get && bookmarkItem.get('partitionNumber') || undefined
-        }, !!e.shiftKey)
+        }, !!e.shiftKey || getSetting(SWITCH_TO_NEW_TABS))
       } else {
         windowActions.loadUrl(activeFrame, bookmarkItem.get('location'))
       }


### PR DESCRIPTION
These commits should fix #3207

There doesn't seem to be any middle-clicking bookmark item(s) test under https://github.com/brave/browser-laptop/blob/ca626503925c6f706a65896b1b679692374d6697/test/components/bookmarksToolbarTest.js.

In order to add some tests according to the test plans I've outlined in the commits, I'd need to know how to:

- Simulate middle clicking on bookmark item(s)
- Whether to do a URL match of a new foreground tab to that of the original bookmark item or check that such an event is fired

I can probably study other tests and figure out how to do these. But it'd be helpful if someone could give me a few pointers. Thank you.