### PR TITLE
Avoid imported bookmarks on new tab page

### DIFF
--- a/app/common/state/aboutNewTabState.js
+++ b/app/common/state/aboutNewTabState.js
@@ -68,6 +68,7 @@ const getTopSites = (state) => {
   // remove folders; sort by visit count; enforce a max limit
   const sites = (state.get('sites') || new Immutable.List())
     .filter((site) => !siteUtil.isFolder(site))
+    .filter((site) => !siteUtil.isImportedBookmark(site))
     .filter((site) => !isSourceAboutUrl(site.get('location')))
     .sort(sortCountDescending)
     .slice(0, aboutNewTabMaxEntries)

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -441,6 +441,15 @@ module.exports.isFolder = function (siteDetail) {
 }
 
 /**
+ * Determines if the site detail is an imported bookmark.
+ * @param siteDetail The site detail to check.
+ * @return true if the site detail is a folder.
+ */
+module.exports.isImportedBookmark = function (siteDetail) {
+  return siteDetail.get('lastAccessedTime') === 0
+}
+
+/**
  * Determines if the site detail is a history entry.
  * @param siteDetail The site detail to check.
  * @return true if the site detail is a history entry.

--- a/test/unit/app/common/state/aboutNewTabStateTest.js
+++ b/test/unit/app/common/state/aboutNewTabStateTest.js
@@ -56,6 +56,9 @@ describe('aboutNewTabState', function () {
     const site5 = Immutable.fromJS({
       location: 'https://example4.com', title: 'sample 5', parentFolderId: 0, count: 23, lastAccessedTime: 456
     })
+    const importedBookmark1 = Immutable.fromJS({
+      location: 'https://example6.com', title: 'sample 6', parentFolderId: 0, count: 23, lastAccessedTime: 0
+    })
     const folder1 = Immutable.fromJS({
       customTitle: 'folder1', parentFolderId: 0, tags: [siteTags.BOOKMARK_FOLDER]
     })
@@ -64,6 +67,14 @@ describe('aboutNewTabState', function () {
       it('does not include bookmark folders', function () {
         const stateWithSites = defaultAppState.set('sites',
           Immutable.List().push(site1).push(folder1))
+        const expectedSites = Immutable.List().push(site1)
+        const actualState = aboutNewTabState.setSites(stateWithSites)
+        assert.deepEqual(actualState.getIn(['about', 'newtab', 'sites']).toJS(), expectedSites.toJS())
+      })
+
+      it('does not include imported bookmarks (lastAccessedTime === 0)', function () {
+        const stateWithSites = defaultAppState.set('sites',
+          Immutable.List().push(site1).push(importedBookmark1))
         const expectedSites = Immutable.List().push(site1)
         const actualState = aboutNewTabState.setSites(stateWithSites)
         assert.deepEqual(actualState.getIn(['about', 'newtab', 'sites']).toJS(), expectedSites.toJS())


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #6217

Auditors: @bsclifton 

Test Plan: covered by automated test

```
npm run test -- --grep="does not include imported bookmarks"
```