### PR TITLE
Sync bookmarks in order, without conflict

### DIFF
--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -490,6 +490,20 @@ module.exports.isHistoryEntry = function (siteDetail) {
 }
 
 /**
+ * Get a folder by folderId
+ * @returns {Immutable.List.<Immutable.Map>} sites
+ * @param {number} folderId
+ * @returns {Array[<number>, <Immutable.Map>]|undefined}
+ */
+module.exports.getFolder = function (sites, folderId) {
+  const entry = sites.findEntry((site, _path) => {
+    return module.exports.isFolder(site) && site.get('folderId') === folderId
+  })
+  if (!entry) { return undefined }
+  return entry
+}
+
+/**
  * Obtains an array of folders
  */
 module.exports.getFolders = function (sites, folderId, parentId, labelPrefix) {

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -853,6 +853,24 @@ describe('siteUtil', function () {
     })
   })
 
+  describe('getFolder', function () {
+    const folder = Immutable.fromJS({
+      customTitle: 'folder1',
+      folderId: 2,
+      parentFolderId: 0,
+      tags: [siteTags.BOOKMARK_FOLDER]
+    })
+    const bookmark = Immutable.fromJS({
+      location: testUrl1,
+      title: 'sample',
+      parentFolderId: 2
+    })
+    const sites = Immutable.fromJS([folder, bookmark])
+    const result = siteUtil.getFolder(sites, bookmark.get('parentFolderId'))
+    assert.deepEqual(result[0], 0)
+    assert.deepEqual(result[1], folder)
+  })
+
   describe('getFolders', function () {
   })
 

--- a/test/unit/state/syncUtilTest.js
+++ b/test/unit/state/syncUtilTest.js
@@ -46,8 +46,8 @@ describe('syncUtil', () => {
         value: {
           site: expectedSite.value,
           isFolder: false,
-          folderId: 0,
-          parentFolderId: 0
+          parentFolderObjectId: undefined,
+          index: 0
         }
       }
       assert.deepEqual(syncUtil.createSiteData(bookmark), expectedBookmark)


### PR DESCRIPTION
Fix https://github.com/brave/sync/issues/48

Auditors: @diracdeltas

Test plan:
1. Start Pyramid 0. It should have bookmarks and bookmark folders.
2. Enable Sync on Pyramid 0, and restart to complete setup.
3. Start Pyramid 1. Add it to Pyramid 0's Sync profile and restart.
4. Bookmarks should sync in the same order.