### PR TITLE
Apply no-drag to all direct descendants except for .endButtons

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -703,11 +703,6 @@
   -webkit-user-select: none;
   z-index: @zindexNavigationBar;
 
-  // #6253 #6680
-  > * {
-    -webkit-app-region: no-drag;
-  }
-
   form {
     -webkit-app-region: drag;
     // Disable window dragging so that selecting text and dragging the favicon is possible.
@@ -717,10 +712,16 @@
   }
 
   &:not(.titleMode) {
+
     > * {
       animation: fadeIn .6s;
       opacity: 0;
       animation-fill-mode: forwards;
+
+      // #5792 Apply no-drag to all direct descendants except for .endButtons, which is empty for now
+      &:not(.endButtons) {
+        -webkit-app-region: no-drag;
+      }
     }
 
     // Create 25x25 square and place .bookmarkButton at the center of it


### PR DESCRIPTION
Closes #5792

Auditors:

Test Plan:
1. Make sure the non-draggable area specified in #5792 is draggable
2. Make sure every button on the navigation bar is clickable
3. Open https://jsfiddle.net/
4. Block scripts from the top right lion icon
5. Make sure the noScript button on the navigation bar is clickable

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

