### PR TITLE
Make addFunds open adjacent to Preferences tab

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -317,8 +317,6 @@ class BitcoinDashboard extends ImmutableComponent {
   openBuyURLTab () {
     // close parent dialog
     this.props.hideParentOverlay()
-    // open the new buyURL frame
-    aboutActions.newFrame({ location: this.ledgerData.get('buyURL') }, true)
   }
   get ledgerData () {
     return this.props.ledgerData
@@ -328,8 +326,7 @@ class BitcoinDashboard extends ImmutableComponent {
   }
   get bitcoinPurchaseButton () {
     if (!this.ledgerData.get('buyURLFrame')) return <Button l10nId='add' className='primaryButton' onClick={this.props.showOverlay.bind(this)} />
-// should also do this.props.hideParentalOverlay
-    return <Button l10nId='add' className='primaryButton' onClick={this.openBuyURLTab} />
+    return <a href={this.ledgerData.get('buyURL')} target='_blank' onClick={this.openBuyURLTab}><Button l10nId='add' className='primaryButton' /></a>
   }
   get qrcodeOverlayContent () {
     return <div>


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #5913

Auditors: @bsclifton
/cc @mrose17

Test Plan:

* Set env var ADDFUNDS_URL to some page i.e. https://cubits.com
* Open Preferences,  go to Payments
* Open any other page
* Go back to Preferences, hit 'Add Funds'
* On modal dialog, hit 'Fund with debit/credit'
* When the new page opens, ensure it follows Preferences tab page right after
* Close the page
* Active page should be Preferences again
