### PR TITLE
remove blue dot in about page timer

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -671,7 +671,6 @@
     content: ' ';
     position: absolute;
     background: #fff;
-    border: 1px solid @focusUrlbarOutline;
     border-radius: 4px;
     box-shadow: 0 0 1px @focusUrlbarOutline, inset 0 0 2px @focusUrlbarOutline, inset 0 1px 8px rgba(0, 137, 255, 0.1);
     color: #333;


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #6441

Auditors @cezaraugusto @bsclifton 

Test Plan:

1. Go to about#preferences
2. Start typing in the urlbar
3. There should be not blue dot at the far right of the urlbar

This was being caused by a border 1px blue on the legend which is empty causing it to look like a blue dot. It came from this commit (https://github.com/brave/browser-laptop/blame/master/less/navigationBar.less#L674) but I don't think it's needed there. Correct me if I'm wrong!
