### PR TITLE
Avoid an unnecessary url.parse() in filtering.

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -222,7 +222,6 @@ function registerForBeforeSendHeaders (session, partition) {
     }
 
     let requestHeaders = details.requestHeaders
-    let parsedUrl = urlParse(details.url || '')
 
     const firstPartyUrl = module.exports.getMainFrameUrl(details)
     // this can happen if the tab is closed and the webContents is no longer available
@@ -251,15 +250,17 @@ function registerForBeforeSendHeaders (session, partition) {
     }
 
     if (module.exports.isResourceEnabled(appConfig.resourceNames.COOKIEBLOCK, firstPartyUrl, isPrivate)) {
-      if (module.exports.isThirdPartyHost(urlParse(firstPartyUrl || '').hostname,
-                                          parsedUrl.hostname)) {
+      const parsedTargetUrl = urlParse(details.url || '')
+      const parsedFirstPartyUrl = urlParse(firstPartyUrl)
+
+      if (module.exports.isThirdPartyHost(parsedFirstPartyUrl.hostname, parsedTargetUrl.hostname)) {
         // Clear cookie and referer on third-party requests
         if (requestHeaders['Cookie'] &&
             getOrigin(firstPartyUrl) !== pdfjsOrigin) {
           requestHeaders['Cookie'] = undefined
         }
         if (requestHeaders['Referer'] &&
-            !refererExceptions.includes(parsedUrl.hostname)) {
+            !refererExceptions.includes(parsedTargetUrl.hostname)) {
           requestHeaders['Referer'] = getOrigin(details.url)
         }
       }


### PR DESCRIPTION
If cookie blocking is disabled, or the resource being requested
is not to be filtered (such as unfilterable protocols like ws:)
or requests from the internal extension, the parse can be skipped.

This is just a tiny optimization I saw while working through https://github.com/brave/browser-laptop/issues/6641.
