### PR TITLE
Auto complete for the custom bookmark titles in the address bar

### DIFF
--- a/js/components/urlBarSuggestions.js
+++ b/js/components/urlBarSuggestions.js
@@ -329,10 +329,15 @@ class UrlBarSuggestions extends ImmutableComponent {
           return site.get('location')
         }),
         sortHandler: sortBasedOnLocationPos,
-        formatTitle: (site) => site.get('title'),
+        formatTitle: (site) => {
+          const customTitle = site.get('customTitle')
+          const title = site.get('title')
+
+          return customTitle ? `${customTitle} (${title})` : title
+        },
         formatUrl: (site) => site.get('location'),
         filterValue: (site) => {
-          const title = site.get('title') || ''
+          const title = site.get('customTitle') || site.get('title') || ''
           const location = site.get('location') || ''
           return (title.toLowerCase().includes(urlLocationLower) ||
             location.toLowerCase().includes(urlLocationLower)) &&


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #6104

## Auditors
@bsclifton, @aekeus, @bradleyrichter

## Test Plan
- Save bookmark with a custom title
- Search in address bar for a custom title
- You should see a bookmark with a custom title in bookmarks section