### PR TITLE
Aligned icons on about:bookmarks

### DIFF
--- a/js/about/bookmarks.js
+++ b/js/about/bookmarks.js
@@ -107,12 +107,15 @@ class BookmarkFolderItem extends React.Component {
           isDragOver: this.state.isDragOver
         })}>
 
-        <span className={cx({
-          bookmarkFolderIcon: true,
-          fa: true,
-          'fa-folder-o': !this.props.selected && !this.state.isDragOver,
-          'fa-folder-open-o': this.props.selected || this.state.isDragOver
-        })} />
+        <div className='bookmarkFolderIconContainer'>
+          <span className={cx({
+            bookmarkFolderIcon: true,
+            fa: true,
+            'fa-folder-o': !this.props.selected && !this.state.isDragOver,
+            'fa-folder-open-o': this.props.selected || this.state.isDragOver
+          })} />
+        </div>
+
         <span data-l10n-id={this.props.dataL10nId}>
           {this.props.bookmarkFolder.get('customTitle') || this.props.bookmarkFolder.get('title')}
         </span>
@@ -227,17 +230,19 @@ class BookmarkTitleCell extends ImmutableComponent {
     const bookmarkLocation = this.props.siteDetail.get('location')
     const defaultIcon = 'fa fa-file-o'
 
-    return <div>
-      {
-        <span
-          className={cx({
-            bookmarkFavicon: true,
-            bookmarkFile: !icon,
-            [defaultIcon]: !icon
-          })}
-          style={iconStyle}
-        />
-      }
+    return <div className='bookmarkItem'>
+      <div className='bookmarkFaviconContainer'>
+        {
+          <span
+            className={cx({
+              bookmarkFavicon: true,
+              bookmarkFile: !icon,
+              [defaultIcon]: !icon
+            })}
+            style={iconStyle}
+          />
+        }
+      </div>
       <span>{bookmarkTitle || bookmarkLocation}</span>
       {
         bookmarkTitle ? <span className='bookmarkLocation'>{bookmarkLocation}</span> : null

--- a/less/about/bookmarks.less
+++ b/less/about/bookmarks.less
@@ -33,6 +33,39 @@
     margin: 0;
     flex: 1;
 
+    // issue #6457
+    .bookmarkFolderList .listItem,
+    .bookmarkItem {
+      display: flex;
+
+      div[class$="Container"] {
+        display: inline-flex;
+        align-items: center;
+        width: 16px;
+        height: 16px;
+        min-width: 16px;
+        min-height: 16px;
+        margin-right: 5px;
+      }
+    }
+
+    .bookmarkFolderList .listItem {
+      align-items: flex-end;
+
+      // because the width of .fa-folder-open-o and .fa-folder-o is slightly different
+      div[class$="Container"] {
+        justify-content: flex-start;
+      }
+    }
+
+    .bookmarkItem {
+      align-items: center;
+
+      div[class$="Container"] {
+        justify-content: center;
+      }
+    }
+
     .folderView {
       min-width: 220px;
       flex-grow: 1;
@@ -79,9 +112,6 @@
             background-color: lighten(@braveOrange, 20%);
           }
         }
-        .bookmarkFolderIcon {
-          margin-right: 5px;
-        }
       }
     }
     .organizeView {
@@ -99,10 +129,7 @@
           padding-left: 10px;
           white-space: nowrap;
           max-width: 0;
-          .bookmarkFavicon {
-            display: inline-block;
-            margin-right: 5px;
-          }
+
           .bookmarkLocation {
             color: @gray;
             margin-left: 12px;
@@ -117,11 +144,6 @@
           span {
             vertical-align: middle;
           }
-
-          .bookmarkFavicon {
-            width: 16px;
-          }
-
         }
         tr:hover {
           .bookmarkLocation {


### PR DESCRIPTION
Closes #6457

Auditors:

Test Plan:
1. Bookmark pages with and without favicons
2. Open about:bookmarks
3. Select "Bookmarks Toolbar" and "Other bookmarks" mutually
4. Make sure these labels are aligned vertically

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
