### PR TITLE
Apply Sync records asynchronously

### DIFF
--- a/app/sync.js
+++ b/app/sync.js
@@ -201,7 +201,7 @@ module.exports.onSyncReady = (isFirstRun, e) => {
       return
     }
     log(`applying resolved ${records.length} ${categoryName}.`)
-    for (let record of records) { syncUtil.applySyncRecord(record) }
+    syncUtil.applySyncRecords(records)
   })
   // Periodically poll for new records
   let startAt = appState.getIn(['sync', 'lastFetchTimestamp']) || 0

--- a/js/state/syncUtil.js
+++ b/js/state/syncUtil.js
@@ -156,6 +156,19 @@ module.exports.applySyncRecord = (record) => {
 }
 
 /**
+ * Apply several SyncRecords in a less blocking manner.
+ * @param {Array<Object>} records
+ */
+module.exports.applySyncRecords = (records) => {
+  if (!records || records.length === 0) { return }
+  setImmediate(() => {
+    const record = records.shift()
+    this.applySyncRecord(record)
+    this.applySyncRecords(records)
+  })
+}
+
+/**
  * Given a category and SyncRecord, get an existing browser object.
  * Used to respond to IPC GET_EXISTING_OBJECTS.
  * @param {string} categoryName


### PR DESCRIPTION
Fix https://github.com/brave/sync/issues/44

Auditors: @diracdeltas

Test Plan:
1. Start Pyramid 1 which should have Sync enabled and a realistic amount (1000+ records total) of syncable data.
2. Setup Pyramid 2 (add `"start2": "node ./tools/start.js --user-data-dir=brave-development-2 --debug=5859 --enable-logging --v=0 --enable-extension-activity-logging --enable-sandbox-logging --enable-dcheck",` to package.json) and specify the Pyramid 1 Sync credentials.
3. When Pyramid 2 restarts and begins syncing data, Brave should be somewhat usable (not completely frozen for 60s).