### PR TITLE
Remove contribution range from PDF statement

### DIFF
--- a/js/about/contributionStatement.js
+++ b/js/about/contributionStatement.js
@@ -389,11 +389,4 @@ function formattedTimeFromTimestamp (timestamp) {
   return moment(new Date(timestamp)).format('h:mma')
 }
 
-function longFormattedDateFromTimestamp (timestamp) {
-  let momentDate = moment(new Date(timestamp))
-
-  // e.g. June 15th at 4:00pm
-  return `${momentDate.format('MMMM Do')} at ${momentDate.format('h:mma')}`
-}
-
 module.exports = <ContributionStatement />

--- a/js/about/contributionStatement.js
+++ b/js/about/contributionStatement.js
@@ -201,30 +201,6 @@ class ContributionStatement extends ImmutableComponent {
     )
   }
 
-  get lastContributionHumanFormattedDate () {
-    if (!this.transactionIds || !this.transactionIds.length || !this.transaction) {
-      return ''
-    }
-
-    let transactionIds = this.transactionIds
-    let currentTxIdx = transactionIds.indexOf(this.transaction.get('viewingId'))
-    let lastTxIdx = (currentTxIdx ? currentTxIdx - 1 : -1)
-    let date = ''
-    if (lastTxIdx > -1) {
-      let previousTransaction = this.transactions.toJS()[lastTxIdx] || {}
-      let previousTimestamp = previousTransaction.submissionStamp
-
-      if (previousTimestamp && previousTimestamp < this.timestamp) {
-        date = longFormattedDateFromTimestamp(previousTimestamp)
-      }
-    }
-    return date
-  }
-
-  get thisContributionHumanFormattedDate () {
-    return longFormattedDateFromTimestamp(this.timestamp)
-  }
-
   get rows () {
     if (!this.transaction) {
       // without a transaction there are no rows to process
@@ -266,9 +242,6 @@ class ContributionStatement extends ImmutableComponent {
     return (
       <div className='contributionStatementDetailTableContainer'>
         <div>
-          <span className='statementDatesCoveredText pull-right'>
-            { this.lastContributionHumanFormattedDate } - { this.thisContributionHumanFormattedDate }
-          </span>
           <table className='contributionStatementDetailTable'>
             <tbody>
               <tr className='headingRow detailTableRow'>


### PR DESCRIPTION
Fixes #6896

Auditor: @bsclifton 

Test Plan:
1. Generate a PDF contribution statement
2. Verify that the contribution range you see here as the last line isn't there any more.
<img width="974" alt="729d24fa-e49a-11e6-8b9f-a831ba1ff6e0" src="https://cloud.githubusercontent.com/assets/400552/22389702/d344b786-e49b-11e6-8a1c-8a8f3a8b7a6e.png">
