### PR TITLE
Made all place of Cubits/buybitcoinworldwide.com button clickable

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -370,11 +370,9 @@ class BitcoinDashboard extends ImmutableComponent {
         <div className='settingsListTitle' data-l10n-id='outsideUSAPayment' />
       </div>
       <div className='settingsPanelDivider'>
-        <button className='browserButton primaryButton'>
-          <a target='_blank' href='https://www.buybitcoinworldwide.com/'>
-            buybitcoinworldwide.com
-          </a>
-        </button>
+        <a target='_blank' href='https://www.buybitcoinworldwide.com/'>
+          <button className='browserButton primaryButton'>buybitcoinworldwide.com</button>
+        </a>
       </div>
     </div>
   }
@@ -417,11 +415,9 @@ class BitcoinDashboard extends ImmutableComponent {
           <div className='settingsListTitle' data-l10n-id='outsideUSAPayment' />
         </div>
         <div className='settingsPanelDivider'>
-          <button className='browserButton primaryButton'>
-            <a target='_blank' href={url}>
-              {name}
-            </a>
-          </button>
+          <a target='_blank' href={url}>
+            <button className='browserButton primaryButton'>{name}</button>
+          </a>
         </div>
       </div>
     }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bsclifton @bbondy

Fixes #6050

Test Plan:
1. Disable "worldWidePanel"
2. Open about:preferences#payments
3. Click the top left corner of "Cubits" button
4. Enable "worldWidePanel"
5. Open about:preferences#payments
6. Click the top left corner of "buybitcoinworldwide.com" button