### PR TITLE
Localize copy version info tooltip

### DIFF
--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -242,3 +242,4 @@ notNow=Not Now
 widevinePanelTitle=Brave needs to install Google Widevine to proceed
 installAndAllow=Install and Allow
 rememberThisDecision=Remember this decision for {{origin}}
+copyToClipboard.title=Copy to clipboard

--- a/js/about/brave.js
+++ b/js/about/brave.js
@@ -43,7 +43,7 @@ class AboutBrave extends React.Component {
       <div className='siteDetailsPageContent aboutAbout'>
         <div className='title'>
           <span className='sectionTitle' data-l10n-id='versionInformation' />
-          <span className='fa fa-clipboard' title='Copy to clipboard' onClick={this.onCopy} />
+          <span className='fa fa-clipboard' data-l10n-id='copyToClipboard' onClick={this.onCopy} />
         </div>
         <SortableTable
           headings={['Name', 'Version']}


### PR DESCRIPTION
Fixes #6371

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Thanks @bsclifton for the help!

Test Plan:

1. Open a new Brave tab and go to about:brave.
2. Mouse over the copy to clipboard button.
3. Make sure the tooltip says "Copy to clipboard"

I'll assign this to 0.13.0 for now.