### PR TITLE
Remove tab icons for about:newtab and about:blank

### DIFF
--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -180,6 +180,8 @@ class Tab extends ImmutableComponent {
         onClick={this.onMuteFrame.bind(this, !this.props.tab.get('audioMuted'))} />
     }
 
+    const locationHasFavicon = this.props.tab.get('location') !== 'about:newtab' && this.props.tab.get('location') !== 'about:blank'
+
     return <div
       className={cx({
         tabArea: true,
@@ -219,11 +221,15 @@ class Tab extends ImmutableComponent {
             className='privateIcon fa fa-user' />
           : null
         }
-        <div className={cx({
-          tabIcon: true,
-          'fa fa-circle-o-notch fa-spin': this.loading
-        })}
-          style={iconStyle} />
+        {
+          locationHasFavicon
+          ? <div className={cx({
+            tabIcon: true,
+            'fa fa-circle-o-notch fa-spin': this.loading
+          })}
+            style={iconStyle} />
+          : null
+        }
         {playIcon}
         {
           !this.isPinned

--- a/less/tabs.less
+++ b/less/tabs.less
@@ -70,9 +70,13 @@
   padding: 0;
   width: 100%;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   border: 1px solid rgba(0, 0, 0, 0.0);
   border-bottom: 1px;
+  padding: 0 4px;
+  @media screen and (max-width: @breakpointFitTabCloseButton) {
+    padding: 0 2px;
+  }
 
   .tabTitle {
     -webkit-user-select: none;
@@ -92,8 +96,6 @@
     background-repeat: no-repeat;
     display: inline-block;
     font-size: 12px;
-    margin-left: 4px;
-    margin-right: 4px;
     text-align: center;
   }
 
@@ -174,8 +176,6 @@
     text-align: center;
     width: 16px;
     height: 16px;
-    margin-left: 4px;
-    margin-right: 4px;
 
     &:hover {
       opacity: 1;

--- a/less/variables.less
+++ b/less/variables.less
@@ -137,6 +137,7 @@
 @breakpointNarrowViewport: 600px;
 @breakpointExtensionButtonPadding: 720px;
 @breakpointSmallWin32: 650px;
+@breakpointFitTabCloseButton: 520px;
 @breakpointTinyWin32: 500px;
 @transitionDuration: 100ms;
 

--- a/test/components/tabTest.js
+++ b/test/components/tabTest.js
@@ -3,7 +3,7 @@
 const Brave = require('../lib/brave')
 const messages = require('../../js/constants/messages')
 const settings = require('../../js/constants/settings')
-const {urlInput, backButton, forwardButton, activeTabTitle, newFrameButton} = require('../lib/selectors')
+const {urlInput, backButton, forwardButton, activeTabTitle, activeTabFavicon, newFrameButton} = require('../lib/selectors')
 
 describe('tab tests', function () {
   function * setup (client) {
@@ -324,6 +324,34 @@ describe('tab tests', function () {
         .windowByUrl(Brave.browserWindowUrl)
         .waitForExist('.tab[data-frame-key="3"]')
       yield this.app.client.waitForExist('.frameWrapper.isActive webview[data-frame-key="3"]')
+    })
+  })
+
+  describe('tabs with icons', function () {
+    Brave.beforeAll(this)
+    before(function * () {
+      yield setup(this.app.client)
+    })
+
+    it('shows tab\'s icon when page is not about:blank or about:newtab ', function * () {
+      var url = Brave.server.url('page1.html')
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(url)
+        .windowByUrl(url)
+        .waitForExist(activeTabFavicon)
+    })
+
+    it('about:newtab and about:blank shouldn\'t have a tab icon', function * () {
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl('about:blank')
+        .windowByUrl('about:blank')
+        .waitForExist(activeTabFavicon, 1000, true)
+        .tabByIndex(0)
+        .loadUrl('about:newtab')
+        .windowByUrl('about:newtab')
+        .waitForExist(activeTabFavicon, 1000, true)
     })
   })
 })


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

After tweaking the UI for tabs with no icon, it also addressed a fix for #5431

Fix #5776
Fix #5431

Auditors: @bsclifton

/cc @bradrichter could you checkout and see if the fix included here for #5431 fits our need?

Screenshot for #5431:
![rsz_close_tab_icon](https://cloud.githubusercontent.com/assets/4672033/20632480/f0140658-b324-11e6-9baf-ace3973a1e4b.png)

## Test Plan (#5776):

* Automated test should pass
* `npm run test -- --grep="tabs with icons"`

## Manual test (Test Plan for #5431):

* Open 10 tabs with icons
* Resize width to minimum possible
* Close button should stay fit to its parent