### PR TITLE
Fixed the bookmark hanger being faded in

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -723,7 +723,10 @@
   }
 
   &:not(.titleMode) {
-    > * {
+
+    // Animate all direct descendants except for the bookmark bar
+    // PR #6382
+    > *:not(.bookmarkHanger) {
       animation: fadeIn .6s;
       opacity: 0;
       animation-fill-mode: forwards;


### PR DESCRIPTION
Fixes #6380

Auditors:

Test Plan:
1. Bookmark a page with the star icon on the URL bar
2. Make sure "Bookmark Added" dialog is instantly prompt without animation

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

unintentionally I broke the animation. I've been not sure that the bookmark dialog was included in #navigator.