### PR TITLE
base64Encode required but never used

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -83,7 +83,6 @@ const async = require('async')
 const tabs = require('./browser/tabs')
 const settings = require('../js/constants/settings')
 const webtorrent = require('./browser/webtorrent')
-const base64Encode = require('../js/lib/base64').encode
 
 // temporary fix for #4517, #4518 and #4472
 app.commandLine.appendSwitch('enable-use-zoom-for-dsf', 'false')


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5914

Looks like we are requiring a library but not using it, causing our linter to error when you try to commit.

Auditor @bsclifton 

