### PR TITLE
Checking in failing test which captures STR for URL bar issue

### DIFF
--- a/test/components/navigationBarTest.js
+++ b/test/components/navigationBarTest.js
@@ -894,44 +894,68 @@ describe('navigationBar tests', function () {
     })
 
     describe('with url input value', function () {
-      Brave.beforeAll(this)
+      describe('with regards to the webview', function () {
+        Brave.beforeAll(this)
 
-      before(function * () {
-        this.page1 = Brave.server.url('page1.html')
+        before(function * () {
+          this.page1 = Brave.server.url('page1.html')
 
-        yield setup(this.app.client)
-        // wait for the urlInput to be fully initialized
-        yield this.app.client.waitForExist(urlInput)
-        yield this.app.client.keys(this.page1)
-        // hit enter
-        yield this.app.client.keys(Brave.keys.ENTER)
-      })
+          yield setup(this.app.client)
+          // wait for the urlInput to be fully initialized
+          yield this.app.client.waitForExist(urlInput)
+          yield this.app.client.keys(this.page1)
+          // hit enter
+          yield this.app.client.keys(Brave.keys.ENTER)
+        })
 
-      it('webview has focus', function * () {
-        yield this.app.client.waitForElementFocus(activeWebview)
-      })
+        it('webview has focus', function * () {
+          yield this.app.client.waitForElementFocus(activeWebview)
+        })
 
-      it('webview loads url', function * () {
-        var page1 = this.page1
-        yield this.app.client.waitUntil(function () {
-          return this.getAttribute(activeWebview, 'src').then((src) => src === page1)
+        it('webview loads url', function * () {
+          var page1 = this.page1
+          yield this.app.client.waitUntil(function () {
+            return this.getAttribute(activeWebview, 'src').then((src) => src === page1)
+          })
+        })
+
+        it('urlbar shows webview url when focused', function * () {
+          var page1 = this.page1
+          yield blur(this.app.client)
+          yield this.app.client.waitUntil(function () {
+            return this.isExisting(urlInput).then((exists) => exists === false)
+          })
+          yield this.app.client
+            .ipcSend('shortcut-focus-url')
+          yield this.app.client.waitUntil(function () {
+            return this.getValue(urlInput).then((val) => val === page1)
+          })
+          yield this.app.client.keys('abc')
+          yield this.app.client.waitUntil(function () {
+            return this.getValue(urlInput).then((val) => val === 'abc')
+          })
         })
       })
 
-      it('urlbar shows webview url when focused', function * () {
-        var page1 = this.page1
-        yield blur(this.app.client)
-        yield this.app.client.waitUntil(function () {
-          return this.isExisting(urlInput).then((exists) => exists === false)
+      describe('when following URLs', function () {
+        Brave.beforeEach(this)
+
+        beforeEach(function * () {
+          yield setup(this.app.client)
+          yield this.app.client.waitForExist(urlInput)
         })
-        yield this.app.client
-          .ipcSend('shortcut-focus-url')
-        yield this.app.client.waitUntil(function () {
-          return this.getValue(urlInput).then((val) => val === page1)
-        })
-        yield this.app.client.keys('abc')
-        yield this.app.client.waitUntil(function () {
-          return this.getValue(urlInput).then((val) => val === 'abc')
+
+        // NOTE: this currently fails
+        // issue is captured with https://github.com/brave/browser-laptop/issues/5911
+        it('goes to the page (instead of search for the URL)', function * () {
+          const url = 'https://e.turbotax.intuit.com/pub/cc?_ri_=3vv-8-e.'
+          yield this.app.client.keys(url)
+          yield this.app.client.keys(Brave.keys.ENTER)
+          yield this.app.client.waitUntil(function () {
+            return this.getValue(urlInput).then((val) => {
+              return val === url
+            })
+          })
         })
       })
     })


### PR DESCRIPTION
Issue this captures steps to reproduce for can be found here:
https://github.com/brave/browser-laptop/issues/5911

Once issue is fixed, test will pass :smile: 

Auditors: @bbondy

Test Plan:
1. Run `npm run uitest -- --grep="when following URLs"`
2. See the test fail
3. Made a sad face