### PR TITLE
Fixes #6378 npm registry name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "brave",
+  "name": "brave-browser",
   "version": "0.13.0",
   "description": "Brave laptop and desktop browser",
   "main": "./app/index.js",


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/6378

Auditors: @anasant, @bbondy 

I accepted / merged https://github.com/brave/browser-laptop/pull/6383 too quickly without testing (sorry, @anasant :frowning_face: ).

When we accept this redo, let's make sure our builds work great with the new name.