### PR TITLE
Always show bookmarks folder title

### DIFF
--- a/app/renderer/components/bookmarksToolbar.js
+++ b/app/renderer/components/bookmarksToolbar.js
@@ -207,7 +207,7 @@ class BookmarkToolbarButton extends ImmutableComponent {
       }
       <span className='bookmarkText'>
         {
-          this.props.showFavicon && this.props.showOnlyFavicon
+          (this.isFolder ? false : (this.props.showFavicon && this.props.showOnlyFavicon))
           ? ''
           : siteDetailTitle || siteDetailLocation
         }

--- a/less/bookmarksToolbar.less
+++ b/less/bookmarksToolbar.less
@@ -82,7 +82,9 @@
       margin: auto 0px;
 
       .bookmarkFavicon, .bookmarkFile {
-        margin-right: 0px;
+        &:not(.bookmarkFolder) {
+          margin-right: 0px;
+        }
       }
     }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes #6078

Test Plan:
1. Open a new Brave window.
2. Make sure Preferences > General > Bookmarks Bar is set to Favicons only.
3. Create a bookmarks folder, if needed.
4. Make sure the title still shows for the folder (see screenshot below).

Screenshot (Favicons only):
![image](https://cloud.githubusercontent.com/assets/19424103/21022353/f6b28d82-bd41-11e6-8bd3-1c031e530bb6.png)

