### PR TITLE
allow search icon to show while loading

### DIFF
--- a/app/renderer/components/urlBarIcon.js
+++ b/app/renderer/components/urlBarIcon.js
@@ -35,18 +35,15 @@ class UrlBarIcon extends ImmutableComponent {
   }
   /**
    * search icon:
-   * - does not show when loading
    * - does not show when in title mode
    * - shows when urlbar is active (ex: you can type)
    * - is a catch-all for: about pages, files, etc
    */
   get isSearch () {
-    const showSearch = this.props.active &&
-                       this.props.loading === false
+    const showSearch = this.props.active
 
     const defaultToSearch = (!this.isSecure && !this.isInsecure && !showSearch) &&
                             !this.props.titleMode &&
-                            this.props.loading === false &&
                             !this.isAboutPage
 
     return showSearch || defaultToSearch


### PR DESCRIPTION
Allow the search icon to show while loading. This removes a display lag
time for URL bar icons.

Fixes #6518.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

There are a bunch of tests failing unrelated to this change:

1) lets you pin a tile (and shows the pinned icon afterwards)
2) detects blocked elements in private tab
3) "after each" hook for "detects adblock resources"
...
