### PR TITLE
Fixed drag and drop for local files

### DIFF
--- a/js/components/tabs.js
+++ b/js/components/tabs.js
@@ -68,8 +68,10 @@ class Tabs extends ImmutableComponent {
       return
     }
     if (e.dataTransfer.files) {
-      Array.from(e.dataTransfer.files).forEach((file) =>
-        windowActions.newFrame({location: file.path, title: file.name}))
+      Array.from(e.dataTransfer.files).forEach((file) => {
+        const path = encodeURI(file.path)
+        return windowActions.newFrame({location: path, title: file.name})
+      })
     }
   }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

## Description
Resolves #3819. 
Problem was that path was not encoded, so if file path contained any spaces or other special characters, url was treated as search query and passed to the search engine.

## Auditors
@Sh1d0w @bradleyrichter @bsclifton 

## Test Plan:
https://github.com/brave/browser-laptop/issues/3819#issue-175740756
