### PR TITLE
webtorrent-remote 0.0.9: no ES6

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "tracking-protection": "1.1.x",
     "underscore": "1.8.3",
     "url-loader": "^0.5.7",
-    "webtorrent-remote": "0.0.8"
+    "webtorrent-remote": "0.0.9"
   },
   "devDependencies": {
     "asar": "^0.11.0",


### PR DESCRIPTION
Fixes #5818 

I've removed all the ES6 syntax from `webtorrent-remote`: https://github.com/dcposch/webtorrent-remote/compare/v0.0.8...v0.0.9

CC @feross , you might want to review the diff above

