### PR TITLE
fix urlbar suggestions dropdown size

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -652,6 +652,7 @@
 @urlbarFormHeight: 25px;
 
 .urlbarForm {
+  position: relative;
   width: 0; // Fixes #4298
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

fix #6472

Auditors: @bsclifton

Test Plan:
* Suggestions dropdown  should have same width as url bar