### PR TITLE
Handle cert fingerprints that contain '/'

### DIFF
--- a/js/about/certerror.js
+++ b/js/about/certerror.js
@@ -57,6 +57,8 @@ class CertErrorPage extends React.Component {
       var validExpiry = new Date()
       validStart.setTime(detail.validStart * 1000)
       validExpiry.setTime(detail.validExpiry * 1000)
+      var fingerprint = detail.fingerprint.split('/')
+      var algorithm = fingerprint.shift()
       this.setState({
         certDetail: true,
         certIssuerName: detail.issuerName,
@@ -64,7 +66,7 @@ class CertErrorPage extends React.Component {
         certSerialNumber: seperateHex(detail.serialNumber),
         certValidStart: validStart.toString(),
         certValidExpiry: validExpiry.toString(),
-        certFingerprint: detail.fingerprint.split('/')
+        certFingerprint: [algorithm, fingerprint.join('/')]
       })
     })
   }


### PR DESCRIPTION
The cert fingerprint emitted by Muon/Electron is base64 encoded [1], so it may contain '/'. I think we were truncating the certificate fingerprint when this was the case, which may have caused the decoding error in #6524.

[1] https://cs.chromium.org/chromium/src/net/base/hash_value.h?q=net::HashValue&sq=package:chromium&l=58

Auditors: @darkdh 

Test Plan:
I don't have an example of a cert with a fingerprint that contains `/`, unfortunately, and Eric Lawrence did not provide his bug-triggering cert. At least to do a regression test:
1. go to a site like https://wrong.host.badssl.com/ with an invalid ssl cert
2. click 'view certificate'
3. the hex-encoded certificate fingerprint should appear