### PR TITLE
Properly align pinned tab icon

### DIFF
--- a/less/tabs.less
+++ b/less/tabs.less
@@ -207,6 +207,10 @@
     &:last-child {
       padding-right: 6px;
     }
+    .tabIcon {
+      margin: 0;
+      padding: 0 4px;
+    }
   }
 
   &.draggingOverLeft {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #6300

Auditors: @bbondy

Test Plan:

Pinned tab should have the same appearance as screenshot:

Previous:

![before](https://cloud.githubusercontent.com/assets/4672033/21326870/ad5abed6-c613-11e6-94d7-ce3ab515d668.png)


After this change:

![after](https://cloud.githubusercontent.com/assets/4672033/21326876/b0395996-c613-11e6-81c5-ae86b36e3533.png)
