### PR TITLE
Refactor about:preferences#payments followups

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -433,16 +433,20 @@ class BitcoinDashboard extends ImmutableComponent {
   get panelFooter () {
     if (this.ledgerData.get('buyURLFrame')) {
       return <div className='panelFooter'>
-        <Button l10nId='done' className='pull-right whiteButton' onClick={this.props.hideParentOverlay} />
+        <Button l10nId='done' className='whiteButton' onClick={this.props.hideParentOverlay} />
       </div>
     } else if (coinbaseCountries.indexOf(this.props.ledgerData.get('countryCode')) > -1) {
-      return <div className='panelFooter'>
-        <div className='coinbaseLogo' />
-        <span className='coinbaseMessage' data-l10n-id='coinbaseMessage' />
-        <Button l10nId='done' className='pull-right whiteButton' onClick={this.props.hideParentOverlay} />
+      return <div className='panelFooter coinbaseFooter'>
+        <div className='coinbase'>
+          <div className='coinbaseLogo' />
+          <span className='coinbaseMessage' data-l10n-id='coinbaseMessage' />
+        </div>
+        <Button l10nId='done' className='whiteButton' onClick={this.props.hideParentOverlay} />
       </div>
     } else {
-      return null
+      return <div className='panelFooter'>
+        <Button l10nId='done' className='whiteButton' onClick={this.props.hideParentOverlay} />
+      </div>
     }
   }
   copyToClipboard (text) {
@@ -477,7 +481,7 @@ class BitcoinDashboard extends ImmutableComponent {
         ? <ModalOverlay content={this.qrcodeOverlayContent} customTitleClasses={'qrcodeOverlay'} footer={this.qrcodeOverlayFooter} onHide={this.props.hideQRcode.bind(this)} />
         : null
       }
-      <div className='board'>
+      <div className='board addFundsBoard'>
         {
           (this.userInAmerica || this.ledgerData.get('buyURLFrame'))
           ? this.coinbasePanel
@@ -497,7 +501,7 @@ class BitcoinDashboard extends ImmutableComponent {
               ? <div className='settingsPanelDivider'>
                 {
                   this.ledgerData.get('hasBitcoinHandler') && this.ledgerData.get('paymentURL')
-                    ? <div>
+                    ? <div className='hasBitcoinHandler'>
                       <a href={this.ledgerData.get('paymentURL')} target='_blank'>
                         <Button l10nId='bitcoinVisitAccount' className='primaryButton bitcoinAddressButton' />
                       </a>

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -265,7 +265,7 @@ class LedgerTable extends ImmutableComponent {
     return [
       rank,
       {
-        html: <a href={publisherURL} target='_blank'>{verified ? this.getVerifiedIcon() : null}{faviconURL ? <img src={faviconURL} alt={site} /> : <span className='fa fa-file-o' />}<span>{site}</span></a>,
+        html: <div className='site'>{verified ? this.getVerifiedIcon() : null}<a href={publisherURL} target='_blank'>{faviconURL ? <img src={faviconURL} alt={site} /> : <span className='fa fa-file-o' />}<span>{site}</span></a></div>,
         value: site
       },
       {
@@ -337,9 +337,9 @@ class BitcoinDashboard extends ImmutableComponent {
   get qrcodeOverlayFooter () {
     if (coinbaseCountries.indexOf(this.props.ledgerData.get('countryCode')) > -1) {
       return <div className='qrcodeOverlayFooter'>
-        <div id='coinbaseLogo' />
-        <a href='https://itunes.apple.com/us/app/coinbase-bitcoin-wallet/id886427730?mt=8' target='_blank' id='appstoreLogo' />
-        <a href='https://play.google.com/store/apps/details?id=com.coinbase.android' target='_blank' id='playstoreLogo' />
+        <div className='coinbaseLogo' />
+        <a target='_blank' className='appstoreLogo' href='https://itunes.apple.com/us/app/coinbase-bitcoin-wallet/id886427730?mt=8' />
+        <a target='_blank' className='playstoreLogo' href='https://play.google.com/store/apps/details?id=com.coinbase.android' />
       </div>
     } else {
       return null
@@ -437,7 +437,7 @@ class BitcoinDashboard extends ImmutableComponent {
       </div>
     } else if (coinbaseCountries.indexOf(this.props.ledgerData.get('countryCode')) > -1) {
       return <div className='panelFooter'>
-        <div id='coinbaseLogo' />
+        <div className='coinbaseLogo' />
         <span className='coinbaseMessage' data-l10n-id='coinbaseMessage' />
         <Button l10nId='done' className='pull-right whiteButton' onClick={this.props.hideParentOverlay} />
       </div>
@@ -532,7 +532,7 @@ class PaymentHistory extends ImmutableComponent {
         addExportFilenamePrefixToTransactions(this.props.ledgerData.get('transactions').toJS())
     )
 
-    return <div id='paymentHistory'>
+    return <div className='paymentHistoryTable'>
       <table className='sort'>
         <thead>
           <tr>
@@ -1195,7 +1195,7 @@ class PaymentsTab extends ImmutableComponent {
   }
 
   get sidebarContent () {
-    return <div id='paymentsSidebar'>
+    return <div className='paymentsSidebar'>
       <h2 data-l10n-id='paymentsSidebarText1' />
       <div data-l10n-id='paymentsSidebarText2' />
       <a href='https://www.privateinternetaccess.com/' target='_blank'><div className='paymentsSidebarPIA' /></a>

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -1019,7 +1019,7 @@ class PaymentsTab extends ImmutableComponent {
     return <div className='board'>
       <div className='panel advancedSettings'>
         <div className='settingsPanelDivider'>
-          <div data-l10n-id='minimumPageTimeSetting' />
+          <div className='minimumPageTimeSetting' data-l10n-id='minimumPageTimeSetting' />
           <SettingsList>
             <SettingItem>
               <select
@@ -1032,7 +1032,7 @@ class PaymentsTab extends ImmutableComponent {
               </select>
             </SettingItem>
           </SettingsList>
-          <div data-l10n-id='minimumVisitsSetting' />
+          <div className='minimumVisitsSetting' data-l10n-id='minimumVisitsSetting' />
           <SettingsList>
             <SettingItem>
               <select
@@ -1079,7 +1079,7 @@ class PaymentsTab extends ImmutableComponent {
     const passphrase = this.props.ledgerData.get('passphrase')
 
     return <div className='board'>
-      <div className='panel'>
+      <div className='panel ledgerBackupContent'>
         <span data-l10n-id='ledgerBackupContent' />
         <div className='copyKeyContainer'>
           <div className='copyContainer'>
@@ -1136,13 +1136,13 @@ class PaymentsTab extends ImmutableComponent {
       }
       <div className='panel recoveryContent'>
         <h4 data-l10n-id='ledgerRecoverySubtitle' />
-        <span data-l10n-id='ledgerRecoveryContent' />
+        <div className='ledgerRecoveryContent' data-l10n-id='ledgerRecoveryContent' />
         <SettingsList>
           <SettingItem>
             <h3 data-l10n-id='firstRecoveryKey' />
-            <input className='form-control' onChange={this.handleFirstRecoveryKeyChange} type='text' />
+            <input className='form-control firstRecoveryKey' onChange={this.handleFirstRecoveryKeyChange} type='text' />
             <h3 data-l10n-id='secondRecoveryKey' />
-            <input className='form-control' onChange={this.handleSecondRecoveryKeyChange} type='text' />
+            <input className='form-control secondRecoveryKey' onChange={this.handleSecondRecoveryKeyChange} type='text' />
           </SettingItem>
         </SettingsList>
       </div>

--- a/js/components/modalOverlay.js
+++ b/js/components/modalOverlay.js
@@ -47,7 +47,7 @@ class ModalOverlay extends ImmutableComponent {
     var button = null
     var title = null
     if (!this.props.emptyDialog) {
-      close = (this.props.onHide ? <button type='button' className='close pull-right' onClick={this.props.onHide} /> : null)
+      close = (this.props.onHide ? <button type='button' className='close' onClick={this.props.onHide} /> : null)
       title = (this.props.title ? <div className='sectionTitle' data-l10n-id={this.props.title} /> : null)
     }
     let customTitleClassesStr = (this.props.customTitleClasses ? this.props.customTitleClasses : '')

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -555,7 +555,9 @@ table.sortableTable {
       .dialog-body {
         .board {
           .panel {
-            &.advancedSettings {
+            &.advancedSettings,
+            &.ledgerBackupContent,
+            &.recoveryContent {
               padding-left: 50px;
               padding-right: 50px;
 
@@ -564,10 +566,27 @@ table.sortableTable {
               }
             }
 
+            &.advancedSettings {
+              .settingsPanelDivider {
+                .settingsListContainer:last-child {
+                  margin-bottom: 0;
+                }
+              }
+            }
+
             &.recoveryContent {
               h4,
-              span {
+              .ledgerRecoveryContent {
                 margin-bottom: 20px;
+
+                & + .settingsListContainer {
+                  margin-bottom: 0;
+
+                  .firstRecoveryKey,
+                  .secondRecoveryKey {
+                    margin-bottom: 20px;
+                  }
+                }
               }
             }
 
@@ -583,6 +602,12 @@ table.sortableTable {
               &:nth-child(2) {
                 text-align: right;
               }
+
+              .minimumPageTimeSetting,
+              .minimumVisitsSetting {
+                margin-bottom: 12px; // @itemMargin in .walletBar
+              }
+
             }
 
             .copyKeyContainer {
@@ -603,6 +628,10 @@ table.sortableTable {
 
                 h3 {
                   margin-bottom: 15px;
+                }
+
+                > span {
+                  white-space: nowrap;
                 }
               }
             }
@@ -780,8 +809,7 @@ table.sortableTable {
 
       .dialog-footer {
         .advancedSettingsFooter {
-          padding-top: 20px;
-          padding-bottom: 20px;
+          padding: 20px;
           display: flex;
           flex-wrap: wrap;
           justify-content: center;

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -483,7 +483,12 @@ table.sortableTable {
 
   .modal {
     .dialog {
+      background: linear-gradient(@modalVeryLightGray, @modalLightGray);
+      border-radius: @borderRadiusModal;
+
       &.coinbaseOverlay {
+        background: transparent;
+
         .dialog-body {
           height: 100%;
           width: 100%;
@@ -498,7 +503,11 @@ table.sortableTable {
         }
 
         .dialog-header {
-          background: #EEE;
+
+          .sectionTitle {
+            margin-bottom: 0;
+            padding: 0;
+          }
         }
 
         .dialog-body {
@@ -534,7 +543,6 @@ table.sortableTable {
         }
 
         .dialog-footer {
-          background: #EEE;
           padding-top: 10px;
           padding-bottom: 10px;
 
@@ -550,26 +558,118 @@ table.sortableTable {
         }
       }
 
-      .dialog-header {}
+      .dialog-header {
+        .sectionTitle {
+          margin-bottom: 0;
+          padding: 25px 0; // text-indent / 2
+        }
+      }
 
       .dialog-body {
         .board {
           .panel {
+            @margin-bottom-header: .5em;
+
+            &:first-child {
+              margin-top: 0;
+            }
+
+            &:last-child {
+              margin-bottom: 0;
+            }
+
             &.advancedSettings,
             &.ledgerBackupContent,
             &.recoveryContent {
               padding-left: 50px;
               padding-right: 50px;
+            }
+
+            &.advancedSettings {
+              display: flex;
+              flex-wrap: nowrap;
 
               select {
                 width: 100%;
               }
+
+              .settingsPanelDivider {
+                width: 100%;
+
+                &:first-child { // select elements
+                  .minimumPageTimeSetting,
+                  .minimumVisitsSetting {
+                    margin-bottom: @margin-bottom-header;
+                  }
+
+                  .settingsListContainer:last-child {
+                    margin-bottom: 0;
+                  }
+                }
+
+                &:last-child { // switches
+                  display: flex;
+                  align-items: center;
+                  width: auto;
+                  position: relative;
+                  left: 1em;
+
+                  .settingsListContainer:last-child {
+                    margin-bottom: 0;
+
+                    .settingsList {
+                      display: flex;
+                      flex-flow: column nowrap;
+                      justify-content: space-between;
+
+                      .settingItem {
+                        display: flex;
+                        margin-bottom: 1em;
+
+                        &:last-child {
+                          margin-bottom: 0;
+                        }
+
+                        label {
+                          margin-bottom: 0;
+                        }
+
+                        .switchControl {
+                          margin-top: 2px;
+                          padding-top: 0;
+                          padding-bottom: 0;
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
 
-            &.advancedSettings {
-              .settingsPanelDivider {
-                .settingsListContainer:last-child {
-                  margin-bottom: 0;
+            &.ledgerBackupContent {
+              .copyKeyContainer {
+                display: flex;
+                align-items: flex-end;
+                width: 75%;
+                margin: 20px auto;
+
+                .copyContainer {
+                  .copyButton {
+                    font-size: 14px;
+                    margin: 0;
+                  }
+                }
+
+                .keyContainer {
+                  margin-left: 2em;
+
+                  h3 {
+                    margin-bottom: @margin-bottom-header;
+                  }
+
+                  > span {
+                    white-space: nowrap;
+                  }
                 }
               }
             }
@@ -582,56 +682,14 @@ table.sortableTable {
                 & + .settingsListContainer {
                   margin-bottom: 0;
 
+                  h3 {
+                    margin-bottom: @margin-bottom-header;
+                  }
+
                   .firstRecoveryKey,
                   .secondRecoveryKey {
                     margin-bottom: 20px;
                   }
-                }
-              }
-            }
-
-            .settingsPanelDivider {
-              width: 50%;
-              position: relative;
-              float: left;
-
-              &:nth-child(1) {
-                text-align: left;
-              }
-
-              &:nth-child(2) {
-                text-align: right;
-              }
-
-              .minimumPageTimeSetting,
-              .minimumVisitsSetting {
-                margin-bottom: 12px; // @itemMargin in .walletBar
-              }
-
-            }
-
-            .copyKeyContainer {
-              display: flex;
-              align-items: flex-end;
-              width: 75%;
-              margin: 20px auto;
-
-              .copyContainer {
-                .copyButton {
-                  font-size: 14px;
-                  margin: 0;
-                }
-              }
-
-              .keyContainer {
-                margin-left: 2em;
-
-                h3 {
-                  margin-bottom: 15px;
-                }
-
-                > span {
-                  white-space: nowrap;
                 }
               }
             }
@@ -733,74 +791,112 @@ table.sortableTable {
           }
 
           .board {
-            .panel {
-              padding-left: 100px;
+            &.addFundsBoard {
+              .panel {
+                display: flex;
+                padding-left: 100px;
 
-              .settingsPanelDivider {
-                width: 50%;
-                position: relative;
-                float: left;
-
-                &:nth-child(1) {
-                  text-align: left;
+                &:nth-child(1) { // credit card
+                  margin-top: 0;
                 }
 
-                &:nth-child(2) {
-                  text-align: right;
-                }
+                &:nth-child(2) { // bitcoin address
 
-                .fa {
-                  position: absolute;
-                  left: -45px;
-
-                  &.fa-credit-card {
-                    font-size: 30px;
-                  }
-                  &.fa-mobile {
-                    font-size: 50px;
+                  .settingsPanelDivider {
+                    .hasBitcoinHandler {
+                      display: flex;
+                      flex-flow: column;
+                      align-items: flex-end;
+                    }
                   }
                 }
 
-                .bitcoinAddressButton {
-                  margin-bottom: 15px; // .walletAddressText
-                }
+                &:nth-child(3) { // mobile phone
+                  margin-bottom: 0;
 
-                .walletLabelText {
-                  font-size: 1em;
-                  color: @braveOrange;
-                  margin-bottom: 5px;
-                }
-
-                .walletAddressText {
-                  font-size: 12px;
-                  color: black;
-                  margin-bottom: 15px; // .bitcoinAddressButton
-                }
-
-                .bitcoinIcon {
-                  position: absolute;
-                  left: -5px;
-                  top: 0;
-
-                  .fa-circle {
-                    color: @bitcoinOrange;
+                  .settingsPanelDivider {
+                    justify-content: center; // align the mobile phone icon and the label vertically
                   }
-                  .fa-bitcoin {
-                    color: white;
-                    transform: rotate(12deg);
+                }
+
+                .settingsPanelDivider {
+                  width: 50%;
+                  position: relative;
+                  display: flex;
+                  flex-flow: column;
+
+                  &:first-child {
+                    align-items: flex-start; // to align the icons and texts left
+
+                    .fa {
+                      position: absolute;
+                      left: -45px;
+
+                      &.fa-credit-card {
+                        font-size: 30px;
+                      }
+
+                      &.fa-mobile {
+                        font-size: 50px;
+                        left: -40px;
+                      }
+                    }
+
+                    .bitcoinIcon {
+                      position: absolute;
+                      left: -5px;
+                      top: 0;
+
+                      .fa-circle {
+                        color: @bitcoinOrange;
+                      }
+                      .fa-bitcoin {
+                        color: white;
+                        transform: rotate(12deg);
+                      }
+                    }
+                  }
+
+                  &:last-child {
+                    align-items: flex-end; // to align the buttons right
+
+                    .bitcoinAddressButton {
+                      margin-bottom: 15px; // .walletAddressText
+                    }
+
+                    .walletLabelText {
+                      font-size: 1em;
+                      color: @braveOrange;
+                      margin-bottom: 5px;
+                    }
+
+                    .walletAddressText {
+                      font-size: 12px;
+                      color: black;
+                      margin-bottom: 15px; // .bitcoinAddressButton
+                    }
                   }
                 }
               }
 
-              &:last-child {
-                margin-bottom: 0;
-              }
-            }
+              .panelFooter {
+                display: flex;
+                align-items: center;
+                justify-content: flex-end;
 
-            .panelFooter {
-              .coinbaseMessage {
-                display: inline-block;
-                max-width: 450px;
+                &.coinbaseFooter {
+                  justify-content: space-between;
+
+                  .coinbase {
+                    display: flex;
+                    align-items: center;
+
+                    .coinbaseMessage {
+                      display: inline-block;
+                      max-width: 450px;
+                    }
+                  }
+                }
               }
             }
           }
@@ -812,7 +908,7 @@ table.sortableTable {
           padding: 20px;
           display: flex;
           flex-wrap: wrap;
-          justify-content: center;
+          justify-content: flex-end;
 
           .recoveryFooterButtons {
             float: right;

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -496,10 +496,11 @@ table.sortableTable {
       }
 
       &.paymentHistory {
+        @padding-horizontal: 30px;
+
         .dialog-header,
-        .dialog-body,
         .dialog-footer {
-          padding: 20px;
+          padding: 20px @padding-horizontal;
         }
 
         .dialog-header {
@@ -507,6 +508,8 @@ table.sortableTable {
           .sectionTitle {
             margin-bottom: 0;
             padding: 0;
+            color: @braveMediumOrange;
+            text-indent: 0;
           }
         }
 
@@ -514,28 +517,56 @@ table.sortableTable {
           background: #FFF;
           height: 300px;
           overflow-y: scroll;
+          padding-right: 0;
+          padding-left: 0;
 
           .paymentHistoryTable {
             background-color: #FFF;
 
-            tr {
-              th {
-                color: @darkGray;
-                font-weight: 500;
-                border-bottom: 2px solid @lightGray;
-                text-align: left;
-                width: 18%;
-              }
+            table {
+              border-spacing: 0;
+              margin-top: 1em;
+              margin-bottom: 1em;
 
-              td {
-                text-align: left;
+              tr {
 
-                &.narrow {
-                  color: @darkGray;
+                &:first-child {
+                  td {
+                    padding-top: .5em;
+                  }
                 }
 
-                &.wide {
-                  color: #777;
+                th,
+                td {
+                  &:first-child {
+                    padding-left: @padding-horizontal;
+                  }
+
+                  &:last-child {
+                    padding-right: @padding-horizontal;
+                  }
+                }
+
+                th {
+                  color: @darkGray;
+                  font-weight: 500;
+                  border-bottom: 2px solid @lightGray;
+                  width: 18%;
+                  padding-bottom: .25em;
+                }
+
+                td {
+                  white-space: nowrap;
+                  height: 1.5em;
+                  padding: .125em;
+
+                  &.narrow {
+                    color: @darkGray;
+                  }
+
+                  &.wide {
+                    color: #777;
+                  }
                 }
               }
             }
@@ -553,6 +584,10 @@ table.sortableTable {
 
             .nextPaymentSubmission {
               font-size: 14px;
+            }
+
+            .browserButton {
+              min-width: 80px;
             }
           }
         }

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -13,35 +13,6 @@ body {
   display: none !important; /* for testing/debug only */
 }
 
-#coinbaseLogo {
-  width: 40px;
-  height: 40px;
-  display: inline-block;
-  margin-right: 10px;
-}
-
-.coinbaseMessage {
-  display: inline-block;
-  max-width: 450px;
-}
-
-#appstoreLogo {
-  background: url('../../app/extensions/brave/img/ios_download.svg');
-  width: 130.5px;
-  height: 42.75px;
-  background-size: 130.5px 42.75px;
-  display: inline-block;
-  margin-right: 5px;
-}
-
-#playstoreLogo {
-  background: url('../../app/extensions/brave/img/android_download.svg');
-  width: 130.5px;
-  height: 42.75px;
-  background-size: 130.5px 42.75px;
-  display: inline-block;
-}
-
 .sectionTitle {
   color: @darkGray;
   cursor: default;
@@ -483,85 +454,8 @@ table.sortableTable {
   }
 }
 
-.ledgerTable {
-
-  tr {
-    th,
-    td {
-      padding: 0 15px;
-    }
-
-    td {
-      position: relative;
-    }
-
-    .th-inner {
-      font-weight: bold;
-
-      &:hover {
-        cursor: pointer;
-        text-decoration: underline;
-      }
-    }
-  }
-}
-
-.modal .dialog.paymentHistory .sectionTitle {
-  text-align: left;
-}
-
-.paymentHistoryFooter span.okButton.primaryButton {
-  background-color: gray;
-  float: right;
-  margin-top: -10px;
-  display: inline;
-  padding-top: 5px;
-  padding-left: 35px;
-  padding-right: 35px;
-}
-
-div.nextPaymentSubmission {
-  display: inline;
-}
-.nextPaymentSubmission span {
-  font-size: 12px;
-  display: inline;
-}
-
-.modal .dialog.paymentHistory {
-  padding: 0px;
-
-  .dialog-header {
-    background-color: #EEE;
-    height: 20px;
-    padding-bottom: 10px;
-  }
-
-  .dialog-body {
-    background-color: #FFF;
-    height: 300px;
-    overflow-y: scroll;
-  }
-
-  .dialog-footer {
-    background-color: #EEE;
-    height: 5px;
-  }
-
-  .dialog-header, .dialog-body, .dialog-footer {
-    padding: 20px;
-  }
-}
-
-.modal .dialog.coinbaseOverlay {
-  .dialog-body {
-    height: 100%;
-    width: 100%;
-  }
-}
-
-
 .paymentsContainer {
+
   @walletTableData: 235px + 30px; // .walletBar td (min-width + padding)
   @barMargin: 15px 0 30px;
   @fontSize: 14.5px; // .form-control
@@ -571,18 +465,322 @@ div.nextPaymentSubmission {
   width: 805px;
 
   a {
-    vertical-align: middle;
     text-decoration: none;
 
     &:hover {
       text-decoration: underline;
     }
+  }
 
-    img {
-      width: 1.5em;
-      height: 1.5em;
-      margin-right: 6px;
-      vertical-align: middle;
+  th {
+    color: @darkGray;
+    font-weight: 600;
+  }
+
+  .sort {
+    text-align: left;
+  }
+
+  .modal {
+    .dialog {
+      &.coinbaseOverlay {
+        .dialog-body {
+          height: 100%;
+          width: 100%;
+        }
+      }
+
+      &.paymentHistory {
+        .dialog-header,
+        .dialog-body,
+        .dialog-footer {
+          padding: 20px;
+        }
+
+        .dialog-header {
+          background: #EEE;
+        }
+
+        .dialog-body {
+          background: #FFF;
+          height: 300px;
+          overflow-y: scroll;
+
+          .paymentHistoryTable {
+            background-color: #FFF;
+
+            tr {
+              th {
+                color: @darkGray;
+                font-weight: 500;
+                border-bottom: 2px solid @lightGray;
+                text-align: left;
+                width: 18%;
+              }
+
+              td {
+                text-align: left;
+
+                &.narrow {
+                  color: @darkGray;
+                }
+
+                &.wide {
+                  color: #777;
+                }
+              }
+            }
+          }
+        }
+
+        .dialog-footer {
+          background: #EEE;
+          padding-top: 10px;
+          padding-bottom: 10px;
+
+          .paymentHistoryFooter {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+
+            .nextPaymentSubmission {
+              font-size: 14px;
+            }
+          }
+        }
+      }
+
+      .dialog-header {}
+
+      .dialog-body {
+        .board {
+          .panel {
+            &.advancedSettings {
+              padding-left: 50px;
+              padding-right: 50px;
+
+              select {
+                width: 100%;
+              }
+            }
+
+            &.recoveryContent {
+              h4,
+              span {
+                margin-bottom: 20px;
+              }
+            }
+
+            .settingsPanelDivider {
+              width: 50%;
+              position: relative;
+              float: left;
+
+              &:nth-child(1) {
+                text-align: left;
+              }
+
+              &:nth-child(2) {
+                text-align: right;
+              }
+            }
+
+            .copyKeyContainer {
+              display: flex;
+              align-items: flex-end;
+              width: 75%;
+              margin: 20px auto;
+
+              .copyContainer {
+                .copyButton {
+                  font-size: 14px;
+                  margin: 0;
+                }
+              }
+
+              .keyContainer {
+                margin-left: 2em;
+
+                h3 {
+                  margin-bottom: 15px;
+                }
+              }
+            }
+          }
+
+          .recoveryOverlay {
+            background-color: @black75;
+            border: 1px solid @black75;
+            position: absolute;
+            top: -1px;
+            left: -1px;
+            width: 100%;
+            height: 100%;
+            text-align: center;
+            z-index: 999;
+
+            h1,
+            p {
+              color: white;
+            }
+
+            h1 {
+              margin-top: 120px;
+            }
+
+            .spaceAround {
+              margin: 50px auto;
+            }
+          }
+        }
+
+        .bitcoinDashboard {
+
+          .coinbaseLogo {
+            width: 40px;
+            height: 40px;
+            display: inline-block;
+            margin-right: 10px;
+            background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAIAAACzY+a1AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAA+1pVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuNi1jMDE0IDc5LjE1Njc5NywgMjAxNC8wOC8yMC0wOTo1MzowMiAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczpkYz0iaHR0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iIHhtbG5zOnhtcE1NPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvbW0vIiB4bWxuczpzdFJlZj0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL3NUeXBlL1Jlc291cmNlUmVmIyIgeG1wOkNyZWF0b3JUb29sPSJBZG9iZSBQaG90b3Nob3AgQ0MgMjAxNCAoTWFjaW50b3NoKSIgeG1wOkNyZWF0ZURhdGU9IjIwMTYtMDYtMjFUMTY6MjM6MjEtMDc6MDAiIHhtcDpNb2RpZnlEYXRlPSIyMDE2LTA2LTIxVDIzOjIzOjMwLTA3OjAwIiB4bXA6TWV0YWRhdGFEYXRlPSIyMDE2LTA2LTIxVDIzOjIzOjMwLTA3OjAwIiBkYzpmb3JtYXQ9ImltYWdlL3BuZyIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDo4MUMwQzUwMzMwMkIxMUU2QjRFREQ0MEVEQkI1MzUzMCIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDo4MUMwQzUwNDMwMkIxMUU2QjRFREQ0MEVEQkI1MzUzMCI+IDx4bXBNTTpEZXJpdmVkRnJvbSBzdFJlZjppbnN0YW5jZUlEPSJ4bXAuaWlkOjgxQzBDNTAxMzAyQjExRTZCNEVERDQwRURCQjUzNTMwIiBzdFJlZjpkb2N1bWVudElEPSJ4bXAuZGlkOjgxQzBDNTAyMzAyQjExRTZCNEVERDQwRURCQjUzNTMwIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+dmddrQAAHspJREFUeNrkXWmwHFd1vud2z/JGb5O1b7ZlLbaMJAtwDBjHOEAlcQXbOGDWpAhJfqQqPwgUCSkoqqiQ5YepVCWpSqqAIrgqkISkgkNIUSRgZONYtjHgVQZJliVLwtqe9PS2eTO9nHTP9no5d52eeY9kkJHeTL+e7vv1Pec73z3nXLjx/sdZ9EJkmRdmf8Dsm9RvLR2DyR8x8zHmf0X7K9Lnx9x1ps6AuZvBxJXlLx8xPwJIX3P6azD/Ye5U+dsT3jjKhij9F2fka9j4saHhx+zwY1L8mAZ+jMSP0fgxGj/ic2QuMVI6+MmAF12OBD/qcTDDj2nih3b4oRQ/1MCPHmTUn385IDpHuvRkEk8M2RQUmizB45XBQucp6W/+rRT8mAg/GQIosCJcDAEK5pXchAqti+gadb8CNZ4fNfho92s6nyJqn194JDKUWDD6J1dyueb42VAYZm5CFdBQrAElkGi6QETJcMusOmq7QFRYNfJ+XZELNMCP2bnAgVJQVjwFZRbDXYALRKGbz0CIoudEAz/sI4Rgg8Bv8BRUJ4QwwE9laVGGtNsXBdVixOIQQsYUViwFVXESi/kndgSofApbjLQPCopyCmpiHPqkoDISpZpVQ6agrDj8Wkdw8W8PiIIyXSttYArkLtCQh5pRUANbhcpxQ2ZwyShRZyyi+EG5QDZsFU3bBSKaUhiKc1g7coqRiuNrnSie6UTxqOsC+47i7fHDAeGHRiEEauGHCTojmXfGLlClgvZFYQzxK9YFFhtCmKswolt2zVwgDlhFM6KgTGp55LeznCoos6cwSFy9a0ZhlATQCD9EE/xQoe8g8X/y2ykAP1YIBWX6IUT+6eMFq2iq422FTi2+qktBbb9ZzypYUFA98o30YPIBUlA2aBWmCBVN2wUaUhgcHAVNjwe61iqzPQU1c4FaKjYbBH79hRB6spUNBc2cy9W2b6YqzEApqNKhFeECC6eghVCYHBKuWQhhkEiBQ1NBVyIFZQOkoJmDuZmKZuUyrVRQpl7QYVIKOmgVTUUXVS6Qwo9pUdDMD7xfCirhVyYL8TYUtJCFXLkLVIaepO+XuECU+nM9+VS6al8gBe1rIZf9nFJQhQuUOQKmTWGQWvI1pqA/zwu52i6wGAqKVhRU30ugLIPNQkVbYSp2gSrMcqloKEUChXGh5MeBUlDD+aec7riM+GE/C/GSECJ/Tm7oAlXswyo9UEpwClLRCqCgqHnFYmBkuYRkCIca5+T9Uphic9HYwCiMHgUVukCU8ja9hSRlLhpDo2cOc4x0xZdDDJqCMrNyCA0Kysxy0YQUVHpOV+X3/h9RUEMXaFCO1AcFVT8TXPSBPQU1U2F+3sohrHJBNXPR1HE8dZFcw/MPuBxCg2hYamf9l0PoLuSqVDQ1hWFqCiP4VbffcgiLXA0jFY0Zu0BmmYuW+0p5XmQR5RDSj9TnxIQvtKgIXNnlEMl3kIVhiMja/2MQ/wfRf5EJiv9WzJpCXSAzozBMZkKTS77/18ohIrg8P/oT41YCKLmwquzUXF52uAssQBZ90gxwwQ/rzcD3Qg/DCFDXgZLDnR6qQ3CBwoVAM1rrGjjBwnJBNaJ4cwoTAbboBX4QjpXdXetqN24c27N5bMe62tqJyvrRcq3sRAhxDojoB+j74VwzmFrwpmcbpy/Xj52bO3Ju/vj5+fMzjUYQRmCXSxzU+PVbDiG0HqqJmxwZV/AVfZdD4PAoaBDiQtMfLfNbt0++fc+6N+9as3PDaKXsyC9wHWPb0+9MzTQOn5l55KcXDr544cjZCGKslh2nA2V/5RAGKox6/mVGBvb8+aP6JtSEgqKufi+M4gVkNPF1QWQPG/6G8cpd+zfcd/Pm/ddMsiJeTS/4wbGprz155tvPnZte8GpVN8JR4QLznShQy1nKFpL09A3Y82ePGrvAgoVstKAw0V/zdf+qWum9t2z58Ju3bV1TYwN4/fTMzBceOv5vPzzTCHCk5KAxfloUVN8FkiMTQ2hgQleAihbZtWYQNpvhXfvXf/xXdu7cNMYG/HriyMXPfP3F58/MlF3erwvsAz+Rc3HNyiGGhp/46yLLuaZW+tS9e+57w1Y2lNcbdq/ds37kRyemWxAOKBdNZZzE5MDVUNH6byqiRUFl61vd083WvZu2Tfz1e/fu3jzGhvV66cz0fxw6WilVWb4oejkoaGZkXEsKKqcwpuUQCkvQxW/Be8fedfe/b9/kqjIb4usfDx69ONeYGGehz7hbFWZF6augWMz8a4+MqzW/is9FE0MsOFWE33teu/H+9+8rl5xh4nd5pv7g4y+PVFv1Q14junVoo2himgyVOb3PuyjwlaDCKClMZD/v2bf+cx8YNn7R68HHXj5+cb4URZkQjRWEXiP06i1StTREei6Q9aOiSWQ/d4WHENFQzS36t1wz+bn37yu5w8av2fS/+vDRUsUB1tVqANBvhsh4qaKlBUrLIfpYHF46F1eo2MtdDrHoBZvHy3/1gX2jIyU29Nf3nj79zKnLlUqJMUi8DSxohs2F1nVDP+UQli4wPbZck05KuGc/KqicwmC8yoB/cu+ea9etGj5+0dc/8L0jyCGWvhNLGp1/hn6MYiyR6+GnvxCICX1KI8uS64YQBvlbuhRUnugKsQv0P3jL1jv3b2TL8Xr62PlHf3KuWiklrxiWbgYw8MNGXaupGSrXgPXaLyFhtlytSN6iqUg/FLR1uoYXXHvVyMfu3FkgKr4fXJ5t1BteGGLJ4bWR0nit7Ahc7D987+icF4xFELYWoICoGIkmQIDeQsxRwREGGdop3npuNXtCd2WqaC0Iw4+8bfvasUr/yE3P1g8+ffrgc2cOn54+P73oNf3I/LkA5aq7brx6zdrRAzvWvmnPxpt2rAPeMUunzs9880enatUSdE1CbvDa1hUQIxQX43iRO6LbR03jpKCgtMVyhx9CMA38FpvBga3jv/4LW/oEb3a+8aX/OvyVg0dePj8XApRKjuNGrq1tDjGcb56+0njqxKWvPXFitOzctG31u2/fed/tu1aNlP/lkWPnZxbHx0ZY++gsQ+95x+guon+FoV8HdwQiFBE1vIQ5fkhPX8REle9wKjo1K3I9P/yd266u9BcFPvniq3/85UM/PnmpOlKujUXj25k3rW/vOrVyNAqlGM4gfPLk5f/50uNfOXj099+x99+ffKVSLXeQyuOXvZ+Yl2IUL7pVSM9FIwpqgV/83Td89vsFVeSiwUKu1FxHXnDH6to3P/rGWtW1xu+fHznyiQceX/DC2kiEBAfOlixiG8R43BEzBBix0fQhZKWyy12eYqIS/JJ8xy2DU2LdTB39wVFTUCTwY73WQaYqtp4QZFmR22iEd792Qz/4/eujx/7gi49ByanVKhChB+m4rqet9DSWVtgAGIMaR4EYm8/YgmYoTPod0jCi34gP5CVM0g9diV8Xv6wvtKjIHQQF7YRbAV414t59wD6QeObouT/68qEIv3LZbeEHWRqS4W6QRLaDXOKX8vj13obsLbcJjt9kkTV13AJcoHT+deLClbY7RERkXnfNxHUbLNeS5uvNj3/50JwfSvFjBH4JHCGX+ZTGDyX4tf8dBk0MPLULNKYwBDR8OBRUO5cJgwDffuO6/Mhqvj7/rRcihlmrlqX4IY0fMiDGOrKvUvzStrn3axihGBlVTfyYJoXJVxUgX1HlEFHEPVbhb9p5lR1+Z6fm/v6hn0T8RY0f08ePKfBDAr/OJ4HXdo0KFVtbCyOrstJNS/L5r9hXCME0Wyv3Vgb8cMfa2o4No3YQfvXho6enF0ulEuMq/JgGftDCL4uVAD+aogCGfnYu5lVsNKOgmdHm1hrwACpyMYJw/9Zx17W5qoVF78EnTlQqZQDSxsm+nTgCIPdMAqGtAFMxxgjFoDUXC6OgmTe5vQvUoqBokE4fH4v7r56we6ae+um5o2dn4zVhSF5QQpcWtFKAPF0EEJsZ6tmQ5aJBW4QLeyjKVFAhfij2qXzAFNSgqU/0p+rw6zdactHvPHumGSLnkB1jadwL+bvOCmpaQTONHySdZBhGwQaikBwgs8Av+owvNwVdOi7ioqtrpavXjFjgFwThUy9dLC0JcpDGD5EMHvI3AswYP1EuE+QMbxiGXhNRukODBgXNHMCXjYLmRiCCcM2q8uSoTXbaq1PzJ8/Plkq8q4IyJX7ZG4E8fmCIH1L49Z7T9he05Jsw0BkZEQXN/BaX6T6mFbn6Oh1Bo5kf4obJil2C08vnZi7Xmy0rKogVUIof8U9QmV1xLhqhw0Fq4H0vsdxvQ2GSvyVtWsKUFAYL3B0iCgq32q4OHn91xvOxJ2YnDSOq8YP0CCciqnRgopWLRpSd5pWBiN80OyiiOJ9NKzmKSrwwMaGsGPw6/h7HbXN8z16eDwGyJhRQgV97xCGfjp0zoTL8klp53pdS+VHQkW9Y4AvmH8opTHIQ3eJVUGaDX/s1VrNMU3v1yiJwDfwIy5gVs4mnEORhVFqyQZoPdw7LCAOhF7/BXUETRtrjZF6uisIwGX3qj4JmmHT04E1ULdd4L881nXaemRw/tMJPSWGycSTq4NcJMKKJGPEt7ipVGNHI88w8zc2/nNCOtiqaQp+Lf6iVLdcI/Ya/RCIg+xACwS3zghpFe4AYQHP8SCqUMKlhgB2LqsKPGk+uzSA1qKVufQFNlxxgI67dCgU2wxC6elbmYjpzk8BPMNeQUF7EFBSYRDNVEJWEm8QgMqoqa0fbM9fQBdpU5CpdYOvI+GHmtg8RJvBDE/ywE7ERdIPEL3X1ALnBAY3nGmnFNQzizhuOK4niycHkKwO/+I5CjDuK2LyAucDziXiQ4SGQVrzs8RNMXB38sJe2k4/iISblsWskR1uYqsQLCCGYmQojSLLCgOG8F9hhWHI5IiZSlBLcZkn5hHQuGujiR7AI0NAyROE1UAPWgz9sLfejLqVor9oPdoMy3da8MQupN0M7U1qruSHLpnhmlOv0HQjDNQ3vDTLGj2mXzHIygsYES6Go2vOb21XkFr1BWefT6bpnB+GGyWoQZoQWpPBDGr+MMCeioJLD0g+jbE6ihjgaz8Yguwgv8FtcT0UTRBmFNTFEFkaXAnPzTTsIN43XeMggbwdJ/BjTDnWkNFbzF5MeN2t3JGfDdsionA/czAX205dQ3hq05ZguLVhCuGX9GOcJcRlZKmLLxAqY/WoJDJiUAZSiSXsFCwUakEBYED8QiKGfzINC4eZ32iraoPbIbb3hOHB6umEH4e5NE6MVN0yKh6mIG9Mxhyl+OSeJQOPHKPyQxk9VxdkFIPQxFDcEQ0Lm1sCvGAqaPZXL+YXLi4sN3wLCbevHNk3W/CBYUpx18FP6kA5+GYmKmkAEfkDhBxR++ayq9HyIUIwIu6CwjROzyniDMmZFQbOniizh+fnGhRmbibhqpLTvmslmM4jHl8h8UeGX45lLsQmBX+5+afzyTzYQKlrex5L2LAxaKBIzhxeRi4ZaHl4lHjk87kzyyoV5O1v6S6/ZRAVdmCOIVMIa5vADEAIjDjHS+JGBPw2qlj8K4+a4+SO5etCHtjsEsEaIh8/M2EF4+97NG8arvh+m4jMGxPo5TRdRPdyYtYmJKsM8pPQJEfXwy1oEaNMbxGzozJd9d4hu8NPKLQF45uS0ZVyxdvQtr9lYb3qy6Z6nizn8kCXmH0rxY2L8sG/8MI3f0pwOOyEjERf2U85iSmEEdrpc4s+eumLHaKLXh9+6u8p5GCAR1grpfho/ANowUm1V0QC/9DCAKsZU8OEw6Re5HD/dXLRCNriCuDv2K1P1F09fsYPw5us33Hlgy/yiR+BH0/30cwpAT6yc7wNh5J+5X0gE6gn89EPq9sG5VZ34AsMwEVT0WQ5R3AZlESmd98KDhy8w29fH771pdbXkBaEUv6zk3aqYJ8t3s7lokLljFOCHQOEHdJEp6Y+AAhtTNQAxipgJ7XUpqEqk0KOg5KvswkMvnAsCS737+m2rP/HOffW6hyrlOk1apeXXUpJDzEmhdqq7EC+o3cnn3sQqHC+SgqIhBaX8bqXkPH965jlbUhO9fvdX93zwtutmZxsCugjZvmiQW+nvRQUowq+3ZJ9DOj3/lqYgvScG6uqxBH6d8ztr3vJbhW1wxbQoKJNtUBZf5lzdHyvxO/bZ1moDvHXf5pM/m/nRyUutvQqACteWHHCmHCJsVRrHG1YkKhSBeMYpPSWXN97pRQ1Uoj/JB0E02QXqPLAIwg/ZUBiDEIIpXWA2VgU4PTX/rlu2WndMcF3+y6/bNjffeOrohYifug6nDCNkMm2i7683Ao7s1167dWqmseAFHKj5xzTxQ8SeRCBNpGDpdU2le8KURpGAcIVsUAYQkZoL041N4+XX71xjbU4j2N5+YOuuDWNHXrl8+tJCiOCk0xR7Xx7vLhOEC3Wfh+xNO9f+xW/e/NF37nvupQvPnLgcWXXi4UdSzxTgJxRMMI8fKvXLHH7R310IzStyC5h/gt9qP/onzs6++41bq2X71iXR64Ztq9916/arV9fmF5pTVxqz9eaiFzRb2wHVvdBrhn4QVh3YsXb07puv/vR9B/7wXTft2BwXOK6qOA8eOtFrFYVK/FCJH5rjByL8koEl7P70QwNUYYjLzu+xSqEehtMzi5+8+4aP3XMjK+IVRcNHfzb9/IlLpy/On5ttNEOcqLrrV1XWX1XbvWX8uo0T1UrqWfG84J2f+fYPT12O3k9GHjr4ZXVY1MGPaaYstfFLntIdDn4SCkoLE8BqtdIXvnv8nlu27tg03j+EwGH31tXRH83jSyXn3b+4/YkHLrKKK8CPUYkwJH6SwYRUnrk+fgKNdID4me7RGT2YruNMLXif/drziMiW43X3G6+9es0qr6Ob6+YoU/ghfbMt14xESAZEPJvRSjOr9gOhoH3g16t3H62V//PZsw9856VlgXDN5MhdN2+rL4p1c8y31QCZ5kwHCTn8kB4Z6BWKpOc9L5rCIOUCNfDLvxsRCQ4j1dKffv3wD49cXBYU33fHjrGKG2akIsGCsUE5BCU6CPUfbOcwi3afBW6jojHdgw1MINlGF5hb4gtB+JEv/uDU+bnhQ7jn2jW337ixvhhQj6Aw7FYNBAjmA5CWKdmRmIz3+TJQUKa9zXjL2Y9U3CNT9d/+uyemZhaHj+Jv3LGDI4pT7qmRRwlxA4EETSZqtHPQxR1/6U0OhkBBdfdY7XpwDqOryj8+eeVDf/P4hSvDRvGOA1tes22y4bWycvK5aJ3FdLnFoivu1fglHwdxvisvUoXpm8LQd9hqDTq+qvz4san3/+WjJ16dHSaElbL7ntu2NxsBtUQBBhWBqfaK9JqwmO3IpgZfHhVNgV/eWMWN8SZGy8+duvKe+x95+NlXh4nivbdu3zJZ9YMwNe4G+C0tE6bJHtALxZB7Vyq5OWtu/9CyqGiKcwma+rgl59KC940nTqEfvn7nGsfhQ4Awim1OnJt98sjFTq/wbnKbFn6QKZFLLumSNFyCH5BwJiBkTDumYSoKo8FmhTs5CK8EW3ql68bVEw89d/bQC+euXVfbtn500BB+69DLX33k+Oyi33liQGMdGTF/JKrw69pm8pTCng2w61PfLcqEGlJQ0lHL6qp6zfDaGwEtLDRLjN3z+o2/d+fufTvWDwK8x54987ffeOG/n/kZlJ1KucTabb4ZUzQVad9vWuZGjfknHhmQDE4LwmVS0ey3iceQhfEoRkF3BOSoE75t7/oPvGXnrXs3VasF7M51abr+8NOn/+ngse8fPtcIcaRWdrjDeD/4MWKhg8YvPzIgfbgBdn3yO5QnWhYKg2Z7rLbreuPqH5yfX3D9xvWbxt9605bb92/au33NutVmO3U1Gt6p83M/Pnr+4WfPPvbiuZMX55kDI1WX89bOdzL8cgORWyZE2UIVhR/L5XuIGU0CwiFTUKbcJl5zj2Nszcgw9P3F+kKz4UdTZtPEyK7N4zdsmdi9dXLLVbWJierkqkq8O1Oror8RhPVmcGW+OTuzeH5m8fjZmRNnZ46dmXllan56wQs5r5bdVke+9tYHkEx7WR78mGwRIwuhHgVFBQWVLATquEBigyuxetA+oiWgRDiGfjMMgigA8Dw/8ONOJpV40wheKTsjDkRGNooMFsMwCvOiA+P961plChzAdZ3oT0xYepscdNae+8cPROOZTonSxy9FbVxzFRQtBVUJfkyMn6Ye2x7yCAFejcApOX7cmzRsra6F8dA3Q2y0kkuhsxUF4xU3OrYEvSTE9idJApiu2lfWAwHohWSMwo/S2zTww8xGsBblEMVTUNEJNfdYhWjOVdDnGHjgtPcOYYlFml6UBthbbu/134PEki0C1TFYTGGEfAI05l/GlknaaRChhTtEFVQ1/4xcIE34urQ98noA3c0+2okN0FNJELpDi0BLlyyLn7I1ryCSo18A1JOdvxKigoeYQu7yqaBMN4Qw2+O4e3DEJOOtk72W+8v3LRHnEpK5aJrTAqXSCCIAEx8sbaZBZ6h2NdIBqmiy3SGkFJTpzT8mwK97d/EmZsCzTfMkFBF08ENaSjHCL+uLQBofZ5eCE1eFXE1D9FU0VLZwUHMiVCp8kj1WibLTiGuWmcOzn4vw0+NZLOFjMzREVA4BILkLCX4gx4+1tt2yqsjVzUVDoQqT/AnF01Be16+3R2fEcACcxFIB1WObwg9FxUIZ/KSWgZrbyf9A5VzE+EHXkBpRUEMXyNQqmh0FzX6JYoOyuPNuu20rOWRUzZ+QwgCZoSvMBQUmGRmQBmzSSlLItpTVUmEMKSjSIYQdhclcEop2ZxE2vY0T/XmZ2nQJRHusZk+4pNTk0kGF809CDiT4AV1aTFWcc52mPmYUVMV4LPGTtB3RwK+HQavhJzAZ8xdQUKCWZ7v4Id3uUoqfeJsn2nwl8UtyNrn8YENB0UrFlrtWZIJiONTrOJZO44hQBBD6CtIVGeIHYvyYCD/Uxg8liRfFUlA9WQ4FoZ7UvevyLHraxii2gw3N1WbRLlzAlJ17iSdRhZ/kRRFedwAU1GwhV4+C5rmCRtNGmVlG4A6GwJZaRwgoqHT+kY8dCEcGpCEu0C4DFeSGF63CsCJdoIyCartAcZZlnC6+tLsANQzCAkFIkSpM2k+RZwDpEhsohg+E98L7rMhVU1DrhcAcalL8mBl+mHaNNH70mkiqHXRW30TGpE823WNfiB8utbtFnW23iiiHsEukMKMw5DlRuFTAmIqyAeNONkQGmkuIrkickg/C2yOiEQo/piCSvN/5xyQU1AQ/tFLRZLuXivHLUtBWbBjXcXNqFy4xfpjpaYokfuIwSNajPYuf0DeBq2SMCp6FehTUunmNnMJoUlAm26AsQQyclpGkimBS+DFq/qFIPhE83LIdSdT4YXbVXruchZnkoknCB8uFJDWFkZ6TKVUY4PFmCdlt6ch9C1EaBCCI2QlmemdSoo582qQuzNV5tM0pTBELgbIpJu3br9sxlY7iY3MK8TbYOa0kZUJlTdq7awuiikC9+5W786XJ79q7wEHjp6/CaFJQDfySwT9GFhUpi6CPn3z+KaNsDfyyGqkNhWFK/Fh/IQRT9502bLeiWQ4RoZhWwAWdoCj85NZVSEE1xKwMfphkpCj0Hyin+yoKigqHakNBkaagmtvEa29QBox390gnl3SF+OnpGyJFHMU6dT5WRS6kMKrv1stFE9EIGfBoQkH1ZD/xG6oNytquUY0fU+EneW4guxAvMKF0J2JeJIUR6KWmFFQnslS4QNQ3ocoNytrVjRxkjzeIHzpQRL06zlEYYmJy2y39XFAzCsPY8lFQVC4k6WxQ1s2VihUcMnsXxIUGoJD4sx1KUD19MdFTuj0LDSmoum54SBQUTVU0VFTEI1IPQPo4ztNZa+nWvyR+koEC1fPNtFrqcV0ih0y7nGVlUFCdhVyd+cdyLSs6nV5AOjIgNk5LogCqx0cQOzEUtEswrsgtohxCLwzXUtFkgqQWBSW+hC544FI+BQq2BRIzR5NUyZ242hRm8OUQwiMN983Qz0UTPumq3Oh2GUZcFKVdkSsU5chrhjwKohvnhVNQ1lc5ROH4oaKpj3SPVYUVAS4QNwUPItHhQhc/ybBzK/z6ozDIFOUQiunSp4qmsBkareITI9PO9k+t3ArMH0isQuYhQNmjjjJD2k85hBWFYSa5aDgQFU1GqpTnXyI44ug2t7WvlMKAYA8QJllV5XQuGkooWd8VuUoKygpQ0frCT10elKvIBTDGLzv5QCE5C+w8b61zoswR6VeK6FNQbbdqpaIVTkGZ1sVkssKV+GlEtKgQCVsOOWwsAHfI1Fh1Oj1jQ8hFQ7OFJFRQULPdigzbdWTqX0CzkpRuY6lK92qvUnjOyDU3x5UCpZF0pnp/6fQqgVx3IV4xrVH9dvG7FanIAXQzuYVbu6IigmTSxKLOZiTQKn2dR5x22LW3Oc25cGEGw2a7RwcQTbzbLSVANf+QepqApVdO01MMaPEic7OSTEnUnn/MerciVbuVvGOLbytcSoCRuUDaziO9Dze2Tuu1wLuCuDC36P2vAAMAt4+866Gti10AAAAASUVORK5CYII=') 0 0 / contain no-repeat;
+          }
+
+          .modal {
+            .qrcodeOverlay {
+              border: 0;
+              width: 350px;
+              height: auto;
+              margin: 100px auto 0 auto;
+              background: white;
+              box-shadow: @dialogShadow;
+
+              &.fade {
+                transition: @transitionFast;
+              }
+
+              img {
+                clear: both;
+                display: block;
+                margin: 0 auto;
+              }
+
+              .dialog-header {}
+
+              .dialog-body {
+                padding: 30px;
+
+                .bitcoinQRTitle {
+                  color: @braveOrange;
+                  text-align: center;
+                }
+              }
+
+              .dialog-footer {
+                .qrcodeOverlayFooter {
+                  display: flex;
+                  justify-content: center;
+                  background: @gray;
+                  padding: 15px 0;
+
+                  .appstoreLogo,
+                  .playstoreLogo {
+                    width: 130.5px;
+                    height: 42.75px;
+                    display: inline-block;
+                  }
+
+                  .appstoreLogo {
+                    background: url('../../app/extensions/brave/img/ios_download.svg');
+                    background-size: 130.5px 42.75px;
+                    margin-right: 5px;
+                  }
+
+                  .playstoreLogo {
+                    background: url('../../app/extensions/brave/img/android_download.svg');
+                    background-size: 130.5px 42.75px;
+                  }
+                }
+              }
+            }
+          }
+
+          .board {
+            .panel {
+              padding-left: 100px;
+
+              .settingsPanelDivider {
+                width: 50%;
+                position: relative;
+                float: left;
+
+                &:nth-child(1) {
+                  text-align: left;
+                }
+
+                &:nth-child(2) {
+                  text-align: right;
+                }
+
+                .fa {
+                  position: absolute;
+                  left: -45px;
+
+                  &.fa-credit-card {
+                    font-size: 30px;
+                  }
+                  &.fa-mobile {
+                    font-size: 50px;
+                  }
+                }
+
+                .walletAddressText {
+                  font-size: 12px;
+                  color: black;
+                  margin-bottom: 20px;
+                }
+
+                .bitcoinIcon {
+                  position: absolute;
+                  left: -5px;
+                  top: 0;
+
+                  .fa-circle {
+                    color: @bitcoinOrange;
+                  }
+                  .fa-bitcoin {
+                    color: white;
+                    transform: rotate(12deg);
+                  }
+                }
+              }
+
+              &:last-child {
+                margin-bottom: 0;
+              }
+            }
+
+            .panelFooter {
+              .coinbaseMessage {
+                display: inline-block;
+                max-width: 450px;
+              }
+            }
+          }
+        }
+      }
+
+      .dialog-footer {
+        .advancedSettingsFooter {
+          padding-top: 20px;
+          padding-bottom: 20px;
+          display: flex;
+          flex-wrap: wrap;
+          justify-content: center;
+
+          .recoveryFooterButtons {
+            float: right;
+          }
+        }
+      }
     }
   }
 
@@ -643,6 +841,51 @@ div.nextPaymentSubmission {
 
     .boldText {
       font-weight: bold;
+    }
+  }
+
+  .paymentsSidebar {
+    opacity: 0.8;
+    width: 200px;
+    float: left;
+    margin-left: 23px;
+
+    .paymentsSidebarPIA {
+      background-image: -webkit-image-set(url(../../app/extensions/brave/img/private_internet_access.png) 1x,
+                                          url(../../app/extensions/brave/img/private_internet_access_2x.png) 2x);
+      width: 195px;
+      height: 20px;
+    }
+
+    .paymentsSidebarBitgo {
+      background-image: -webkit-image-set(url(../../app/extensions/brave/img/bitgo.png) 1x,
+                                          url(../../app/extensions/brave/img/bitgo_2x.png) 2x);
+      width: 100px;
+      height: 25px;
+    }
+
+    .paymentsSidebarCoinbase {
+      background-image: -webkit-image-set(url(../../app/extensions/brave/img/coinbase.png) 1x,
+                                          url(../../app/extensions/brave/img/coinbase_2x.png) 2x);
+      width: 100px;
+      height: 35px;
+    }
+
+    div {
+      font-size: 12px;
+      margin: 50px 0 20px 12px;
+    }
+
+    a {
+      div {
+        margin-top: 0;
+      }
+    }
+
+    h2 {
+      font-size: 18px;
+      font-weight: 200;
+      margin: 70px 0 -15px 12px;
     }
   }
 
@@ -742,31 +985,6 @@ div.nextPaymentSubmission {
       }
     }
 
-    th {
-      text-align: left;
-    }
-
-    tr {
-      height: 1em;
-    }
-
-    td {
-      font-size: @fontSize;
-      padding: 10px 30px 0 0; // .settingsList .settingItem > *:not(.switchControl) 10px
-      width: auto;
-      min-width: 235px;
-      vertical-align: top;
-
-      .settingsListContainer {
-        margin-bottom: 0;
-
-        .fundsSelectBox {
-          width: auto;
-          margin-bottom: 0;
-        }
-      }
-    }
-
     .fundsAmount {
       display: inline;
       margin: 0;
@@ -783,168 +1001,64 @@ div.nextPaymentSubmission {
     }
   }
 
-  .sort {
-    text-align: left;
-  }
-
-  #paymentHistory {
-    background-color: #FFF;
-
+  .ledgerTable {
     tr {
-       th {
-         color: @darkGray;
-         font-weight: 500;
-         border-bottom: 2px solid @lightGray;
-         text-align: left;
-         width: 18%;
-       }
-       td {
-          text-align: left;
-          &.narrow {
-            color: @darkGray;
+      height: 26px;
+
+      &.paymentsDisabled {
+        opacity: 0.6;
+      }
+
+      th,
+      td {
+        padding: 0 15px;
+      }
+
+      td {
+        position: relative;
+
+        &.alignRight {
+          text-align: right;
+        }
+
+        .site {
+          .verified {
+            height: 20px;
+            width: 20px;
+            background: url('../../img/toolbar/verified_green_icon.svg') center no-repeat;
+            display: inline-block;
+            position: absolute;
+            left: -10px;
+            top: 3px; // (26px - 20px)/2
           }
-          &.wide {
-            color: #777;
+
+          a {
+            height: 24px;
+
+            .fa-file-o {
+              font-size: 15px;
+              margin-right: 6px;
+              text-align: center;
+              width: 24px;
+            }
+
+            img {
+              width: 1.5em;
+              height: 1.5em;
+              margin-right: 6px;
+              vertical-align: middle;
+            }
           }
-       }
-    }
-  }
+        }
+      }
 
-  tr {
-
-    th {
-      color: @darkGray;
-      font-weight: 600;
-    }
-
-    &.paymentsDisabled {
-      opacity: 0.6;
-    }
-
-    td {
-
-      a {
-        vertical-align: middle;
-        text-decoration: none;
+      .th-inner {
+        font-weight: bold;
 
         &:hover {
+          cursor: pointer;
           text-decoration: underline;
         }
-
-        img {
-          width: 1.5em;
-          height: 1.5em;
-          margin-right: 6px;
-          vertical-align: middle;
-        }
-      }
-
-      .fa-file-o {
-        font-size: 15px;
-        margin-right: 6px;
-        text-align: center;
-        width: 24px;
-      }
-
-      .verified {
-        height: 20px;
-        width: 20px;
-        background: url('../../img/toolbar/verified_green_icon.svg') center no-repeat;
-        display: inline-block;
-        position: absolute;
-        left: -10px;
-      }
-
-      &.alignRight {
-        text-align: right;
-      }
-
-      input[type='range'] {
-        background: transparent;
-        -webkit-appearance: none;
-        width: 90%;
-        margin: 0 0 0 20%;
-        outline: none;
-
-        &::-webkit-slider-runnable-track {
-          -webkit-appearance: none;
-          background: @gray25;
-          border-radius: 1000px;
-          height: 1em;
-        }
-
-        &::-webkit-slider-thumb {
-          -webkit-appearance: none;
-          background: linear-gradient(to bottom, @braveOrange, @braveDarkOrange);
-          width: 1em;
-          height: 1em;
-          border-radius: 50%;
-          box-shadow: 0 0 6px @black25;
-          cursor: pointer;
-        }
-      }
-    }
-  }
-}
-
-.bitcoinDashboard {
-
-  .modal {
-    .qrcodeOverlay {
-      border: 0;
-      width: 350px;
-      height: auto;
-      margin: 100px auto 0 auto;
-      background: white;
-      box-shadow: @dialogShadow;
-
-      &.fade {
-        transition: @transitionFast;
-      }
-
-      button.close span {
-        color: @gray;
-        font-size: 2.5em;
-      }
-
-      img {
-        clear: both;
-        display: block;
-        margin: 0 auto;
-      }
-
-      .dialog-header {}
-
-      .dialog-body {
-        padding: 30px;
-
-        .bitcoinQRTitle {
-          color: @braveOrange;
-          text-align: center;
-        }
-      }
-
-      .dialog-footer {
-        .qrcodeOverlayFooter {
-          display: flex;
-          justify-content: center;
-          background: @gray;
-          padding: 15px 0;
-        }
-      }
-    }
-  }
-
-  .sort {
-    text-align: left;
-  }
-
-  .board {
-    .panel {
-      padding-left: 100px;
-
-      &:last-child {
-        margin-bottom: 0;
       }
     }
   }
@@ -961,86 +1075,6 @@ div.nextPaymentSubmission {
     margin-bottom: 8px;
     padding: 25px 20px;
 
-    &.advancedSettings {
-      display: flex;
-      flex-wrap: nowrap;
-
-      .settingsPanelDivider {
-        width: 100%;
-      }
-
-      .settingsPanelDivider:nth-child(1) {
-        .settingsListContainer:last-child {
-          margin-bottom: 0;
-        }
-      }
-
-      .settingsPanelDivider:nth-child(2) {
-        display: flex;
-        align-items: center;
-        width: auto;
-        margin-left: 1em;
-
-         .settingsListContainer:last-child {
-           margin-bottom: 0;
-
-          .settingsList {
-            display: flex;
-            flex-flow: column nowrap;
-            justify-content: space-between;
-
-            .settingItem {
-              display: flex;
-              margin-bottom: 1em;
-
-              &:last-child {
-                margin-bottom: 0;
-              }
-
-              label {
-                margin-bottom: 0;
-              }
-
-              .switchControl {
-                margin-top: 2px;
-                padding-top: 0;
-                padding-bottom: 0;
-              }
-            }
-          }
-        }
-      }
-    }
-
-    .settingsPanelDivider {
-      width: 50%;
-      position: relative;
-      float: left;
-
-      &:nth-child(1) {
-        text-align: left;
-      }
-
-      &:nth-child(2) {
-        text-align: right;
-      }
-      .fa {
-        position: absolute;
-        left: -45px;
-
-        &.fa-credit-card {
-          font-size: 30px;
-        }
-        &.fa-mobile {
-          font-size: 50px;
-        }
-      }
-      .bitcoinIcon {
-        position: absolute;
-        left: -5px;
-        top: 0;
-      }
-    }
     #bitcoinPaymentURL {
       cursor: pointer;
       background-color: @lightGray;
@@ -1099,15 +1133,6 @@ div.nextPaymentSubmission {
       color: @braveOrange;
       margin-bottom: 5px;
     }
-    .bitcoinIcon {
-      .fa-circle {
-        color: @bitcoinOrange;
-      }
-      .fa-bitcoin {
-        color: white;
-        transform: rotate(12deg);
-      }
-    }
 
     .primaryButton {
       min-width: 180px;
@@ -1126,35 +1151,15 @@ div.nextPaymentSubmission {
       line-height: 1.3em;
       margin-bottom: 60px;
     }
-
-    .copyKeyContainer {
-      display: flex;
-      align-items: flex-end;
-      width: 75%;
-      margin: 20px auto;
-
-      .copyContainer {
-        .copyButton {
-          font-size: 14px;
-          margin: 0;
-        }
-      }
-
-      .keyContainer {
-        margin-left: 2em;
-
-        h3 {
-          margin-bottom: 15px;
-        }
-      }
-    }
   }
+
   .panelFooter {
     color: @darkGray;
     font-size: 13px;
     font-style: italic;
     padding: 20px 20px 20px 50px;
   }
+
   &.contrast {
     background: @highlightBlue;
     color: white;
@@ -1163,35 +1168,11 @@ div.nextPaymentSubmission {
       color: white;
     }
   }
+
   .disabledPanel {
     div:nth-of-type(2) {
       padding: 15px 0;
     }
-  }
-
-  .recoveryContent {
-    h4,
-    span {
-      margin-bottom: 20px;
-    }
-  }
-
-  .recoveryFooterButtons {
-    float: right;
-  }
-}
-
-.advancedSettingsFooter {
-  padding-top: 20px;
-  padding-bottom: 20px;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
-.recoveryOverlay {
-  .spaceAround {
-    margin: 50px auto;
   }
 }
 
@@ -1288,62 +1269,6 @@ div.nextPaymentSubmission {
       width: @switchNubDiameter;
       box-shadow: @switchNubShadow;
     }
-  }
-}
-
-#paymentsSidebar {
-  opacity: 0.8;
-  width: 200px;
-  float: left;
-  margin-left: 23px;
-
-  .paymentsSidebarPIA {
-    background-image: -webkit-image-set(url(../../app/extensions/brave/img/private_internet_access.png) 1x,
-                                        url(../../app/extensions/brave/img/private_internet_access_2x.png) 2x);
-    width: 195px;
-    height: 20px;
-  }
-
-  .paymentsSidebarBitgo {
-    background-image: -webkit-image-set(url(../../app/extensions/brave/img/bitgo.png) 1x,
-                                        url(../../app/extensions/brave/img/bitgo_2x.png) 2x);
-    width: 100px;
-    height: 25px;
-  }
-
-  .paymentsSidebarCoinbase {
-    background-image: -webkit-image-set(url(../../app/extensions/brave/img/coinbase.png) 1x,
-                                        url(../../app/extensions/brave/img/coinbase_2x.png) 2x);
-    width: 100px;
-    height: 35px;
-  }
-  div {
-    font-size: 12px;
-    margin: 50px 0 20px 12px;
-  }
-
-  a {
-    div {
-      margin-top: 0;
-    }
-  }
-
-  h2 {
-    font-size: 18px;
-    font-weight: 200;
-    margin: 70px 0 -15px 12px;
-  }
-
-  a {
-    div {
-      margin-top: 0;
-    }
-  }
-
-  h2 {
-    font-size: 18px;
-    font-weight: 200;
-    margin: 70px 0 -15px 12px;
   }
 }
 

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -732,10 +732,20 @@ table.sortableTable {
                   }
                 }
 
+                .bitcoinAddressButton {
+                  margin-bottom: 15px; // .walletAddressText
+                }
+
+                .walletLabelText {
+                  font-size: 1em;
+                  color: @braveOrange;
+                  margin-bottom: 5px;
+                }
+
                 .walletAddressText {
                   font-size: 12px;
                   color: black;
-                  margin-bottom: 20px;
+                  margin-bottom: 15px; // .bitcoinAddressButton
                 }
 
                 .bitcoinIcon {
@@ -1082,22 +1092,6 @@ table.sortableTable {
         background-color: @gray;
       }
       font-size: 0.9em;
-    }
-
-    .bitcoinAddressButton {
-      margin-bottom: 15px; // .walletAddressText
-    }
-
-    .walletLabelText {
-      font-size: 1em;
-      color: @braveOrange;
-      margin-bottom: 5px;
-    }
-
-    .walletAddressText {
-      font-size: 12px;
-      color: black;
-      margin-bottom: 15px; // .bitcoinAddressButton
     }
 
     .settingsListTitle {

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -504,7 +504,6 @@ table.sortableTable {
       }
     }
   }
-
 }
 
 .modal .dialog.paymentHistory .sectionTitle {
@@ -565,10 +564,27 @@ div.nextPaymentSubmission {
 .paymentsContainer {
   @walletTableData: 235px + 30px; // .walletBar td (min-width + padding)
   @barMargin: 15px 0 30px;
+  @fontSize: 14.5px; // .form-control
 
   position: relative;
   overflow-x: hidden;
   width: 805px;
+
+  a {
+    vertical-align: middle;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+
+    img {
+      width: 1.5em;
+      height: 1.5em;
+      margin-right: 6px;
+      vertical-align: middle;
+    }
+  }
 
   .titleBar {
     overflow: hidden;
@@ -609,15 +625,14 @@ div.nextPaymentSubmission {
     border-radius: @borderRadiusUIbox;
     margin: @barMargin;
     padding: 40px;
-    font-size: 1.3em;
-    line-height: 1.3em;
+    font-size: @fontSize;
+    line-height: 1.8em;
     color: @mediumGray;
     width: 500px;
     float: left;
 
     > div {
       padding: 0.5em 0;
-      font-size: 14px;
     }
 
     > h3 {
@@ -632,18 +647,55 @@ div.nextPaymentSubmission {
   }
 
   .walletBar {
-    padding: 20px;
-    padding-bottom: 10px;
+    @itemMargin: 12px; // button, .nextReconcileDate, .accountBalanceError, .nextReconcileDate
+
+    padding: calc(@itemMargin * 1.5);
     background: @lightGray;
     border-radius: @borderRadiusUIbox;
     margin: @barMargin;
 
+    th {
+      text-align: left;
+    }
+
+    tr {
+      height: 1em;
+    }
+
+    td {
+      font-size: @fontSize;
+      padding: 10px 30px 0 0; // .settingsList .settingItem > *:not(.switchControl) 10px
+      width: auto;
+      min-width: 235px;
+      vertical-align: top;
+
+      .settingsListContainer {
+        margin-bottom: 0;
+
+        .settingsList {
+          .settingItem {
+            .fundsAmount,
+            .fundsSelectBox,
+            .addFunds {
+              min-width: 180px;
+              width: auto;
+            }
+
+            .fundsSelectBox {
+              margin-bottom: 0;
+            }
+          }
+        }
+      }
+    }
+
     .settingsList .settingItem {
+
       .paymentHistoryButton {
         display: block;
+        font-size: @fontSize;
         color: @braveOrange;
-        font-size: 14px;
-        margin: 0;
+        margin-top: @itemMargin;
         padding: 0;
         text-align: left;
         cursor: pointer;
@@ -655,6 +707,10 @@ div.nextPaymentSubmission {
         vertical-align: 0;
         height: 100%;
         margin-bottom: 0;
+
+        span {
+          font-size: @fontSize; // for "Loading..." and .fundsFAQ
+        }
 
         > span {
           height: 2.25em; // .form-control
@@ -670,12 +726,18 @@ div.nextPaymentSubmission {
         }
 
         + button {
-          margin-top: 12px; // .nextReconcileDate
+          margin-top: @itemMargin;
         }
 
-        .fundsFAQ {
-          color: @gray;
-          margin: 0 0 0 5px;
+        a {
+          &:hover {
+            text-decoration: none;
+          }
+
+          .fundsFAQ {
+            color: @gray;
+            margin: 0 0 0 5px;
+          }
         }
       }
     }
@@ -689,7 +751,8 @@ div.nextPaymentSubmission {
     }
 
     td {
-      padding: 15px 30px 0 0;
+      font-size: @fontSize;
+      padding: 10px 30px 0 0; // .settingsList .settingItem > *:not(.switchControl) 10px
       width: auto;
       min-width: 235px;
       vertical-align: top;
@@ -699,11 +762,8 @@ div.nextPaymentSubmission {
 
         .fundsSelectBox {
           width: auto;
+          margin-bottom: 0;
         }
-      }
-
-      .walletStatus {
-        font-size: 14.5px; // .form-control
       }
     }
 
@@ -715,8 +775,11 @@ div.nextPaymentSubmission {
 
     .accountBalanceError,
     .nextReconcileDate {
-      font-size: 14px;
-      margin: 10px 0;
+      margin-top: @itemMargin;
+    }
+
+    .nextReconcileDate {
+      margin-bottom: 0;
     }
   }
 
@@ -726,6 +789,7 @@ div.nextPaymentSubmission {
 
   #paymentHistory {
     background-color: #FFF;
+
     tr {
        th {
          color: @darkGray;
@@ -747,7 +811,6 @@ div.nextPaymentSubmission {
   }
 
   tr {
-    height: 1.7em;
 
     th {
       color: @darkGray;
@@ -870,6 +933,10 @@ div.nextPaymentSubmission {
         }
       }
     }
+  }
+
+  .sort {
+    text-align: left;
   }
 
   .board {

--- a/less/button.less
+++ b/less/button.less
@@ -143,7 +143,7 @@ span.buttonSeparator {
 .prefBody {
   .settingsList > .settingItem + button,
   .settingItem > span + button,
-  #paymentsContainer button:not(.close) {
+  .paymentsContainer button:not(.close) {
     font-size: 0.9rem;
     padding: 8px 20px;
     margin: 0;
@@ -157,7 +157,7 @@ span.buttonSeparator {
     margin-top: 5px;
   }
 
-  #paymentsContainer {
+  .paymentsContainer {
     .browserButton + .browserButton {
       margin-left: 8px;
     }

--- a/less/button.less
+++ b/less/button.less
@@ -144,8 +144,9 @@ span.buttonSeparator {
   .settingsList > .settingItem + button,
   .settingItem > span + button,
   #paymentsContainer button:not(.close) {
-    font-size: 13px;
+    font-size: 0.9rem;
     padding: 8px 20px;
+    margin: 0;
   }
 
   .settingsList > .settingItem + button {

--- a/less/modalOverlay.less
+++ b/less/modalOverlay.less
@@ -77,14 +77,10 @@
       transition: @transitionFast;
     }
 
-    &:not(.paymentHistory) {
-      .sectionTitle {
-        font-size: 22px;
-        padding: 35px 0 10px 0;
-        text-indent: 50px;
-      }
-    }
     .sectionTitle {
+      font-size: 22px;
+      padding: 35px 0 10px 0;
+      text-indent: 50px;
       color: @darkGray;
     }
   }

--- a/less/modalOverlay.less
+++ b/less/modalOverlay.less
@@ -87,27 +87,6 @@
     .sectionTitle {
       color: @darkGray;
     }
-
-    .recoveryOverlay {
-      background-color: @black75;
-      border: 1px solid @black75;
-      position: absolute;
-      top: -1px;
-      left: -1px;
-      width: 100%;
-      height: 100%;
-      text-align: center;
-      z-index: 999;
-
-      h1,
-      p {
-        color: white;
-      }
-
-      h1 {
-        margin-top: 120px;
-      }
-    }
   }
 
   button {

--- a/less/variables.less
+++ b/less/variables.less
@@ -8,6 +8,7 @@
 @borderRadiusTabs: 4px;
 @borderRadiusURL: 4px;
 @borderRadiusUIbox: 8px;
+@borderRadiusModal: 8px;
 @bigBorderRadius: 14px;
 @privateTabBackground: #392e54;
 
@@ -92,6 +93,9 @@
 @gray: rgb(153, 153, 153);
 @mediumGray: rgb(101, 101, 101);
 @darkGray: rgb(68, 68, 68);
+
+@modalVeryLightGray: rgb(247, 247, 247);
+@modalLightGray: rgb(231, 231, 231);
 
 @white25: rgba(255, 255, 255, 0.25);
 @white50: rgba(255, 255, 255, 0.5);


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

*This is a follow-up of #6009*

This PR has 6 commits:
1. Polishment of titleBar and walletBar
2. Made the selectors specific on about:preferences#payments to avoid unexpected regressions 
3. Added margin-bottom of the transfer funds button (Redo #6049)
4. Fixed advanced settings modal dialogs on about:preferences#payments
5. Polishment of modal dialog and advanced settings dialog on about:preferences#payments
6. Restyled payment history table

## 1st commit

Polishment of titleBar and walletBar

On about:preferences#payments
- Disabled underline of the anchor link of fundsFAQ (fixes #6083)
- Set font-size of the elements to 14.5px
- Set margin of the elements to 12px
- Set min-width to the select, input, and button
- Set padding, based on the margin of the items inside it

On about:preferences
- Made button size consistent by replacing em with rem (to avoid font-size inconsistency of the buttons inside walletBar) (fixes #6216)
- Set the default margin of the buttons to 0

<img width="838" alt="screenshot 2016-12-10 14 31 04" src="https://cloud.githubusercontent.com/assets/3362943/21071519/19624458-bee6-11e6-8fd0-66a786c59cf0.png">

### Test Plan 1

1. Open about:preferences
2. Make sure the style of about:preferences looks consistent

## 2nd commit

Made the selectors specific on about:preferences#payments to avoid unexpected regressions

- Classes and ids were renamed (fixes #6081)
- Classes were moved under .paymentsContainer, .bitcoinDashboard, and .ledgerTable
- Some elements and classes were removed
- Moved elements above classes/ids
- Moved .verified out of anchor link (the verified icon is no longer clickable) (fix #6225)

See the commit message for more details

Also .paymentHistoryFooter was introduced to fix #6061
<img width="751" alt="screenshot 2016-12-10 14 41 44" src="https://cloud.githubusercontent.com/assets/3362943/21071542/d0974966-bee6-11e6-9c7b-dcc2fc29f84f.png">

### Test Plan 2

1. Make sure all of the selectors listed up in the commit message (except removed ones) can be actually found in the code, especially `preferences.js`
2. Make sure the style of about:preferences#payments is not broken
    - Open about:preferences#payments
    - Toggle off/on switch
    - Click "Advanced Settings..."
    - Click "Backup your wallet" and "Done"
    - Click "Recover your wallet" and "Done"
    - Click "Add funds..."
    - Click "Display QR code"
3. Make sure the verified icon is no longer clickable

## 3rd commit

Added margin-bottom of the transfer funds button (Redo #6049) 
This fixes #6048

<img width="303" alt="screenshot 2016-12-10 14 42 30" src="https://cloud.githubusercontent.com/assets/3362943/21071548/eed1631c-bee6-11e6-800d-8a4fffead94b.png">

### Test Plan 3

1. Open https://jsfiddle.net/LnwtLckc/5/
2. Click "register"
3. Make sure "Transfer BTC" button has the margin-bottom on add funds dialog on about:preferences#payments

## 4th commit

*This commit will be squashed with the 5th commit after review*

Fixed advanced settings modal dialogs on about:preferences#payments

Added white-space:nowrap to recovery keys (fixes #6220)

### Test Plan 4
(n/a; covered by Test Plan 5)

## 5th commit
Polishment of modal dialog and advanced settings dialog on about:preferences#payments

Mockup images by @bradleyrichter: https://github.com/brave/browser-laptop/issues/5719#issuecomment-262431933

Restyled modal dialog under .paymentsContainer
- Made the background of modal dialog consistent
- Changed border-radius of modal dialog (fixes #6223)
- Fixed spacing of the modal dialog header (fixes #6221)
- Set margin-top/margin-bottom to panel inside .board
- Aligned buttons in the footer with flex-end (fixes #6219)
- Aligned fa icons on the payment panel with display:flex (fixes #6222)
- Fixed panelFooter in .addFundsBoard (fixes #5799)
  - Aligned Coinbase icon and message
  - Display the footer

<img width="730" alt="screenshot 2016-12-15 3 32 43" src="https://cloud.githubusercontent.com/assets/3362943/21195457/3429e63a-c277-11e6-9bcb-05050e504513.png">

For US
<img width="730" alt="screenshot 2016-12-15 3 25 51" src="https://cloud.githubusercontent.com/assets/3362943/21195226/3a2c3aa2-c276-11e6-9d04-14c15a302d58.png">

For non-US
<img width="738" alt="screenshot 2016-12-15 3 23 27" src="https://cloud.githubusercontent.com/assets/3362943/21195134/e2f92286-c275-11e6-9014-ee7892ae10e3.png">

Restyled advanced settings dialog
- Designed "hide sites if" options on the dialog (closes #6201, which is a follow-up of #4681)
- Made the margin consistent between the headers/labels and the input/select elements
  - Addresses https://github.com/brave/browser-laptop/pull/6047#issuecomment-265946727

<img width="729" alt="screenshot 2016-12-15 3 33 58" src="https://cloud.githubusercontent.com/assets/3362943/21195506/63961fb0-c277-11e6-963a-f425a1b6008f.png">

## Test Plan 5

For "Restyled modal dialog under .paymentsContainer"
1. Enable Coinbase if not
2. Open about:preferences#payments
3. Click "Add funds..."
4. Make sure the board is well styled
5. Make sure the footer is aligned horizontally
6. Click "Fund with debit/credit"
7. Make sure Coinbase widget is displayed with transparent background
8. Open https://jsfiddle.net/LnwtLckc/5/
9. Click "register" and go back
10. Make sure "Transfer BTC" button is aligned to right

For "Restyled advanced settings dialog"
1. Click "Advanced Settings..."
2. Check the margin between the labels and the select forms
3. Click "Backup your wallet"
4. Check the margin between the labels and the keys
5. Click "Done" and "Recover your wallet"
6. Check the margin between the labels and the input forms

## 6th commit
Restyled payment history table

Closes #6202
Closes #3485

- Removed "pull-right" class from the close button in modalOverlay.less (to confirm 21ece29 of #6009 fixed #5719)
- Added color:@braveMediumOrange to .sectionTitle of .paymentHistory (fixes #6229)
- Added padding-left and padding-right to th and td (fixes #6231)
- Added white-space:nowrap to disable wrap (fixes #6230)
- Added min-width:80px to the button inside the footer (fixes #6232)
- Made sectionTitle consistent
  - Removed ":not(.paymentHistory)" from modalOverlay.less

<img width="736" alt="screenshot 2016-12-15 3 36 37" src="https://cloud.githubusercontent.com/assets/3362943/21195619/e1ad79e8-c277-11e6-8d5d-d5d428b9247e.png">

Test Plan:
1. Disable the ledger
2. run `npm run add-simulated-payment-history` some times
3. Enable the ledger
4. Click "View Payment History..."
5. Click "OK" button