### PR TITLE
Add Yandex.com as a search engine

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -287,7 +287,8 @@ class Main extends ImmutableComponent {
         if (entry.name === engine) {
           windowActions.setSearchDetail(Immutable.fromJS({
             searchURL: entry.search,
-            autocompleteURL: entry.autocomplete
+            autocompleteURL: entry.autocomplete,
+            platformClientId: entry.platformClientId
           }))
           this.lastLoadedSearchProviders = engine
           return false

--- a/js/data/searchProviders.js
+++ b/js/data/searchProviders.js
@@ -124,6 +124,18 @@ module.exports = { "providers" :
       "search" : "https://www.qwant.com/?q={searchTerms}&client=brave",
       "autocomplete": "https://api.qwant.com/api/suggest/?q={searchTerms}&client=brave",
       "shortcut" : ":q"
+    },
+    {
+      "name" : "Yandex",
+      "base" : "https://yandex.com",
+      "image" : "https://yastatic.net/islands-icons/_/6jyHGXR8-HAc8oJ1bU8qMUQQz_g.ico",
+      "search" : "https://yandex.com/search/?text={searchTerms}&clid={platformClientId}",
+      "shortcut" : ":ya",
+      "platformClientId": {
+        "win32": 2274777,
+        "darwin": 2274776,
+        "linux": 2274778
+      }
     }
   ]
 }

--- a/test/components/navigationBarTest.js
+++ b/test/components/navigationBarTest.js
@@ -381,31 +381,22 @@ describe('navigationBar tests', function () {
       yield setup(this.app.client)
     })
 
-    it('Uses the default favicon when one is not specified', function * () {
-      const page1Url = Brave.server.url('page1.html')
-      yield this.app.client.tabByUrl(Brave.newTabUrl).url(page1Url).waitForUrl(page1Url).windowParentByUrl(page1Url)
-      yield this.app.client.waitUntil(() =>
-        this.app.client.getCssProperty(activeTabFavicon, 'background-image').then((backgroundImage) =>
-          backgroundImage.value === `url("${Brave.server.url('favicon.ico')}")`
-        ))
-    })
-
     it('Parses favicon when one is present', function * () {
       const pageWithFavicon = Brave.server.url('favicon.html')
       yield this.app.client.tabByUrl(Brave.newTabUrl).url(pageWithFavicon).waitForUrl(pageWithFavicon).windowParentByUrl(pageWithFavicon)
-      yield this.app.client.waitUntil(() =>
-        this.app.client.getCssProperty(activeTabFavicon, 'background-image').then((backgroundImage) =>
-          backgroundImage.value === `url("${Brave.server.url('img/test.ico')}")`
-      ))
+      yield this.app.client.waitUntil(function () {
+        return this.getCssProperty(activeTabFavicon, 'background-image').then((backgroundImage) =>
+          backgroundImage.value === `url("${Brave.server.url('img/test.ico')}")`)
+      })
     })
 
     it('Fallback to default icon when no one is specified', function * () {
       const pageWithNoFavicon = Brave.server.url('page_no_favicon.html')
       yield this.app.client.tabByUrl(Brave.newTabUrl).url(pageWithNoFavicon).waitForUrl(pageWithNoFavicon).windowParentByUrl(pageWithNoFavicon)
-      yield this.app.client.waitUntil(() =>
-        this.app.client.getAttribute(activeTabFavicon, 'class').then((className) =>
-          className === 'tabIcon bookmarkFile fa fa-file-o'
-      ))
+      yield this.app.client.waitUntil(function () {
+        return this.getAttribute(activeTabFavicon, 'class').then((className) =>
+          className === 'tabIcon bookmarkFile fa fa-file-o')
+      })
     })
   })
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes https://github.com/brave/browser-laptop/issues/2703

Also includes
- small refactor in js/components/urlBar.js which should make future changes easier (and opens this up to unit testing)
- removes permafail webdriver test that should have been removed with https://github.com/brave/browser-laptop/pull/5826 (I missed the fact CI failed on this when reviewing)

This does **not** include search suggestions; I broke that out and captured with https://github.com/brave/browser-laptop/issues/5963

Auditors: @bbondy, @cezaraugusto

## Test Plan
1. Launch Brave and open Preferences
2. Set Yandex as your default search engine
3. Search in the omnibox, confirm it shows results on yandex.com
4. Check the URL that was created; client ID (clid=) should be:
  - 2274777 on Windows
  - 2274776 on macOS
  - 2274778 on linux
5. Try the search engine shortcut, :ya and do a search in the omnibox