### PR TITLE
sync site settings, add SYNC_CLEAR HISTORY

### DIFF
--- a/js/actions/syncActions.js
+++ b/js/actions/syncActions.js
@@ -26,6 +26,42 @@ const syncActions = {
       actionType: syncConstants.SYNC_REMOVE_SITE,
       item
     })
+  },
+
+  clearHistory: function () {
+    AppDispatcher.dispatch({
+      actionType: syncConstants.SYNC_CLEAR_HISTORY
+    })
+  },
+
+  clearSiteSettings: function () {
+    AppDispatcher.dispatch({
+      actionType: syncConstants.SYNC_CLEAR_SITE_SETTINGS
+    })
+  },
+
+  addSiteSetting: function (hostPattern, item) {
+    AppDispatcher.dispatch({
+      actionType: syncConstants.SYNC_ADD_SITE_SETTING,
+      item,
+      hostPattern
+    })
+  },
+
+  updateSiteSetting: function (hostPattern, item) {
+    AppDispatcher.dispatch({
+      actionType: syncConstants.SYNC_UPDATE_SITE_SETTING,
+      item,
+      hostPattern
+    })
+  },
+
+  removeSiteSetting: function (hostPattern, item) {
+    AppDispatcher.dispatch({
+      actionType: syncConstants.SYNC_REMOVE_SITE_SETTING,
+      item,
+      hostPattern
+    })
   }
 }
 

--- a/js/constants/syncConstants.js
+++ b/js/constants/syncConstants.js
@@ -8,7 +8,12 @@ const _ = null
 const syncConstants = {
   SYNC_ADD_SITE: _, /** @param {Immutable.Map} item */
   SYNC_UPDATE_SITE: _, /** @param {Immutable.Map} item */
-  SYNC_REMOVE_SITE: _  /** @param {Immutable.Map} item */
+  SYNC_REMOVE_SITE: _,  /** @param {Immutable.Map} item */
+  SYNC_CLEAR_HISTORY: _,
+  SYNC_CLEAR_SITE_SETTINGS: _,
+  SYNC_ADD_SITE_SETTING: _, /** @param {string} hostPattern, @param {Immutable.Map} item */
+  SYNC_UPDATE_SITE_SETTING: _, /** @param {string} hostPattern, @param {Immutable.Map} item */
+  SYNC_REMOVE_SITE_SETTING: _  /** @param {string} hostPattern, @param {Immutable.Map} item */
 }
 
 module.exports = mapValuesByKeys(syncConstants)

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -522,12 +522,16 @@ module.exports.filterSitesRelativeTo = function (sites, relSite) {
  * - filtering out entries which have no tags
  * - setting lastAccessedTime to null for remaining entries (bookmarks)
  * @param sites The application state's Immutable sites list.
+ * @param {function} syncCallback
  */
-module.exports.clearHistory = function (sites) {
+module.exports.clearHistory = function (sites, syncCallback) {
   let bookmarks = sites.filter((site) => site.get('tags') && site.get('tags').size > 0)
   bookmarks.forEach((site, index) => {
     if (site.get('lastAccessedTime')) {
       bookmarks = bookmarks.setIn([index, 'lastAccessedTime'], null)
+      if (syncCallback && site.get('objectId')) {
+        syncCallback(site.set('lastAccessedTime', null))
+      }
     }
   })
   return bookmarks

--- a/js/state/syncUtil.js
+++ b/js/state/syncUtil.js
@@ -5,6 +5,20 @@
 
 const Immutable = require('immutable')
 
+const siteSettingDefaults = {
+  hostPattern: '',
+  zoomLevel: 0,
+  shieldsUp: true,
+  adControl: 1,
+  cookieControl: 0,
+  safeBrowsing: true,
+  noScript: false,
+  httpsEverywhere: true,
+  fingerprintingProtection: false,
+  ledgerPayments: true,
+  ledgerPaymentsShown: true
+}
+
 /**
  * Sets object id on a state entry.
  * @param {Immutable.Map} item
@@ -19,4 +33,125 @@ module.exports.setObjectId = (item) => {
   }
   const crypto = require('crypto')
   return item.set('objectId', new Immutable.List(crypto.randomBytes(16)))
+}
+
+/**
+ * Gets current time in seconds
+ */
+module.exports.now = () => {
+  return Math.floor(Date.now() / 1000)
+}
+
+/**
+ * Checks whether an object is syncable as a record of the given type
+ * @param {string} type
+ * @param {Immutable.Map} item
+ * @returns {boolean}
+ */
+module.exports.isSyncable = (type, item) => {
+  if (type === 'bookmark' && item.get('tags')) {
+    return (item.get('tags').includes('bookmark') ||
+      item.get('tags').includes('bookmark-folder'))
+  } else if (type === 'siteSetting') {
+    for (let field in siteSettingDefaults) {
+      if (item.has(field)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+/**
+ * Sets a new object ID for an existing object in appState
+ * @param {Array.<string>} objectPath - Path to get to the object from appState root,
+ *   for use with Immutable.setIn
+ * @returns {Array.<number>}
+ */
+module.exports.newObjectId = (objectPath) => {
+  const crypto = require('crypto')
+  const appActions = require('../actions/appActions')
+  const objectId = new Immutable.List(crypto.randomBytes(16))
+  appActions.setObjectId(objectId, objectPath)
+  return objectId.toJS()
+}
+
+/**
+ * Converts a site object into input for sendSyncRecords
+ * @param {Object} site
+ * @param {number=} siteIndex
+ * @returns {{name: string, value: object, objectId: Array.<number>}}
+ */
+module.exports.createSiteData = (site, siteIndex) => {
+  const siteData = {
+    location: '',
+    title: '',
+    customTitle: '',
+    lastAccessedTime: 0,
+    creationTime: 0
+  }
+  for (let field in site) {
+    if (field in siteData) {
+      siteData[field] = site[field]
+    }
+  }
+  if (module.exports.isSyncable('bookmark', Immutable.fromJS(site))) {
+    if (!site.objectId && typeof siteIndex !== 'number') {
+      throw new Error('Missing bookmark objectId.')
+    }
+    return {
+      name: 'bookmark',
+      objectId: site.objectId || module.exports.newObjectId(['sites', siteIndex]),
+      value: {
+        site: siteData,
+        isFolder: site.tags.includes('bookmark-folder'),
+        folderId: site.folderId || 0,
+        parentFolderId: site.parentFolderId || 0
+      }
+    }
+  } else if (!site.tags || !site.tags.length) {
+    if (!site.objectId && typeof siteIndex !== 'number') {
+      throw new Error('Missing historySite objectId.')
+    }
+    return {
+      name: 'historySite',
+      objectId: site.objectId || module.exports.newObjectId(['sites', siteIndex]),
+      value: siteData
+    }
+  }
+}
+
+/**
+ * Converts a site settings object into input for sendSyncRecords
+ * @param {string} hostPattern
+ * @param {Object} setting
+ * @returns {{name: string, value: object, objectId: Array.<number>}}
+ */
+module.exports.createSiteSettingsData = (hostPattern, setting) => {
+  const adControlEnum = {
+    showBraveAds: 0,
+    blockAds: 1,
+    allowAdsAndTracking: 2
+  }
+  const cookieControlEnum = {
+    block3rdPartyCookie: 0,
+    allowAllCookies: 1
+  }
+  const value = Object.assign({}, siteSettingDefaults, {hostPattern})
+
+  for (let field in setting) {
+    if (field === 'adControl') {
+      value.adControl = adControlEnum[setting.adControl]
+    } else if (field === 'cookieControl') {
+      value.cookieControl = cookieControlEnum[setting.cookieControl]
+    } else if (field in value) {
+      value[field] = setting[field]
+    }
+  }
+
+  return {
+    name: 'siteSetting',
+    objectId: setting.objectId || module.exports.newObjectId(['siteSettings', hostPattern]),
+    value
+  }
 }

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -10,6 +10,7 @@ const AppDispatcher = require('../dispatcher/appDispatcher')
 const appConfig = require('../constants/appConfig')
 const settings = require('../constants/settings')
 const siteUtil = require('../state/siteUtil')
+const syncUtil = require('../state/syncUtil')
 const siteSettings = require('../state/siteSettings')
 const appUrlUtil = require('../lib/appUrlUtil')
 const electron = require('electron')
@@ -510,9 +511,11 @@ const handleAppAction = (action) => {
       appState = appState.set('sites', siteUtil.moveSite(appState.get('sites'), action.sourceDetail, action.destinationDetail, action.prepend, action.destinationIsParent, false))
       break
     case appConstants.APP_CLEAR_HISTORY:
-      appState = appState.set('sites', siteUtil.clearHistory(appState.get('sites')))
+      appState = appState.set('sites',
+        siteUtil.clearHistory(appState.get('sites'), syncActions.updateSite))
       appState = aboutNewTabState.setSites(appState, action)
       appState = aboutHistoryState.setHistory(appState, action)
+      syncActions.clearHistory()
       break
     case appConstants.APP_DEFAULT_WINDOW_PARAMS_CHANGED:
       if (action.size && action.size.size === 2) {
@@ -589,8 +592,13 @@ const handleAppAction = (action) => {
     case appConstants.APP_CHANGE_SITE_SETTING:
       {
         let propertyName = action.temporary ? 'temporarySiteSettings' : 'siteSettings'
-        appState = appState.set(propertyName,
-          siteSettings.mergeSiteSetting(appState.get(propertyName), action.hostPattern, action.key, action.value))
+        let newSiteSettings = siteSettings.mergeSiteSetting(appState.get(propertyName), action.hostPattern, action.key, action.value)
+        if (!action.temporary) {
+          let syncObject = syncUtil.setObjectId(newSiteSettings.get(action.hostPattern))
+          syncActions.updateSiteSetting(action.hostPattern, syncObject)
+          newSiteSettings = newSiteSettings.set(action.hostPattern, syncObject)
+        }
+        appState = appState.set(propertyName, newSiteSettings)
         break
       }
     case appConstants.APP_REMOVE_SITE_SETTING:
@@ -598,6 +606,11 @@ const handleAppAction = (action) => {
         let propertyName = action.temporary ? 'temporarySiteSettings' : 'siteSettings'
         let newSiteSettings = siteSettings.removeSiteSetting(appState.get(propertyName),
           action.hostPattern, action.key)
+        if (!action.temporary) {
+          let syncObject = syncUtil.setObjectId(newSiteSettings.get(action.hostPattern))
+          syncActions.updateSiteSetting(action.hostPattern, syncObject)
+          newSiteSettings = newSiteSettings.set(action.hostPattern, syncObject)
+        }
         appState = appState.set(propertyName, newSiteSettings)
         break
       }
@@ -606,7 +619,11 @@ const handleAppAction = (action) => {
         let propertyName = action.temporary ? 'temporarySiteSettings' : 'siteSettings'
         let newSiteSettings = new Immutable.Map()
         appState.get(propertyName).map((entry, hostPattern) => {
-          newSiteSettings = newSiteSettings.set(hostPattern, entry.delete(action.key))
+          let newEntry = entry.delete(action.key)
+          newSiteSettings = newSiteSettings.set(hostPattern, newEntry)
+          if (entry.get('objectId')) {
+            syncActions.updateSiteSetting(hostPattern, newEntry)
+          }
         })
         appState = appState.set(propertyName, newSiteSettings)
         break
@@ -716,6 +733,7 @@ const handleAppAction = (action) => {
       if (action.clearDataDetail.get('savedSiteSettings')) {
         appState = appState.set('siteSettings', Immutable.Map())
         appState = appState.set('temporarySiteSettings', Immutable.Map())
+        syncActions.clearSiteSettings()
       }
       break
     case appConstants.APP_IMPORT_BROWSER_DATA:


### PR DESCRIPTION
also refactors reusable sync methods from app/sync.js to js/state/syncUtil.js

Auditors: @ayumi

Test Plan:
1. start Brave
2. go to bing.com
3. disable shields
4. you should see the console log a setting with 'shieldsUp: false', indicating the sync-client sent the record.
5. enable shields
6. same as 4 but with 'shieldsUp: true'
