### PR TITLE
Put back in handler for null/empty context menu detail. This is requi…

### DIFF
--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -658,9 +658,10 @@ const doAction = (action) => {
     case windowConstants.WINDOW_AUTOFILL_POPUP_HIDDEN:
     case windowConstants.WINDOW_SET_CONTEXT_MENU_DETAIL:
       if (!action.detail) {
+        windowState = windowState.delete('contextMenuDetail')
+
         if (windowState.getIn(['contextMenuDetail', 'type']) === 'autofill' &&
             windowState.getIn(['contextMenuDetail', 'tabId']) === action.tabId) {
-          windowState = windowState.delete('contextMenuDetail')
           if (action.notify) {
             ipc.send('autofill-popup-hidden', action.tabId)
           }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Put back in handler for null/empty context menu detail. This is required in order to hide any ContextMenu object

Caused by https://github.com/brave/browser-laptop/commit/7fb2e4c30c98b592c00fc390648f99672a6caad7#diff-733d30fbf34816322d3f25dd59c1eb99

Fixes https://github.com/brave/browser-laptop/issues/6236

Auditors: @bridiver, @darkdh

Test Plan:
1. Launch Brave and use the kabob / cheeseburger icon
2. Notice the context menu comes up
3. Click anywhere on the screen (outside of the context menu)
4. Notice context menu closes itself