### PR TITLE
Fix: about:about title adjustment (fixes #6183)

### DIFF
--- a/js/about/about.js
+++ b/js/about/about.js
@@ -17,7 +17,9 @@ class AboutAbout extends ImmutableComponent {
       </div>
 
       <div className='siteDetailsPageContent aboutAbout'>
-        <div className='sectionTitle' data-l10n-id='listOfAboutPages' />
+        <div className='title'>
+          <span className='sectionTitle' data-l10n-id='listOfAboutPages' />
+        </div>
         <ul>
           {
             aboutUrls.keySeq().sort().filter((aboutSourceUrl) => isNavigatableAboutPage(aboutSourceUrl)).map((aboutSourceUrl) =>


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

Just go to about:about page to check the title alignment.
