### PR TITLE
initial check-in

### DIFF
--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -8,6 +8,7 @@ const ImmutableComponent = require('./immutableComponent')
 
 const windowActions = require('../actions/windowActions')
 const dragTypes = require('../constants/dragTypes')
+const messages = require('../constants/messages')
 const cx = require('../lib/classSet')
 const {getTextColorForBackground} = require('../lib/color')
 const {isIntermediateAboutPage} = require('../lib/appUrlUtil')
@@ -15,6 +16,7 @@ const {isIntermediateAboutPage} = require('../lib/appUrlUtil')
 const contextMenus = require('../contextMenus')
 const dnd = require('../dnd')
 const windowStore = require('../stores/windowStore')
+const ipc = global.require('electron').ipcRenderer
 
 class Tab extends ImmutableComponent {
   constructor () {
@@ -254,4 +256,12 @@ class Tab extends ImmutableComponent {
   }
 }
 
+windowStore.addChangeListener(() => {
+  var presentP = false
+  const windowState = windowStore.getState().toJS()
+
+  windowState.tabs.forEach((tab) => { if (tab.location === 'about:preferences#payments') presentP = true })
+
+  ipc.send(messages.LEDGER_PAYMENTS_PRESENT, presentP)
+})
 module.exports = Tab

--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -256,12 +256,22 @@ class Tab extends ImmutableComponent {
   }
 }
 
+const paymentsEnabled = () => {
+  const getSetting = require('../settings').getSetting
+  const settings = require('../constants/settings')
+  return getSetting(settings.PAYMENTS_ENABLED)
+}
+
 windowStore.addChangeListener(() => {
-  var presentP = false
-  const windowState = windowStore.getState().toJS()
-
-  windowState.tabs.forEach((tab) => { if (tab.location === 'about:preferences#payments') presentP = true })
-
-  ipc.send(messages.LEDGER_PAYMENTS_PRESENT, presentP)
+  if (paymentsEnabled()) {
+    const windowState = windowStore.getState()
+    const tabs = windowState && windowState.get('tabs')
+    if (tabs) {
+      const presentP = tabs.some((tab) => {
+        return tab.get('location') === 'about:preferences#payments'
+      })
+      ipc.send(messages.LEDGER_PAYMENTS_PRESENT, presentP)
+    }
+  }
 })
 module.exports = Tab

--- a/js/constants/coinbaseCountries.js
+++ b/js/constants/coinbaseCountries.js
@@ -3,6 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const coinbaseCountries = [
+/* although coibnase operates in all these countries, the debit/credit payment service is, at present, only in the US
   'AT',
   'AU',
   'BE',
@@ -35,6 +36,7 @@ const coinbaseCountries = [
   'SI',
   'SK',
   'SM',
+ */
   'US'
 ]
 

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -146,6 +146,7 @@ const messages = {
   // Debugging
   DEBUG_REACT_PROFILE: _,
   // Ledger
+  LEDGER_PAYMENTS_PRESENT: _,
   LEDGER_PUBLISHER: _,
   LEDGER_UPDATED: _,
   LEDGER_CREATE_WALLET: _,


### PR DESCRIPTION
Auditor: @bsclifton 

Test fix for #5788 -
- from outside the US, go to `about:preferences#payments`
- click on `Add funds...`
- note that there is no Coinbase decoration at the bottom of the modal window
- click on `Display QR code`
- note that there is no Coinbase decoration at the bottom of the QR code window

Test fix for #4114 -
- add a `console.log()` call to the `getBalance()` function
- verify that it fires every minute or so when you have `about:preferences#payments` in a tab somewhere
- verify that it doesn't fire when you don't have `about:preferences#payments` in a tab somewhere

For the person who fixes #4720 - when `appActions.ledgerRecoveryFailed()` is invoked, you will find `ledgerState.error` filled in

1. Fixes #5788
2. Fixes #4114
3. Partially addresses #4720