### PR TITLE
Fix broken array concat behavior during app relaunch

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -476,7 +476,9 @@ app.on('ready', () => {
         prefsRestartCallbacks[message] = (buttonIndex, persist) => {
           delete prefsRestartCallbacks[message]
           if (buttonIndex === 0) {
-            app.relaunch({args: process.argv.slice(1) + ['--relaunch']})
+            const args = process.argv.slice(1)
+            args.push('--relaunch')
+            app.relaunch({args})
             app.quit()
           } else {
             delete prefsRestartLastValue[config]

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -359,7 +359,6 @@ const setVersionInformation = (data) => {
       {name: 'os.platform', version: os.platform()},
       {name: 'os.release', version: os.release()},
       {name: 'os.arch', version: os.arch()}
-      // TODO(bsclifton): read the latest commit hash from a file, etc.
     ]
     data.about = data.about || {}
     data.about.brave = {


### PR DESCRIPTION
The + turns it from an array into a string on Windows (new node behavior?). Definitely wrong.

This fix is to help with https://github.com/brave/browser-laptop/issues/5938.  Tested on Mac and Windows.  Please note: it doesn't fix the issue, but it does correct the wrong behavior

Fixes https://github.com/brave/browser-laptop/issues/6369

Auditors: @bbondy, @bridiver 