### PR TITLE
Separate input and select styles using Aphrodite

### DIFF
--- a/app/extensions/brave/img/caret_down_grey.svg
+++ b/app/extensions/brave/img/caret_down_grey.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32.86 17.81"><defs><style>.cls-1{fill:gray;}</style></defs><title>caret_down_grey</title><g id="Layer_2" data-name="Layer 2"><g id="Layer_1_copy" data-name="Layer 1 copy"><path class="cls-1" d="M15.3,17.35.49,2.77A1.62,1.62,0,0,1,1.62,0H31.24a1.62,1.62,0,0,1,1.14,2.77L17.57,17.35A1.62,1.62,0,0,1,15.3,17.35Z"/></g></g></svg>

--- a/app/renderer/components/dropdown.js
+++ b/app/renderer/components/dropdown.js
@@ -6,12 +6,14 @@ const React = require('react')
 const ImmutableComponent = require('../../../js/components/immutableComponent')
 const {StyleSheet, css} = require('aphrodite')
 const globalStyles = require('./styles/global')
+const commonStyles = require('./styles/commonStyles')
+
 const caretDownGrey = require('../../extensions/brave/img/caret_down_grey.svg')
 
 class Dropdown extends ImmutableComponent {
   render () {
     const className = css(
-      this.props['data-isFormControl'] && styles.formControl,
+      this.props['data-isFormControl'] && commonStyles.formControl,
       styles.dropdown,
       this.props['data-isSettings'] && styles.settings
     )
@@ -37,20 +39,6 @@ class SettingDropdown extends ImmutableComponent {
 const selectPadding = '0.4em'
 
 const styles = StyleSheet.create({
-  'formControl': {
-    background: 'white',
-    border: `solid 1px ${globalStyles.color.black20}`,
-    borderRadius: globalStyles.radius.borderRadius,
-    boxShadow: `inset 0 1px 1px ${globalStyles.color.black10}`,
-    boxSizing: 'border-box',
-    display: 'block',
-    color: globalStyles.color.darkGray,
-    fontSize: '14.5px',
-    height: '2.25em',
-    outline: 'none',
-    padding: '0.4em',
-    width: '100%'
-  },
   'dropdown': {
     background: `url(${caretDownGrey}) calc(100% - ${selectPadding}) 50% / contain no-repeat`,
     backgroundColor: '#fefefe',

--- a/app/renderer/components/dropdown.js
+++ b/app/renderer/components/dropdown.js
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const React = require('react')
+const ImmutableComponent = require('../../../js/components/immutableComponent')
+const {StyleSheet, css} = require('aphrodite')
+const globalStyles = require('./styles/global')
+const caretDownGrey = require('../../extensions/brave/img/caret_down_grey.svg')
+
+class Dropdown extends ImmutableComponent {
+  render () {
+    const className = css(
+      this.props['data-isFormControl'] && styles.formControl,
+      styles.dropdown,
+      this.props['data-isSettings'] && styles.settings
+    )
+
+    return <select className={className} {...this.props}>
+      {this.props.children}
+    </select>
+  }
+}
+
+class FormDropdown extends ImmutableComponent {
+  render () {
+    return <Dropdown data-isFormControl='true' {...this.props} />
+  }
+}
+
+class SettingDropdown extends ImmutableComponent {
+  render () {
+    return <FormDropdown data-isSettings='true' {...this.props} />
+  }
+}
+
+const selectPadding = '0.4em'
+
+const styles = StyleSheet.create({
+  'formControl': {
+    background: 'white',
+    border: `solid 1px ${globalStyles.color.black20}`,
+    borderRadius: globalStyles.radius.borderRadius,
+    boxShadow: `inset 0 1px 1px ${globalStyles.color.black10}`,
+    boxSizing: 'border-box',
+    display: 'block',
+    color: globalStyles.color.darkGray,
+    fontSize: '14.5px',
+    height: '2.25em',
+    outline: 'none',
+    padding: '0.4em',
+    width: '100%'
+  },
+  'dropdown': {
+    background: `url(${caretDownGrey}) calc(100% - ${selectPadding}) 50% / contain no-repeat`,
+    backgroundColor: '#fefefe',
+    backgroundSize: '12px 12px',
+    boxShadow: `-1px 1px 3px -1px ${globalStyles.color.mediumGray}`,
+    height: '2rem',
+    outline: 'none',
+    padding: selectPadding,
+    '-webkit-appearance': 'none',
+    width: 'auto'
+  },
+  'outlineable': {
+    ':focus': {
+      outlineColor: globalStyles.color.statsBlue,
+      outlineOffset: '-4px',
+      outlineStyle: 'solid',
+      outlineWidth: '1px'
+    }
+  },
+  'settings': {
+    width: '280px'
+  }
+})
+
+module.exports = {
+  Dropdown,
+  FormDropdown,
+  SettingDropdown
+}

--- a/app/renderer/components/dropdown.js
+++ b/app/renderer/components/dropdown.js
@@ -46,7 +46,8 @@ const styles = StyleSheet.create({
     boxShadow: `-1px 1px 3px -1px ${globalStyles.color.mediumGray}`,
     height: '2rem',
     outline: 'none',
-    padding: selectPadding,
+    // right padding is larger, to account for the down arrow SVG
+    padding: `${selectPadding} 1.5em ${selectPadding} ${selectPadding}`,
     '-webkit-appearance': 'none',
     width: 'auto'
   },

--- a/app/renderer/components/settings.js
+++ b/app/renderer/components/settings.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const React = require('react')
+const ImmutableComponent = require('../../../js/components/immutableComponent')
+
+class SettingsList extends ImmutableComponent {
+  render () {
+    return <div className='settingsListContainer'>
+      {
+        this.props.dataL10nId
+        ? <div className='settingsListTitle' data-l10n-id={this.props.dataL10nId} />
+        : null
+      }
+      <div className='settingsList'>
+        {this.props.children}
+      </div>
+    </div>
+  }
+}
+
+class SettingItem extends ImmutableComponent {
+  render () {
+    return <div className='settingItem'>
+      {
+        this.props.dataL10nId
+          ? <span data-l10n-id={this.props.dataL10nId} />
+          : null
+      }
+      {this.props.children}
+    </div>
+  }
+}
+
+module.exports = {
+  SettingsList,
+  SettingItem
+}

--- a/app/renderer/components/styles/commonStyles.js
+++ b/app/renderer/components/styles/commonStyles.js
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const {StyleSheet} = require('aphrodite')
+const globalStyles = require('./global')
+
+const styles = StyleSheet.create({
+  'formControl': {
+    background: 'white',
+    border: `solid 1px ${globalStyles.color.black20}`,
+    borderRadius: globalStyles.radius.borderRadius,
+    boxShadow: `inset 0 1px 1px ${globalStyles.color.black10}`,
+    boxSizing: 'border-box',
+    display: 'block',
+    color: globalStyles.color.darkGray,
+    fontSize: '14.5px',
+    height: '2.25em',
+    outline: 'none',
+    padding: '0.4em',
+    width: '100%'
+  }
+})
+
+module.exports = styles

--- a/app/renderer/components/styles/global.js
+++ b/app/renderer/components/styles/global.js
@@ -46,6 +46,7 @@ const globalStyles = {
     gray25: 'rgba(116, 116, 130, 0.25)',
     gray50: 'rgba(116, 116, 130, 0.5)',
     black10: 'rgba(0, 0, 0, 0.1)',
+    black20: 'rgba(0, 0, 0, 0.2)',
     black25: 'rgba(0, 0, 0, 0.25)',
     black50: 'rgba(0, 0, 0, 0.5)',
     black75: 'rgba(0, 0, 0, 0.75)',

--- a/app/renderer/components/textbox.js
+++ b/app/renderer/components/textbox.js
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const React = require('react')
+const ImmutableComponent = require('../../../js/components/immutableComponent')
+const {StyleSheet, css} = require('aphrodite')
+const globalStyles = require('./styles/global')
+
+class Textbox extends ImmutableComponent {
+  render () {
+    const className = css(
+      this.props['data-isFormControl'] && styles.formControl,
+      styles.textbox,
+      this.props['data-isSettings'] && styles.isSettings,
+      (this.props.readonly || this.props.readOnly) ? styles.readOnly : styles.outlineable,
+      this.props['data-isRecoveryKeyTextbox'] && styles.recoveryKeys
+    )
+
+    return <input type='text' className={className} {...this.props} />
+  }
+}
+
+class FormTextbox extends ImmutableComponent {
+  render () {
+    return <Textbox data-isFormControl='true' {...this.props} />
+  }
+}
+
+class SettingTextbox extends ImmutableComponent {
+  render () {
+    return <FormTextbox data-isSettings='true' {...this.props} />
+  }
+}
+
+class RecoveryKeyTextbox extends ImmutableComponent {
+  render () {
+    return <SettingTextbox data-isRecoveryKey='true' {...this.props} />
+  }
+}
+
+const styles = StyleSheet.create({
+  'formControl': {
+    background: 'white',
+    border: `solid 1px ${globalStyles.color.black20}`,
+    borderRadius: globalStyles.radius.borderRadius,
+    boxShadow: `inset 0 1px 1px ${globalStyles.color.black10}`,
+    boxSizing: 'border-box',
+    display: 'block',
+    color: globalStyles.color.darkGray,
+    fontSize: '14.5px',
+    height: '2.25em',
+    outline: 'none',
+    padding: '0.4em',
+    width: '100%'
+  },
+  'textbox': {
+    boxSizing: 'border-box',
+    width: 'auto'
+  },
+  'outlineable': {
+    ':focus': {
+      outlineColor: globalStyles.color.statsBlue,
+      outlineOffset: '-4px',
+      outlineStyle: 'solid',
+      outlineWidth: '1px'
+    }
+  },
+  'isSettings': {
+    width: '280px'
+  },
+  'readOnly': {
+    background: globalStyles.color.veryLightGray,
+    boxShadow: 'none',
+    outline: 'none'
+  },
+  'recoveryKeys': {
+    marginBottom: '20px'
+  }
+})
+
+module.exports = {
+  Textbox,
+  FormTextbox,
+  SettingTextbox,
+  RecoveryKeyTextbox
+}

--- a/app/renderer/components/textbox.js
+++ b/app/renderer/components/textbox.js
@@ -6,11 +6,12 @@ const React = require('react')
 const ImmutableComponent = require('../../../js/components/immutableComponent')
 const {StyleSheet, css} = require('aphrodite')
 const globalStyles = require('./styles/global')
+const commonStyles = require('./styles/commonStyles')
 
 class Textbox extends ImmutableComponent {
   render () {
     const className = css(
-      this.props['data-isFormControl'] && styles.formControl,
+      this.props['data-isFormControl'] && commonStyles.formControl,
       styles.textbox,
       this.props['data-isSettings'] && styles.isSettings,
       (this.props.readonly || this.props.readOnly) ? styles.readOnly : styles.outlineable,
@@ -40,20 +41,6 @@ class RecoveryKeyTextbox extends ImmutableComponent {
 }
 
 const styles = StyleSheet.create({
-  'formControl': {
-    background: 'white',
-    border: `solid 1px ${globalStyles.color.black20}`,
-    borderRadius: globalStyles.radius.borderRadius,
-    boxShadow: `inset 0 1px 1px ${globalStyles.color.black10}`,
-    boxSizing: 'border-box',
-    display: 'block',
-    color: globalStyles.color.darkGray,
-    fontSize: '14.5px',
-    height: '2.25em',
-    outline: 'none',
-    padding: '0.4em',
-    width: '100%'
-  },
   'textbox': {
     boxSizing: 'border-box',
     width: 'auto'

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -832,15 +832,14 @@ class TabsTab extends ImmutableComponent {
           </SettingDropdown>
         </SettingItem>
         <SettingItem dataL10nId='tabCloseAction'>
-          <select
-            className='form-control'
+          <FormDropdown
             value={getSetting(settings.TAB_CLOSE_ACTION, this.props.settings)}
             onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.TAB_CLOSE_ACTION)}>
             <option data-l10n-id='tabCloseActionLastActive' value={tabCloseAction.LAST_ACTIVE} />
             <option data-l10n-id='tabCloseActionNext' value={tabCloseAction.NEXT} />
             <option data-l10n-id='tabCloseActionFirst' value={tabCloseAction.FIRST} />
             <option data-l10n-id='tabCloseActionParent' value={tabCloseAction.PARENT} />
-          </select>
+          </FormDropdown>
         </SettingItem>
         <SettingCheckbox dataL10nId='switchToNewTabs' prefKey={settings.SWITCH_TO_NEW_TABS} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
         <SettingCheckbox dataL10nId='paintTabs' prefKey={settings.PAINT_TABS} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -8,6 +8,10 @@ const ImmutableComponent = require('../components/immutableComponent')
 const Immutable = require('immutable')
 const SwitchControl = require('../components/switchControl')
 const ModalOverlay = require('../components/modalOverlay')
+const {SettingsList, SettingItem} = require('../../app/renderer/components/settings')
+const {FormTextbox, SettingTextbox, RecoveryKeyTextbox} = require('../../app/renderer/components/textbox')
+const {FormDropdown, SettingDropdown} = require('../../app/renderer/components/dropdown')
+const Button = require('../components/button')
 const cx = require('../lib/classSet')
 const ledgerExportUtil = require('../../app/common/lib/ledgerExportUtil')
 const addExportFilenamePrefixToTransactions = ledgerExportUtil.addExportFilenamePrefixToTransactions
@@ -31,7 +35,6 @@ const WidevineInfo = require('../../app/renderer/components/widevineInfo')
 const aboutActions = require('./aboutActions')
 const getSetting = require('../settings').getSetting
 const SortableTable = require('../components/sortableTable')
-const Button = require('../components/button')
 const searchProviders = require('../data/searchProviders')
 const punycode = require('punycode')
 const moment = require('moment')
@@ -106,34 +109,6 @@ const changeSetting = (cb, key, e) => {
       value = Math.min(e.target.getAttribute('max'), Math.max(value, e.target.getAttribute('min')))
     }
     cb(key, value)
-  }
-}
-
-class SettingsList extends ImmutableComponent {
-  render () {
-    return <div className='settingsListContainer'>
-      {
-        this.props.dataL10nId
-        ? <div className='settingsListTitle' data-l10n-id={this.props.dataL10nId} />
-        : null
-      }
-      <div className='settingsList'>
-        {this.props.children}
-      </div>
-    </div>
-  }
-}
-
-class SettingItem extends ImmutableComponent {
-  render () {
-    return <div className='settingItem'>
-      {
-        this.props.dataL10nId
-          ? <span data-l10n-id={this.props.dataL10nId} />
-          : null
-      }
-      {this.props.children}
-    </div>
   }
 }
 
@@ -686,25 +661,25 @@ class GeneralTab extends ImmutableComponent {
       <div className='sectionTitle' data-l10n-id='generalSettings' />
       <SettingsList>
         <SettingItem dataL10nId='startsWith'>
-          <select className='form-control' value={getSetting(settings.STARTUP_MODE, this.props.settings)}
-            onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.STARTUP_MODE)} >
+          <SettingDropdown value={getSetting(settings.STARTUP_MODE, this.props.settings)}
+            onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.STARTUP_MODE)}>
             <option data-l10n-id='startsWithOptionLastTime' value={startsWithOption.WINDOWS_TABS_FROM_LAST_TIME} />
             <option data-l10n-id='startsWithOptionHomePage' value={startsWithOption.HOMEPAGE} />
             <option data-l10n-id='startsWithOptionNewTabPage' value={startsWithOption.NEW_TAB_PAGE} />
-          </select>
+          </SettingDropdown>
         </SettingItem>
         <SettingItem dataL10nId='newTabMode'>
-          <select className='form-control' value={getSetting(settings.NEWTAB_MODE, this.props.settings)}
+          <SettingDropdown value={getSetting(settings.NEWTAB_MODE, this.props.settings)}
             onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.NEWTAB_MODE)} >
             <option data-l10n-id='newTabNewTabPage' value={newTabMode.NEW_TAB_PAGE} />
             <option data-l10n-id='newTabHomePage' value={newTabMode.HOMEPAGE} />
             <option data-l10n-id='newTabDefaultSearchEngine' value={newTabMode.DEFAULT_SEARCH_ENGINE} />
             <option data-l10n-id='newTabEmpty' value={newTabMode.EMPTY_NEW_TAB} />
-          </select>
+          </SettingDropdown>
         </SettingItem>
         <SettingItem dataL10nId='myHomepage'>
-          <input spellCheck='false'
-            className='form-control'
+          <SettingTextbox
+            spellCheck='false'
             data-l10n-id='homepageInput'
             value={homepageValue}
             onChange={changeSetting.bind(null, this.onChangeSetting, settings.HOMEPAGE)} />
@@ -717,25 +692,24 @@ class GeneralTab extends ImmutableComponent {
         }
         <SettingCheckbox dataL10nId='disableTitleMode' prefKey={settings.DISABLE_TITLE_MODE} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
         <SettingItem dataL10nId='bookmarkToolbarSettings'>
-          <select className='form-control' id='bookmarksBarSelect' value={getSetting(settings.BOOKMARKS_TOOLBAR_MODE, this.props.settings)}
-            onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.BOOKMARKS_TOOLBAR_MODE)} >
+          <SettingDropdown id='bookmarksBarSelect' value={getSetting(settings.BOOKMARKS_TOOLBAR_MODE, this.props.settings)}
+            onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.BOOKMARKS_TOOLBAR_MODE)}>
             <option data-l10n-id='bookmarksBarTextOnly' value={bookmarksToolbarMode.TEXT_ONLY} />
             <option data-l10n-id='bookmarksBarTextAndFavicon' value={bookmarksToolbarMode.TEXT_AND_FAVICONS} />
             <option data-l10n-id='bookmarksBarFaviconOnly' value={bookmarksToolbarMode.FAVICONS_ONLY} />
-          </select>
+          </SettingDropdown>
           <SettingCheckbox id='bookmarksBarSwitch' dataL10nId='bookmarkToolbar'
             prefKey={settings.SHOW_BOOKMARKS_TOOLBAR} settings={this.props.settings}
             onChangeSetting={this.props.onChangeSetting} />
         </SettingItem>
         <SettingItem dataL10nId='selectedLanguage'>
-          <select className='form-control' value={getSetting(settings.LANGUAGE, this.props.settings) || defaultLanguage}
-            onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.LANGUAGE)} >
+          <SettingDropdown value={getSetting(settings.LANGUAGE, this.props.settings) || defaultLanguage}
+            onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.LANGUAGE)}>
             {languageOptions}
-          </select>
+          </SettingDropdown>
         </SettingItem>
         <SettingItem dataL10nId='defaultZoomLevel'>
-          <select
-            className='form-control'
+          <SettingDropdown
             value={defaultZoomSetting === undefined || defaultZoomSetting === null ? config.zoom.defaultValue : defaultZoomSetting}
             data-type='float'
             onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.DEFAULT_ZOOM_LEVEL)}>
@@ -743,7 +717,7 @@ class GeneralTab extends ImmutableComponent {
               config.zoom.zoomLevels.map((x) =>
                 <option value={x} key={x}>{getZoomValuePercentage(x) + '%'}</option>)
             }
-          </select>
+          </SettingDropdown>
         </SettingItem>
         <SettingItem dataL10nId='importBrowserData'>
           <Button l10nId='importNow' className='primaryButton importNowButton'
@@ -846,8 +820,7 @@ class TabsTab extends ImmutableComponent {
       <div className='sectionTitle' data-l10n-id='tabSettings' />
       <SettingsList>
         <SettingItem dataL10nId='tabsPerTabPage'>
-          <select
-            className='form-control'
+          <SettingDropdown
             value={getSetting(settings.TABS_PER_PAGE, this.props.settings)}
             data-type='number'
             onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.TABS_PER_PAGE)}>
@@ -856,7 +829,7 @@ class TabsTab extends ImmutableComponent {
               [6, 8, 10, 20].map((x) =>
                 <option value={x} key={x}>{x}</option>)
             }
-          </select>
+          </SettingDropdown>
         </SettingItem>
         <SettingItem dataL10nId='tabCloseAction'>
           <select
@@ -948,7 +921,7 @@ class PaymentsTab extends ImmutableComponent {
     return <div className='balance'>
       {
       !(this.props.ledgerData.get('balance') === undefined || this.props.ledgerData.get('balance') === null)
-        ? <input className='form-control fundsAmount' readOnly value={this.btcToCurrencyString(this.props.ledgerData.get('balance'))} />
+        ? <FormTextbox readOnly data-test-id='fundsAmount' value={this.btcToCurrencyString(this.props.ledgerData.get('balance'))} />
         : <span><span data-l10n-id='accountBalanceLoading' /></span>
       }
       <a href='https://brave.com/Payments_FAQ.html' target='_blank'>
@@ -1083,27 +1056,25 @@ class PaymentsTab extends ImmutableComponent {
           <div className='minimumPageTimeSetting' data-l10n-id='minimumPageTimeSetting' />
           <SettingsList>
             <SettingItem>
-              <select
-                className='form-control'
+              <SettingDropdown
                 defaultValue={minDuration || 8000}
                 onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.MINIMUM_VISIT_TIME)}>>
                 <option value='5000'>5 seconds</option>
                 <option value='8000'>8 seconds</option>
                 <option value='60000'>1 minute</option>
-              </select>
+              </SettingDropdown>
             </SettingItem>
           </SettingsList>
           <div className='minimumVisitsSetting' data-l10n-id='minimumVisitsSetting' />
           <SettingsList>
             <SettingItem>
-              <select
-                className='form-control'
+              <SettingDropdown
                 defaultValue={minPublisherVisits || 5}
                 onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.MINIMUM_VISITS)}>>>
                 <option value='2'>2 visits</option>
                 <option value='5'>5 visits</option>
                 <option value='10'>10 visits</option>
-              </select>
+              </SettingDropdown>
             </SettingItem>
           </SettingsList>
         </div>
@@ -1204,9 +1175,9 @@ class PaymentsTab extends ImmutableComponent {
         <SettingsList>
           <SettingItem>
             <h3 data-l10n-id='firstRecoveryKey' />
-            <input className='form-control firstRecoveryKey' onChange={this.handleFirstRecoveryKeyChange} type='text' />
+            <RecoveryKeyTextbox id='firstRecoveryKey' onChange={this.handleFirstRecoveryKeyChange} />
             <h3 data-l10n-id='secondRecoveryKey' />
-            <input className='form-control secondRecoveryKey' onChange={this.handleSecondRecoveryKeyChange} type='text' />
+            <RecoveryKeyTextbox id='secondRecoveryKey' onChange={this.handleFirstRecoveryKeyChange} />
           </SettingItem>
         </SettingsList>
       </div>
@@ -1319,16 +1290,17 @@ class PaymentsTab extends ImmutableComponent {
               <td>
                 <SettingsList>
                   <SettingItem>
-                    <select className='form-control fundsSelectBox'
+                    <FormDropdown
+                      data-test-id='fundsSelectBox'
                       value={getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT,
                         this.props.settings)}
-                      onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.PAYMENTS_CONTRIBUTION_AMOUNT)} >
+                      onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.PAYMENTS_CONTRIBUTION_AMOUNT)}>
                       {
                         [5, 10, 15, 20].map((amount) =>
                           <option value={amount}>{amount} {this.props.ledgerData.get('currency') || 'USD'}</option>
                         )
                       }
-                    </select>
+                    </FormDropdown>
                   </SettingItem>
                   <SettingItem>
                     {this.paymentHistoryButton}
@@ -1597,21 +1569,21 @@ class ShieldsTab extends ImmutableComponent {
       <div className='sectionTitle' data-l10n-id='braveryDefaults' />
       <SettingsList>
         <SettingItem dataL10nId='adControl'>
-          <select className='form-control'
+          <SettingDropdown
             value={this.props.braveryDefaults.get('adControl')}
             onChange={this.onChangeAdControl}>
             <option data-l10n-id='showBraveAds' value='showBraveAds' />
             <option data-l10n-id='blockAds' value='blockAds' />
             <option data-l10n-id='allowAdsAndTracking' value='allowAdsAndTracking' />
-          </select>
+          </SettingDropdown>
         </SettingItem>
         <SettingItem dataL10nId='cookieControl'>
-          <select className='form-control'
+          <SettingDropdown
             value={this.props.braveryDefaults.get('cookieControl')}
             onChange={this.onChangeCookieControl}>
             <option data-l10n-id='block3rdPartyCookie' value='block3rdPartyCookie' />
             <option data-l10n-id='allowAllCookies' value='allowAllCookies' />
-          </select>
+          </SettingDropdown>
         </SettingItem>
         <SettingCheckbox checked={this.props.braveryDefaults.get('httpsEverywhere')} dataL10nId='httpsEverywhere' onChange={this.onToggleHTTPSE} />
         <SettingCheckbox checked={this.props.braveryDefaults.get('safeBrowsing')} dataL10nId='safeBrowsing' onChange={this.onToggleSafeBrowsing} />
@@ -1674,7 +1646,7 @@ class SecurityTab extends ImmutableComponent {
       <div className='sectionTitle' data-l10n-id='passwordsAndForms' />
       <SettingsList>
         <SettingItem dataL10nId='passwordManager'>
-          <select className='form-control'
+          <SettingDropdown
             value={getSetting(settings.ACTIVE_PASSWORD_MANAGER, this.props.settings)}
             onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.ACTIVE_PASSWORD_MANAGER)} >
             <option data-l10n-id='builtInPasswordManager' value={passwordManagers.BUILT_IN} />
@@ -1682,7 +1654,7 @@ class SecurityTab extends ImmutableComponent {
             <option data-l10n-id='dashlane' value={passwordManagers.DASHLANE} />
             <option data-l10n-id='lastPass' value={passwordManagers.LAST_PASS} />
             <option data-l10n-id='doNotManageMyPasswords' value={passwordManagers.UNMANAGED} />
-          </select>
+          </SettingDropdown>
         </SettingItem>
         {
           getSetting(settings.ACTIVE_PASSWORD_MANAGER, this.props.settings) === passwordManagers.BUILT_IN

--- a/js/about/styles.js
+++ b/js/about/styles.js
@@ -10,42 +10,121 @@ require('../../less/about/styles.less')
 require('../../less/button.less')
 require('../../less/forms.less')
 
+const {Textbox, FormTextbox, SettingTextbox, RecoveryKeyTextbox} = require('../../app/renderer/components/textbox')
+const {Dropdown, FormDropdown, SettingDropdown} = require('../../app/renderer/components/dropdown')
+
 class AboutStyle extends ImmutableComponent {
   render () {
     return <div className='wrapper'>
       <h1 data-l10n-id='introTitle' />
       <p data-l10n-id='intro' />
+
+      <hr />
+
       <h1 className='typography' data-l10n-id='typography' />
       <h1 data-l10n-id='h1' />
       <h2 data-l10n-id='h2' />
       <h3 data-l10n-id='h3' />
       <h4 data-l10n-id='h4' />
 
-      <h1 data-l10n-id='forms' />
-      <h2 data-l10n-id='inputs' />
+      <hr />
+
+      <h1 data-l10n-id='textboxes' />
+
       <div className='container'>
-        <input placeholder='Input box' className='form-control' type='text' />
+        <h2>Plain textbox</h2>
+        <Textbox placeholder='Textbox' />
         <pre><code>
-          // require('less/forms.less'){'\n'}{'\n'}
-          &lt;input className='form-control' type='text' />
-        </code></pre>
-      </div>
-      <div className='container'>
-        <select className='form-control'>
-          <option>Select Box</option>
-          <option>Second Choice</option>
-          <option>Third Choice</option>
-        </select>
-        <pre><code>
-          &lt;select className='form-control'>{'\n'}
-          &lt;option>Select Box&lt;/option>{'\n'}
-          &lt;option>Second Choice&lt;/option>{'\n'}
-          &lt;option>Third Choice&lt;/option>{'\n'}
-          &lt;/select>
+          const { '{Textbox}' } = require('../../app/renderer/components/textbox'){'\n'}
+          &lt;Textbox />
         </code></pre>
       </div>
 
-      <h2 data-l10n-id='buttons' />
+      <div className='container'>
+        <h2>Textbox for use in forms</h2>
+        <FormTextbox placeholder='FormTextbox' />
+        <pre><code>
+          const { '{FormTextbox}' } = require('../../app/renderer/components/textbox'){'\n'}
+          &lt;FormTextbox />
+        </code></pre>
+      </div>
+
+      <div className='container'>
+        <h2>Texbox used mostly in Preferences; has a fixed width</h2>
+        <SettingTextbox placeholder='SettingTextbox' />
+        <pre><code>
+          const { '{SettingTextbox}' } = require('../../app/renderer/components/textbox'){'\n'}
+          &lt;SettingTextbox />
+        </code></pre>
+      </div>
+
+      <div className='container'>
+        <h2>Textbox used on wallet recovery screen in Brave Payments</h2>
+        <RecoveryKeyTextbox placeholder='RecoveryKeyTextbox' />
+        <pre><code>
+          const { '{RecoveryKeyTextbox}' } = require('../../app/renderer/components/textbox'){'\n'}
+          &lt;RecoveryKeyTextbox />
+        </code></pre>
+      </div>
+
+      <hr />
+
+      <h1 data-l10n-id='dropdowns' />
+
+      <div className='container'>
+        <h2>Plain dropdown</h2>
+        <Dropdown>
+          <option>Select Box</option>
+          <option>Second Choice</option>
+          <option>Third Choice</option>
+        </Dropdown>
+        <pre><code>
+          const { '{Dropdown}' } = require('../../app/renderer/components/dropdown'){'\n'}
+          &lt;Dropdown>{'\n'}
+          &nbsp;&nbsp;&lt;option>Select Box&lt;/option>{'\n'}
+          &nbsp;&nbsp;&lt;option>Second Choice&lt;/option>{'\n'}
+          &nbsp;&nbsp;&lt;option>Third Choice&lt;/option>{'\n'}
+          &lt;/Dropdown>
+        </code></pre>
+      </div>
+
+      <div className='container'>
+        <h2>Dropdown for use in forms</h2>
+        <FormDropdown>
+          <option>Select Box</option>
+          <option>Second Choice</option>
+          <option>Third Choice</option>
+        </FormDropdown>
+        <pre><code>
+          const { '{FormDropdown}' } = require('../../app/renderer/components/dropdown'){'\n'}
+          &lt;FormDropdown>{'\n'}
+          &nbsp;&nbsp;&lt;option>Select Box&lt;/option>{'\n'}
+          &nbsp;&nbsp;&lt;option>Second Choice&lt;/option>{'\n'}
+          &nbsp;&nbsp;&lt;option>Third Choice&lt;/option>{'\n'}
+          &lt;/FormDropdown>
+        </code></pre>
+      </div>
+
+      <div className='container'>
+        <h2>Dropdown used mostly in Preferences; has a fixed width</h2>
+        <SettingDropdown>
+          <option>Select Box</option>
+          <option>Second Choice</option>
+          <option>Third Choice</option>
+        </SettingDropdown>
+        <pre><code>
+          const { '{SettingDropdown}' } = require('../../app/renderer/components/dropdown'){'\n'}
+          &lt;SettingDropdown>{'\n'}
+          &nbsp;&nbsp;&lt;option>Select Box&lt;/option>{'\n'}
+          &nbsp;&nbsp;&lt;option>Second Choice&lt;/option>{'\n'}
+          &nbsp;&nbsp;&lt;option>Third Choice&lt;/option>{'\n'}
+          &lt;/SettingDropdown>
+        </code></pre>
+      </div>
+
+      <hr />
+
+      <h1 data-l10n-id='buttons' />
       <button data-l10n-id='browserButton' className='browserButton' onClick={this.onRemoveBookmark} />
       <pre><code>
         &lt;button data-l10n-id='done' className='browserButton'{'\n'}

--- a/js/components/braveryPanel.js
+++ b/js/components/braveryPanel.js
@@ -9,6 +9,7 @@ const ImmutableComponent = require('./immutableComponent')
 const config = require('../constants/config')
 const Dialog = require('./dialog')
 const SwitchControl = require('./switchControl')
+const {FormDropdown} = require('../../app/renderer/components/dropdown')
 const windowActions = require('../actions/windowActions')
 const appActions = require('../actions/appActions')
 const urlParse = require('url').parse
@@ -287,11 +288,11 @@ class BraveryPanel extends ImmutableComponent {
                     braverySelectTitle: true,
                     disabled: !shieldsUp
                   })} data-l10n-id='adControl' />
-                  <select className='adsBlockedControl form-control' value={adControl} onChange={this.onToggleAdControl} disabled={!shieldsUp}>
+                  <FormDropdown data-test-id='adsBlockedControl' value={adControl} onChange={this.onToggleAdControl} disabled={!shieldsUp}>
                     <option data-l10n-id='showBraveAds' value='showBraveAds' />
                     <option data-l10n-id='blockAds' value='blockAds' />
                     <option data-l10n-id='allowAdsAndTracking' value='allowAdsAndTracking' />
-                  </select>
+                  </FormDropdown>
                   <SwitchControl onClick={this.onToggleHTTPSE} rightl10nId='httpsEverywhere' checkedOn={httpseEnabled} disabled={!shieldsUp} />
                   <SwitchControl onClick={this.onToggleNoScript} rightl10nId='noScript' checkedOn={noScriptEnabled} disabled={!shieldsUp} className='noScriptSwitch' />
                 </div>
@@ -300,10 +301,10 @@ class BraveryPanel extends ImmutableComponent {
                     braverySelectTitle: true,
                     disabled: !shieldsUp
                   })} data-l10n-id='cookieControl' />
-                  <select className='form-control' value={this.props.braverySettings.cookieControl} onChange={this.onToggleCookieControl} disabled={!shieldsUp}>
+                  <FormDropdown value={this.props.braverySettings.cookieControl} onChange={this.onToggleCookieControl} disabled={!shieldsUp}>
                     <option data-l10n-id='block3rdPartyCookie' value='block3rdPartyCookie' />
                     <option data-l10n-id='allowAllCookies' value='allowAllCookies' />
-                  </select>
+                  </FormDropdown>
                   <SwitchControl onClick={this.onToggleFp} rightl10nId='fingerprintingProtection' checkedOn={fpEnabled} disabled={!shieldsUp} onInfoClick={this.onInfoClick} infoTitle={config.fingerprintingInfoUrl} className='fingerprintingProtectionSwitch' />
                   <SwitchControl onClick={this.onToggleSafeBrowsing} rightl10nId='safeBrowsing' checkedOn={this.props.braverySettings.safeBrowsing} disabled={!shieldsUp} />
                 </div>

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -367,13 +367,6 @@ span.settingsListCopy {
   }
 }
 
-input:not([type="checkbox"]), select {
-  &.form-control {
-    box-sizing: border-box;
-    width: 280px;
-  }
-}
-
 input[type="checkbox"][disabled] {
   opacity: 0.8;
   pointer-events: none;
@@ -741,11 +734,6 @@ table.sortableTable {
 
                   h3 {
                     margin-bottom: @margin-bottom-header;
-                  }
-
-                  .firstRecoveryKey,
-                  .secondRecoveryKey {
-                    margin-bottom: 20px;
                   }
                 }
               }

--- a/less/button.less
+++ b/less/button.less
@@ -94,14 +94,14 @@ span.buttonSeparator {
 
   &.primaryButton {
     background: linear-gradient(@braveLightOrange, @braveOrange);
-    border: 1px solid transparent;
-    border-top: 1px solid @braveLightOrange;
-    border-bottom: 1px solid @braveOrange;
+    border: 2px solid transparent;
+    border-top: 2px solid @braveLightOrange;
+    border-bottom: 2px solid @braveOrange;
     box-shadow: @buttonShadow;
     font-weight: 500;
 
     &:hover {
-      border: 1px solid white;
+      border: 2px solid white;
       color: white;
       cursor: pointer;
     }

--- a/less/forms.less
+++ b/less/forms.less
@@ -5,20 +5,6 @@ select {
   box-sizing: border-box;
 }
 
-.form-control {
-  display: block;
-  background: white;
-  border: solid 1px @lightGray;
-  border-radius: @borderRadius;
-  box-shadow: inset 0 1px 1px rgba(0,0,0,.075);
-  box-sizing: border-box;
-  color: @darkGray;
-  font-size: 14.5px;
-  height: 2.25em;
-  padding: 0.4em;
-  width: 100%;
-}
-
 .flyoutDialog {
   background-color: @toolbarBackground;
   border-radius: @borderRadius;

--- a/test/components/navigationBarTest.js
+++ b/test/components/navigationBarTest.js
@@ -770,7 +770,7 @@ describe('navigationBar tests', function () {
       const page1Url = Brave.server.url('page1.html')
       yield this.app.client.tabByUrl(Brave.newTabUrl).url(page1Url).waitForUrl(page1Url).windowParentByUrl(page1Url)
       let background = yield this.app.client.getCssProperty(activeTab, 'background')
-      assert.equal(background.value, 'rgba(0,0,0,0)linear-gradient(rgb(255,255,255),rgb(243,243,243))repeatscroll0%0%/autopadding-boxborder-box')
+      assert.equal(background.value, 'rgba(0,0,0,0)linear-gradient(white,rgb(243,243,243))repeatscroll0%0%/autopadding-boxborder-box')
     })
 
     // We need a newer electron build first

--- a/test/lib/selectors.js
+++ b/test/lib/selectors.js
@@ -37,7 +37,7 @@ module.exports = {
   braveMenu: '.braveMenu:not(.braveShieldsDisabled)',
   braveMenuDisabled: '.braveMenu.braveShieldsDisabled',
   adsBlockedStat: '.braveryStat.adsBlockedStat',
-  adsBlockedControl: '.adsBlockedControl',
+  adsBlockedControl: '[data-test-id="adsBlockedControl"]',
   showAdsOption: '[data-l10n-id="allowAdsAndTracking"]',
   blockAdsOption: '[data-l10n-id="blockAds"]',
   braveryPanel: '.braveryPanel',

--- a/test/lib/selectors.js
+++ b/test/lib/selectors.js
@@ -60,7 +60,7 @@ module.exports = {
   walletSwitch: '.enablePaymentsSwitch .switchBackground',
   addFundsButton: '.addFunds',
   advancedSettings: '.advancedSettings',
-  fundsSelectBox: '.fundsSelectBox',
+  fundsSelectBox: '[data-test-id="fundsSelectBox"]',
   paymentsStatus: '.walletStatus',
   siteSettingItem: '.siteSettingItem',
   ledgerTable: '.ledgerTable',


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

This is an Aphrodite friendly redo of https://github.com/brave/browser-laptop/pull/6084

Fixes https://github.com/brave/browser-laptop/issues/5972

I tested each area manually and did my best to compare to the original PR.  @luixxiul, please let me know what you think.  I did omit a two updates to select (because they looked bad):
- select box font being 1em
- select box having margin 0 5px

## screenshots of textbox / dropdown
![screen shot 2017-01-16 at 3 38 14 pm](https://cloud.githubusercontent.com/assets/4733304/22001409/46617210-dc02-11e6-919b-547ce6c07260.png)

![screen shot 2017-01-16 at 3 39 27 pm](https://cloud.githubusercontent.com/assets/4733304/22001410/496a2c7c-dc02-11e6-9143-c6bcc88cd376.png)

## Updates to about:styles
![screen shot 2017-01-16 at 3 41 08 pm](https://cloud.githubusercontent.com/assets/4733304/22001413/4f78227c-dc02-11e6-8118-62b6d5f01cdf.png)

![screen shot 2017-01-16 at 3 41 18 pm](https://cloud.githubusercontent.com/assets/4733304/22001416/529bc440-dc02-11e6-8409-e3203aa077be.png)
