### PR TITLE
Removed min-width for buttons on the footer of payment history dialog

### DIFF
--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -585,10 +585,6 @@ table.sortableTable {
             .nextPaymentSubmission {
               font-size: 14px;
             }
-
-            .browserButton {
-              min-width: 80px;
-            }
           }
         }
       }


### PR DESCRIPTION
The min-width for the buttons were specified with #6384 globally, so it is no longer necessary

Closes #6685

Auditors:

Test Plan:
https://github.com/brave/browser-laptop/issues/6685#issue-201079354

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
