### PR TITLE
Make context menu for newtab button always visible

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -1249,7 +1249,15 @@ function onTabContextMenu (frameProps, e) {
 }
 
 function onNewTabContextMenu (target) {
+  const rootElement = window.getComputedStyle(document.querySelector(':root'))
+  const contextMenuSize = Number.parseInt(rootElement.getPropertyValue('--context-menu-single-max-width'), 10)
+
+  const containerRect = target.parentNode.getBoundingClientRect()
   const rect = target.getBoundingClientRect()
+
+  const contextMenuMaxVisibleWidth = rect.right + contextMenuSize / 2
+  const contextMenuHasOverflow = contextMenuMaxVisibleWidth > containerRect.right
+
   const menuTemplate = [
     CommonMenu.newTabMenuItem(),
     CommonMenu.newPrivateTabMenuItem(),
@@ -1258,7 +1266,9 @@ function onNewTabContextMenu (target) {
   ]
 
   windowActions.setContextMenuDetail(Immutable.fromJS({
-    left: rect.left,
+    left: contextMenuHasOverflow
+      ? contextMenuMaxVisibleWidth - contextMenuSize - rect.width
+      : rect.left,
     top: rect.bottom + 2,
     template: menuTemplate
   }))

--- a/less/contextMenu.less
+++ b/less/contextMenu.less
@@ -4,6 +4,10 @@
 
 @import "variables.less";
 
+:root {
+  --context-menu-single-max-width: 400px;
+}
+
 .contextMenu {
   border-radius: @borderRadius;
   box-sizing: border-box;
@@ -36,7 +40,7 @@
     box-sizing: border-box;
     display: table;
     min-width: 220px;
-    max-width: 400px;
+    max-width: var(--context-menu-single-max-width);
 
     &.isSubmenu {
       position: relative;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5763

Auditors: @bsclifton

## Test plan

* For each new tab open, right click and/or long press the + button on tab's right-side
* Context menu should never be overflown by window at any browser width