### PR TITLE
Fixed font-weight on about:preferences#payments

### DIFF
--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -1007,7 +1007,6 @@ table.sortableTable {
     }
 
     > h3 {
-      font-weight: 200;
       font-size: 18px;
       padding-bottom: 0.5em;
     }
@@ -1057,7 +1056,6 @@ table.sortableTable {
 
     h2 {
       font-size: 18px;
-      font-weight: 200;
       margin: 70px 0 -15px 12px;
     }
   }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Closes #6310

Removed two font-weight properties

<img width="905" alt="screenshot 2016-12-20 13 31 15" src="https://cloud.githubusercontent.com/assets/3362943/21338428/8ec10664-c6b9-11e6-8b3e-1c15f834967e.png">

Auditors: @bradleyrichter

Test Plan:
1. Open about:preferences#payments
2. Set the switch to "Off"