### PR TITLE
Tweak on PinnedTopSite icon to avoid overflow in new tab page

### DIFF
--- a/less/about/newtab.less
+++ b/less/about/newtab.less
@@ -275,6 +275,7 @@ ul {
           }
 
           .pinnedTopSite {
+            transition: @transitionFast;
             opacity: 1;
             visibility: visible;
             position: absolute;
@@ -287,6 +288,7 @@ ul {
             display: flex;
             align-items: center;
             justify-content: center;
+            z-index: 2;
 
             .pin {
               font-size: 10px;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #6281

Auditors: @luixxiul

Test Plan:

* Go to about:newtab
* Pin a site
* Pinned icon should not be overflown by favicon (should be aesthetically correct)
