### PR TITLE
Fixed the regression of unclickable buttons under #navigator

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -574,8 +574,6 @@
     background: white;
     box-shadow: 0px 1px 5px 0px rgba(0, 0, 0, 0.15);
   }
-
-  -webkit-app-region: no-drag;
 }
 
 .noScriptButtonContainer {
@@ -705,6 +703,11 @@
   -webkit-user-select: none;
   z-index: @zindexNavigationBar;
 
+  // #6253 #6680
+  > * {
+    -webkit-app-region: no-drag;
+  }
+
   form {
     -webkit-app-region: drag;
     // Disable window dragging so that selecting text and dragging the favicon is possible.
@@ -828,7 +831,6 @@
     > * {
       position: relative;
       top: 1px;
-      -webkit-app-region: no-drag;
     }
 
     .inputbar-wrapper {


### PR DESCRIPTION
This fixes the regression I unintentionally introduced with https://github.com/brave/browser-laptop/commit/19360c107c21d4693b782169ec5d583e31767261#diff-02c4b23ad267fe636760179e32fa29ceR842 for #6035

Fixes #6680
Closes #6253

Auditors: @bsclifton

Test Plan:
1. Make sure every button on the navigation bar is clickable
2. Open https://jsfiddle.net/
3. Block scripts from the top right lion icon
4. Make sure the noScript button on the navigation bar is clickable

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
