### PR TITLE
Add Paste Without Formatting to context menu

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -631,7 +631,7 @@ function getMisspelledSuggestions (selection, isMisspelled, suggestions) {
   return menuUtil.sanitizeTemplateItems(template)
 }
 
-function getEditableItems (selection, editFlags) {
+function getEditableItems (selection, editFlags, hasFormat) {
   const hasSelection = selection.length > 0
   const hasClipboard = clipboard.readText().length > 0
   const template = []
@@ -659,6 +659,16 @@ function getEditableItems (selection, editFlags) {
       enabled: hasClipboard,
       role: 'paste'
     })
+    if (hasFormat) {
+      template.push({
+        label: locale.translation('pasteWithoutFormatting'),
+        accelerator: 'Shift+CmdOrCtrl+V',
+        enabled: hasClipboard,
+        click: function (item, focusedWindow) {
+          focusedWindow.webContents.pasteAndMatchStyle()
+        }
+      })
+    }
   }
   return menuUtil.sanitizeTemplateItems(template)
 }
@@ -979,7 +989,7 @@ function mainTemplateInit (nodeProps, frame) {
       }
     }
 
-    const editableItems = getEditableItems(nodeProps.selectionText, nodeProps.editFlags)
+    const editableItems = getEditableItems(nodeProps.selectionText, nodeProps.editFlags, true)
     template.push(...misspelledSuggestions, {
       label: locale.translation('undo'),
       accelerator: 'CmdOrCtrl+Z',


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes #5822

Unlike #6126 (first attempt), Paste Without Formatting is not added to the url bar or find bar (#6268).

Test Plan:
1. Open a new Brave tab and navigate to a site with an input field (preferably a field that accepts rich text).
2. Open your favorite rich text editor (e.g. TextEdit).
3. Type a string of text and give the text some formatting (e.g. bold).
4. Switch back to Brave. Right click the input field.
5. Click `Paste Without Formatting`.
6. Make sure the pasted text has no formatting.

Screenshot:
![image](https://cloud.githubusercontent.com/assets/19424103/21068007/a0365198-be34-11e6-8c3a-23d258d38a3b.png)