### PR TITLE
Add local search history to url bar suggestions

### DIFF
--- a/app/common/state/localSearchHistoryState.js
+++ b/app/common/state/localSearchHistoryState.js
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const Immutable = require('immutable')
+
+const localSearchHistoryState = {
+  // update the timestamp for an existing local search history item
+  update: (localSearchTerms, localSearchDetails) => {
+    let entryIndex = localSearchTerms.findIndex((history) => {
+      return history.get('searchTerm') === localSearchDetails.get('searchTerm')
+    })
+    if (entryIndex !== -1) {
+      let entry = localSearchTerms.get(entryIndex)
+      entry = entry.set('ts', (new Date()).getTime())
+      localSearchTerms.set(entryIndex, entry)
+    } else {
+      localSearchTerms = localSearchTerms.push(localSearchDetails)
+    }
+    return localSearchTerms
+  },
+
+  // build a new entry
+  buildEntry: (searchTerm) => {
+    return {
+      ts: (new Date()).getTime(),
+      searchTerm: searchTerm
+    }
+  },
+
+  // clear search terms
+  clear: () => {
+    return Immutable.fromJS([])
+  }
+}
+
+module.exports = localSearchHistoryState

--- a/app/common/state/localSearchHistoryState.js
+++ b/app/common/state/localSearchHistoryState.js
@@ -13,7 +13,7 @@ const localSearchHistoryState = {
     if (entryIndex !== -1) {
       let entry = localSearchTerms.get(entryIndex)
       entry = entry.set('ts', (new Date()).getTime())
-      localSearchTerms.set(entryIndex, entry)
+      localSearchTerms = localSearchTerms.set(entryIndex, entry)
     } else {
       localSearchTerms = localSearchTerms.push(localSearchDetails)
     }

--- a/app/renderer/components/urlBar.js
+++ b/app/renderer/components/urlBar.js
@@ -23,6 +23,7 @@ const windowStore = require('../../../js/stores/windowStore')
 const UrlUtil = require('../../../js/lib/urlutil')
 const {eventElHasAncestorWithClasses, isForSecondaryAction} = require('../../../js/lib/eventUtil')
 const {isUrl, isIntermediateAboutPage} = require('../../../js/lib/appUrlUtil')
+const localSearchHistoryState = require('../../common/state/localSearchHistoryState')
 
 class UrlBar extends ImmutableComponent {
   constructor () {
@@ -195,9 +196,20 @@ class UrlBar extends ImmutableComponent {
             }
             windowActions.activeSuggestionClicked(isForSecondaryAction(e), e.shiftKey)
           } else {
+            if (this.activateSearchEngine && this.searchSelectEntry !== null && !isLocationUrl) {
+              const replaceRE = new RegExp('^' + this.searchSelectEntry.shortcut + ' ', 'g')
+              location = location.replace(replaceRE, '')
+            }
+
+            // saved search history
+            if (!isLocationUrl && !this.props.isPrivate) {
+              appActions.addLocalSearchHistory(localSearchHistoryState.buildEntry(location))
+            }
+
             location = isLocationUrl
               ? location
               : this.buildSearchUrl(location)
+
             // do search.
             if (e.altKey) {
               windowActions.newFrame({ location }, true)
@@ -541,6 +553,7 @@ class UrlBar extends ImmutableComponent {
             selectedIndex={this.props.urlbar.getIn(['suggestions', 'selectedIndex'])}
             suggestionList={this.props.urlbar.getIn(['suggestions', 'suggestionList'])}
             hasLocationValueSuffix={this.props.hasLocationValueSuffix}
+            localSearchTerms={this.props.localSearchTerms}
             menubarVisible={this.props.menubarVisible} />
           : null
         }

--- a/app/renderer/suggestionClickHandlers.js
+++ b/app/renderer/suggestionClickHandlers.js
@@ -6,6 +6,7 @@
 
 const windowActions = require('../../js/actions/windowActions')
 const windowStore = require('../../js/stores/windowStore')
+const appActions = require('../../js/actions/appActions')
 const {getActiveFrame} = require('../../js/state/frameStateUtil')
 
 const navigateSiteClickHandler = (formatUrl) => (site, isForSecondaryAction, shiftKey) => {
@@ -24,10 +25,22 @@ const navigateSiteClickHandler = (formatUrl) => (site, isForSecondaryAction, shi
   }
 }
 
+const navigateLocalSearchClickHandler = (formatUrl) => {
+  return function (site, isForSecondaryAction, shiftKey) {
+    // Update the local search time only if not in a private frame
+    if (!getActiveFrame(windowStore.state).get('isPrivate')) {
+      appActions.addLocalSearchHistory(site)
+    }
+    // delegate click handling
+    navigateSiteClickHandler(formatUrl)(site, isForSecondaryAction, shiftKey)
+  }
+}
+
 const frameClickHandler = (frameProps) =>
   windowActions.setActiveFrame(frameProps)
 
 module.exports = {
   navigateSiteClickHandler,
+  navigateLocalSearchClickHandler,
   frameClickHandler
 }

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -127,6 +127,13 @@ const appActions = {
     })
   },
 
+  addLocalSearchHistory: function (localSearchDetails) {
+    AppDispatcher.dispatch({
+      actionType: AppConstants.APP_ADD_LOCAL_SEARCH,
+      localSearchDetails
+    })
+  },
+
   /**
    * Clears history (all sites without tags). Indirectly called by appActions.onClearBrowsingData().
    */

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -129,7 +129,7 @@ const appActions = {
 
   addLocalSearchHistory: function (localSearchDetails) {
     AppDispatcher.dispatch({
-      actionType: AppConstants.APP_ADD_LOCAL_SEARCH,
+      actionType: appConstants.APP_ADD_LOCAL_SEARCH,
       localSearchDetails
     })
   },

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -902,6 +902,7 @@ class Main extends ImmutableComponent {
       !customTitlebar.menubarSelectedIndex
 
     const appStateSites = this.props.appState.get('sites')
+    const appLocalSearchTerms = this.props.appState.get('localSearchTerms')
 
     return <div id='window'
       className={cx({
@@ -982,6 +983,7 @@ class Main extends ImmutableComponent {
                 ref={(node) => { this.navBar = node }}
                 navbar={activeFrame && activeFrame.get('navbar')}
                 sites={appStateSites}
+                localSearchTerms={appLocalSearchTerms}
                 activeFrameKey={activeFrame && activeFrame.get('key') || undefined}
                 location={activeFrame && activeFrame.get('location') || ''}
                 title={activeFrame && activeFrame.get('title') || ''}
@@ -992,6 +994,7 @@ class Main extends ImmutableComponent {
                 isSecure={activeFrame && activeFrame.getIn(['security', 'isSecure']) &&
                  !activeFrame.getIn(['security', 'runInsecureContent'])}
                 hasLocationValueSuffix={activeFrame && activeFrame.getIn(['navbar', 'urlbar', 'suggestions', 'urlSuffix'])}
+                isPrivate={activeFrame.get('isPrivate')}
                 startLoadTime={activeFrame && activeFrame.get('startLoadTime') || undefined}
                 endLoadTime={activeFrame && activeFrame.get('endLoadTime') || undefined}
                 loading={activeFrame && activeFrame.get('loading')}

--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -194,6 +194,7 @@ class NavigationBar extends ImmutableComponent {
         }
       </div>
       <UrlBar ref='urlBar'
+        localSearchTerms={this.props.localSearchTerms}
         activeFrameKey={this.props.activeFrameKey}
         searchDetail={this.props.searchDetail}
         loading={this.loading}
@@ -201,7 +202,7 @@ class NavigationBar extends ImmutableComponent {
         title={this.props.title}
         history={this.props.history}
         isSecure={this.props.isSecure}
-        hasLocationValueSuffix={this.props.hasLocationValueSuffix}
+        isPrivate={this.props.isPrivate}
         startLoadTime={this.props.startLoadTime}
         endLoadTime={this.props.endLoadTime}
         titleMode={this.titleMode}

--- a/js/components/urlBarSuggestions.js
+++ b/js/components/urlBarSuggestions.js
@@ -1,0 +1,459 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const React = require('react')
+const ReactDOM = require('react-dom')
+
+const windowActions = require('../actions/windowActions')
+const ImmutableComponent = require('./immutableComponent')
+
+const config = require('../constants/config')
+const top500 = require('./../data/top500')
+const {aboutUrls, isNavigatableAboutPage, isSourceAboutUrl, isUrl} = require('../lib/appUrlUtil')
+const Immutable = require('immutable')
+const debounce = require('../lib/debounce')
+const settings = require('../constants/settings')
+const siteTags = require('../constants/siteTags')
+const suggestionTypes = require('../constants/suggestionTypes')
+const getSetting = require('../settings').getSetting
+const eventUtil = require('../lib/eventUtil')
+const cx = require('../lib/classSet')
+const locale = require('../l10n')
+const windowStore = require('../stores/windowStore')
+const suggestion = require('../../app/renderer/lib/suggestion')
+
+class UrlBarSuggestions extends ImmutableComponent {
+  constructor (props) {
+    super(props)
+    this.searchXHR = debounce(this.searchXHR.bind(this), 50)
+  }
+
+  get activeFrame () {
+    return windowStore.getFrame(this.props.activeFrameKey)
+  }
+
+  get activeIndex () {
+    if (this.props.suggestionList === null) {
+      return 0
+    }
+    return Math.abs(this.props.selectedIndex % (this.props.suggestionList.size + 1))
+  }
+
+  nextSuggestion () {
+    // If the user presses down and don't have an explicit selected index, skip to the 2nd one
+    if (this.props.locationValueSuffix && this.props.selectedIndex === null && this.props.suggestionList.size > 1) {
+      this.updateSuggestions(2)
+      return
+    }
+
+    this.updateSuggestions(this.props.selectedIndex + 1)
+  }
+
+  previousSuggestion () {
+    const suggestions = this.props.suggestionList
+    if (!suggestions) {
+      return
+    }
+
+    let newIndex = this.props.selectedIndex - 1
+    if (newIndex < 0) {
+      newIndex = suggestions.size
+    }
+    this.updateSuggestions(newIndex)
+  }
+
+  blur () {
+    window.removeEventListener('click', this)
+    windowActions.setUrlBarSuggestions(null, null)
+    windowActions.setUrlBarPreview(null)
+  }
+
+  clickSelected (e) {
+    this.ctrlKey = e.ctrlKey
+    this.metaKey = e.metaKey
+    this.shiftKey = e.shiftKey
+    const node = ReactDOM.findDOMNode(this)
+    if (node) {
+      node.getElementsByClassName('selected')[0].click()
+    }
+  }
+
+  // Whether the suggestions box should be rendered
+  shouldRender () {
+    return this.props.suggestionList && this.props.suggestionList.size > 0
+  }
+
+  render () {
+    window.removeEventListener('click', this)
+
+    if (!this.shouldRender()) {
+      return null
+    }
+
+    // Add an event listener on the window to hide suggestions when they are shown.
+    window.addEventListener('click', this)
+
+    // If there is a URL suffix that means there's an active autocomplete for the first element.
+    // We should show that as selected so the user knows what is being matched.
+
+    const suggestions = this.props.suggestionList
+    const bookmarkSuggestions = suggestions.filter((s) => s.type === suggestionTypes.BOOKMARK)
+    const historySuggestions = suggestions.filter((s) => s.type === suggestionTypes.HISTORY)
+    const aboutPagesSuggestions = suggestions.filter((s) => s.type === suggestionTypes.ABOUT_PAGES)
+    const tabSuggestions = suggestions.filter((s) => s.type === suggestionTypes.TAB)
+    const searchSuggestions = suggestions.filter((s) => s.type === suggestionTypes.SEARCH)
+    const topSiteSuggestions = suggestions.filter((s) => s.type === suggestionTypes.TOP_SITE)
+
+    let items = []
+    let index = 0
+    const addToItems = (suggestions, sectionKey, title, icon) => {
+      if (suggestions.size > 0) {
+        items.push(<li className='suggestionSection'>
+          {
+            icon
+            ? <span className={cx({
+              suggestionSectionIcon: true,
+              [sectionKey]: true,
+              fa: true,
+              [icon]: true
+            })} />
+            : null
+          }
+          <span className='suggestionSectionTitle'>{title}</span>
+        </li>)
+      }
+      items = items.concat(suggestions.map((suggestion, i) => {
+        const currentIndex = index + i
+        const selected = this.activeIndex === currentIndex + 1 || (!this.activeIndex && currentIndex === 0 && this.props.locationValueSuffix)
+        return <li data-index={currentIndex + 1}
+          onMouseOver={this.onMouseOver.bind(this)}
+          onClick={suggestion.onClick}
+          key={`${suggestion.location}|${index + i}`}
+          ref={(node) => { selected && (this.selectedElement = node) }}
+          className={cx({
+            selected,
+            suggestionItem: true,
+            [suggestion.type]: true
+          })}>
+          {
+            suggestion.type !== suggestionTypes.TOP_SITE && suggestion.title
+            ? <div className='suggestionTitle'>{suggestion.title}</div>
+            : null
+          }
+          {
+            suggestion.type !== suggestionTypes.SEARCH && suggestion.type !== suggestionTypes.ABOUT_PAGES
+            ? <div className='suggestionLocation'>{suggestion.location}</div>
+            : null
+          }
+        </li>
+      }))
+      index += suggestions.size
+    }
+    addToItems(historySuggestions, 'historyTitle', locale.translation('historySuggestionTitle'), 'fa-clock-o')
+    addToItems(bookmarkSuggestions, 'bookmarksTitle', locale.translation('bookmarksSuggestionTitle'), 'fa-star-o')
+    addToItems(aboutPagesSuggestions, 'aboutPagesTitle', locale.translation('aboutPagesSuggestionTitle'), null)
+    addToItems(tabSuggestions, 'tabsTitle', locale.translation('tabsSuggestionTitle'), 'fa-external-link')
+    addToItems(searchSuggestions, 'searchTitle', locale.translation('searchSuggestionTitle'), 'fa-search')
+    addToItems(topSiteSuggestions, 'topSiteTitle', locale.translation('topSiteSuggestionTitle'), 'fa-link')
+    const documentHeight = Number.parseInt(window.getComputedStyle(document.querySelector(':root')).getPropertyValue('--navbar-height'), 10)
+    const menuHeight = this.props.menubarVisible ? 30 : 0
+    return <ul className='urlBarSuggestions' style={{
+      maxHeight: document.documentElement.offsetHeight - documentHeight - 2 - menuHeight
+    }}>
+      {items}
+    </ul>
+  }
+
+  onMouseOver (e) {
+    this.updateSuggestions(parseInt(e.target.dataset.index, 10))
+  }
+
+  componentDidMount () {
+    if (this.props.urlLocation.length > 0) {
+      this.suggestionList = this.getNewSuggestionList(this.props)
+      this.searchXHR(this.props, true)
+    }
+  }
+
+  componentWillUpdate (nextProps) {
+    if (this.selectedElement) {
+      this.selectedElement.scrollIntoView()
+    }
+    // If both the URL is the same and the number of sites to consider is
+    // the same then we don't need to regenerate the suggestions list.
+    if (this.props.urlLocation === nextProps.urlLocation &&
+        this.props.sites.size === nextProps.sites.size &&
+        // Make sure to update if there are online suggestions
+        this.props.searchResults.size === nextProps.searchResults.size) {
+      return
+    }
+    this.suggestionList = this.getNewSuggestionList(nextProps)
+    this.searchXHR(nextProps, !(this.props.urlLocation === nextProps.urlLocation))
+  }
+
+  getNewSuggestionList (props) {
+    props = props || this.props
+    if (!props.urlLocation && !props.urlPreview) {
+      return null
+    }
+
+    const navigateClickHandler = (formatUrl) => (site, e) => {
+      // We have a wonky way of fake clicking from keyboard enter,
+      // so remove the meta keys from the real event here.
+      e.metaKey = e.metaKey || this.metaKey
+      e.ctrlKey = e.ctrlKey || this.ctrlKey
+      e.shiftKey = e.shiftKey || this.shiftKey
+      delete this.metaKey
+      delete this.ctrlKey
+      delete this.shiftKey
+
+      const location = formatUrl(site)
+      // When clicked make sure to hide autocomplete
+      windowActions.setRenderUrlBarSuggestions(false)
+      if (eventUtil.isForSecondaryAction(e)) {
+        windowActions.newFrame({
+          location,
+          partitionNumber: site && site.get && site.get('partitionNumber') || undefined
+        }, !!e.shiftKey)
+        e.preventDefault()
+        windowActions.setNavBarFocused(true)
+      } else {
+        windowActions.loadUrl(this.activeFrame, location)
+        windowActions.setUrlBarActive(false)
+        windowActions.setUrlBarPreview(null)
+        this.blur()
+      }
+    }
+
+    const urlLocationLower = props.urlLocation.toLowerCase()
+    let suggestions = new Immutable.List()
+    const defaultme = (x) => x
+    const mapListToElements = ({data, maxResults, type, clickHandler = navigateClickHandler,
+        sortHandler = defaultme, formatTitle = defaultme, formatUrl = defaultme,
+        filterValue = (site) => site.toLowerCase().includes(urlLocationLower)
+    }) => // Filter out things which are already in our own list at a smaller index
+      data
+      // Per suggestion provider filter
+      .filter(filterValue)
+      // Filter out things which are already in the suggestions list
+      .filter((site) =>
+        suggestions.findIndex((x) => (x.location || '').toLowerCase() === (formatUrl(site) || '').toLowerCase()) === -1 ||
+          // Tab autosuggestions should always be included since they will almost always be in history
+          type === suggestionTypes.TAB)
+      .sort(sortHandler)
+      .take(maxResults)
+      .map((site) => {
+        return {
+          onClick: clickHandler.bind(null, site),
+          title: formatTitle(site),
+          location: formatUrl(site),
+          type
+        }
+      })
+
+    const shouldNormalize = suggestion.shouldNormalizeLocation(urlLocationLower)
+    const urlLocationLowerNormalized = suggestion.normalizeLocation(urlLocationLower)
+    const sortBasedOnLocationPos = (s1, s2) => {
+      const location1 = shouldNormalize ? suggestion.normalizeLocation(s1.get('location')) : s1.get('location')
+      const location2 = shouldNormalize ? suggestion.normalizeLocation(s2.get('location')) : s2.get('location')
+      const pos1 = location1.indexOf(urlLocationLowerNormalized)
+      const pos2 = location2.indexOf(urlLocationLowerNormalized)
+      if (pos1 === -1 && pos2 === -1) {
+        return 0
+      } else if (pos1 === -1) {
+        return 1
+      } else if (pos2 === -1) {
+        return -1
+      } else {
+        if (pos1 - pos2 !== 0) {
+          return pos1 - pos2
+        } else {
+          // sort site.com higher than site.com/somepath
+          const sdnv1 = suggestion.simpleDomainNameValue(s1)
+          const sdnv2 = suggestion.simpleDomainNameValue(s2)
+          if (sdnv1 !== sdnv2) {
+            return sdnv2 - sdnv1
+          } else {
+            // If there's a tie on the match location, use the age
+            // decay modified access count
+            return suggestion.sortByAccessCountWithAgeDecay(s1, s2)
+          }
+        }
+      }
+    }
+
+    const historyFilter = (site) => {
+      if (!site) {
+        return false
+      }
+      const title = site.get('title') || ''
+      const location = site.get('location') || ''
+      // Note: Bookmark sites are now included in history. This will allow
+      // sites to appear in the auto-complete regardless of their bookmark
+      // status. If history is turned off, bookmarked sites will appear
+      // in the bookmark section.
+      return (title.toLowerCase().includes(urlLocationLower) ||
+              location.toLowerCase().includes(urlLocationLower)) &&
+              site.get('lastAccessedTime')
+    }
+    var historySites = props.sites.filter(historyFilter)
+
+    // potentially append virtual history items (such as www.google.com when
+    // searches have been made but the root site has not been visited)
+    historySites = historySites.concat(suggestion.createVirtualHistoryItems(historySites))
+
+    // history
+    if (getSetting(settings.HISTORY_SUGGESTIONS)) {
+      suggestions = suggestions.concat(mapListToElements({
+        data: historySites,
+        maxResults: config.urlBarSuggestions.maxHistorySites,
+        type: suggestionTypes.HISTORY,
+        clickHandler: navigateClickHandler((site) => {
+          return site.get('location')
+        }),
+        sortHandler: sortBasedOnLocationPos,
+        formatTitle: (site) => site.get('title'),
+        formatUrl: (site) => site.get('location'),
+        filterValue: historyFilter
+      }))
+    }
+
+    // bookmarks
+    if (getSetting(settings.BOOKMARK_SUGGESTIONS)) {
+      suggestions = suggestions.concat(mapListToElements({
+        data: props.sites,
+        maxResults: config.urlBarSuggestions.maxBookmarkSites,
+        type: suggestionTypes.BOOKMARK,
+        clickHandler: navigateClickHandler((site) => {
+          return site.get('location')
+        }),
+        sortHandler: sortBasedOnLocationPos,
+        formatTitle: (site) => site.get('title'),
+        formatUrl: (site) => site.get('location'),
+        filterValue: (site) => {
+          const title = site.get('title') || ''
+          const location = site.get('location') || ''
+          return (title.toLowerCase().includes(urlLocationLower) ||
+            location.toLowerCase().includes(urlLocationLower)) &&
+            site.get('tags') && site.get('tags').includes(siteTags.BOOKMARK)
+        }
+      }))
+    }
+
+    // about pages
+    suggestions = suggestions.concat(mapListToElements({
+      data: aboutUrls.keySeq().filter((x) => isNavigatableAboutPage(x)),
+      maxResults: config.urlBarSuggestions.maxAboutPages,
+      type: suggestionTypes.ABOUT_PAGES,
+      clickHandler: navigateClickHandler((x) => x)}))
+
+    // opened frames
+    if (getSetting(settings.OPENED_TAB_SUGGESTIONS)) {
+      suggestions = suggestions.concat(mapListToElements({
+        data: windowStore.getFrames(),
+        maxResults: config.urlBarSuggestions.maxOpenedFrames,
+        type: suggestionTypes.TAB,
+        clickHandler: (frameProps) =>
+          windowActions.setActiveFrame(frameProps),
+        sortHandler: sortBasedOnLocationPos,
+        formatTitle: (frame) => frame.get('title'),
+        formatUrl: (frame) => frame.get('location'),
+        filterValue: (frame) => !isSourceAboutUrl(frame.get('location')) &&
+          frame.get('key') !== props.activeFrameKey &&
+          (frame.get('title') && frame.get('title').toLowerCase().includes(urlLocationLower) ||
+          frame.get('location') && frame.get('location').toLowerCase().includes(urlLocationLower))}))
+    }
+
+    // Search suggestions
+    if (getSetting(settings.OFFER_SEARCH_SUGGESTIONS) && props.searchResults) {
+      suggestions = suggestions.concat(mapListToElements({
+        data: props.searchResults,
+        maxResults: config.urlBarSuggestions.maxSearch,
+        type: suggestionTypes.SEARCH,
+        clickHandler: navigateClickHandler((searchTerms) => {
+          let searchURL = props.searchSelectEntry
+          ? props.searchSelectEntry.search : props.searchDetail.get('searchURL')
+          return searchURL.replace('{searchTerms}', encodeURIComponent(searchTerms))
+        })
+      }))
+    }
+
+    // Local search suggestions
+    suggestions = suggestions.concat(mapListToElements({
+      data: props.localSearchTerms.map((e) => { return e.get('searchTerm') }),
+      maxResults: config.urlBarSuggestions.maxSearch,
+      type: suggestionTypes.SEARCH,
+      clickHandler: navigateClickHandler((searchTerms) => {
+        let searchURL = props.searchSelectEntry ? props.searchSelectEntry.search : props.searchDetail.get('searchURL')
+        return searchURL.replace('{searchTerms}', encodeURIComponent(searchTerms))
+      })
+    }))
+
+    // Alexa top 500
+    suggestions = suggestions.concat(mapListToElements({
+      data: top500,
+      maxResults: config.urlBarSuggestions.maxTopSites,
+      type: suggestionTypes.TOP_SITE,
+      clickHandler: navigateClickHandler((x) => x)}))
+
+    return suggestions
+  }
+
+  updateSuggestions (newIndex) {
+    const suggestions = this.suggestionList || this.props.suggestionList
+    if (!suggestions) {
+      return
+    }
+    // Update the urlbar preview content
+    if (newIndex === 0 || newIndex > suggestions.size) {
+      windowActions.setUrlBarPreview(null)
+      newIndex = null
+    } else {
+      const currentActive = suggestions.get(newIndex - 1)
+      if (currentActive && currentActive.title) {
+        windowActions.setUrlBarPreview(currentActive.title)
+      }
+    }
+    windowActions.setUrlBarSuggestions(suggestions, newIndex)
+  }
+
+  searchXHR (props, searchOnline) {
+    props = props || this.props
+    let autocompleteURL = props.searchSelectEntry
+    ? props.searchSelectEntry.autocomplete : props.searchDetail.get('autocompleteURL')
+    if (!getSetting(settings.OFFER_SEARCH_SUGGESTIONS) || !autocompleteURL) {
+      windowActions.setUrlBarSuggestionSearchResults(Immutable.fromJS([]))
+      this.updateSuggestions(props.selectedIndex)
+      return
+    }
+
+    let urlLocation = props.urlLocation
+    if (!isUrl(urlLocation) && urlLocation.length > 0) {
+      if (props.searchSelectEntry) {
+        const replaceRE = new RegExp('^' + props.searchSelectEntry.shortcut + ' ', 'g')
+        urlLocation = urlLocation.replace(replaceRE, '')
+      }
+      // Render all suggestions asap
+      this.updateSuggestions(props.selectedIndex)
+
+      if (searchOnline) {
+        const xhr = new window.XMLHttpRequest({mozSystem: true})
+        xhr.open('GET', autocompleteURL
+          .replace('{searchTerms}', encodeURIComponent(urlLocation)), true)
+        xhr.responseType = 'json'
+        xhr.send()
+        xhr.onload = () => {
+          // Once we have the online suggestions, append them to the others
+          windowActions.setUrlBarSuggestionSearchResults(Immutable.fromJS(xhr.response[1]))
+          this.updateSuggestions(props.selectedIndex)
+        }
+      }
+    } else {
+      windowActions.setUrlBarSuggestionSearchResults(Immutable.fromJS([]))
+      this.updateSuggestions(props.selectedIndex)
+    }
+  }
+}
+
+module.exports = UrlBarSuggestions

--- a/js/constants/appConstants.js
+++ b/js/constants/appConstants.js
@@ -85,7 +85,8 @@ const appConstants = {
   APP_FLASH_PERMISSION_REQUESTED: _,
   APP_SHUTTING_DOWN: _,
   APP_CLIPBOARD_TEXT_UPDATED: _,
-  APP_TAB_CLONED: _
+  APP_TAB_CLONED: _,
+  APP_ADD_LOCAL_SEARCH: _
 }
 
 module.exports = mapValuesByKeys(appConstants)

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -44,6 +44,7 @@ const aboutHistoryState = require('../../app/common/state/aboutHistoryState')
 const windowState = require('../../app/common/state/windowState')
 
 const webtorrent = require('../../app/browser/webtorrent')
+const localSearchHistoryState = require('../../app/common/state/localSearchHistoryState')
 
 const isDarwin = process.platform === 'darwin'
 const isWindows = process.platform === 'win32'
@@ -481,6 +482,11 @@ const handleAppAction = (action) => {
     case appConstants.APP_DATA_URL_COPIED:
       nativeImage.copyDataURL(action.dataURL, action.html, action.text)
       break
+    case appConstants.APP_ADD_LOCAL_SEARCH:
+      let localSearchTerms = appState.get('localSearchTerms') || Immutable.fromJS([])
+      localSearchTerms = localSearchHistoryState.update(localSearchTerms, action.localSearchDetails)
+      appState = appState.set('localSearchTerms', localSearchTerms)
+      break
     case appConstants.APP_ADD_SITE:
       const oldSiteSize = appState.get('sites').size
       if (action.siteDetail.constructor === Immutable.List) {
@@ -512,6 +518,7 @@ const handleAppAction = (action) => {
       appState = appState.set('sites', siteUtil.clearHistory(appState.get('sites')))
       appState = aboutNewTabState.setSites(appState, action)
       appState = aboutHistoryState.setHistory(appState, action)
+      appState = appState.set('localSearchTerms', localSearchHistoryState.clear())
       break
     case appConstants.APP_DEFAULT_WINDOW_PARAMS_CHANGED:
       if (action.size && action.size.size === 2) {

--- a/test/unit/state/localSearchHistoryStateTest.js
+++ b/test/unit/state/localSearchHistoryStateTest.js
@@ -1,0 +1,27 @@
+/* global describe, before, it */
+
+const localSearchHistoryState = require('../../../app/common/state/localSearchHistoryState')
+const assert = require('assert')
+const Immutable = require('immutable')
+
+describe('localSearchHistory', function () {
+  before(function () {})
+  it('build a search term entry', function () {
+    var entry = localSearchHistoryState.buildEntry('search term')
+    assert.ok(entry.searchTerm === 'search term', 'search term stored')
+    assert.ok(entry.ts > 0, 'timestamp recorded')
+  })
+  it('clear history', function () {
+    var history = localSearchHistoryState.clear()
+    assert.ok(history.size === 0, 'history cleared')
+  })
+  it('adds a new entry', function () {
+    var history = localSearchHistoryState.clear()
+    var entry1 = Immutable.Map({ searchTerm: 'search term' })
+    history = localSearchHistoryState.update(history, entry1)
+    assert.ok(history.size === 1, 'one entry added to history')
+    var entry2 = Immutable.Map({ searchTerm: 'search term' })
+    history = localSearchHistoryState.update(history, entry2)
+    assert.ok(history.size === 1, 'one entry updated in history')
+  })
+})


### PR DESCRIPTION
- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Ran `git rebase -i` to squash commits (if needed).

## Test Plan

  * Add search history for non-private tabs to session
  * Add search history entries to url bar auto-completion
  * If the remote search history preference is turned on, combine
    the results into a single Search section in the auto-complete
  * Add units tests

Auditors: @bbondy

## Test plan

Section I

  a) Open a new tab and type ‘capital of canada’ in the url bar
  b) Press enter to force a search
  c) Open a new tab and type ‘capital of’ in the url bar
  d) Ensure that the ‘capital of canada’ entry is available in the auto-complete (under search)

Section II

  a) Open a private tab and type ‘capital of brazil’ in the url bar
  b) Press enter to force a search
  c) Open a new normal tab and type ‘capital of’ in the url bar
  d) Ensure that the ‘capital of brazil’ entry is NOT in the auto-complete (under search; it may show if tab is already open)

Section III

  a) Open preferences and enable ‘Autocomplete search term as you type’
  b) Open a new tab and type ‘capital of’
  c) Ensure remote search results include the local ‘capital of canada’ entry

Fixes: #5919