### PR TITLE
Reduce space for count/text inside timeSaved stat

### DIFF
--- a/less/about/newtab.less
+++ b/less/about/newtab.less
@@ -112,6 +112,8 @@ ul {
         }
         &.timeSaved {
           color: @statsLightGray;
+          display: flex;
+          align-items: baseline;
         }
 
         .text {
@@ -119,6 +121,7 @@ ul {
           color: @statsLightGray;
           font-size: 20px;
           line-height: 24px;
+          margin-left: 3px;
         }
       }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bradleyrichter

Screenshot:

![new_space](https://cloud.githubusercontent.com/assets/4672033/20853487/4c9cc0a0-b8d3-11e6-86e3-4723da49670b.png)

Fix #5994

Test Plan:

Inside new tab page, space between count and string for Estimated Time Saved
should be reduced, looking the same as the attached screenshot