### PR TITLE
Add cancel option for Basic Auth Login

### DIFF
--- a/js/components/loginRequired.js
+++ b/js/components/loginRequired.js
@@ -90,6 +90,7 @@ class LoginRequired extends React.Component {
             : null
           }
           <div className='formRow'>
+            <Button l10nId='cancel' className='primaryButton whiteButton' onClick={this.onClose} />
             <Button l10nId='ok' className='primaryButton' onClick={this.onSave.bind(this)} />
           </div>
         </div>


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @luixxiul

Fix #6855

## Test Plan
* Go to a website that requires basic auth login. i.e. ftp://ftp.unde.co
* With dialog login open, click "cancel"
* The Dialog should be closed (same with ESC key)