### PR TITLE
Update newtab stats to have locale-aware formatting

### DIFF
--- a/js/about/newTabComponents/stats.js
+++ b/js/about/newTabComponents/stats.js
@@ -59,15 +59,15 @@ class Stats extends ImmutableComponent {
     })
     return <ul className='statsContainer'>
       <li className='statsBlock'>
-        <span className='counter trackers'>{trackedBlockersCount}</span>
+        <span className='counter trackers'>{trackedBlockersCount.toLocaleString()}</span>
         <span className='statsText' data-l10n-id='trackersBlocked' data-l10n-args={blockedArgs} />
       </li>
       <li className='statsBlock'>
-        <span className='counter ads'>{adblockCount}</span>
+        <span className='counter ads'>{adblockCount.toLocaleString()}</span>
         <span className='statsText' data-l10n-id='adsBlocked' data-l10n-args={blockedArgs} />
       </li>
       <li className='statsBlock'>
-        <span className='counter https'>{httpsUpgradedCount}</span>
+        <span className='counter https'>{httpsUpgradedCount.toLocaleString()}</span>
         <span className='statsText' data-l10n-id='httpsUpgraded' data-l10n-args={blockedArgs} />
       </li>
       <li className='statsBlock'>


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes https://github.com/brave/browser-laptop/issues/5827

Auditors: @cezaraugusto, @jkup

## Test Plan
1. Launch Brave and open a new tab
2. View the stats and ensure it looks correct
3. Go to Preferences and change your locale
4. Quit and go back to step 1 for as many locales as you wish to test

## Screenshots
**_English (en-US)_**
![screen shot 2016-11-28 at 5 19 19 pm](https://cloud.githubusercontent.com/assets/4733304/20691694/dd26d2ba-b58f-11e6-9f85-9273437f8d6d.png)

**_French (fr-FR)_**
![screen shot 2016-11-28 at 5 19 59 pm](https://cloud.githubusercontent.com/assets/4733304/20691707/ef393a6a-b58f-11e6-8dac-393e513e475a.png)

**_Japanese (ja-JP)_**
![screen shot 2016-11-28 at 5 20 36 pm](https://cloud.githubusercontent.com/assets/4733304/20691722/17f2f81a-b590-11e6-9f7b-44751f638e9b.png)

**_Spanish (es) - NOTE: looks like translations are missing_**
![screen shot 2016-11-28 at 5 21 17 pm](https://cloud.githubusercontent.com/assets/4733304/20691742/4a63786a-b590-11e6-9625-ae4e234e1aaf.png)
