### PR TITLE
Add Look Up for selected text in input fields (macOS-only)

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -993,6 +993,9 @@ function mainTemplateInit (nodeProps, frame) {
     }
 
     if (isTextSelected) {
+      if (isDarwin) {
+        template.push(showDefinitionMenuItem(nodeProps.selectionText), CommonMenu.separatorMenuItem)
+      }
       template.push(searchSelectionMenuItem(nodeProps.selectionText), CommonMenu.separatorMenuItem)
     }
   } else if (isTextSelected) {


### PR DESCRIPTION
Fixes #6536

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Open a new Brave tab and navigate to any site with a text field.
2. Activate the text field and type some text.
3. Select the text.
4. Right-click.
5. Click the Look Up… option.
6. Make sure the definition is shown for the selected text.

![image](https://cloud.githubusercontent.com/assets/19424103/21695565/068772da-d350-11e6-8562-8bc1eab67eac.png)
