### PR TITLE
fixing contribution stmt PDF filename

### DIFF
--- a/app/common/lib/ledgerExportUtil.js
+++ b/app/common/lib/ledgerExportUtil.js
@@ -4,6 +4,7 @@
 
 const base64Encode = require('../../../js/lib/base64').encode
 const underscore = require('underscore')
+const moment = require('moment')
 
 /**
  * Generates a contribution breakdown by publisher as a CSV data URL from an array of one or more transactions
@@ -299,7 +300,7 @@ module.exports.getTransactionCSVText = (transactions, viewingIds, addTotalRow) =
 
 /**
  * Adds an `exportFilenamePrefix` field to the provided transaction(s)
- * of form `Brave_Payments_${MM-D(D)-YYYY}`, with "_<n>" added for the nth time a date occurs (n > 1)
+ * of form `Brave_Payments_${YYYY-MM-DD}`, with "_<n>" added for the nth time a date occurs (n > 1)
  *
  * @param {Object[]} transactions - an array of transaction(s) or single transaction object
  *
@@ -320,7 +321,8 @@ module.exports.addExportFilenamePrefixToTransactions = (transactions) => {
 
   return transactions.map(function (transaction) {
     const timestamp = transaction.submissionStamp
-    let numericDateStr = (new Date(timestamp)).toLocaleDateString().replace(/\//g, '-')
+
+    let numericDateStr = moment(new Date(timestamp)).format('YYYY-MM-DD')
 
     let dateCount = (dateCountMap[numericDateStr] ? dateCountMap[numericDateStr] : 1)
     dateCountMap[numericDateStr] = dateCount + 1

--- a/test/unit/app/common/lib/ledgerExportUtilTest.js
+++ b/test/unit/app/common/lib/ledgerExportUtilTest.js
@@ -2,6 +2,7 @@
 const assert = require('assert')
 const underscore = require('underscore')
 const uuid = require('node-uuid')
+const moment = require('moment')
 
 require('../../../braveUnit')
 
@@ -22,7 +23,7 @@ const CSV_DATA_URI_PREFIX = 'data:' + CSV_CONTENT_TYPE + ';base64,'
 const EMPTY_CSV_DATA_URL = CSV_DATA_URI_PREFIX + base64Encode(EMPTY_CSV)
 
 const EXPORT_FILENAME_CONST_PREFIX_PART = 'Brave_Payments_'
-const EXPORT_FILENAME_PREFIX_EXPECTED_FORM = `${EXPORT_FILENAME_CONST_PREFIX_PART}\${MM-D(D)-YYYY}`
+const EXPORT_FILENAME_PREFIX_EXPECTED_FORM = `${EXPORT_FILENAME_CONST_PREFIX_PART}\${YYYY-MM-DD}`
 
 const exampleTransactions = require('../../../fixtures/exampleLedgerData').transactions
 const exampleTransaction = exampleTransactions[0]
@@ -466,7 +467,7 @@ describe('ledger export utilities test', function () {
 
       let tx = txs[0]
       let timestamp = tx.submissionStamp
-      let dateStr = (new Date(timestamp)).toLocaleDateString().replace(/\//g, '-')
+      let dateStr = moment(new Date(timestamp)).format('YYYY-MM-DD')
       let expectedExportFilenamePrefix = `${EXPORT_FILENAME_CONST_PREFIX_PART}${dateStr}`
 
       assert.equal(typeof tx.exportFilenamePrefix, 'string', 'transaction should have "exportFilenamePrefix" field with type "string"')


### PR DESCRIPTION
Fixes issue #5974, where contribution PDFs are broken by a change in Date#toLocaleDateString behavior that has appeared with chromium54 changes.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
- run updated test
`npm run test -- --grep="addExportFilenamePrefixToTransactions"`