### PR TITLE
Add Cut/Copy/Paste functionality to hamburger menu

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -730,6 +730,30 @@ function hamburgerTemplateInit (location, e) {
       ]
     },
     CommonMenu.downloadsMenuItem(),
+    CommonMenu.separatorMenuItem,
+    {
+      l10nLabelId: 'edit',
+      type: 'multi',
+      submenu: [{
+        l10nLabelId: 'cut',
+        click: () => {
+          document.querySelector('.frameWrapper.isActive webview').cut()
+          windowActions.setContextMenuDetail()
+        }
+      }, {
+        l10nLabelId: 'copy',
+        click: () => {
+          document.querySelector('.frameWrapper.isActive webview').copy()
+          windowActions.setContextMenuDetail()
+        }
+      }, {
+        l10nLabelId: 'paste',
+        click: () => {
+          document.querySelector('.frameWrapper.isActive webview').paste()
+          windowActions.setContextMenuDetail()
+        }
+      }]
+    },
     CommonMenu.findOnPageMenuItem(),
     CommonMenu.printMenuItem(),
     CommonMenu.separatorMenuItem,
@@ -1241,6 +1265,7 @@ function mainTemplateInit (nodeProps, frame, tab) {
 }
 
 function onHamburgerMenu (location, e) {
+  webviewActions.setWebviewFocused()
   const menuTemplate = hamburgerTemplateInit(location, e)
   const rect = e.target.parentNode.getBoundingClientRect()
   windowActions.setContextMenuDetail(Immutable.fromJS({

--- a/test/components/tabTest.js
+++ b/test/components/tabTest.js
@@ -4,7 +4,7 @@ const Brave = require('../lib/brave')
 const messages = require('../../js/constants/messages')
 const assert = require('assert')
 const settings = require('../../js/constants/settings')
-const {urlInput, backButton, forwardButton, activeTabTitle, activeTabFavicon, newFrameButton} = require('../lib/selectors')
+const {urlInput, backButton, forwardButton, activeTabTitle, activeTabFavicon, newFrameButton, hamburgerMenuButton} = require('../lib/selectors')
 
 describe('tab tests', function () {
   function * setup (client) {
@@ -352,6 +352,20 @@ describe('tab tests', function () {
         .waitForVisible('.tab[data-frame-key="2"]')
         // This should not be converted to a waitUntil
         .getText('.tab[data-frame-key="2"]').then((val) => assert.equal(val, 'Untitled'))
+    })
+  })
+
+  describe('hamburger menu', function () {
+    Brave.beforeAll(this)
+    before(function * () {
+      yield setup(this.app.client)
+    })
+
+    it('opens hamburger menu on click', function * () {
+      yield this.app.client
+        .waitForBrowserWindow()
+        .click(hamburgerMenuButton)
+        .waitForExist('.contextMenuSingle')
     })
   })
 })

--- a/test/lib/selectors.js
+++ b/test/lib/selectors.js
@@ -88,5 +88,6 @@ module.exports = {
   tabsToolbar: '.tabsToolbar',
   hamburgerMenu: '.menuButton',
   contextMenu: '.contextMenu',
-  okButton: '[data-l10n-id="ok"]'
+  okButton: '[data-l10n-id="ok"]',
+  hamburgerMenuButton: 'span.navbutton.menuButton'
 }


### PR DESCRIPTION
This addition to the hamburger menu mimics the behavior of chrome and firefox

fixes #1421

Auditors: @bsclifton

Test Plan:

Add Hamburger Menu Test
Asserts menu opens on click

Auditors: @bsclifton

Test Plan:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
