### PR TITLE
Fix immutable.getIn and autofillPopupHidden condition

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -688,7 +688,10 @@ class Frame extends ImmutableComponent {
       contextMenus.onShowAutofillMenu(e.suggestions, e.rect, this.frame)
     })
     this.webview.addEventListener('hide-autofill-popup', (e) => {
-      windowActions.autofillPopupHidden(this.props.tabId)
+      let webContents = this.webview.getWebContents()
+      if (webContents && webContents.isFocused()) {
+        windowActions.autofillPopupHidden(this.props.tabId)
+      }
     })
     this.webview.addEventListener('ipc-message', (e) => {
       let method = () => {}

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -658,8 +658,8 @@ const doAction = (action) => {
     case windowConstants.WINDOW_AUTOFILL_POPUP_HIDDEN:
     case windowConstants.WINDOW_SET_CONTEXT_MENU_DETAIL:
       if (!action.detail) {
-        if (windowState.getIn('contextMenuDetail', 'type') === 'autofill' &&
-            windowState.getIn('contextMenuDetail', 'tabId') === action.tabId) {
+        if (windowState.getIn(['contextMenuDetail', 'type']) === 'autofill' &&
+            windowState.getIn(['contextMenuDetail', 'tabId']) === action.tabId) {
           windowState = windowState.delete('contextMenuDetail')
           if (action.notify) {
             ipc.send('autofill-popup-hidden', action.tabId)


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan: Covered by auto test

fix #6233

Auditors: @bridiver, @bbondy