### PR TITLE
Change CSP img-src directive on about:extensions

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -141,7 +141,7 @@ let generateBraveManifest = () => {
     'form-action': '\'none\'',
     'referrer': 'no-referrer',
     'style-src': '\'self\' \'unsafe-inline\'',
-    'img-src': '* data:',
+    'img-src': '\'self\' file://*',
     'frame-src': '\'self\' https://buy.coinbase.com'
   }
 


### PR DESCRIPTION
Fix #6257

Auditors: @bbondy

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

* Enable an extension
* Open about:extensions
* Extension icon must be visible