### PR TITLE
Add layer for topSites to avoid dupe icon/bg color

### DIFF
--- a/less/about/newtab.less
+++ b/less/about/newtab.less
@@ -254,6 +254,22 @@ ul {
           height: 80px;
           font-size: 38px;
 
+          // Add an opacity layer on top of tile
+          // to avoid backgrounds with the same color as icon
+          // (as seen on issue #5868)
+          &:before {
+              content: '';
+              position: absolute;
+              top: 0;
+              left: 0;
+              width: 100%;
+              height: 100%;
+              background-color: #fff;
+              opacity: 0.15;
+              z-index: 0;
+              border-radius: 4px;
+          }
+
           .pinnedTopSite {
             opacity: 1;
             visibility: visible;
@@ -275,6 +291,8 @@ ul {
 
           }
           img {
+            position: relative;
+            z-index: 1;
             max-width: 64px;
             max-height: 64px;
           }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bradleyrichter, @jkup 

Preview (notice Youtube and trakt.tv with different colors):

![topsites](https://cloud.githubusercontent.com/assets/4672033/20842634/53aba44e-b89f-11e6-9e6d-37aeee13fc2e.png)

The amount of opacity was made arbitrarily and can be changed per request.

Note: this is a global change for topSites and will change opacity color of other sites as well, thus why I opted for white transparency.

Fix #5868

Test Plan:

* Go to a website that has same icon color than background (i.e. Youtube)
* Go back to new tab page and ensure tile's background should be 15% lighter