### PR TITLE
Specify the font-size of textarea

### DIFF
--- a/less/about/adblock.less
+++ b/less/about/adblock.less
@@ -29,6 +29,7 @@
   .customFiltersInput {
     margin: 10px 0;
     padding: 5px;
+    font-size: 14.5px; // Issue #6851
   }
 
   .adblockSubtext {


### PR DESCRIPTION
Closes #6851

Auditors: @bradleyrichter 

Test Plan:
1. Open about:adblock
2. Input some strings in the custom filters area
3. Make sure they are readable

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
