### PR TITLE
Avoid imported bookmarks on new tab page

### DIFF
--- a/app/common/state/aboutNewTabState.js
+++ b/app/common/state/aboutNewTabState.js
@@ -5,7 +5,6 @@
 const Immutable = require('immutable')
 const {makeImmutable} = require('./immutableUtil')
 const siteUtil = require('../../../js/state/siteUtil')
-const {isSourceAboutUrl} = require('../../../js/lib/appUrlUtil')
 const aboutNewTabMaxEntries = 100
 
 const compareSites = (site1, site2) => {
@@ -68,7 +67,7 @@ const getTopSites = (state) => {
   // remove folders; sort by visit count; enforce a max limit
   const sites = (state.get('sites') || new Immutable.List())
     .filter((site) => !siteUtil.isFolder(site))
-    .filter((site) => !isSourceAboutUrl(site.get('location')))
+    .filter((site) => siteUtil.isHistoryEntry(site))
     .sort(sortCountDescending)
     .slice(0, aboutNewTabMaxEntries)
 

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -447,7 +447,7 @@ module.exports.isFolder = function (siteDetail) {
  */
 module.exports.isHistoryEntry = function (siteDetail) {
   if (siteDetail && typeof siteDetail.get('location') === 'string') {
-    if (siteDetail.get('location').startsWith('about:')) {
+    if (siteDetail.get('location').startsWith('about:') || siteDetail.get('lastAccessedTime') === 0) {
       return false
     }
     return !!siteDetail.get('lastAccessedTime') && !module.exports.isFolder(siteDetail)

--- a/test/about/newTabTest.js
+++ b/test/about/newTabTest.js
@@ -6,6 +6,7 @@ const {getTargetAboutUrl} = require('../../js/lib/appUrlUtil')
 const settings = require('../../js/constants/settings')
 const {newTabMode} = require('../../app/common/constants/settingsEnums')
 const aboutNewTabUrl = getTargetAboutUrl('about:newtab')
+const siteTags = require('../../js/constants/siteTags')
 
 describe('about:newtab tests', function () {
   function * setup (client) {
@@ -62,6 +63,22 @@ describe('about:newtab tests', function () {
       .waitForExist('.tab[data-frame-key="1"]')
       .tabByIndex(0)
       .url(aboutNewTabUrl)
+  }
+
+  function * addDemoImportedBookmarks (client) {
+    yield client
+      .addSite({
+        lastAcessedTime: 0,
+        location: 'page1.html',
+        title: 'page 1',
+        tags: [siteTags.BOOKMARK]
+      })
+      .addSite({
+        lastAcessedTime: 0,
+        location: 'page2.html',
+        title: 'page 2',
+        tags: [siteTags.BOOKMARK]
+      })
   }
 
   function * waitForPageLoad (client) {
@@ -228,6 +245,16 @@ describe('about:newtab tests', function () {
 
         yield this.app.client
           .waitForExist('.topSitesElementFavicon', 3000, true)
+      })
+
+      it('skip imported bookmarks on topSites grid', function * () {
+        yield this.app.client.clearAppData({browserHistory: true})
+
+        yield addDemoImportedBookmarks(this.app.client)
+
+        yield this.app.client
+          .tabByUrl(aboutNewTabUrl)
+          .waitForExist('.topSitesElementFavicon', true)
       })
 
       it('shows favicon image for topSites', function * () {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #6217

Auditors: @bsclifton

Test Plan:

Automated test must pass:

```
npm run test -- --grep="skip imported bookmarks on topSites grid"
```
Unit tests for edited function must pass:
```
npm run test -- --grep="siteUtil"
```