### PR TITLE
Remove border around new tab button; also increases width of button

### DIFF
--- a/less/tabs.less
+++ b/less/tabs.less
@@ -53,14 +53,14 @@
 
   .newFrameButton {
     background: @buttonColor;
-    width: 15px;
-    height: 26px;
-    line-height: 24px;
+    min-width: 25px;
+    min-height: 25px;
     -webkit-mask-image: url('../img/toolbar/newtab_btn.svg');
     -webkit-mask-repeat: no-repeat;
     -webkit-mask-position: center;
     -webkit-mask-size: 12px 12px;
-
+    -webkit-mask-origin: border;
+    border: 3px solid @tabsBackground;
     &:hover {
       opacity: 1.0;
       background-color: black;


### PR DESCRIPTION
Remove border around new tab button; also increases width of button making it much easier to click)

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes https://github.com/brave/browser-laptop/issues/6467
Also fixes https://github.com/brave/browser-laptop/issues/6125

Regression was caused by the combination of these two commits:
https://github.com/brave/browser-laptop/commit/010e708d4cc2539a0adc5bb3c84b7629865335d7
https://github.com/brave/browser-laptop/commit/615a6ec152a4535531a5cf46b7d6489d73060d62

Auditors: @bbondy, @bradleyrichter

## How it looks with these changes

Hitbox is now 25 wide by 25 tall, instead of 15 wide by 25 tall
![screen shot 2016-12-30 at 10 53 02 am](https://cloud.githubusercontent.com/assets/4733304/21569903/30d03f08-ce7e-11e6-854a-ba1b435116a1.png)

mini-video of it in action
![new-tab-button](https://cloud.githubusercontent.com/assets/4733304/21569861/84a68640-ce75-11e6-9513-b8ab207972cd.gif)

## How it looked before these changes

comparison to the old one (*crowd boos*):
![screen shot 2016-12-09 at 5 22 07 pm](https://cloud.githubusercontent.com/assets/4733304/21069114/1d9e249a-be34-11e6-99ca-514149ec0231.png)

and for good measure, here's the border issue that this fixes (which I could only repro on Windows at > 100% DPI):
![image](https://cloud.githubusercontent.com/assets/17010094/21565013/78f009e2-ce8a-11e6-8439-26ac5d851953.png)