### PR TITLE
Add Paste Without Formatting to context menu

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -640,6 +640,13 @@ function getEditableItems (selection, editFlags) {
       accelerator: 'CmdOrCtrl+V',
       enabled: hasClipboard,
       role: 'paste'
+    }, {
+      label: locale.translation('pasteWithoutFormatting'),
+      accelerator: 'Shift+CmdOrCtrl+V',
+      enabled: hasClipboard,
+      click: function (item, focusedWindow) {
+        focusedWindow.webContents.pasteAndMatchStyle()
+      }
     })
   }
   return menuUtil.sanitizeTemplateItems(template)


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes #5822

Test Plan:
1. Open a new Brave tab and navigate to a site with an input field (preferably a field that accepts rich text).
3. Open your favorite rich text editor (e.g. TextEdit).
4. Type a string of text and give the text some formatting (e.g. **bold**).
5. Switch back to Brave. Right click the input field.
6. Click `Paste Without Formatting`.
7. Make sure the pasted text has no formatting.

Screenshot:
![image](https://cloud.githubusercontent.com/assets/19424103/21068007/a0365198-be34-11e6-8c3a-23d258d38a3b.png)

