### PR TITLE
Sync siteSettings with browser data

### DIFF
--- a/docs/appActions.md
+++ b/docs/appActions.md
@@ -291,7 +291,7 @@ Changes an application level setting
 
 
 
-### changeSiteSetting(hostPattern, key, value, temp) 
+### changeSiteSetting(hostPattern, key, value, temp, skipSync)
 
 Change a hostPattern's config
 
@@ -306,9 +306,11 @@ Change a hostPattern's config
 **temp**: `boolean`, Whether to change temporary or persistent
   settings. defaults to false (persistent).
 
+**skipSync**: `boolean`, Set true if a site isn't eligible for Sync (e.g. if this update was triggered by Sync)
 
 
-### removeSiteSetting(hostPattern, key, temp) 
+
+### removeSiteSetting(hostPattern, key, temp, skipSync)
 
 Removes a site setting
 
@@ -320,6 +322,8 @@ Removes a site setting
 
 **temp**: `boolean`, Whether to change temporary or persistent
   settings. defaults to false (persistent).
+
+**skipSync**: `boolean`, Set true if a site isn't eligible for Sync (e.g. if this update was triggered by Sync)
 
 
 

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -368,14 +368,16 @@ const appActions = {
    * @param {string|number} value - The value to update to
    * @param {boolean} temp - Whether to change temporary or persistent
    *   settings. defaults to false (persistent).
+   * @param {boolean} skipSync - Set true if a site isn't eligible for Sync (e.g. if addSite was triggered by Sync)
    */
-  changeSiteSetting: function (hostPattern, key, value, temp) {
+  changeSiteSetting: function (hostPattern, key, value, temp, skipSync) {
     AppDispatcher.dispatch({
       actionType: appConstants.APP_CHANGE_SITE_SETTING,
       hostPattern,
       key,
       value,
-      temporary: temp || false
+      temporary: temp || false,
+      skipSync
     })
   },
 
@@ -385,13 +387,15 @@ const appActions = {
    * @param {string} key - The config key to update
    * @param {boolean} temp - Whether to change temporary or persistent
    *   settings. defaults to false (persistent).
+   * @param {boolean} skipSync - Set true if a site isn't eligible for Sync (e.g. if addSite was triggered by Sync)
    */
-  removeSiteSetting: function (hostPattern, key, temp) {
+  removeSiteSetting: function (hostPattern, key, temp, skipSync) {
     AppDispatcher.dispatch({
       actionType: appConstants.APP_REMOVE_SITE_SETTING,
       hostPattern,
       key,
-      temporary: temp || false
+      temporary: temp || false,
+      skipSync
     })
   },
 

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -596,7 +596,11 @@ const handleAppAction = (action) => {
         let newSiteSettings = siteSettings.mergeSiteSetting(appState.get(propertyName), action.hostPattern, action.key, action.value)
         if (!action.temporary) {
           let syncObject = siteUtil.setObjectId(newSiteSettings.get(action.hostPattern))
-          syncActions.updateSiteSetting(action.hostPattern, syncObject)
+          if (!action.skipSync) {
+            const objectId = syncObject.get('objectId')
+            const item = new Immutable.Map({objectId, [action.key]: action.value})
+            syncActions.updateSiteSetting(action.hostPattern, item)
+          }
           newSiteSettings = newSiteSettings.set(action.hostPattern, syncObject)
         }
         appState = appState.set(propertyName, newSiteSettings)
@@ -609,7 +613,11 @@ const handleAppAction = (action) => {
           action.hostPattern, action.key)
         if (!action.temporary) {
           let syncObject = siteUtil.setObjectId(newSiteSettings.get(action.hostPattern))
-          syncActions.updateSiteSetting(action.hostPattern, syncObject)
+          if (!action.skipSync) {
+            const objectId = syncObject.get('objectId')
+            const item = new Immutable.Map({objectId, [action.key]: null})
+            syncActions.removeSiteSetting(action.hostPattern, item)
+          }
           newSiteSettings = newSiteSettings.set(action.hostPattern, syncObject)
         }
         appState = appState.set(propertyName, newSiteSettings)
@@ -621,10 +629,13 @@ const handleAppAction = (action) => {
         let newSiteSettings = new Immutable.Map()
         appState.get(propertyName).map((entry, hostPattern) => {
           let newEntry = entry.delete(action.key)
-          newSiteSettings = newSiteSettings.set(hostPattern, newEntry)
-          if (entry.get('objectId')) {
-            syncActions.updateSiteSetting(hostPattern, newEntry)
+          if (!action.skipSync) {
+            newEntry = siteUtil.setObjectId(newEntry)
+            const objectId = newEntry.get('objectId')
+            const item = new Immutable.Map({objectId, [action.key]: null})
+            syncActions.removeSiteSetting(hostPattern, item)
           }
+          newSiteSettings = newSiteSettings.set(hostPattern, newEntry)
         })
         appState = appState.set(propertyName, newSiteSettings)
         break


### PR DESCRIPTION
Auditors: @diracdeltas

Test Plan:

Prep:

0. Update sync lib to `brave/sync #fix/resolve-delete-nonexistant-props`.
1. Prepare 2 instances (pyramids) of Brave with Sync enabled.
  a. Enable Sync and close Brave.
  b. Copy `{userData}/brave-development` to `{userData}/brave-development-2`.
  c. Edit `brave-development-2/session-store-1` `deviceId` to `1`.
  d. To `browser-laptop` `package.json` add `"start2": "node ./tools/start.js --user-data-dir=brave-development-2 --debug=5859 --enable-logging --v=0 --enable-extension-activity-logging --enable-sandbox-logging --enable-dcheck",`
2. In `appConfig.js` `sync.fetchInterval` reduce to 5 seconds.

Play:

3. Open both pyramid 1 and pyramid 2.
4. In pyramid 1 visit a webpage and open up the bravery panel.
5. In pyramid 2 visit the same page and open up the bravery panel.
6. In pyramid 2 toggle each available siteSetting. Observe it appears in pyramid 1 after 1–5s.
7. Try toggling multiple settings at once, and toggling different settings simulatenously on both pyramids.
8. In both go to Preferences #Shields. Clear siteSettings with the Clear links and the red X's. Observe they sync over.
