### PR TITLE
Dismiss autofill context menu when tabId is different

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -734,7 +734,7 @@ class Frame extends ImmutableComponent {
     })
     this.webview.addEventListener('hide-autofill-popup', (e) => {
       if (this.props.contextMenuDetail && this.props.contextMenuDetail.get('type') === 'autofill' &&
-        this.webview.isFocused()) {
+        (this.props.contextMenuDetail.get('tabId') !== this.props.tabId || this.webview.isFocused())) {
         windowActions.autofillPopupHidden(this.props.tabId)
       }
     })

--- a/test/components/autofillTest.js
+++ b/test/components/autofillTest.js
@@ -614,4 +614,39 @@ describe('Autofill', function () {
       })
     })
   })
+  describe('autofill context menu', function () {
+    Brave.beforeAll(this)
+    before(function * () {
+      yield setup(this.app.client)
+      this.formfill = Brave.server.url('formfill.html')
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(this.formfill)
+        .waitForVisible('<form>')
+        .setValue('[name="04fullname"]', 'test')
+        .click('#submit')
+    })
+    it('hide when scroll', function * () {
+      yield this.app.client
+        .tabByIndex(0)
+        .waitForVisible('<form>')
+        .click('[name="04fullname"]')
+        .click('[name="04fullname"]')
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForVisible('.contextMenuItemText')
+        .keys(Brave.keys.PAGEDOWN)
+        .waitForVisible('.contextMenuItemText', 1000, true)
+    })
+    it('hide when new tab', function * () {
+      yield this.app.client
+        .tabByIndex(0)
+        .waitForVisible('<form>')
+        .click('[name="04fullname"]')
+        .click('[name="04fullname"]')
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForVisible('.contextMenuItemText')
+        .ipcSend(messages.SHORTCUT_NEW_FRAME, this.formfill + '?2')
+        .waitForVisible('.contextMenuItemText', 1000, true)
+    })
+  })
 })

--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -81,7 +81,8 @@ var exports = {
     BACKSPACE: '\ue003',
     DELETE: '\ue017',
     DOWN: '\ue015',
-    UP: '\ue013'
+    UP: '\ue013',
+    PAGEDOWN: '\uE00F'
   },
 
   defaultTimeout: 10000,


### PR DESCRIPTION
fix #6820

Auditors: @bbondy, @bsclifon

Test Plan: Covered by automatic test

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).