### PR TITLE
Improve clarity of the Ubuntu install instructions

### DIFF
--- a/docs/linuxInstall.md
+++ b/docs/linuxInstall.md
@@ -27,7 +27,9 @@ sudo apt-get install -y gdebi && sudo gdebi brave.deb
 To install brave using apt:
 ``` 
 curl https://s3-us-west-2.amazonaws.com/brave-apt/keys.asc | sudo apt-key add -
-deb https://s3-us-west-2.amazonaws.com/brave-apt [xenial/trusty] main  
+echo "deb https://s3-us-west-2.amazonaws.com/brave-apt [xenial/trusty] main" | sudo tee -a /etc/apt/sources.list
+sudo apt update
+sudo apt install brave
 ```
 
 Upgrades can be done via:


### PR DESCRIPTION
What
===
Change the Ubuntu AMD64 installation instructions to show the commands required to append the sources.list entry and complete the full installation, rather than only show the entry that needs to be made.

Why
===
The instructions are not clear that the deb entry needs to be added to the sources.list and the way it is included makes it look like a command the user needs to execute. The instructions are also missing the `apt update` and `apt install brave` that are also necessary.