### PR TITLE
Clean [about, newtab] and [about, history] when clear on close

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -294,6 +294,8 @@ module.exports.cleanAppData = (data, isShutdown) => {
     const clearHistory = isShutdown && getSetting(settings.SHUTDOWN_CLEAR_HISTORY) === true
     if (clearHistory) {
       data.sites = siteUtil.clearHistory(Immutable.fromJS(data.sites)).toJS()
+      delete data.about.history
+      delete data.about.newtab
     }
   }
   if (data.downloads) {


### PR DESCRIPTION
see APP_CLEAR_HISTORY in appStore.js

fix #6673

Auditors: @bbondy, @bsclifton

Test Plan:
1. Make sure there are some history and new tab tiles
2. Choose clear "Browsing History" on close in about:preferences#security
3. Restart Brave
4. There shouldn't be any history in about:history and tiles in about:newtab

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
