### PR TITLE
Apply animation:fadeIn to every element directly under #navigator:not(.titleMode)

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -728,9 +728,7 @@
   }
 
   &:not(.titleMode) {
-    .urlbarForm,
-    .bookmarkButtonContainer,
-    span[class$="Button"] {
+    > * {
       animation: fadeIn .6s;
       opacity: 0;
       animation-fill-mode: forwards;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Since the type of elements can change, the wildcard would work better.

Closes #5664 (redo #5667)

Auditors: @bsclifton /cc: @Liunkae

Test Plan:
1. Open about:preferences
2. Disable/enable "Always show the URL bar" option