### PR TITLE
Import browser data switches misaligned

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -192,7 +192,7 @@
       }
 
       &.importBrowserSubDataOptions {
-        padding: 0 10px;
+        padding: 0 15px;
       }
 
       &.importBrowserDataButtons {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5860

Auditors @bsclifton @darkdh @bradleyrichter 

Tiny change like @bradleyrichter recommended but I think it looks a bit more obvious. I'm fine to scrap it if you disagree!

Test Plan:
1. Open Brave
2. Go to Preferences
3. Click "Import now..."
4. See that the nested switch for merge favorites is pushed to the right.

Old:
<img width="425" alt="screen shot 2016-11-27 at 5 31 24 pm" src="https://cloud.githubusercontent.com/assets/490294/20653784/622a58a2-b4c7-11e6-9e79-2a5577758f18.png">

New:
<img width="425" alt="screen shot 2016-11-27 at 5 28 59 pm" src="https://cloud.githubusercontent.com/assets/490294/20653783/620aa0fc-b4c7-11e6-9ae8-0d754cc29199.png">


