### PR TITLE
input and select are not equal width

### DIFF
--- a/less/forms.less
+++ b/less/forms.less
@@ -601,6 +601,7 @@
 
   input,
   select {
+    box-sizing: border-box;
     display: block;
     width: 100%;
     max-width: 250px;

--- a/less/forms.less
+++ b/less/forms.less
@@ -1,5 +1,10 @@
 @import "variables.less";
 
+input,
+select {
+  box-sizing: border-box;
+}
+
 .form-control {
   display: block;
   background: white;
@@ -601,7 +606,6 @@
 
   input,
   select {
-    box-sizing: border-box;
     display: block;
     width: 100%;
     max-width: 250px;
@@ -682,7 +686,6 @@
 #navigator {
   .urlBarSuggestions {
     .flyoutDialog;
-    box-sizing: border-box;
     color: @chromeText;
     left: 0;
     overflow-y: auto;

--- a/less/forms.less
+++ b/less/forms.less
@@ -6,6 +6,7 @@
   border: solid 1px @lightGray;
   border-radius: @borderRadius;
   box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
+  box-sizing: border-box;
   color: @darkGray;
   font-size: 14.5px;
   height: 2.25em;

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -817,87 +817,89 @@
     text-overflow: ellipsis;
   }
 
-  .loadTime {
-    color: @loadTimeColor;
-    background: @navigationBarBackground;
-    font-size: 12px;
-    right: 10px;
-    text-align: right;
-    margin: 2px 0 0 0;
-    top: 9px;
-    cursor: default;
-    padding-top: 1px;
+  .urlbarForm {
+    .loadTime {
+      color: @loadTimeColor;
+      background: @navigationBarBackground;
+      font-size: 12px;
+      right: 10px;
+      text-align: right;
+      margin: 2px 0 0 0;
+      top: 9px;
+      cursor: default;
+      padding-top: 1px;
 
-    &.onFocus {
-        display: none;
-    }
-  }
-
-  /* Disable selection of button text */
-  > span {
-     -webkit-user-select: none;
-  }
-
-  > * {
-    -webkit-app-region: no-drag;
-  }
-
-  .inputbar-wrapper {
-    background: white;
-    display: flex;
-    flex: 1 1 0;
-    border-radius: 4px;
-    align-items: center;
-    justify-content: center;
-  }
-
-  input {
-    background: @navigationBarBackground;
-    border: none;
-    box-sizing: border-box;
-    color: @chromeText;
-    cursor: text;
-    font-size: @defaultFontSize;
-    font-weight: normal;
-    margin: 2px 0 0 3px;
-    outline: none;
-    text-overflow: ellipsis;
-    flex-grow: 1;
-    min-width: 0%; // allow the navigator to shrink
-
-    &:hover {
-      background: @chromeControlsBackground2;
+      &.onFocus {
+          display: none;
+      }
     }
 
+    /* Disable selection of button text */
+    > span {
+       -webkit-user-select: none;
+    }
 
-    &.private {
-      background: @privateTabBackground;
+    > * {
+      -webkit-app-region: no-drag;
+    }
+
+    .inputbar-wrapper {
+      background: white;
+      display: flex;
+      flex: 1 1 0;
+      border-radius: 4px;
+      align-items: center;
+      justify-content: center;
+    }
+
+    input {
+      background: @navigationBarBackground;
+      border: none;
+      box-sizing: border-box;
       color: @chromeText;
+      cursor: text;
+      font-size: @defaultFontSize;
+      font-weight: normal;
+      margin: 2px 0 0 3px;
+      outline: none;
+      text-overflow: ellipsis;
+      flex-grow: 1;
+      min-width: 0%; // allow the navigator to shrink
+
+      &:hover {
+        background: @chromeControlsBackground2;
+      }
+
+
+      &.private {
+        background: @privateTabBackground;
+        color: @chromeText;
+      }
     }
-  }
 
-  .urlbarIcon {
-    color: @siteSecureColor;
-    left: 14px;
-    margin-top: 1px;
-    font-size: 13px;
-    min-height: 10px;
-    min-width: 16px;
-
-    &.fa-lock,
-    &.fa-unlock {
-      margin-top: 2px;
-      font-size: 15px;
+    .urlbarIcon {
+      color: @siteSecureColor;
+      left: 14px;
+      margin-top: 1px;
+      font-size: 13px;
       min-height: 10px;
       min-width: 16px;
-    }
 
-    &.fa-unlock {
-        color: @siteInsecureColor;
-    }
+      &.fa-lock,
+      &.fa-unlock {
+        margin-top: 1px;
+        font-size: 16px;
+        min-height: 10px;
+        min-width: 16px;
+      }
 
-    &.extendedValidation {
-      color: @siteEVColor;
+      &.fa-unlock {
+          color: @siteInsecureColor;
+      }
+
+      &.extendedValidation {
+        color: @siteEVColor;
+      }
     }
   }
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

TIL that select boxes aren't box-sizing: border-box like input elements are which is causing them to be wider than they should be if they have padding. The easy fix is just manually setting all inputs and selects to border-box (this is what Bootstrap does, although they apply it to the entire html selector!)

Fix #5192

Auditors @bradleyrichter @bsclifton 

Test Plan:

1. Open Brave
2. Add a bookmark on Bookmark toolbar
3. Make sure the Title and Folder are the same width
4. Open about:bookmarks
5. Cick the star icon on the page
6. Make sure three rows are the same width