### PR TITLE
Setting min-width for buttons

### DIFF
--- a/less/button.less
+++ b/less/button.less
@@ -82,6 +82,7 @@ span.buttonSeparator {
     padding-bottom: 5px;
     width: auto;
     height: auto;
+    min-width: calc(@defaultFontSize * 6); // issue #6384
   }
 
   &.primaryButton,


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Per @bradleyrichter the min-width was set to 6 times the default character's size

Closes #6384

Auditors: @bradleyrichter @bsclifton @jkup

Test Plan:
1. Open about:autofill
2. Click "Add Address"
3. Make sure the width of the button "Cancel" and "Save" is equal

<img width="205" alt="screenshot 2016-12-22 18 43 38" src="https://cloud.githubusercontent.com/assets/3362943/21421497/9cf8bf6a-c876-11e6-8be2-1a3592b4624e.png">
into
<img width="196" alt="screenshot 2016-12-22 18 43 45" src="https://cloud.githubusercontent.com/assets/3362943/21421498/9cf9d058-c876-11e6-8d62-abd777e15edb.png">
