### PR TITLE
[WiP] extend blue outline in url bar

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -560,7 +560,7 @@
     border-bottom: 10px solid #FFFFFF;
     position: relative;
     bottom: 10px;
-    left: 37px;
+    left: 32px;
 
     &.withHomeButton {
       left: 61px;

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -650,8 +650,10 @@
     height: 0;
     width: 14px;
     height: 14px;
-    position: relative;
-    left: 5px;
+    margin: 0;
+    position: absolute;
+    top: 3.5px;
+    left: 4px;
 
     &.removeBookmarkButton {
       background: url('../img/toolbar/bookmark_marked.svg') center no-repeat;
@@ -696,7 +698,7 @@
   align-items: center;
   justify-content: center;
   height: 25px;
-  padding: 0 10px;
+  padding: 0 10px 0 30px;
 
   display: flex;
   flex-grow: 1;
@@ -726,8 +728,6 @@
   #navigator:not(.titleMode) & {
     background: white;
     border-radius: @borderRadiusURL;
-    border-top-left-radius: 0;
-    border-bottom-left-radius: 0;
     box-shadow: inset 0 0 0 1px rgba(0,0,0,0.1), inset 0 1px 0 rgba(0,0,0,0.05), inset 0 1px 1px rgba(0,0,0,0.1);
     color: @chromeText;
   }
@@ -763,16 +763,21 @@
       animation-fill-mode: forwards;
     }
 
+    .startButtons {
+      position: relative;
+      z-index: 999;
+      width: 0;
+    }
+
     .bookmarkButtonContainer {
-      border: 1px solid #CBCBCB;
-      border-radius: @borderRadius;
-      border-right: none;
-      border-top-right-radius: 0;
-      border-bottom-right-radius: 0;
+      background-color: #f7f7f7;
       box-sizing: border-box;
-      display: block;
-      height: 25px;
-      width: 25px;
+      height: 21px;
+      width: 23px;
+      position: relative;
+      left: 2px;
+      top: 2px;
+      display: inline-block;
     }
   }
 
@@ -903,7 +908,7 @@
   .urlbarIcon {
     color: @siteSecureColor;
     left: 14px;
-    margin-top: 1px;
+    margin: 1px 5px 0 3px;
     font-size: 13px;
     min-height: 10px;
     min-width: 16px;

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -765,7 +765,7 @@
 
     .startButtons {
       position: relative;
-      z-index: 999;
+      z-index: @zindexStartButtons;
       width: 0;
     }
 

--- a/less/variables.less
+++ b/less/variables.less
@@ -122,6 +122,7 @@
 
 @zindexNavigationBar: 2000;
 @zindexUrlbarNotLegend: 2100;
+@zindexStartButtons: 2100;
 
 @zindexPopUp: 3000;
 @zindexContextMenu: 3000;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5439

Work in progress as I got it working on Mac but I'm still having trouble setting up my Windows VM with Brave.

Test Plan:

Need to make sure urlbar looks like this screenshot and that the bookmark button still works on Windows.

![urlbar](https://cloud.githubusercontent.com/assets/490294/20772563/d1c497ee-b702-11e6-9911-3848e2c5d365.png)


