### PR TITLE
Added .5em margin around "No saved addresses/credit cards"

### DIFF
--- a/js/about/autofill.js
+++ b/js/about/autofill.js
@@ -133,7 +133,7 @@ class AboutAutofill extends React.Component {
 
   render () {
     var savedAddresssPage = this.isAddresssEmpty
-    ? <div><span data-l10n-id='noAddressesSaved' /></div>
+    ? <div><span className='notSaved' data-l10n-id='noAddressesSaved' /></div>
     : <div>
       <table className='autofillList'>
         <thead>
@@ -162,7 +162,7 @@ class AboutAutofill extends React.Component {
     </div>
 
     var savedCreditCardsPage = this.isCreditCardsEmpty
-    ? <div><span data-l10n-id='noCreditCardsSaved' /></div>
+    ? <div><span className='notSaved' data-l10n-id='noCreditCardsSaved' /></div>
     : <div>
       <table className='autofillList'>
         <thead>

--- a/less/about/autofill.less
+++ b/less/about/autofill.less
@@ -6,6 +6,11 @@
   .autofillPageContent {
     border-top: 1px solid @chromeBorderColor;
 
+    .notSaved {
+      display: block;
+      margin: .5em 0;
+    }
+
     .autofillList {
       padding-top: 10px;
       overflow: hidden;


### PR DESCRIPTION
Fixes #6328

Auditors: @bsclifton

Test Plan:
1. Open about:autofill
2. Delete entries if any
3. Make sure there are margins around the "No saved addresses/credit cards"

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

<img width="279" alt="screenshot 2016-12-20 23 00 05" src="https://cloud.githubusercontent.com/assets/3362943/21353371/06a9a9c0-c709-11e6-97ed-ebe73f35d4b4.png">

