### PR TITLE
Rename React root div from windowContainer to appContainer

### DIFF
--- a/app/extensions/brave/index-dev.html
+++ b/app/extensions/brave/index-dev.html
@@ -19,7 +19,7 @@
     <link rel="localization" href="locales/{locale}/downloads.properties">
   </head>
   <body>
-    <div id="windowContainer">
+    <div id="appContainer">
       <div id="webpackLoading" style="display:none">
         <p>
           <span>Loading...</span>

--- a/app/extensions/brave/index.html
+++ b/app/extensions/brave/index.html
@@ -19,7 +19,7 @@
     <link rel="localization" href="locales/{locale}/downloads.properties"/>
   </head>
   <body>
-    <div id="windowContainer"/>
+    <div id="appContainer"/>
   </body>
 
 </html>

--- a/js/entry.js
+++ b/js/entry.js
@@ -79,5 +79,5 @@ ipc.on(messages.INITIALIZE_WINDOW, (e, disposition, appState, frames, initWindow
   appStoreRenderer.state = Immutable.fromJS(appState)
   ReactDOM.render(
     <Window includePinnedSites={disposition !== 'new-popup'} frames={frames} initWindowState={initWindowState} />,
-    document.getElementById('windowContainer'))
+    document.getElementById('appContainer'))
 })

--- a/less/window.less
+++ b/less/window.less
@@ -31,6 +31,7 @@ html,
   }
 }
 
+#appContainer,
 #windowContainer {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
Rename windowContainer to appContainer to avoid duplicate IDs in the DOM.

Fixes #6568

Auditors: @bridiver @darkdh 