### PR TITLE
Harden context menu icon handling and add getPathFromFileURI utility function

### DIFF
--- a/app/common/lib/platformUtil.js
+++ b/app/common/lib/platformUtil.js
@@ -24,6 +24,15 @@ module.exports.getPlatformStyles = () => {
   return styleList
 }
 
+module.exports.getPathFromFileURI = (fileURI) => {
+  const path = decodeURI(fileURI)
+  if (process.platform === 'win32') {
+    return path.replace('file:///', '')
+  } else {
+    return path.replace('file://', '')
+  }
+}
+
 module.exports.isDarwin = () => {
   return process.platform === 'darwin' ||
     navigator.platform === 'MacIntel'

--- a/test/unit/app/common/lib/platformUtilTest.js
+++ b/test/unit/app/common/lib/platformUtilTest.js
@@ -77,6 +77,23 @@ describe('platformUtil', function () {
     })
   })
 
+  describe('getPathFromFileURI', function () {
+    const winFileURI = 'file:///C:/brave/brave%20is%20awesome'
+    const fileURI = 'file:///brave/brave%20is%20awesome'
+    const winExpectedResult = 'C:/brave/brave is awesome'
+    const expectedResult = '/brave/brave is awesome'
+    it('return path for window', function () {
+      loadMocks(mockWin10)
+      const result = platformUtil.getPathFromFileURI(winFileURI)
+      assert.equal(result, winExpectedResult)
+    })
+    it('return path for non window', function () {
+      loadMocks(mockMacOS)
+      const result = platformUtil.getPathFromFileURI(fileURI)
+      assert.equal(result, expectedResult)
+    })
+  })
+
   describe('isDarwin', function () {
     it('returns true if using macOS', function () {
       loadMocks(mockMacOS)


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix https://github.com/brave/electron/issues/113

Auditors: @bbondy, @bsclifton

Test Plan:
1. Enable the LastPass extension
2. Enable the Pocket extension
3. Navigate to "Profile folder"/Extensions/hdokiejnpimakedhajhdlcegeplioahd
4. Remove "16": "icon2.png", from manifest.json and save
5. Restart Brave
6. Right-click context menu should have lastpass with no icon and pocket with icon