### PR TITLE
Added arrow navigation to the autofill

### DIFF
--- a/app/renderer/components/menubar.js
+++ b/app/renderer/components/menubar.js
@@ -53,22 +53,19 @@ class MenubarItem extends ImmutableComponent {
     }
     // If clicking on an already selected item, deselect it
     const selected = this.props.menubar.props.selectedIndex
-      ? this.props.menubar.props.selectedIndex[0]
-      : null
     if (selected && selected === this.props.index) {
       windowActions.setContextMenuDetail()
-      windowActions.setSubmenuSelectedIndex()
+      windowActions.setMenuBarSelectedIndex()
       return
     }
     // Otherwise, mark item as selected and show its context menu
-    windowActions.setSubmenuSelectedIndex([this.props.index])
+    windowActions.setMenuBarSelectedIndex(this.props.index)
+    windowActions.setContextMenuSelectedIndex([0])
     const rect = e.target.getBoundingClientRect()
     showContextMenu(rect, this.props.submenu, this.props.lastFocusedSelector)
   }
   onMouseOver (e) {
     const selected = this.props.menubar.props.selectedIndex
-      ? this.props.menubar.props.selectedIndex[0]
-      : null
     if (typeof selected === 'number' && selected !== this.props.index) {
       this.onClick(e)
     }
@@ -102,195 +99,74 @@ class Menubar extends ImmutableComponent {
   }
 
   /**
-   * Used to get the submenu of a top level menu like File, Edit, etc.
-   * Index will default to the selected menu if not provided / valid.
-   */
-  getTemplate (index) {
-    if (typeof index !== 'number') index = this.props.selectedIndex[0]
-    return this.props.template.get(index).get('submenu')
-  }
-  /**
-   * Same as getTemplate but excluding line separators and items that are not visible.
-   */
-  getTemplateItemsOnly (index) {
-    return this.getTemplate(index).filter((element) => {
-      if (element.get('type') === separatorMenuItem.type) return false
-      if (element.has('visible')) return element.get('visible')
-      return true
-    })
-  }
-  /**
    * Get client rect for the MenubarItem controls.
    * Used to position the context menu object.
    */
   getMenubarItemBounds (index) {
-    if (typeof index !== 'number') index = this.props.selectedIndex[0]
+    if (typeof index !== 'number') index = this.props.selectedIndex
     const selected = document.querySelectorAll('.menubar .menubarItem[data-index=\'' + index + '\']')
     if (selected.length === 1) {
       return selected.item(0).getBoundingClientRect()
     }
     return null
   }
-  /**
-   * Get client rect for the actively selected ContextMenu.
-   * Used to position the child menu if parent has children.
-   */
-  getContextMenuItemBounds () {
-    const selected = document.querySelectorAll('.contextMenuItem.selectedByKeyboard')
-    if (selected.length > 0) {
-      return selected.item(selected.length - 1).getBoundingClientRect()
-    }
-    return null
-  }
-  /**
-   * Returns index for the active / focused menu.
-   */
-  get currentIndex () {
-    return this.props.selectedIndex[this.props.selectedIndex.length - 1]
-  }
-  /**
-   * Upper bound for the active / focused menu.
-   */
-  get maxIndex () {
-    return this.getMenuByIndex().size - 1
-  }
-  /**
-   * Returns true is current state is inside a regular menu.
-   */
-  get hasMenuSelection () {
-    return this.props.selectedIndex.length > 1
-  }
-  /**
-   * Returns true if current state is inside a submenu.
-   */
-  get hasSubmenuSelection () {
-    return this.props.selectedIndex.length > 2
-  }
-  /**
-   * Fetch menu based on selected index.
-   * Will navigate children to find nested menus.
-   */
-  getMenuByIndex (parentItem, currentDepth) {
-    if (!parentItem) parentItem = this.getTemplateItemsOnly()
-    if (!currentDepth) currentDepth = 0
-
-    const selectedIndices = this.props.selectedIndex.slice(1)
-    if (selectedIndices.length === 0) return parentItem
-
-    const submenuIndex = selectedIndices[currentDepth]
-    const childItem = parentItem.get(submenuIndex)
-
-    if (childItem && childItem.get('submenu') && currentDepth < (selectedIndices.length - 1)) {
-      return this.getMenuByIndex(childItem.get('submenu'), currentDepth + 1)
-    }
-
-    return parentItem
-  }
 
   onKeyDown (e) {
     const selectedIndex = this.props.selectedIndex
+    const template = this.props.template
+    const contextMenuIndex = this.props.contextMenuSelectedIndex
 
-    if (!selectedIndex || !this.props.template) return
+    if (!template) return
 
     switch (e.which) {
-      case keyCodes.ENTER:
-        e.preventDefault()
-        const selectedLabel = this.getMenuByIndex().getIn([this.currentIndex, 'label'])
-        windowActions.clickMenubarSubmenu(selectedLabel)
-        windowActions.resetMenuState()
-        break
-
       case keyCodes.LEFT:
       case keyCodes.RIGHT:
+        if (contextMenuIndex !== null) {
+          const currentTemplate = template.get(selectedIndex).get('submenu').filter((element) => {
+            if (element.get('type') === separatorMenuItem.type) return false
+            if (element.has('visible')) return element.get('visible')
+            return true
+          }).get(contextMenuIndex[0])
+
+          if (currentTemplate && currentTemplate.has('submenu')) {
+            break
+          }
+        }
+
         e.preventDefault()
-
-        // Left arrow inside a submenu
-        // <= go back one level
-        if (e.which === keyCodes.LEFT && this.hasSubmenuSelection) {
-          const newIndices = selectedIndex.slice()
-          newIndices.pop()
-          windowActions.setSubmenuSelectedIndex(newIndices)
-
-          let openedSubmenuDetails = this.props.contextMenuDetail.get('openedSubmenuDetails')
-            ? this.props.contextMenuDetail.get('openedSubmenuDetails')
-            : new Immutable.List()
-          openedSubmenuDetails = openedSubmenuDetails.pop()
-
-          windowActions.setContextMenuDetail(this.props.contextMenuDetail.set('openedSubmenuDetails', openedSubmenuDetails))
-          break
-        }
-
-        const selectedMenuItem = selectedIndex
-          ? this.getMenuByIndex().get(this.currentIndex)
-          : null
-
-        // Right arrow on a menu item which has a submenu
-        // => go up one level (default next menu to item 0)
-        if (e.which === keyCodes.RIGHT && selectedMenuItem && selectedMenuItem.has('submenu')) {
-          const newIndices = selectedIndex.slice()
-          newIndices.push(0)
-          windowActions.setSubmenuSelectedIndex(newIndices)
-
-          let openedSubmenuDetails = this.props.contextMenuDetail.get('openedSubmenuDetails')
-            ? this.props.contextMenuDetail.get('openedSubmenuDetails')
-            : new Immutable.List()
-
-          const rect = this.getContextMenuItemBounds()
-          const itemHeight = (rect.bottom - rect.top)
-
-          openedSubmenuDetails = openedSubmenuDetails.push(Immutable.fromJS({
-            y: (rect.top - itemHeight),
-            template: selectedMenuItem.get('submenu')
-          }))
-
-          windowActions.setContextMenuDetail(this.props.contextMenuDetail.set('openedSubmenuDetails', openedSubmenuDetails))
-          break
-        }
+        e.stopPropagation()
 
         // Regular old menu item
         const nextIndex = selectedIndex === null
           ? 0
           : wrappingClamp(
-              selectedIndex[0] + (e.which === keyCodes.LEFT ? -1 : 1),
+              selectedIndex + (e.which === keyCodes.LEFT ? -1 : 1),
               0,
               this.props.template.size - 1)
 
-        // Context menu already being displayed; auto-open the next one
+        windowActions.setMenuBarSelectedIndex(nextIndex)
+
         if (this.props.contextMenuDetail) {
-          windowActions.setSubmenuSelectedIndex([nextIndex, 0])
-          showContextMenu(this.getMenubarItemBounds(nextIndex), this.getTemplate(nextIndex).toJS(), this.props.lastFocusedSelector)
+          windowActions.setContextMenuSelectedIndex([0])
+          showContextMenu(this.getMenubarItemBounds(nextIndex), template.get(nextIndex).get('submenu').toJS(), this.props.lastFocusedSelector)
         } else {
-          windowActions.setSubmenuSelectedIndex([nextIndex])
+          windowActions.setContextMenuSelectedIndex()
+        }
+        break
+
+      case keyCodes.DOWN:
+      case keyCodes.ENTER:
+        e.preventDefault()
+        if (contextMenuIndex === null && template.get(selectedIndex).has('submenu')) {
+          e.stopPropagation()
+          windowActions.setContextMenuSelectedIndex([0])
+          showContextMenu(this.getMenubarItemBounds(selectedIndex), template.get(selectedIndex).get('submenu').toJS(), this.props.lastFocusedSelector)
         }
         break
 
       case keyCodes.UP:
-      case keyCodes.DOWN:
         e.preventDefault()
-        if (this.getTemplateItemsOnly()) {
-          if (!this.props.contextMenuDetail) {
-            // First time hitting up/down; popup the context menu
-            const newIndices = selectedIndex.slice()
-            newIndices.push(0)
-            windowActions.setSubmenuSelectedIndex(newIndices)
-            showContextMenu(this.getMenubarItemBounds(), this.getTemplate().toJS(), this.props.lastFocusedSelector)
-          } else {
-            // Context menu already visible; move selection up or down
-            const nextIndex = wrappingClamp(
-              this.currentIndex + (e.which === keyCodes.UP ? -1 : 1),
-              0,
-              this.maxIndex)
 
-            const newIndices = selectedIndex.slice()
-            if (this.hasMenuSelection) {
-              newIndices[selectedIndex.length - 1] = nextIndex
-            } else {
-              newIndices.push(0)
-            }
-            windowActions.setSubmenuSelectedIndex(newIndices)
-          }
-        }
-        break
     }
   }
   shouldComponentUpdate (nextProps, nextState) {
@@ -309,7 +185,7 @@ class Menubar extends ImmutableComponent {
             lastFocusedSelector: this.props.lastFocusedSelector,
             menubar: this
           }
-          if (this.props.selectedIndex && props.index === this.props.selectedIndex[0]) {
+          if (props.index === this.props.selectedIndex) {
             props.selected = true
           }
           return <MenubarItem {...props} />

--- a/docs/windowActions.md
+++ b/docs/windowActions.md
@@ -845,11 +845,23 @@ Used by `main.js` when click happens on content area (not on a link or react con
 
 
 
-### setSubmenuSelectedIndex(index) 
+### setMenuBarSelectedIndex(index) 
 
 (Windows only)
-Used to track selected index of a context menu
+Used to track selected index of a menu bar
 Needed because arrow keys can be used to navigate the custom menu
+
+**Parameters**
+
+**index**: `number`, zero based index of the item.
+  Index excludes menu separators and hidden items.
+
+
+
+### setContextMenuSelectedIndex(index) 
+
+Used to track selected index of a context menu
+Needed because arrow keys can be used to navigate the context menu
 
 **Parameters**
 

--- a/js/actions/windowActions.js
+++ b/js/actions/windowActions.js
@@ -1088,14 +1088,27 @@ const windowActions = {
 
   /**
    * (Windows only)
-   * Used to track selected index of a context menu
+   * Used to track selected index of a menu bar
    * Needed because arrow keys can be used to navigate the custom menu
    * @param {number} index - zero based index of the item.
    *   Index excludes menu separators and hidden items.
    */
-  setSubmenuSelectedIndex: function (index) {
+  setMenuBarSelectedIndex: function (index) {
     dispatch({
-      actionType: windowConstants.WINDOW_SET_SUBMENU_SELECTED_INDEX,
+      actionType: windowConstants.WINDOW_SET_MENUBAR_SELECTED_INDEX,
+      index
+    })
+  },
+
+  /**
+   * Used to track selected index of a context menu
+   * Needed because arrow keys can be used to navigate the context menu
+   * @param {number} index - zero based index of the item.
+   *   Index excludes menu separators and hidden items.
+   */
+  setContextMenuSelectedIndex: function (index) {
+    dispatch({
+      actionType: windowConstants.WINDOW_SET_CONTEXT_MENU_SELECTED_INDEX,
       index
     })
   },

--- a/js/components/contextMenu.js
+++ b/js/components/contextMenu.js
@@ -391,7 +391,7 @@ class ContextMenu extends ImmutableComponent {
   }
 
   get hasSubmenuSelection () {
-    return this.props.selectedIndex.length > 1
+    return (this.props.selectedIndex === null) ? false : this.props.selectedIndex.length > 1
   }
 
   render () {

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -156,10 +156,10 @@ class Main extends ImmutableComponent {
                 windowActions.toggleMenubarVisible(null)
               } else {
                 if (customTitlebar.menubarSelectedIndex) {
-                  windowActions.setSubmenuSelectedIndex()
+                  windowActions.setMenuBarSelectedIndex()
                   windowActions.setContextMenuDetail()
                 } else {
-                  windowActions.setSubmenuSelectedIndex([0])
+                  windowActions.setMenuBarSelectedIndex(0)
                 }
               }
             }
@@ -172,7 +172,7 @@ class Main extends ImmutableComponent {
             }
             if (customTitlebar.menubarSelectedIndex) {
               e.preventDefault()
-              windowActions.setSubmenuSelectedIndex()
+              windowActions.setMenuBarSelectedIndex()
               windowActions.setContextMenuDetail()
             }
             break
@@ -825,15 +825,15 @@ class Main extends ImmutableComponent {
     const customTitlebarEnabled = isWindows
     const captionButtonsVisible = customTitlebarEnabled
     const menubarVisible = customTitlebarEnabled && (!getSetting(settings.AUTO_HIDE_MENU) || this.props.windowState.getIn(['ui', 'menubar', 'isVisible']))
-    const selectedIndex = this.props.windowState.getIn(['ui', 'menubar', 'selectedIndex'])
+    const selectedIndex = this.props.windowState.getIn(['ui', 'contextMenu', 'selectedIndex'])
     return {
       enabled: customTitlebarEnabled,
       captionButtonsVisible: captionButtonsVisible,
       menubarVisible: menubarVisible,
       menubarTemplate: menubarVisible ? this.props.appState.getIn(['menu', 'template']) : null,
-      menubarSelectedIndex: selectedIndex,
-      contextMenuSelectedIndex: typeof selectedIndex === 'object' && Array.isArray(selectedIndex) && selectedIndex.length > 1
-        ? selectedIndex.slice(1)
+      menubarSelectedIndex: this.props.windowState.getIn(['ui', 'menubar', 'selectedIndex']),
+      contextMenuSelectedIndex: typeof selectedIndex === 'object' && Array.isArray(selectedIndex) && selectedIndex.length > 0
+        ? selectedIndex
         : null,
       lastFocusedSelector: this.props.windowState.getIn(['ui', 'menubar', 'lastFocusedSelector']),
       isMaximized: currentWindow.isMaximized() || currentWindow.isFullScreen()
@@ -938,6 +938,7 @@ class Main extends ImmutableComponent {
                   <Menubar
                     template={customTitlebar.menubarTemplate}
                     selectedIndex={customTitlebar.menubarSelectedIndex}
+                    contextMenuSelectedIndex={customTitlebar.contextMenuSelectedIndex}
                     contextMenuDetail={this.props.windowState.get('contextMenuDetail')}
                     autohide={getSetting(settings.AUTO_HIDE_MENU)}
                     lastFocusedSelector={customTitlebar.lastFocusedSelector} />

--- a/js/constants/windowConstants.js
+++ b/js/constants/windowConstants.js
@@ -44,6 +44,7 @@ const windowConstants = {
   WINDOW_SET_FIND_DETAIL: _,
   WINDOW_SET_BOOKMARK_DETAIL: _, // If set, also indicates that add/edit is shown
   WINDOW_SET_CONTEXT_MENU_DETAIL: _, // If set, also indicates that the context menu is shown
+  WINDOW_SET_CONTEXT_MENU_SELECTED_INDEX: _,
   WINDOW_SET_POPUP_WINDOW_DETAIL: _, // If set, also indicates that the popup window is shown
   WINDOW_HIDE_BOOKMARK_HANGER: _,
   WINDOW_SET_AUDIO_MUTED: _,
@@ -76,7 +77,7 @@ const windowConstants = {
   WINDOW_TOGGLE_MENUBAR_VISIBLE: _,
   WINDOW_CLICK_MENUBAR_SUBMENU: _,
   WINDOW_RESET_MENU_STATE: _,
-  WINDOW_SET_SUBMENU_SELECTED_INDEX: _,
+  WINDOW_SET_MENUBAR_SELECTED_INDEX: _,
   WINDOW_SET_LAST_FOCUSED_SELECTOR: _,
   WINDOW_GOT_RESPONSE_DETAILS: _,
   WINDOW_SET_BOOKMARKS_TOOLBAR_SELECTED_FOLDER_ID: _,

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -871,7 +871,7 @@ const doAction = (action) => {
           : !windowState.getIn(['ui', 'menubar', 'isVisible'])
         // Clear selection when menu is shown
         if (newVisibleStatus) {
-          doAction({ actionType: windowConstants.WINDOW_SET_SUBMENU_SELECTED_INDEX, index: [0] })
+          doAction({ actionType: windowConstants.WINDOW_SET_MENUBAR_SELECTED_INDEX, index: 0 })
         }
         windowState = windowState.setIn(['ui', 'menubar', 'isVisible'], newVisibleStatus)
       }
@@ -890,14 +890,18 @@ const doAction = (action) => {
       } else {
         doAction({actionType: windowConstants.WINDOW_SET_CONTEXT_MENU_DETAIL})
       }
-      doAction({actionType: windowConstants.WINDOW_SET_SUBMENU_SELECTED_INDEX})
+      doAction({actionType: windowConstants.WINDOW_SET_MENUBAR_SELECTED_INDEX})
+      doAction({actionType: windowConstants.WINDOW_SET_CONTEXT_MENU_SELECTED_INDEX})
       doAction({actionType: windowConstants.WINDOW_SET_BOOKMARKS_TOOLBAR_SELECTED_FOLDER_ID})
       break
-    case windowConstants.WINDOW_SET_SUBMENU_SELECTED_INDEX:
-      windowState = windowState.setIn(['ui', 'menubar', 'selectedIndex'],
-        Array.isArray(action.index)
-        ? action.index
-        : null)
+    case windowConstants.WINDOW_SET_MENUBAR_SELECTED_INDEX:
+      windowState = windowState.setIn(['ui', 'menubar', 'selectedIndex'], action.index)
+      break
+    case windowConstants.WINDOW_SET_CONTEXT_MENU_SELECTED_INDEX:
+      windowState = windowState.setIn(['ui', 'contextMenu', 'selectedIndex'],
+          Array.isArray(action.index)
+          ? action.index
+          : null)
       break
     case windowConstants.WINDOW_SET_LAST_FOCUSED_SELECTOR:
       windowState = windowState.setIn(['ui', 'menubar', 'lastFocusedSelector'], action.selector)

--- a/test/components/contextMenuTest.js
+++ b/test/components/contextMenuTest.js
@@ -1,0 +1,128 @@
+/* global describe, it, before */
+
+const Brave = require('../lib/brave')
+const {urlInput} = require('../lib/selectors')
+
+describe('ContextMenu', function () {
+  function * setup (client) {
+    yield client
+      .waitForUrl(Brave.newTabUrl)
+      .waitForBrowserWindow()
+      .waitForEnabled(urlInput)
+  }
+
+  describe('navigation', function () {
+    Brave.beforeAll(this)
+
+    before(function *() {
+      yield setup(this.app.client)
+      this.formfill = Brave.server.url('formfill.html')
+      this.input = '[name="01___title"]'
+      this.values = ['Value 1', 'Value 2', 'Value 3', 'Value 4']
+
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(this.formfill)
+        .waitForVisible('<form>')
+
+      for (let i = 0; i < this.values.length; i++) {
+        yield this.app.client
+          .click(this.input)
+          .keys(this.values[i])
+          .click('#submit')
+          .waitForVisible('<form>')
+      }
+    })
+
+    it('check if context menu exists', function *() {
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(this.formfill)
+        .waitForVisible('<form>')
+        .click(this.input)
+        .click(this.input)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForVisible('.contextMenuItemText')
+    })
+
+    it('check if enter is prevented', function *() {
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(this.formfill)
+        .waitForVisible('<form>')
+        .click('[name="02frstname"]')
+        .keys('Test value')
+        .click(this.input)
+        .click(this.input)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForVisible('.contextMenu')
+        .keys('\uE015')
+        .pause(10)
+        .keys('\uE015')
+        .pause(10)
+        .keys('\uE007')
+        .pause(10)
+        .tabByUrl(this.formfill)
+        .getValue('[name="02frstname"]').should.eventually.be.equal('Test value')
+        .getValue(this.input).should.eventually.be.equal(this.values[2])
+    })
+
+    it('click on item', function *() {
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(this.formfill)
+        .waitForVisible('<form>')
+        .click(this.input)
+        .click(this.input)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForVisible('.contextMenu')
+        .click('.contextMenuItem')
+        .tabByUrl(this.formfill)
+        .getValue(this.input).should.eventually.be.equal(this.values[0])
+    })
+
+    it('select item via click and keys', function *() {
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(this.formfill)
+        .waitForVisible('<form>')
+        .click(this.input)
+        .click(this.input)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForVisible('.contextMenu')
+        .keys('\uE015')
+        .pause(10)
+        .keys('\uE015')
+        .pause(10)
+        .keys('\uE007')
+        .pause(10)
+        .tabByUrl(this.formfill)
+        .getValue(this.input).should.eventually.be.equal(this.values[2])
+    })
+
+    it('select item via keys only', function *() {
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(this.formfill)
+        .waitForVisible('<form>')
+        .click(this.input)
+        .windowByUrl(Brave.browserWindowUrl)
+        .keys('\uE015')
+        .waitForVisible('.contextMenu')
+        .keys('\uE015')
+        .pause(10)
+        .keys('\uE015')
+        .pause(10)
+        .keys('\uE015')
+        .pause(10)
+        .keys('\uE015')
+        .pause(10)
+        .keys('\uE013')
+        .pause(10)
+        .keys('\uE007')
+        .pause(10)
+        .tabByUrl(this.formfill)
+        .getValue(this.input).should.eventually.be.equal(this.values[3])
+    })
+  })
+})

--- a/test/components/contextMenuTest.js
+++ b/test/components/contextMenuTest.js
@@ -124,5 +124,32 @@ describe('ContextMenu', function () {
         .tabByUrl(this.formfill)
         .getValue(this.input).should.eventually.be.equal(this.values[3])
     })
+
+    it('check left/right on non sub menu item', function *() {
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(this.formfill)
+        .waitForVisible('<form>')
+        .click(this.input)
+        .windowByUrl(Brave.browserWindowUrl)
+        .keys('\uE015')
+        .waitForVisible('.contextMenu')
+        .keys('\uE012') // left
+        .pause(10)
+        .keys('\uE014') // right
+        .pause(10)
+        .keys('\uE014') // right
+        .pause(10)
+        .keys('\uE012') // left
+        .pause(10)
+        .keys('\uE015')
+        .pause(10)
+        .keys('\uE015')
+        .pause(10)
+        .keys('\uE007')
+        .pause(10)
+        .tabByUrl(this.formfill)
+        .getValue(this.input).should.eventually.be.equal(this.values[2])
+    })
   })
 })


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

### Description
Resolves #1302

### Auditors 
@bsclifton

### Test Plan
- go to website with a form
- submit form so that autofill will be triggered
- go to the same website and double click on the input to trigger autofill
- use down arrow to select value and press enter
- value should be field into the input

## Automated tests
- `npm run watch-test`
- `npm run uitest -- --grep="ContextMenu"`