### PR TITLE
Follow-up: Button styles consistent

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -514,7 +514,7 @@ class BitcoinDashboard extends ImmutableComponent {
                       <div data-l10n-id='bitcoinPaymentURL' className='labelText' />
                     </div>
                 }
-                <span className='smallText'>{this.ledgerData.get('address')}</span>
+                <div className='walletAddressText'>{this.ledgerData.get('address')}</div>
                 <Button className='primaryButton' l10nId='copyToClipboard' onClick={this.copyToClipboard.bind(this, this.ledgerData.get('address'))} />
               </div>
             : <div className='settingsPanelDivider'>

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -851,11 +851,13 @@ div.nextPaymentSubmission {
       }
       font-size: 0.9em;
     }
-    .smallText {
+
+    .walletAddressText {
       font-size: 12px;
       color: black;
       margin-bottom: 20px;
     }
+
     .settingsListTitle {
       color: @darkGray;
       font-weight: bold;
@@ -899,10 +901,7 @@ div.nextPaymentSubmission {
     }
 
     .primaryButton {
-      display: block;
-      float: right;
-      width: 180px;
-      margin-bottom: 15px;
+      min-width: 180px;
     }
 
     &:after {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Based on https://github.com/brave/browser-laptop/pull/5916#issuecomment-264613245 this fixes

- Margin-bottom of the brave wallet address
- Button text overflow (l10n-friendly)

<img width="729" alt="screenshot 2016-12-03 12 53 35" src="https://cloud.githubusercontent.com/assets/3362943/20856699/17435f96-b959-11e6-88eb-2cb795b3d1f8.png">
<img width="220" alt="screenshot 2016-12-03 12 56 47" src="https://cloud.githubusercontent.com/assets/3362943/20856701/175786d8-b959-11e6-9412-5c37cf27281c.png">


Auditors: @bradleyrichter

Test Plan: