### PR TITLE
Add support for Enpass password manager.

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -391,6 +391,12 @@ module.exports.init = () => {
       disableExtension(extensionIds[passwordManagers.LAST_PASS])
     }
 
+    if (activePasswordManager === passwordManagers.ENPASS) {
+      registerComponent(extensionIds[passwordManagers.ENPASS])
+    } else {
+      disableExtension(extensionIds[passwordManagers.ENPASS])
+    }
+
     if (getSetting(settings.POCKET_ENABLED)) {
       registerComponent(config.PocketExtensionId)
     } else {

--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -182,6 +182,7 @@ builtInPasswordManager=Brave Built-In
 onePassword=1Password&reg; (requires application)
 dashlane=Dashlane&reg; (requires application)
 lastPass=LastPass&reg;
+enpass=Enpass&reg; (requires application)
 doNotManageMyPasswords=Don't manage my passwords
 usePDFJS=Enable HTML5 PDF reader (requires browser restart)
 enableFlash=Enable Adobe Flash support

--- a/docs/state.md
+++ b/docs/state.md
@@ -213,6 +213,7 @@ AppStore
     'security.passwords.manager-enabled': boolean, // whether to use default password manager
     'security.passwords.one-password-enabled': boolean, // true if the 1Password extension should be enabled
     'security.passwords.dashlane-enabled': boolean, // true if the Dashlane extension should be enabled
+    'security.passwords.enpass-enabled': boolean, // true if the Enpass extension should be enabled
     'bookmarks.toolbar.show': boolean, // true if the bookmakrs toolbar should be shown
     'bookmarks.toolbar.showFavicon': boolean, // true if bookmark favicons should be shown on the bookmarks toolbar
     'bookmarks.toolbar.showOnlyFavicon': boolean, // true if only favicons should be shown on the bookmarks toolbar

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -1652,6 +1652,7 @@ class SecurityTab extends ImmutableComponent {
             <option data-l10n-id='onePassword' value={passwordManagers.ONE_PASSWORD} />
             <option data-l10n-id='dashlane' value={passwordManagers.DASHLANE} />
             <option data-l10n-id='lastPass' value={passwordManagers.LAST_PASS} />
+            <option data-l10n-id='enpass' value={passwordManagers.ENPASS} />
             <option data-l10n-id='doNotManageMyPasswords' value={passwordManagers.UNMANAGED} />
           </SettingDropdown>
         </SettingItem>

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -142,6 +142,7 @@ module.exports = {
     'security.passwords.one-password-enabled': false,
     'security.passwords.dashlane-enabled': false,
     'security.passwords.last-pass-enabled': false,
+    'security.passwords.enpass-enabled': false,
     'security.flash.installed': false,
     'general.downloads.default-save-path': null,
     'general.disable-title-mode': process.platform === 'linux',

--- a/js/constants/passwordManagers.js
+++ b/js/constants/passwordManagers.js
@@ -7,6 +7,7 @@ const passwordManagers = {
   ONE_PASSWORD: '1Password',
   DASHLANE: 'Dashlane',
   LAST_PASS: 'LastPass',
+  ENPASS: 'Enpass',
   UNMANAGED: 'Unmanaged'
 }
 
@@ -17,6 +18,7 @@ extensionIds[passwordManagers.BUILT_IN] = null
 extensionIds[passwordManagers.ONE_PASSWORD] = 'aomjjhallfgjeglblehebfpbcfeobpgk'
 extensionIds[passwordManagers.DASHLANE] = 'fdjamakpfbbddfjaooikfcpapjohcfmg'
 extensionIds[passwordManagers.LAST_PASS] = 'hdokiejnpimakedhajhdlcegeplioahd'
+extensionIds[passwordManagers.ENPASS] = 'kmcfomidfpdkfieipokbalgegidffkal'
 extensionIds[passwordManagers.UNMANAGED] = null
 
 let displayNames = {}
@@ -24,6 +26,7 @@ displayNames[passwordManagers.BUILT_IN] = null
 displayNames[passwordManagers.ONE_PASSWORD] = '1Password'
 displayNames[passwordManagers.DASHLANE] = 'Dashlane'
 displayNames[passwordManagers.LAST_PASS] = 'LastPass'
+displayNames[passwordManagers.ENPASS] = 'Enpass'
 displayNames[passwordManagers.UNMANAGED] = null
 
 module.exports = {

--- a/js/constants/settings.js
+++ b/js/constants/settings.js
@@ -76,6 +76,7 @@ const settings = {
   ONE_PASSWORD_ENABLED: 'security.passwords.one-password-enabled',
   DASHLANE_ENABLED: 'security.passwords.dashlane-enabled',
   LAST_PASS_ENABLED: 'security.passwords.last-pass-enabled',
+  ENPASS_ENABLED: 'security.passwords.enpass-enabled',
   // > phased out with 0.12.6
   SHOW_BOOKMARKS_TOOLBAR_FAVICON: 'bookmarks.toolbar.showFavicon',
   SHOW_BOOKMARKS_TOOLBAR_ONLY_FAVICON: 'bookmarks.toolbar.showOnlyFavicon',

--- a/js/settings.js
+++ b/js/settings.js
@@ -18,6 +18,9 @@ const passwordManagerDefault = (settingKey, settingsCollection) => {
   const lastPassEnabled = resolveValue(settings.LAST_PASS_ENABLED, settingsCollection) === true
   if (lastPassEnabled) return passwordManagers.LAST_PASS
 
+  const enpassEnabled = resolveValue(settings.ENPASS_ENABLED, settingsCollection) === true
+  if (enpassEnabled) return passwordManagers.ENPASS
+
   const disabled = resolveValue(settings.PASSWORD_MANAGER_ENABLED, settingsCollection) === false
   if (disabled) return passwordManagers.UNMANAGED
 

--- a/test/about/extensionsTest.js
+++ b/test/about/extensionsTest.js
@@ -91,4 +91,18 @@ describe('about:extensions', function () {
         .waitForVisible(`[data-extension-id="${extensionIds[passwordManagers.LAST_PASS]}"]`, extensionDownloadWaitTime)
     })
   })
+  describe('Enpass installs when enabled', function () {
+    Brave.beforeAll(this)
+    before(function * () {
+      yield setup(this.app.client)
+    })
+    it('installs', function * () {
+      yield this.app.client
+        .windowByUrl(Brave.browserWindowUrl)
+        .changeSetting(settingsConst.ACTIVE_PASSWORD_MANAGER, passwordManagers.ENPASS)
+        .waitForVisible(`.extensionBrowserAction[data-button-value="${extensionIds[passwordManagers.ENPASS]}"]`)
+        .tabByIndex(0)
+        .waitForVisible(`[data-extension-id="${extensionIds[passwordManagers.ENPASS]}"]`, extensionDownloadWaitTime)
+    })
+  })
 })

--- a/test/unit/settingsTest.js
+++ b/test/unit/settingsTest.js
@@ -76,13 +76,19 @@ describe('settings unit test', function () {
           assert.equal(response, passwordManagers.LAST_PASS)
         })
 
+        it('returns `Enpass` if ENPASS_ENABLED was true', function () {
+          settingsCollection[settingsConst.ENPASS_ENABLED] = true
+          const response = settings.getSetting(settingsConst.ACTIVE_PASSWORD_MANAGER, settingsCollection)
+          assert.equal(response, passwordManagers.ENPASS)
+        })
+
         it('returns `BuiltIn` if PASSWORD_MANAGER_ENABLED was true', function () {
           settingsCollection[settingsConst.PASSWORD_MANAGER_ENABLED] = true
           const response = settings.getSetting(settingsConst.ACTIVE_PASSWORD_MANAGER, settingsCollection)
           assert.equal(response, passwordManagers.BUILT_IN)
         })
 
-        it('returns `1Password`/`Dashlane`/`LastPass`, even if PASSWORD_MANAGER_ENABLED was true', function () {
+        it('returns `1Password`/`Dashlane`/`LastPass`/`Enpass`, even if PASSWORD_MANAGER_ENABLED was true', function () {
           // 1Password
           settingsCollection[settingsConst.ONE_PASSWORD_ENABLED] = true
           settingsCollection[settingsConst.PASSWORD_MANAGER_ENABLED] = true
@@ -100,6 +106,12 @@ describe('settings unit test', function () {
           settingsCollection[settingsConst.PASSWORD_MANAGER_ENABLED] = true
           response = settings.getSetting(settingsConst.ACTIVE_PASSWORD_MANAGER, settingsCollection)
           assert.equal(response, passwordManagers.LAST_PASS)
+          // Enpass
+          settingsCollection = {}
+          settingsCollection[settingsConst.ENPASS_ENABLED] = true
+          settingsCollection[settingsConst.PASSWORD_MANAGER_ENABLED] = true
+          response = settings.getSetting(settingsConst.ACTIVE_PASSWORD_MANAGER, settingsCollection)
+          assert.equal(response, passwordManagers.ENPASS)
         })
 
         it('returns `Unmanaged` if PASSWORD_MANAGER_ENABLED was false', function () {


### PR DESCRIPTION
This change adds support for Enpass password manager using the compatible Chrome extension:

https://chrome.google.com/webstore/detail/enpass-password-manager/kmcfomidfpdkfieipokbalgegidffkal?hl=en-US

This extension requires an external application, just like 1Password.

**TESTING**

I've added tests similar to the ones present for other password managers.

The Enpass desktop applications are free if this requires more testing, you can download them from https://www.enpass.io/downloads.

Fixes #5097

Signed-off-by: David Calavera <david.calavera@gmail.com>