### PR TITLE
Removed the hacks of the buttons on the navigation bar (for Windows)

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -36,25 +36,7 @@
     padding-left: 5px;
   }
 
-  .startButtons {
-    position: relative;
-    top: -1px;
-  }
-
   #navigator {
-    margin-right: 0px;
-
-    .homeButton {
-      margin: 0 0 3px 0;
-    }
-
-    .stopButton {
-      margin: 0 2px 6px 2px;
-    }
-
-    .reloadButton {
-      margin: 0 3px 2px 3px;
-    }
     input {
       font-weight: 500;
       margin: 1px 0 0 3px;
@@ -62,15 +44,6 @@
   }
 
   #urlInput { width: 100%; }
-
-  #navigator {
-    &:not(.titleMode) {
-      .bookmarkButtonContainer {
-        margin-top: 4px;
-        line-height: 24px;
-      }
-    }
-  }
 
   // changes to ensure window can be as small as 480px wide
   // and still be useable and have the caption buttons intact
@@ -770,7 +743,8 @@
       border-top-right-radius: 0;
       border-bottom-right-radius: 0;
       box-sizing: border-box;
-      display: block;
+      display: flex;
+      align-items: center;
       height: 25px;
       width: 25px;
     }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes #5928

Thanks to #5739 and #5750 (#5737) these hacks are no longer necessary.

Auditors: @srirambv @bsclifton 

Test Plan:
1. Enable Home Button
2. Open some pages in the same tab to enable backButton and forwardButton
3. Make sure every place of the buttons are clickable
4. Make sure height and width of the buttons remain the same (34x24, 26x24)
5. Make sure stopButton is centered
6. Make sure the bookmark icon is properly aligned on each platforms