### PR TITLE
Open brave payments contrib pdf in PDF.js after generated (WIP)

### DIFF
--- a/app/pdf.js
+++ b/app/pdf.js
@@ -6,13 +6,13 @@
 
 const electron = require('electron')
 const BrowserWindow = electron.BrowserWindow
+const Tabs = require('./browser/tabs')
+const {fileUrl} = require('../js/lib/appUrlUtil')
 
 const renderUrlToPdf = (appState, action, testingMode) => {
   let url = action.url
   let savePath = action.savePath
   let openAfterwards = action.openAfterwards
-
-  let currentBw = BrowserWindow.getFocusedWindow()
 
   let bw = new BrowserWindow({show: !!testingMode, backgroundColor: '#ffffff'})
 
@@ -41,14 +41,14 @@ const renderUrlToPdf = (appState, action, testingMode) => {
           if (state === 'completed') {
             let finalSavePath = item && item.getSavePath()
 
-            if (openAfterwards && savePath) {
-              currentBw.webContents.loadURL('file://' + finalSavePath)
-            }
-
             if (bw && !testingMode) {
               try {
                 bw.close()
               } catch (exc) {}
+            }
+
+            if (openAfterwards && finalSavePath) {
+              Tabs.create({url: fileUrl(finalSavePath)})
             }
           }
         })

--- a/js/about/aboutActions.js
+++ b/js/about/aboutActions.js
@@ -364,11 +364,12 @@ const aboutActions = {
   /**
    * Dispatches a message to render a URL into a PDF file
    */
-  renderUrlToPdf: function (url, savePath) {
+  renderUrlToPdf: function (url, savePath, openAfterwards) {
     aboutActions.dispatchAction({
       actionType: appConstants.APP_RENDER_URL_TO_PDF,
       url: url,
-      savePath: savePath
+      savePath: savePath,
+      openAfterwards: openAfterwards
     })
   }
 }

--- a/js/about/contributionStatement.js
+++ b/js/about/contributionStatement.js
@@ -280,7 +280,7 @@ class ContributionStatement extends ImmutableComponent {
               <tr className='spacingRow' />
               {
               page.map(function (row, idx) {
-                let publisherSynopsis = this.synopsis[row.siteColumn] || {}
+                let publisherSynopsis = (this.synopsis.filter((entry) => { return entry.site === row[0] }) || [])[0] || {}
 
                 let verified = publisherSynopsis.verified
                 let site = row[0]

--- a/js/about/contributionStatement.js
+++ b/js/about/contributionStatement.js
@@ -127,7 +127,7 @@ class ContributionStatement extends ImmutableComponent {
   }
 
   renderPdf () {
-    aboutActions.renderUrlToPdf(this.htmlDataURL, this.receiptFileName())
+    aboutActions.renderUrlToPdf(this.htmlDataURL, this.receiptFileName(), true)
   }
 
   get transaction () {


### PR DESCRIPTION
part of issue #6039

opening this as WIP because it depends on PDF.js being able to open local files (#2714 ~~, I think, but may have been fixed in #6330~~)

I'm looking into PDF.js myself right now but I am at total newbie with Chrome extensions so feel free to let me know if you have tips on how to fix it.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests). (not yet)
- [ ] Ran `git rebase -i` to squash commits (if needed). (not squashed yet)

Test Plan:
- Navigate to `about:preferences#payments`
- Click 'View Payment History'
- Click one of the receipt ilnks
- Choose path to save PDF
- Observe PDF is also opened in new tab
