### PR TITLE
Fix width of input element on New Bookmark Folder form

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -600,6 +600,7 @@
 
   input,
   select {
+    box-sizing: border-box;
     display: block;
     width: 100%;
     max-width: 250px;

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -817,87 +817,89 @@
     text-overflow: ellipsis;
   }
 
-  .loadTime {
-    color: @loadTimeColor;
-    background: @navigationBarBackground;
-    font-size: 12px;
-    right: 10px;
-    text-align: right;
-    margin: 2px 0 0 0;
-    top: 9px;
-    cursor: default;
-    padding-top: 1px;
+  .urlbarForm {
+    .loadTime {
+      color: @loadTimeColor;
+      background: @navigationBarBackground;
+      font-size: 12px;
+      right: 10px;
+      text-align: right;
+      margin: 2px 0 0 0;
+      top: 9px;
+      cursor: default;
+      padding-top: 1px;
 
-    &.onFocus {
-        display: none;
-    }
-  }
-
-  /* Disable selection of button text */
-  > span {
-     -webkit-user-select: none;
-  }
-
-  > * {
-    -webkit-app-region: no-drag;
-  }
-
-  .inputbar-wrapper {
-    background: white;
-    display: flex;
-    flex: 1 1 0;
-    border-radius: 4px;
-    align-items: center;
-    justify-content: center;
-  }
-
-  input {
-    background: @navigationBarBackground;
-    border: none;
-    box-sizing: border-box;
-    color: @chromeText;
-    cursor: text;
-    font-size: @defaultFontSize;
-    font-weight: normal;
-    margin: 2px 0 0 3px;
-    outline: none;
-    text-overflow: ellipsis;
-    flex-grow: 1;
-    min-width: 0%; // allow the navigator to shrink
-
-    &:hover {
-      background: @chromeControlsBackground2;
+      &.onFocus {
+          display: none;
+      }
     }
 
+    /* Disable selection of button text */
+    > span {
+       -webkit-user-select: none;
+    }
 
-    &.private {
-      background: @privateTabBackground;
+    > * {
+      -webkit-app-region: no-drag;
+    }
+
+    .inputbar-wrapper {
+      background: white;
+      display: flex;
+      flex: 1 1 0;
+      border-radius: 4px;
+      align-items: center;
+      justify-content: center;
+    }
+
+    input {
+      background: @navigationBarBackground;
+      border: none;
+      box-sizing: border-box;
       color: @chromeText;
+      cursor: text;
+      font-size: @defaultFontSize;
+      font-weight: normal;
+      margin: 2px 0 0 3px;
+      outline: none;
+      text-overflow: ellipsis;
+      flex-grow: 1;
+      min-width: 0%; // allow the navigator to shrink
+
+      &:hover {
+        background: @chromeControlsBackground2;
+      }
+
+
+      &.private {
+        background: @privateTabBackground;
+        color: @chromeText;
+      }
     }
-  }
 
-  .urlbarIcon {
-    color: @siteSecureColor;
-    left: 14px;
-    margin-top: 1px;
-    font-size: 13px;
-    min-height: 10px;
-    min-width: 16px;
-
-    &.fa-lock,
-    &.fa-unlock {
+    .urlbarIcon {
+      color: @siteSecureColor;
+      left: 14px;
       margin-top: 1px;
-      font-size: 16px;
+      font-size: 13px;
       min-height: 10px;
       min-width: 16px;
-    }
 
-    &.fa-unlock {
-        color: @siteInsecureColor;
-    }
+      &.fa-lock,
+      &.fa-unlock {
+        margin-top: 1px;
+        font-size: 16px;
+        min-height: 10px;
+        min-width: 16px;
+      }
 
-    &.extendedValidation {
-      color: @siteEVColor;
+      &.fa-unlock {
+          color: @siteInsecureColor;
+      }
+
+      &.extendedValidation {
+        color: @siteEVColor;
+      }
     }
   }
 }


### PR DESCRIPTION
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.

Fix #5192

Both input elements on the New Bookmark Folder form have the following
CSS properties set:

 * width: 100%;
 * max-width: 250px;
 * padding: 0 5px;

The default value for box-sizing is content-box (see
https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing). This
causes the input field for the bookmark folder's title to be 100% +
5px + 5px (width + padding left + padding right) wide. However, the
padding is not applied to the select field for parent folder selection,
causing the field to be only 100% wide (without the padding).

Using border-box as value for the box-sizing attribute for both form
fields renders them at an equal width.

Test Plan:

1. Open Brave
2. In the menu bar open the Bookmarks menu and click on Bookmarks Manager...
3. Click on the Add Folder icon in the left pane
4. Make sure both form fields (Title and Folder) have the same width (see screenshot 1 below)

screenshot 1:
![screenshot_fix-5192](https://cloud.githubusercontent.com/assets/606491/20626434/f2695b16-b319-11e6-9e0d-4c29ef702118.png)
