### PR TITLE
Keep bookmarked entries on history

### DIFF
--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -86,6 +86,7 @@ module.exports.getNextFolderId = (sites) => {
 // Some details can be copied from the existing siteDetail if null
 // ex: parentFolderId, partitionNumber, and favicon
 const mergeSiteDetails = (oldSiteDetail, newSiteDetail, tag, folderId) => {
+  const siteDetailExist = newSiteDetail.get('lastAccessedTime') !== undefined || oldSiteDetail && oldSiteDetail.get('lastAccessedTime')
   let tags = oldSiteDetail && oldSiteDetail.get('tags') || new Immutable.List()
   if (tag) {
     tags = tags.toSet().add(tag).toList()
@@ -97,7 +98,9 @@ const mergeSiteDetails = (oldSiteDetail, newSiteDetail, tag, folderId) => {
 
   let lastAccessedTime
   if (isBookmark(tag) || isBookmarkFolder(tag)) {
-    lastAccessedTime = newSiteDetail.get('lastAccessedTime') || 0
+    siteDetailExist
+      ? lastAccessedTime = newSiteDetail.get('lastAccessedTime') || oldSiteDetail.get('lastAccessedTime')
+      : lastAccessedTime = 0
   } else {
     lastAccessedTime = newSiteDetail.get('lastAccessedTime') || new Date().getTime()
   }

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -286,6 +286,11 @@ describe('siteUtil', function () {
           assert.equal(!!processedSites.getIn([0, 'lastAccessedTime']), true)
           assert.deepEqual(processedSites.getIn([0, 'tags']).toJS(), [])
         })
+        it('returns newSiteDetail value for lastAccessedTime when oldSite value is undefined', function () {
+          const processedSites = siteUtil.addSite(emptySites, bookmarkAllFields)
+          const expectedSites = Immutable.fromJS([bookmarkAllFields])
+          assert.deepEqual(processedSites.getIn([0, 'lastAccessedTime']), expectedSites.getIn([0, 'lastAccessedTime']))
+        })
       })
     })
     describe('for existing entries (oldSite is an existing siteDetail)', function () {
@@ -339,6 +344,23 @@ describe('siteUtil', function () {
         const processedSites = siteUtil.addSite(sites, newSiteDetail, siteTags.BOOKMARK, oldSiteDetail)
         const expectedSites = Immutable.fromJS([newSiteDetail])
         assert.deepEqual(processedSites.toJS(), expectedSites.toJS())
+      })
+      it('returns oldSiteDetail value for lastAccessedTime when newSite value is undefined', function () {
+        const oldSiteDetail = Immutable.fromJS({
+          lastAccessedTime: 456,
+          location: testUrl1,
+          title: 'a brave title'
+        })
+        const newSiteDetail = Immutable.fromJS({
+          tags: [siteTags.BOOKMARK],
+          location: testUrl1,
+          title: 'a brave title'
+        })
+
+        const sites = Immutable.fromJS([oldSiteDetail])
+        const processedSites = siteUtil.addSite(sites, newSiteDetail, siteTags.BOOKMARK, oldSiteDetail)
+        const expectedSites = sites
+        assert.deepEqual(processedSites.getIn([0, 'lastAccessedTime']), expectedSites.getIn([0, 'lastAccessedTime']))
       })
     })
   })


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditor: @bsclifton, @darkdh

Fix #6160

Test plan:

Automated tests must pass
```
npm run test -- --grep="returns newSiteDetail value for lastAccessedTime when oldSite value is undefined"
```
```
npm run test -- --grep="returns oldSiteDetail value for lastAccessedTime when newSite value is undefined"
```

Manual tests:

1. Visit a site
2. Go to `about:history` and check entry is there
3. Bookmark that site
4. Entry should still be visible on `about:history`
5. Bookmark `about:history`
6. History should be bookmarked (but not visible on about:history as we don't store about pages)