### PR TITLE
Made the width of "Advanced Settings..." button on about:preferences#payments wider

### DIFF
--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -977,6 +977,10 @@ table.sortableTable {
         }
       }
     }
+
+    .advancedSettings {
+      min-width: 235px; // .walletBar td min-width
+    }
   }
 
   & > table,


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Set min-width:235px to the button to make it as wide as the table data inside '.walletBar'

Closes #6285

Auditors: @bradleyrichter @bsclifton

Test Plan:
1. Change your lang setting on the browser
2. Open about:preferences#payments
3. Check the width of the button

<img width="837" alt="screenshot 2016-12-18 3 05 16" src="https://cloud.githubusercontent.com/assets/3362943/21288878/5aa05634-c4d2-11e6-9ba4-480a2e01bbbc.png">
