### PR TITLE
Smoother transition when newtab image loads slowly

### DIFF
--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -32,6 +32,7 @@ class NewTabPage extends React.Component {
     this.state = {
       showSiteRemovalNotification: false,
       imageLoadFailed: false,
+      imageLoadCompleted: false,
       updatedStamp: undefined,
       showEmptyPage: true,
       showImages: false,
@@ -61,6 +62,7 @@ class NewTabPage extends React.Component {
       })
     })
   }
+
   get showImages () {
     return this.state.showImages && !!this.state.backgroundImage
   }
@@ -227,6 +229,21 @@ class NewTabPage extends React.Component {
         : this.fallbackImage
     })
   }
+  /**
+   * Displays background image once it loads
+   */
+  onImageLoadCompleted () {
+    this.setState({
+      imageLoadCompleted: true
+    })
+  }
+  /**
+   * Helper for background className
+   */
+  get backgroundClassName () {
+    return 'backgroundContainer' +
+      (this.state.imageLoadCompleted ? ' backgroundLoaded' : '')
+  }
 
   render () {
     // don't render if user prefers an empty page
@@ -249,12 +266,17 @@ class NewTabPage extends React.Component {
       backgroundProps.style = this.state.backgroundImage.style
       gradientClassName = 'bgGradient'
     }
-    return <div className='dynamicBackground' {...backgroundProps}>
-      {
-        this.showImages
-          ? <img src={this.state.backgroundImage.source} onError={this.onImageLoadFailed.bind(this)} data-test-id='backgroundImage' />
-          : null
-      }
+    return <div className='dynamicBackground'>
+      <div className={this.backgroundClassName} {...backgroundProps}>
+        {
+          this.showImages
+            ? <img src={this.state.backgroundImage.source}
+              onLoad={this.onImageLoadCompleted.bind(this)}
+              onError={this.onImageLoadFailed.bind(this)}
+              data-test-id='backgroundImage' />
+            : null
+        }
+      </div>
       <div className={gradientClassName} />
       <div className='content'>
         <main>

--- a/less/about/newtab.less
+++ b/less/about/newtab.less
@@ -20,7 +20,7 @@ body {
   background: #fff;
 }
 
-body, .dynamicBackground, bgGradient {
+bgGradient {
   opacity: 0;
   animation: fadeIn 200ms;
   animation-fill-mode: forwards;
@@ -45,13 +45,27 @@ ul {
 }
 
 .dynamicBackground {
+  display: flex;
+  flex: 1;
+  background-color: #000;
+}
+
+.backgroundContainer {
   background-position: top center;
   background-repeat: no-repeat;
   background-size: cover;
-  display: flex;
-  flex: 1;
+  position: absolute;
+  left: 0px;
+  top: 0px;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
   > img {
     display: none;
+  }
+  &.backgroundLoaded {
+    animation: fadeIn 200ms;
+    animation-fill-mode: forwards;
   }
 }
 


### PR DESCRIPTION
Fixes #5309

When opening a new tab, the background image can load slowly, especially if it's not cached, giving a rough appearance (especially for new users).  Previously, the entire newtab page contents were faded in on page load, which doesn't help if the image takes awhile to load - you can still see the image progressively rendering as it loads.

Now, the image is hidden until it loads, while the rest of the newtab page is displayed immediately with no fade for immediate interaction.  Once the image loads, it fades in.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Clear browser cache
2. Open a new tab
3. Note that UI elements are interactive right away, while image fades in once it loads.
