### PR TITLE
ledger recovery error if fields are not set

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -850,6 +850,10 @@ class TabsTab extends ImmutableComponent {
 class PaymentsTab extends ImmutableComponent {
   constructor () {
     super()
+    this.state = {
+      FirstRecoveryKey: '',
+      SecondRecoveryKey: ''
+    }
 
     this.printKeys = this.printKeys.bind(this)
     this.saveKeys = this.saveKeys.bind(this)


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #6447

Auditors @cezaraugusto @bsclifton 

This just adds default blank values for the first and second key so if the user clicks recover with either or both unset it won't cause a JavaScript error (just a ledger recovery failed error!)

Test Plan:
  1. Go to Preferences > Payments
  2. Click on Advanced Settings
  3. Click Recover Your Wallet
  4. Click Recover (with the fields blank)
  5. Make sure there is no error in the console and that you *do* see the recovery failed screen.

<img width="749" alt="screen shot 2016-12-29 at 8 13 04 pm" src="https://cloud.githubusercontent.com/assets/490294/21559565/42034a02-ce03-11e6-818d-7a183a867687.png">

