### PR TITLE
Small fixes of buttons on about:certerror and .noScriptInfo

### DIFF
--- a/js/about/certerror.js
+++ b/js/about/certerror.js
@@ -138,10 +138,9 @@ class CertErrorPage extends React.Component {
       <div className='buttons'>
         <Button l10nId='certErrorSafety' className='actionButton' onClick={this.onSafety.bind(this)} />
         {this.state.url ? (this.state.advanced
-          ? (<div>
-            <Button l10nId='certErrorButtonText' className='subtleButton' onClick={this.onAccept.bind(this)} />
-            <Button l10nId='certErrorShowCertificate' className='subtleButton' onClick={this.onDetail.bind(this)} />
-          </div>)
+          ? (<Button l10nId='certErrorButtonText' className='subtleButton' onClick={this.onAccept.bind(this)} />) : null) : null}
+        {this.state.url ? (this.state.advanced
+          ? (<Button l10nId='certErrorShowCertificate' className='subtleButton' onClick={this.onDetail.bind(this)} />)
           : <Button l10nId='certErrorAdvanced' className='subtleButton' onClick={this.onAdvanced.bind(this)} />) : null}
       </div>
     </div>

--- a/js/components/noScriptInfo.js
+++ b/js/components/noScriptInfo.js
@@ -64,7 +64,7 @@ class NoScriptInfo extends ImmutableComponent {
       site: this.props.frameProps.get('location') || 'this page'
     }
     return <Dialog onHide={this.props.onHide} className='noScriptInfo' isClickDismiss>
-      <div>
+      <div className='dialogInner'>
         <div className='truncate' data-l10n-args={JSON.stringify(l10nArgs)}
           data-l10n-id={this.numberBlocked === 1 ? 'scriptBlocked' : 'scriptsBlocked'} />
         {this.buttons}

--- a/less/about/error.less
+++ b/less/about/error.less
@@ -20,6 +20,18 @@
         padding-bottom: 1rem;
       }
 
+      .buttons {
+        display: flex;
+        flex-flow: row wrap;
+        position: relative;
+        right: .2em; // cancel margin: .2em to align .buttons and .certErrorText
+
+        > .browserButton {
+          margin: .2em;
+          font-size: 14px;
+        }
+      }
+
       .errorLogo {
         margin-bottom: 2rem;
 

--- a/less/forms.less
+++ b/less/forms.less
@@ -515,7 +515,7 @@ select {
 }
 
 .noScriptInfo {
-  >div {
+  .dialogInner {
     .flyoutDialog;
     right: 20px;
     width: auto;
@@ -523,6 +523,10 @@ select {
     text-align: center;
     font-size: 15px;
     cursor: default;
+
+    .truncate {
+      margin-bottom: 5px;
+    }
   }
 }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Closes #6317

- Removed a div from certerror.js
- Set margin:.2em and font-size:14px to buttons inside .buttons on about:certerror
- Added 5px margin-bottom to .truncate inside .dialogInner of .noScriptInfo

Auditors: @bsclifton / cc: @bradleyrichter for the size of the margins

Test Plan 1
1. Open https://expired.badssl.com/
2. Click advanced settings
3. Make sure the buttons have margins (as seen in screenshot)
<img width="488" alt="screenshot 2016-12-20 20 43 42" src="https://cloud.githubusercontent.com/assets/3362943/21349392/0a86b57e-c6f5-11e6-9bc3-1c433cffff54.png">

Test Plan 2
1. Open https://jsfiddle.net/
2. Disable JavaScript with the shield
3. Click the NoScript icon
4. Make sure the text has margin-bottom
<img width="362" alt="screenshot 2016-12-20 20 43 48" src="https://cloud.githubusercontent.com/assets/3362943/21349393/0abd01ba-c6f5-11e6-9371-fbe8869efb4b.png">
