### PR TITLE
Fix positioning for audio icon in the tab title (which is next to site icon)

### DIFF
--- a/less/tabs.less
+++ b/less/tabs.less
@@ -70,13 +70,9 @@
   padding: 0;
   width: 100%;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   border: 1px solid rgba(0, 0, 0, 0.0);
   border-bottom: 1px;
-  padding: 0 4px;
-  @media screen and (max-width: @breakpointFitTabCloseButton) {
-    padding: 0 2px;
-  }
 
   .tabTitle {
     -webkit-user-select: none;
@@ -97,6 +93,8 @@
     display: inline-block;
     font-size: 12px;
     text-align: center;
+    margin-left: 4px;
+    margin-right: 4px;
   }
 
   .privateIcon {
@@ -176,6 +174,8 @@
     text-align: center;
     width: 16px;
     height: 16px;
+    margin-left: 4px;
+    margin-right: 4px;
 
     &:hover {
       opacity: 1;

--- a/less/variables.less
+++ b/less/variables.less
@@ -137,7 +137,6 @@
 @breakpointNarrowViewport: 600px;
 @breakpointExtensionButtonPadding: 720px;
 @breakpointSmallWin32: 650px;
-@breakpointFitTabCloseButton: 520px;
 @breakpointTinyWin32: 500px;
 @transitionDuration: 100ms;
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix positioning for audio icon in the tab title (which is next to site icon)

Partial backout of https://github.com/brave/browser-laptop/pull/5845
- Unfixes https://github.com/brave/browser-laptop/issues/5431

- Does not affect https://github.com/brave/browser-laptop/issues/5776
    (tests for those still pass great; npm run uitest -- --grep="tabs with icons")


Auditors: @cezaraugusto, @bbondy