### PR TITLE
Remove currency symbol from Brave Payments UI

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -23,7 +23,6 @@ const preferenceTabs = require('../constants/preferenceTabs')
 const messages = require('../constants/messages')
 const settings = require('../constants/settings')
 const coinbaseCountries = require('../constants/coinbaseCountries')
-const getSymbolFromCurrency = require('currency-symbol-map').getSymbolFromCurrency
 const {passwordManagers, extensionIds} = require('../constants/passwordManagers')
 const {startsWithOption, newTabMode, bookmarksToolbarMode} = require('../../app/common/constants/settingsEnums')
 const {l10nErrorText} = require('../../app/common/lib/httpUtil')
@@ -599,7 +598,7 @@ class PaymentHistoryRow extends ImmutableComponent {
 
   render () {
     var date = this.formattedDate
-    var totalAmountStr = `${getSymbolFromCurrency(this.currency)} ${this.totalAmount}`
+    var totalAmountStr = `${this.totalAmount} ${this.currency}`
 
     return <tr>
       <td className='narrow' data-sort={this.timestamp}>{date}</td>
@@ -1192,13 +1191,13 @@ class PaymentsTab extends ImmutableComponent {
 
   btcToCurrencyString (btc) {
     const balance = Number(btc || 0)
-    const currency = getSymbolFromCurrency(this.props.ledgerData.get('currency')) || getSymbolFromCurrency('USD')
+    const currency = this.props.ledgerData.get('currency') || 'USD'
     if (balance === 0) {
-      return `${currency} 0`
+      return `0 ${currency}`
     }
     if (this.props.ledgerData.get('btc') && typeof this.props.ledgerData.get('amount') === 'number') {
       const btcValue = this.props.ledgerData.get('btc') / this.props.ledgerData.get('amount')
-      return `${currency} ${(balance / btcValue).toFixed(2)}`
+      return `${(balance / btcValue).toFixed(2)} ${currency}`
     }
     return `${balance} BTC`
   }
@@ -1254,7 +1253,7 @@ class PaymentsTab extends ImmutableComponent {
                       onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.PAYMENTS_CONTRIBUTION_AMOUNT)} >
                       {
                         [5, 10, 15, 20].map((amount) =>
-                          <option value={amount}>{getSymbolFromCurrency(this.props.ledgerData.get('currency')) || getSymbolFromCurrency('USD')} {amount}</option>
+                          <option value={amount}>{amount} {this.props.ledgerData.get('currency') || 'USD'}</option>
                         )
                       }
                     </select>

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "ad-block": "^2.0.0",
     "aphrodite": "^1.0.0",
     "async": "^2.0.1",
-    "currency-symbol-map": "^3.1.0",
     "electron-localshortcut": "^0.6.0",
     "electron-prebuilt": "brave/electron-prebuilt",
     "electron-squirrel-startup": "brave/electron-squirrel-startup",


### PR DESCRIPTION
Revert "Add currency symbols where appropriate"
This reverts commit 004c04aec750dca79f78cb5e432655c477e57a28 (originally submitted with https://github.com/brave/browser-laptop/pull/6249)

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
