### PR TITLE
Make *Submit feedback* link go to wanted page

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -1713,7 +1713,9 @@ class HelpfulHints extends ImmutableComponent {
       </span>
       <div data-l10n-id={`hint${this.props.hintNumber}`} />
       <div className='helpfulHintsBottom'>
-        <a target='_blank' href='https://community.brave.com/' data-l10n-id='submitFeedback' />
+        <span className='link' data-l10n-id='submitFeedback' onClick={aboutActions.newFrame.bind(null, {
+          location: 'https://community.brave.com/'
+        }, true)} />
       </div>
     </div>
   }

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -1438,3 +1438,9 @@ table.sortableTable {
     cursor: pointer;
   }
 }
+
+.link {
+  cursor: pointer;
+  text-decoration: underline;
+  color: white;
+}


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bsclifton

Fix #6252

Test Plan:

* Open preferences page
* On page sidebar, Click on *Submit feedback* link under helpful hints
* Link should open and go to https://community.brave.com/