### PR TITLE
Updated sanitization logic for separators

### DIFF
--- a/app/common/lib/menuUtil.js
+++ b/app/common/lib/menuUtil.js
@@ -161,7 +161,7 @@ const isItemValid = (currentItem, previousItem) => {
  * - entries which don't have a label or type
  */
 module.exports.sanitizeTemplateItems = (template) => {
-  const result = template.reduce((previousValue, currentValue, currentIndex, array) => {
+  const reduced = template.reduce((previousValue, currentValue, currentIndex, array) => {
     const result = currentIndex === 1 ? [] : previousValue
     if (currentIndex === 1) {
       if (isItemValid(previousValue)) {
@@ -177,7 +177,17 @@ module.exports.sanitizeTemplateItems = (template) => {
     return result
   })
 
-  return Array.isArray(result)
-    ? result
-    : [result]
+  const result = Array.isArray(reduced)
+    ? reduced
+    : [reduced]
+
+  if (result.length > 0 && result[0] === CommonMenu.separatorMenuItem) {
+    result.shift()
+  }
+
+  if (result.length > 0 && result[result.length - 1] === CommonMenu.separatorMenuItem) {
+    result.pop()
+  }
+
+  return result
 }

--- a/test/unit/app/common/lib/menuUtilTest.js
+++ b/test/unit/app/common/lib/menuUtilTest.js
@@ -244,9 +244,9 @@ describe('menuUtil tests', function () {
       assert.deepEqual(result, expectedResult)
     })
     it('removes duplicate menu separators', function () {
-      const template = [separator, separator, {label: 'lol'}]
+      const template = [{label: 'lol1'}, separator, separator, {label: 'lol2'}]
       const result = menuUtil.sanitizeTemplateItems(template)
-      const expectedResult = [separator, {label: 'lol'}]
+      const expectedResult = [{label: 'lol1'}, separator, {label: 'lol2'}]
       assert.deepEqual(result, expectedResult)
     })
     it('removes items which are missing label or type', function () {
@@ -265,6 +265,24 @@ describe('menuUtil tests', function () {
       const template = [{label: 'lol'}]
       const result = menuUtil.sanitizeTemplateItems(template)
       const expectedResult = [{label: 'lol'}]
+      assert.deepEqual(result, expectedResult)
+    })
+    it('does not allow the list to start with a separator', function () {
+      const template = [separator, {label: 'lol'}]
+      const result = menuUtil.sanitizeTemplateItems(template)
+      const expectedResult = [{label: 'lol'}]
+      assert.deepEqual(result, expectedResult)
+    })
+    it('does not allow the list to end with a separator', function () {
+      const template = [{label: 'lol'}, separator]
+      const result = menuUtil.sanitizeTemplateItems(template)
+      const expectedResult = [{label: 'lol'}]
+      assert.deepEqual(result, expectedResult)
+    })
+    it('does not allow only a separator', function () {
+      const template = [separator]
+      const result = menuUtil.sanitizeTemplateItems(template)
+      const expectedResult = []
       assert.deepEqual(result, expectedResult)
     })
   })


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Updated sanitization logic for separators
- don't allow menu to start with one
- don't allow menu to end with one
- don't allow only a separator

Fixes https://github.com/brave/browser-laptop/issues/5765

Auditors: @bbondy, @cezaraugusto 

Test Plan:
1. Launch Brave on Windows and go to preferences
2. Disable pocket and any password managers
3. Visit about:about
4. Right click the page; you should not see any separators at the end

