### PR TITLE
Prevent duplicate separators for all context menu items.

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -20,7 +20,7 @@ const siteTags = require('../../js/constants/siteTags')
 const dialog = electron.dialog
 const BrowserWindow = electron.BrowserWindow
 const {fileUrl} = require('../../js/lib/appUrlUtil')
-const menuUtil = require('./lib/menuUtil')
+const menuUtil = require('../common/lib/menuUtil')
 const getSetting = require('../../js/settings').getSetting
 const locale = require('../locale')
 const {isSiteBookmarked} = require('../../js/state/siteUtil')
@@ -329,7 +329,7 @@ const createHistorySubmenu = () => {
       }
     }
   ]
-  submenu = submenu.concat(menuUtil.createRecentlyClosedMenuItems(Immutable.fromJS(Object.keys(closedFrames).map(key => closedFrames[key]))))
+  submenu = submenu.concat(menuUtil.createRecentlyClosedTemplateItems(Immutable.fromJS(Object.keys(closedFrames).map(key => closedFrames[key]))))
 
   submenu.push(
     // TODO: recently visited
@@ -374,7 +374,7 @@ const createBookmarksSubmenu = () => {
     CommonMenu.importBrowserDataMenuItem()
   ]
 
-  const bookmarks = menuUtil.createBookmarkMenuItems(appStore.getState().get('sites'))
+  const bookmarks = menuUtil.createBookmarkTemplateItems(appStore.getState().get('sites'))
   if (bookmarks.length > 0) {
     submenu.push(CommonMenu.separatorMenuItem)
     submenu = submenu.concat(bookmarks)

--- a/app/common/lib/historyUtil.js
+++ b/app/common/lib/historyUtil.js
@@ -34,7 +34,7 @@ module.exports.groupEntriesByDay = (history, locale) => {
   const reduced = history.reduce((previousValue, currentValue, currentIndex, array) => {
     const result = currentIndex === 1 ? [] : previousValue
     if (currentIndex === 1) {
-      const firstDate = getDayString(currentValue, locale)
+      const firstDate = getDayString(previousValue, locale)
       result.push({date: firstDate, entries: [previousValue]})
     }
     const date = getDayString(currentValue, locale)

--- a/app/common/lib/menuUtil.js
+++ b/app/common/lib/menuUtil.js
@@ -69,7 +69,7 @@ module.exports.setTemplateItemChecked = (template, label, checked) => {
   return null
 }
 
-const createBookmarkMenuItems = (bookmarks, parentFolderId) => {
+const createBookmarkTemplateItems = (bookmarks, parentFolderId) => {
   const filteredBookmarks = parentFolderId
     ? bookmarks.filter((bookmark) => bookmark.get('parentFolderId') === parentFolderId)
     : bookmarks.filter((bookmark) => !bookmark.get('parentFolderId'))
@@ -99,7 +99,7 @@ const createBookmarkMenuItems = (bookmarks, parentFolderId) => {
       const submenuItems = bookmarks.filter((bookmark) => bookmark.get('parentFolderId') === folderId)
       payload.push({
         label: site.get('customTitle') || site.get('title'),
-        submenu: submenuItems.count() > 0 ? createBookmarkMenuItems(bookmarks, folderId) : null
+        submenu: submenuItems.count() > 0 ? createBookmarkTemplateItems(bookmarks, folderId) : null
       })
     }
   })
@@ -107,15 +107,18 @@ const createBookmarkMenuItems = (bookmarks, parentFolderId) => {
 }
 
 /**
- * Add bookmarks / folders to "Bookmarks" menu
+ * Used to create bookmarks and bookmark folder entries for the "Bookmarks" menu
  *
  * @param sites The application state's Immutable sites list
  */
-module.exports.createBookmarkMenuItems = (sites) => {
-  return createBookmarkMenuItems(siteUtil.getBookmarks(sites))
+module.exports.createBookmarkTemplateItems = (sites) => {
+  return createBookmarkTemplateItems(siteUtil.getBookmarks(sites))
 }
 
-module.exports.createRecentlyClosedMenuItems = (lastClosedFrames) => {
+/**
+ * Create "recently closed" history entries for the "History" menu
+ */
+module.exports.createRecentlyClosedTemplateItems = (lastClosedFrames) => {
   const payload = []
   if (lastClosedFrames && lastClosedFrames.size > 0) {
     payload.push(
@@ -140,4 +143,37 @@ module.exports.createRecentlyClosedMenuItems = (lastClosedFrames) => {
     })
   }
   return payload
+}
+
+const isItemValid = (currentItem, previousItem) => {
+  if (previousItem && previousItem === CommonMenu.separatorMenuItem) {
+    if (currentItem === CommonMenu.separatorMenuItem) {
+      return false
+    }
+  }
+  return currentItem && (typeof currentItem.label === 'string' || typeof currentItem.type === 'string')
+}
+
+/**
+ * Remove invalid entries from a menu template:
+ * - null or falsey entries
+ * - extra menu separators
+ * - entries which don't have a label or type
+ */
+module.exports.sanitizeTemplateItems = (template) => {
+  return template.reduce((previousValue, currentValue, currentIndex, array) => {
+    const result = currentIndex === 1 ? [] : previousValue
+    if (currentIndex === 1) {
+      if (isItemValid(previousValue)) {
+        result.push(previousValue)
+      }
+    }
+    const previousItem = result.length > 0
+      ? result[result.length - 1]
+      : undefined
+    if (isItemValid(currentValue, previousItem)) {
+      result.push(currentValue)
+    }
+    return result
+  })
 }

--- a/test/unit/app/common/lib/formatUtilTest.js
+++ b/test/unit/app/common/lib/formatUtilTest.js
@@ -1,8 +1,8 @@
 /* global describe, before, after, it */
-const formatUtil = require('../../../app/common/lib/formatUtil')
+const formatUtil = require('../../../../../app/common/lib/formatUtil')
 const assert = require('assert')
 
-require('../braveUnit')
+require('../../../braveUnit')
 
 describe('formatUtil', function () {
   describe('formatAccelerator', function () {

--- a/test/unit/app/common/lib/historyUtilTest.js
+++ b/test/unit/app/common/lib/historyUtilTest.js
@@ -1,8 +1,9 @@
 /* global describe, it */
 const assert = require('assert')
 const Immutable = require('immutable')
-const historyUtil = require('../../../app/common/lib/historyUtil')
-require('../braveUnit')
+const historyUtil = require('../../../../../app/common/lib/historyUtil')
+
+require('../../../braveUnit')
 
 describe('historyUtil', function () {
   const historyDayOne = Immutable.fromJS({

--- a/test/unit/app/common/lib/httpUtilTest.js
+++ b/test/unit/app/common/lib/httpUtilTest.js
@@ -1,8 +1,8 @@
 /* global describe, it */
-const httpUtil = require('../../../app/common/lib/httpUtil')
+const httpUtil = require('../../../../../app/common/lib/httpUtil')
 const assert = require('assert')
 
-require('../braveUnit')
+require('../../../braveUnit')
 
 describe('httpUtil test', function () {
   describe('responseHasContent', function () {

--- a/test/unit/app/common/lib/ledgerUtilTest.js
+++ b/test/unit/app/common/lib/ledgerUtilTest.js
@@ -1,8 +1,8 @@
 /* global describe, it */
-const ledgerUtil = require('../../../app/common/lib/ledgerUtil')
+const ledgerUtil = require('../../../../../app/common/lib/ledgerUtil')
 const assert = require('assert')
 
-require('../braveUnit')
+require('../../../braveUnit')
 
 describe('ledgerUtil test', function () {
   describe('shouldTrackView', function () {

--- a/test/unit/app/common/lib/menuUtilTest.js
+++ b/test/unit/app/common/lib/menuUtilTest.js
@@ -1,12 +1,14 @@
 /* global describe, before, after, it */
-const siteTags = require('../../../js/constants/siteTags')
+const siteTags = require('../../../../../js/constants/siteTags')
 const mockery = require('mockery')
 const assert = require('assert')
 const Immutable = require('immutable')
-require('../braveUnit')
 
-describe('menuUtil', function () {
+require('../../../braveUnit')
+
+describe('menuUtil tests', function () {
   let menuUtil
+  let separator
 
   before(function () {
     mockery.enable({
@@ -14,8 +16,10 @@ describe('menuUtil', function () {
       warnOnUnregistered: false,
       useCleanCache: true
     })
-    mockery.registerMock('electron', require('./fakeElectron'))
-    menuUtil = require('../../../app/browser/lib/menuUtil')
+    // This is required; commonMenu is included by menuUtil (and references electron)
+    mockery.registerMock('electron', require('../../../lib/fakeElectron'))
+    menuUtil = require('../../../../../app/common/lib/menuUtil')
+    separator = require('../../../../../app/common/commonMenu').separatorMenuItem
   })
 
   after(function () {
@@ -116,13 +120,13 @@ describe('menuUtil', function () {
     })
   })
 
-  describe('createBookmarkMenuItems', function () {
+  describe('createBookmarkTemplateItems', function () {
     it('returns an array of items w/ the bookmark tag', function () {
       const appStateSites = Immutable.fromJS([
         { tags: [siteTags.BOOKMARK], title: 'my website', location: 'https://brave.com' }
       ])
 
-      const menuItems = menuUtil.createBookmarkMenuItems(appStateSites)
+      const menuItems = menuUtil.createBookmarkTemplateItems(appStateSites)
 
       assert.equal(Array.isArray(menuItems), true)
       assert.equal(menuItems.length, 1)
@@ -133,7 +137,7 @@ describe('menuUtil', function () {
         { tags: [siteTags.BOOKMARK], customTitle: 'use this', title: 'not this', location: 'https://brave.com' }
       ])
 
-      const menuItems = menuUtil.createBookmarkMenuItems(appStateSites)
+      const menuItems = menuUtil.createBookmarkTemplateItems(appStateSites)
 
       assert.equal(menuItems[0].label, 'use this')
     })
@@ -144,7 +148,7 @@ describe('menuUtil', function () {
         ]
       })
 
-      const menuItems = menuUtil.createBookmarkMenuItems(appStateSites)
+      const menuItems = menuUtil.createBookmarkTemplateItems(appStateSites)
 
       assert.deepEqual(menuItems, [])
     })
@@ -155,7 +159,7 @@ describe('menuUtil', function () {
         ]
       })
 
-      const menuItems = menuUtil.createBookmarkMenuItems(appStateSites)
+      const menuItems = menuUtil.createBookmarkTemplateItems(appStateSites)
 
       assert.deepEqual(menuItems, [])
     })
@@ -164,7 +168,7 @@ describe('menuUtil', function () {
         { tags: [siteTags.PINNED], title: 'pinned site', location: 'https://pinned-website.com' },
         { tags: [siteTags.BOOKMARK], title: 'my website', location: 'https://brave.com' }
       ])
-      const menuItems = menuUtil.createBookmarkMenuItems(appStateSites)
+      const menuItems = menuUtil.createBookmarkTemplateItems(appStateSites)
 
       assert.equal(menuItems.length, 1)
       assert.equal(menuItems[0].label, 'my website')
@@ -174,7 +178,7 @@ describe('menuUtil', function () {
         { tags: [siteTags.BOOKMARK_FOLDER], title: 'my folder', folderId: 123 },
         { tags: [siteTags.BOOKMARK], title: 'my website', location: 'https://brave.com', parentFolderId: 123 }
       ])
-      const menuItems = menuUtil.createBookmarkMenuItems(appStateSites)
+      const menuItems = menuUtil.createBookmarkTemplateItems(appStateSites)
 
       assert.equal(menuItems.length, 1)
       assert.equal(menuItems[0].label, 'my folder')
@@ -187,20 +191,20 @@ describe('menuUtil', function () {
         { tags: [siteTags.BOOKMARK], title: 'my website', location: 'https://brave.com', parentFolderId: 123 }
       ])
 
-      const menuItems = menuUtil.createBookmarkMenuItems(appStateSites)
+      const menuItems = menuUtil.createBookmarkTemplateItems(appStateSites)
 
       assert.equal(menuItems.length, 1)
       assert.equal(menuItems[0].label, 'use this')
     })
   })
 
-  describe('createRecentlyClosedMenuItems', function () {
+  describe('createRecentlyClosedTemplateItems', function () {
     it('returns an array of closedFrames preceded by a separator and "Recently Closed" items', function () {
       const windowStateClosedFrames = Immutable.fromJS([{
         title: 'sample',
         location: 'https://brave.com'
       }])
-      const menuItems = menuUtil.createRecentlyClosedMenuItems(windowStateClosedFrames)
+      const menuItems = menuUtil.createRecentlyClosedTemplateItems(windowStateClosedFrames)
 
       assert.equal(Array.isArray(menuItems), true)
       assert.equal(menuItems.length, 3)
@@ -224,11 +228,38 @@ describe('menuUtil', function () {
         { title: 'site10', location: 'https://brave10.com' },
         { title: 'site11', location: 'https://brave11.com' }
       ])
-      const menuItems = menuUtil.createRecentlyClosedMenuItems(windowStateClosedFrames)
+      const menuItems = menuUtil.createRecentlyClosedTemplateItems(windowStateClosedFrames)
 
       assert.equal(menuItems.length, 12)
       assert.equal(menuItems[2].label, windowStateClosedFrames.get(1).get('title'))
       assert.equal(menuItems[11].label, windowStateClosedFrames.get(10).get('title'))
+    })
+  })
+
+  describe('sanitizeTemplateItems', function () {
+    it('removes entries which are falsey', function () {
+      const template = [null, undefined, false, {label: 'lol'}]
+      const result = menuUtil.sanitizeTemplateItems(template)
+      const expectedResult = [{label: 'lol'}]
+      assert.deepEqual(result, expectedResult)
+    })
+    it('removes duplicate menu separators', function () {
+      const template = [separator, separator, {label: 'lol'}]
+      const result = menuUtil.sanitizeTemplateItems(template)
+      const expectedResult = [separator, {label: 'lol'}]
+      assert.deepEqual(result, expectedResult)
+    })
+    it('removes items which are missing label or type', function () {
+      const template = [{}, {test: 'test'}, {label: 'lol'}]
+      const result = menuUtil.sanitizeTemplateItems(template)
+      const expectedResult = [{label: 'lol'}]
+      assert.deepEqual(result, expectedResult)
+    })
+    it('removes items which have non-string values for label or type', function () {
+      const template = [{label: true}, {type: function () { console.log('test') }}, {label: 'lol'}]
+      const result = menuUtil.sanitizeTemplateItems(template)
+      const expectedResult = [{label: 'lol'}]
+      assert.deepEqual(result, expectedResult)
     })
   })
 })

--- a/test/unit/app/common/lib/platformUtilTest.js
+++ b/test/unit/app/common/lib/platformUtilTest.js
@@ -1,9 +1,9 @@
 /* global describe, it */
 const mockery = require('mockery')
 const assert = require('assert')
-let platformUtil = require('../../../app/common/lib/platformUtil')
+let platformUtil = require('../../../../../app/common/lib/platformUtil')
 
-require('../braveUnit')
+require('../../../braveUnit')
 
 describe('platformUtil', function () {
   const mockWin7 = {
@@ -26,11 +26,11 @@ describe('platformUtil', function () {
   const loadMocks = (osMock) => {
     mockery.enable({ warnOnReplace: false, warnOnUnregistered: false, useCleanCache: true })
     mockery.registerMock('os', osMock)
-    platformUtil = require('../../../app/common/lib/platformUtil')
+    platformUtil = require('../../../../../app/common/lib/platformUtil')
   }
   const unloadMocks = () => {
     mockery.disable()
-    platformUtil = require('../../../app/common/lib/platformUtil')
+    platformUtil = require('../../../../../app/common/lib/platformUtil')
   }
 
   describe('getPlatformStyles', function () {

--- a/test/unit/app/common/state/aboutHistoryStateTest.js
+++ b/test/unit/app/common/state/aboutHistoryStateTest.js
@@ -1,5 +1,5 @@
 /* global describe, it */
-const aboutHistoryState = require('../../../../app/common/state/aboutHistoryState')
+const aboutHistoryState = require('../../../../../app/common/state/aboutHistoryState')
 const Immutable = require('immutable')
 const assert = require('assert')
 

--- a/test/unit/app/common/state/aboutNewTabStateTest.js
+++ b/test/unit/app/common/state/aboutNewTabStateTest.js
@@ -1,8 +1,8 @@
 /* global describe, it */
-const aboutNewTabState = require('../../../../app/common/state/aboutNewTabState')
+const aboutNewTabState = require('../../../../../app/common/state/aboutNewTabState')
 const Immutable = require('immutable')
 const assert = require('assert')
-const siteTags = require('../../../../js/constants/siteTags')
+const siteTags = require('../../../../../js/constants/siteTags')
 
 const defaultAppState = Immutable.fromJS({
   about: {

--- a/test/unit/app/common/state/basicAuthStateTest.js
+++ b/test/unit/app/common/state/basicAuthStateTest.js
@@ -1,6 +1,6 @@
 /* global describe, it, before */
-const basicAuthState = require('../../../../app/common/state/basicAuthState')
-const tabState = require('../../../../app/common/state/tabState')
+const basicAuthState = require('../../../../../app/common/state/basicAuthState')
+const tabState = require('../../../../../app/common/state/tabState')
 const Immutable = require('immutable')
 const assert = require('assert')
 

--- a/test/unit/app/common/state/extensionStateTest.js
+++ b/test/unit/app/common/state/extensionStateTest.js
@@ -1,5 +1,5 @@
 /* global describe, it, before */
-const extensionState = require('../../../../app/common/state/extensionState')
+const extensionState = require('../../../../../app/common/state/extensionState')
 const Immutable = require('immutable')
 const assert = require('assert')
 

--- a/test/unit/app/common/state/tabStateTest.js
+++ b/test/unit/app/common/state/tabStateTest.js
@@ -1,5 +1,5 @@
 /* global describe, it, before */
-const tabState = require('../../../../app/common/state/tabState')
+const tabState = require('../../../../../app/common/state/tabState')
 const Immutable = require('immutable')
 const assert = require('assert')
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

This update will ensure we will never have double separators going forward on Windows or Linux.
Fixes https://github.com/brave/browser-laptop/issues/5765

Auditor: @bbondy, @cezaraugusto

Includes these changes:
- Added new `sanitizeTemplateItems` method to filter out bad entries
- Moved `menuUtil` from `app/browser` => `app/common`
- Moved some tests to match the new directory structure (ex: `test/unit/app`, instead of `test/unit/lib`)
- Rename template functions in `menuUtil` and items in `contextMenu.js` to reinforce distinction between **template** items and **electron  menu** items (the compiled template)
- **The new sanitize method is called in each method which builds a context menu**

## Test plan
- Launch Brave on Windows or Linux
- Right click on each of the about pages and ensure there are no double separators (might be easy to go to about:about to launch each)
- Try other context menus
  - Right clicking on a tab
  - right clicking on page
  - right clicking a bookmark / bookmark folder in the bookmarks toolbar
  - right clicking inside the downloads bar (shown after downloading an item)