### PR TITLE
Add focus ring to about page form elements

### DIFF
--- a/app/renderer/components/bookmarksToolbar.js
+++ b/app/renderer/components/bookmarksToolbar.js
@@ -172,7 +172,7 @@ class BookmarkToolbarButton extends ImmutableComponent {
         : siteDetailLocation
     }
 
-    return <span
+    return <button
       className={cx({
         bookmarkToolbarButton: true,
         draggingOverLeft: this.isDraggingOverLeft && !this.isExpanded,
@@ -217,7 +217,7 @@ class BookmarkToolbarButton extends ImmutableComponent {
         ? <span className='bookmarkFolderChevron fa fa-chevron-down' />
         : null
       }
-    </span>
+    </button>
   }
 }
 

--- a/less/bookmarksToolbar.less
+++ b/less/bookmarksToolbar.less
@@ -61,6 +61,12 @@
       box-shadow: 0px 1px 5px 0px rgba(0, 0, 0, 0.1);
     }
 
+    &:focus {
+      outline-color: rgb(59, 153, 252);
+      outline-style: auto;
+      outline-width: 5px;
+    }
+
     &.draggingOverLeft {
       &:not(.isDragging) {
         margin-left: 25px;

--- a/less/button.less
+++ b/less/button.less
@@ -6,7 +6,6 @@
 
 button[class*="Button"] {
   background: none;
-  outline: none;
   border: none;
   margin: 0;
   white-space: nowrap;

--- a/less/forms.less
+++ b/less/forms.less
@@ -15,7 +15,6 @@ select {
   color: @darkGray;
   font-size: 14.5px;
   height: 2.25em;
-  outline: none;
   padding: 0.4em;
   width: 100%;
 }

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -545,6 +545,11 @@
   }
 }
 
+.navbutton,
+.navigationButton {
+  outline: none;
+}
+
 .navigationButton {
   background-color: @buttonColor;
   display: inline-block;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5971

Auditor @bsclifton, @cezaraugusto 

## Test Plan

1. Open Brave
2. Go to Preferences
3. Start tabbing through the document. Make sure all buttons and inputs/selects have blue focus rings.
4. Then Add some bookmarks
5. Toggle on show bookmark bar
6. Click in the urlbar
7. Start tabbing through, make sure each bookmark also gets a blue focus ring

