### PR TITLE
Properly handle URL bar icon when searching and focus changes

### DIFF
--- a/app/renderer/components/urlBar.js
+++ b/app/renderer/components/urlBar.js
@@ -508,6 +508,7 @@ class UrlBar extends ImmutableComponent {
           searchSelectEntry={this.searchSelectEntry}
           title={this.props.title}
           titleMode={this.props.titleMode}
+          isSearching={this.props.location !== this.props.urlbar.get('location')}
         />
       </div>
       {

--- a/app/renderer/components/urlBarIcon.js
+++ b/app/renderer/components/urlBarIcon.js
@@ -11,6 +11,19 @@ const dndData = require('../../../js/dndData')
 const {isSourceAboutUrl} = require('../../../js/lib/appUrlUtil')
 const searchIconSize = 16
 
+const getIconCssClass = (ctx) => {
+  if (ctx.isSearch) {
+    return 'fa-search'
+  } else if (ctx.isAboutPage && !ctx.props.titleMode) {
+    return 'fa-list'
+  } else if (ctx.isSecure) {
+    // NOTE: EV style not approved yet; see discussion at https://github.com/brave/browser-laptop/issues/791
+    return 'fa-lock'
+  } else if (ctx.inInsecure) {
+    return 'fa-unlock'
+  }
+}
+
 class UrlBarIcon extends ImmutableComponent {
   constructor () {
     super()
@@ -40,7 +53,7 @@ class UrlBarIcon extends ImmutableComponent {
    * - is a catch-all for: about pages, files, etc
    */
   get isSearch () {
-    const showSearch = this.props.active
+    const showSearch = this.props.isSearching && !this.props.titleMode
 
     const defaultToSearch = (!this.isSecure && !this.isInsecure && !showSearch) &&
                             !this.props.titleMode &&
@@ -60,11 +73,7 @@ class UrlBarIcon extends ImmutableComponent {
     return cx({
       urlbarIcon: true,
       'fa': true,
-      // NOTE: EV style not approved yet; see discussion at https://github.com/brave/browser-laptop/issues/791
-      'fa-lock': this.isSecure,
-      'fa-unlock': this.isInsecure,
-      'fa-search': this.isSearch && !this.isAboutPage,
-      'fa-list': this.isAboutPage && !this.props.titleMode
+      [ getIconCssClass(this) ]: true
     })
   }
   get iconStyles () {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes https://github.com/brave/browser-laptop/issues/6273

## Test Plan: 
- enable "always show URL bar", to make testing easier
- go to google.com and notice the lock in the omnibox
- start typing a search into a the omnibox and notice icon changes to magnifying glass
- click inside the webpage. icon should stay as magnifying glass and search terms should still be shown.  This confirms the fix (the bug before was that it would revert to showing the lock icon next to the search terms)
- click in the omnibox and press escape. This should reset icon back to lock and reset input back to google.com