### PR TITLE
Fix: Add right margin when url bar is in focus (fixes #5814)

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -868,6 +868,10 @@
         background: @privateTabBackground;
         color: @chromeText;
       }
+
+      &:focus {
+        margin-right: 3px;
+      }
     }
 
     .urlbarIcon {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

SAme as mentioned in issue #5814 