### PR TITLE
hide-autofill-popup only when webcontent is focused

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -722,7 +722,10 @@ class Frame extends ImmutableComponent {
       contextMenus.onShowAutofillMenu(e.suggestions, e.rect, this.frame)
     })
     this.webview.addEventListener('hide-autofill-popup', (e) => {
-      windowActions.autofillPopupHidden(this.props.tabId)
+      let webContents = this.webview.getWebContents()
+      if (webContents && webContents.isFocused()) {
+        windowActions.autofillPopupHidden(this.props.tabId)
+      }
     })
     this.webview.addEventListener('ipc-message', (e) => {
       let method = () => {}

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -636,7 +636,7 @@ const doAction = (action) => {
       windowStore.emitChanges()
       return
     case WindowConstants.WINDOW_AUTOFILL_SELECTION_CLICKED:
-      ipc.send('autofill-selection-clicked', action.tabId, action.value, action.frontendId, action.index)
+      ipc.send('autofill-selection-clicked', action.tabId, action.value, action.frontEndId, action.index)
       windowState = windowState.delete('contextMenuDetail')
       break
     case WindowConstants.WINDOW_AUTOFILL_POPUP_HIDDEN:


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

also fix frontend id typo leads to crash

fix #5939

Auditor: @bridiver

Test plan:
1. Create an autofill entry
2. Open https://www.roboform.com/filling-test-all-fields
3. Click on the field to show autofill suggestion, it should fill the fields after clicking on the suggestion