### PR TITLE
Replaced fa-times for close button on download bar with SVG button (redo #6071)

### DIFF
--- a/app/renderer/components/downloadsBar.js
+++ b/app/renderer/components/downloadsBar.js
@@ -39,8 +39,7 @@ class DownloadsBar extends ImmutableComponent {
         }
       </div>
       <div className='downloadBarButtons'>
-        <Button iconClass='fa-times'
-          className='hideDownloadsToolbar downloadButton smallButton hideButton'
+        <Button className='downloadButton hideDownloadsToolbar'
           onClick={this.onHideDownloadsToolbar} />
       </div>
     </div>


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Closes #6070

Fixes brave@2c55150
The close button implemented fa-times on the download bar has been replaced with the SVG button with the PR: #6071

![downloadbar0](https://cloud.githubusercontent.com/assets/3362943/21253917/4fa046be-c3a5-11e6-9a03-7339fa02f13a.gif)

into
![downloadbar](https://cloud.githubusercontent.com/assets/3362943/21253865/0482864c-c3a5-11e6-8227-de40b84e2a38.gif)

Auditors: @bsclifton @bbondy

Test Plan:
1. Download a file
2. Make sure the download button is replaced with the same SVG button as brave#6071