### PR TITLE
Added needed cursor indicators requested in #5896

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -537,6 +537,7 @@
 
 .dialog > .bookmarkDialog .fa-close {
   color: #999;
+  cursor: pointer;
   font-size: 16px;
   float: right;
   margin-top: 7px;
@@ -617,6 +618,7 @@
 
   select {
     box-shadow: 0px 1px 5px -1px rgba(0, 0, 0, 0.8);
+    cursor: pointer;
   }
 }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

This CSS change resolves issue #5896 requested that the cursor indicate that items are clickable. The two items were the close icon and a SELECT element.