### PR TITLE
Added .5em margin around .autofillList

### DIFF
--- a/less/about/autofill.less
+++ b/less/about/autofill.less
@@ -6,13 +6,16 @@
   .autofillPageContent {
     border-top: 1px solid @chromeBorderColor;
 
-    .notSaved {
-      display: block;
+    .notSaved,
+    .autofillList {
       margin: .5em 0;
     }
 
+    .notSaved {
+      display: block;
+    }
+
     .autofillList {
-      padding-top: 10px;
       overflow: hidden;
     }
   }


### PR DESCRIPTION
<img width="141" alt="screenshot 2016-12-30 19 07 10" src="https://cloud.githubusercontent.com/assets/3362943/21563222/373d7a28-cec3-11e6-9335-6a5bdf1fbd1b.png">

Closes #6328

Auditors:

Test Plan:
1. Open about:autofill
2. Delete entries if any
3. Make sure padding exists around the "No saved addresses/credit cards"
4. Add an entry
5. Select the entry on hover
6. Make sure padding exists between the list and the button

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
