### PR TITLE
Redo: Add copy to clipboard for about brave page (fixes #5790)

### DIFF
--- a/js/about/brave.js
+++ b/js/about/brave.js
@@ -11,6 +11,7 @@ const aboutActions = require('./aboutActions')
 const ipc = window.chrome.ipcRenderer
 
 require('../../less/about/history.less')
+require('../../less/about/brave.less')
 require('../../node_modules/font-awesome/css/font-awesome.css')
 
 const tranformVersionInfoToString = (versionInformation) =>

--- a/less/about/brave.less
+++ b/less/about/brave.less
@@ -1,0 +1,16 @@
+@import "./common.less";
+
+.siteDetailsPage {
+  .siteDetailsPageContent {
+    .sectionTitle {
+      padding-left: 0;
+    }
+
+    .title {
+      width: 400px;
+      display: flex;
+      justify-content: space-between;
+      margin-left: @aboutPageSectionPadding;
+    }
+  }
+}

--- a/less/about/siteDetails.less
+++ b/less/about/siteDetails.less
@@ -78,16 +78,10 @@ body {
     display: block;
     clear: both;
 
-    .title {
-      width: 400px;
-      display: flex;
-      justify-content: space-between;
-      margin-left: @aboutPageSectionPadding;
-    }
-
     .sectionTitle {
       font-size: 16px;
       margin-bottom: 12px;
+      padding-left: @aboutPageSectionPadding;
     }
   }
 }


### PR DESCRIPTION
Original PR was closed https://github.com/brave/browser-laptop/pull/6186

This PR fixes https://github.com/brave/browser-laptop/issues/6183

Does not include changes to about:brave, because that was re-committed with https://github.com/brave/browser-laptop/commit/5324f3c64449b2043ffce4a7d9ba86ece2f88591

Auditors: @luixxiul

Test Plan:
1. Visit about:about
