### PR TITLE
Changing language settings prompts to restart the browser

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -1849,6 +1849,7 @@ class AboutPreferences extends React.Component {
     aboutActions.changeSetting(key, value)
     if (key === settings.HARDWARE_ACCELERATION_ENABLED ||
         key === settings.DO_NOT_TRACK ||
+        key === settings.LANGUAGE ||
         key === settings.PDFJS_ENABLED || key === settings.TORRENT_VIEWER_ENABLED ||
         key === settings.SMOOTH_SCROLL_ENABLED || key === settings.SEND_CRASH_REPORTS) {
       ipc.send(messages.PREFS_RESTART, key, value)


### PR DESCRIPTION
Closes #4777

Auditors: @bbondy

Test Plan:
1. Change the language setting on about:preferences
2. Click "Yes" on the notification bar
3. Make sure the browser is restarted taking effect the change

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
