### PR TITLE
Added margin-bottom to the transfer funds button on about:preferences#payments

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -506,12 +506,12 @@ class BitcoinDashboard extends ImmutableComponent {
                   this.ledgerData.get('hasBitcoinHandler') && this.ledgerData.get('paymentURL')
                     ? <div>
                       <a href={this.ledgerData.get('paymentURL')} target='_blank'>
-                        <Button l10nId='bitcoinVisitAccount' className='primaryButton' />
+                        <Button l10nId='bitcoinVisitAccount' className='primaryButton bitcoinAddressButton' />
                       </a>
-                      <div data-l10n-id='bitcoinAddress' className='labelText' />
+                      <div data-l10n-id='bitcoinAddress' className='walletLabelText' />
                     </div>
                     : <div>
-                      <div data-l10n-id='bitcoinPaymentURL' className='labelText' />
+                      <div data-l10n-id='bitcoinPaymentURL' className='walletLabelText' />
                     </div>
                 }
                 <div className='walletAddressText'>{this.ledgerData.get('address')}</div>

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -941,10 +941,20 @@ div.nextPaymentSubmission {
       font-size: 0.9em;
     }
 
+    .bitcoinAddressButton {
+      margin-bottom: 15px; // .walletAddressText
+    }
+
+    .walletLabelText {
+      font-size: 1em;
+      color: @braveOrange;
+      margin-bottom: 5px;
+    }
+
     .walletAddressText {
       font-size: 12px;
       color: black;
-      margin-bottom: 20px;
+      margin-bottom: 15px; // .bitcoinAddressButton
     }
 
     .settingsListTitle {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Closes #6048

Auditors: @bbondy

Test Plan:
1. Open https://jsfiddle.net/LnwtLckc/5/
2. Click register
3. Make sure "Transfer BTC" button has the margin-bottom on add funds dialog on about:preferences#payments:
<img width="716" alt="screenshot 2016-12-07 4 10 40" src="https://cloud.githubusercontent.com/assets/3362943/20939754/58dfc444-bc33-11e6-8565-5ec37b34119d.png">

