### PR TITLE
Prevent duplicate separators for all context menu items

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -20,7 +20,7 @@ const siteTags = require('../../js/constants/siteTags')
 const dialog = electron.dialog
 const BrowserWindow = electron.BrowserWindow
 const {fileUrl} = require('../../js/lib/appUrlUtil')
-const menuUtil = require('./lib/menuUtil')
+const menuUtil = require('../common/lib/menuUtil')
 const getSetting = require('../../js/settings').getSetting
 const locale = require('../locale')
 const {isSiteBookmarked} = require('../../js/state/siteUtil')
@@ -329,7 +329,7 @@ const createHistorySubmenu = () => {
       }
     }
   ]
-  submenu = submenu.concat(menuUtil.createRecentlyClosedMenuItems(Immutable.fromJS(Object.keys(closedFrames).map(key => closedFrames[key]))))
+  submenu = submenu.concat(menuUtil.createRecentlyClosedTemplateItems(Immutable.fromJS(Object.keys(closedFrames).map(key => closedFrames[key]))))
 
   submenu.push(
     // TODO: recently visited
@@ -374,7 +374,7 @@ const createBookmarksSubmenu = () => {
     CommonMenu.importBrowserDataMenuItem()
   ]
 
-  const bookmarks = menuUtil.createBookmarkMenuItems(appStore.getState().get('sites'))
+  const bookmarks = menuUtil.createBookmarkTemplateItems(appStore.getState().get('sites'))
   if (bookmarks.length > 0) {
     submenu.push(CommonMenu.separatorMenuItem)
     submenu = submenu.concat(bookmarks)

--- a/app/common/lib/historyUtil.js
+++ b/app/common/lib/historyUtil.js
@@ -34,7 +34,7 @@ module.exports.groupEntriesByDay = (history, locale) => {
   const reduced = history.reduce((previousValue, currentValue, currentIndex, array) => {
     const result = currentIndex === 1 ? [] : previousValue
     if (currentIndex === 1) {
-      const firstDate = getDayString(currentValue, locale)
+      const firstDate = getDayString(previousValue, locale)
       result.push({date: firstDate, entries: [previousValue]})
     }
     const date = getDayString(currentValue, locale)

--- a/test/unit/app/common/lib/formatUtilTest.js
+++ b/test/unit/app/common/lib/formatUtilTest.js
@@ -1,8 +1,8 @@
 /* global describe, before, after, it */
-const formatUtil = require('../../../app/common/lib/formatUtil')
+const formatUtil = require('../../../../../app/common/lib/formatUtil')
 const assert = require('assert')
 
-require('../braveUnit')
+require('../../../braveUnit')
 
 describe('formatUtil', function () {
   describe('formatAccelerator', function () {

--- a/test/unit/app/common/lib/historyUtilTest.js
+++ b/test/unit/app/common/lib/historyUtilTest.js
@@ -1,8 +1,9 @@
 /* global describe, it */
 const assert = require('assert')
 const Immutable = require('immutable')
-const historyUtil = require('../../../app/common/lib/historyUtil')
-require('../braveUnit')
+const historyUtil = require('../../../../../app/common/lib/historyUtil')
+
+require('../../../braveUnit')
 
 describe('historyUtil', function () {
   const historyDayOne = Immutable.fromJS({

--- a/test/unit/app/common/lib/httpUtilTest.js
+++ b/test/unit/app/common/lib/httpUtilTest.js
@@ -1,8 +1,8 @@
 /* global describe, it */
-const httpUtil = require('../../../app/common/lib/httpUtil')
+const httpUtil = require('../../../../../app/common/lib/httpUtil')
 const assert = require('assert')
 
-require('../braveUnit')
+require('../../../braveUnit')
 
 describe('httpUtil test', function () {
   describe('responseHasContent', function () {

--- a/test/unit/app/common/lib/ledgerUtilTest.js
+++ b/test/unit/app/common/lib/ledgerUtilTest.js
@@ -1,8 +1,8 @@
 /* global describe, it */
-const ledgerUtil = require('../../../app/common/lib/ledgerUtil')
+const ledgerUtil = require('../../../../../app/common/lib/ledgerUtil')
 const assert = require('assert')
 
-require('../braveUnit')
+require('../../../braveUnit')
 
 describe('ledgerUtil test', function () {
   describe('shouldTrackView', function () {

--- a/test/unit/app/common/lib/platformUtilTest.js
+++ b/test/unit/app/common/lib/platformUtilTest.js
@@ -1,9 +1,9 @@
 /* global describe, it */
 const mockery = require('mockery')
 const assert = require('assert')
-let platformUtil = require('../../../app/common/lib/platformUtil')
+let platformUtil = require('../../../../../app/common/lib/platformUtil')
 
-require('../braveUnit')
+require('../../../braveUnit')
 
 describe('platformUtil', function () {
   const mockWin7 = {
@@ -26,11 +26,11 @@ describe('platformUtil', function () {
   const loadMocks = (osMock) => {
     mockery.enable({ warnOnReplace: false, warnOnUnregistered: false, useCleanCache: true })
     mockery.registerMock('os', osMock)
-    platformUtil = require('../../../app/common/lib/platformUtil')
+    platformUtil = require('../../../../../app/common/lib/platformUtil')
   }
   const unloadMocks = () => {
     mockery.disable()
-    platformUtil = require('../../../app/common/lib/platformUtil')
+    platformUtil = require('../../../../../app/common/lib/platformUtil')
   }
 
   describe('getPlatformStyles', function () {

--- a/test/unit/app/common/state/aboutHistoryStateTest.js
+++ b/test/unit/app/common/state/aboutHistoryStateTest.js
@@ -1,5 +1,5 @@
 /* global describe, it */
-const aboutHistoryState = require('../../../../app/common/state/aboutHistoryState')
+const aboutHistoryState = require('../../../../../app/common/state/aboutHistoryState')
 const Immutable = require('immutable')
 const assert = require('assert')
 

--- a/test/unit/app/common/state/aboutNewTabStateTest.js
+++ b/test/unit/app/common/state/aboutNewTabStateTest.js
@@ -1,8 +1,8 @@
 /* global describe, it */
-const aboutNewTabState = require('../../../../app/common/state/aboutNewTabState')
+const aboutNewTabState = require('../../../../../app/common/state/aboutNewTabState')
 const Immutable = require('immutable')
 const assert = require('assert')
-const siteTags = require('../../../../js/constants/siteTags')
+const siteTags = require('../../../../../js/constants/siteTags')
 
 const defaultAppState = Immutable.fromJS({
   about: {

--- a/test/unit/app/common/state/basicAuthStateTest.js
+++ b/test/unit/app/common/state/basicAuthStateTest.js
@@ -1,6 +1,6 @@
 /* global describe, it, before */
-const basicAuthState = require('../../../../app/common/state/basicAuthState')
-const tabState = require('../../../../app/common/state/tabState')
+const basicAuthState = require('../../../../../app/common/state/basicAuthState')
+const tabState = require('../../../../../app/common/state/tabState')
 const Immutable = require('immutable')
 const assert = require('assert')
 

--- a/test/unit/app/common/state/extensionStateTest.js
+++ b/test/unit/app/common/state/extensionStateTest.js
@@ -1,5 +1,5 @@
 /* global describe, it, before */
-const extensionState = require('../../../../app/common/state/extensionState')
+const extensionState = require('../../../../../app/common/state/extensionState')
 const Immutable = require('immutable')
 const assert = require('assert')
 

--- a/test/unit/app/common/state/tabStateTest.js
+++ b/test/unit/app/common/state/tabStateTest.js
@@ -1,5 +1,5 @@
 /* global describe, it, before */
-const tabState = require('../../../../app/common/state/tabState')
+const tabState = require('../../../../../app/common/state/tabState')
 const Immutable = require('immutable')
 const assert = require('assert')
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Includes all content PLUS a fix for a bug found in the original PR https://github.com/brave/browser-laptop/pull/5846
(which was reverted with https://github.com/brave/browser-laptop/pull/5867)

This PR fixes https://github.com/brave/browser-laptop/issues/5765

Auditors: @bbondy

## Includes these changes
- Added new `sanitizeTemplateItems` method to filter out bad entries
- Moved `menuUtil` from `app/browser` => `app/common`
- Moved some tests to match the new directory structure (ex: `test/unit/app`, instead of `test/unit/lib`)
- Rename template functions in `menuUtil` and items in `contextMenu.js` to reinforce distinction between **template** items and **electron  menu** items (the compiled template)
- **The new sanitize method is called in each method which builds a context menu**

## Automated test plan
- `npm run uitest -- --grep="bookmarksToolbar"` (this was the one which had a failing test which I missed)
- `npm run unittest -- --grep="sanitizeTemplateItems"`

## Manual test plan
- Launch Brave on Windows or Linux
- Right click on each of the about pages and ensure there are no double separators (might be easy to go to about:about to launch each)
- Try other context menus
  - Right clicking on a tab
  - right clicking on page
  - right clicking a bookmark / bookmark folder in the bookmarks toolbar
  - right clicking inside the downloads bar (shown after downloading an item)