### PR TITLE
Add support for bitwarden password manager - resolves #4776

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -449,6 +449,12 @@ module.exports.init = () => {
       disableExtension(extensionIds[passwordManagers.ENPASS])
     }
 
+    if (activePasswordManager === passwordManagers.BITWARDEN) {
+      registerComponent(extensionIds[passwordManagers.BITWARDEN])
+    } else {
+      disableExtension(extensionIds[passwordManagers.BITWARDEN])
+    }
+
     if (getSetting(settings.POCKET_ENABLED)) {
       registerComponent(config.PocketExtensionId)
     } else {

--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -222,6 +222,7 @@ onePassword=1Password&reg; (requires application)
 dashlane=Dashlane&reg; (requires application)
 lastPass=LastPass&reg;
 enpass=Enpass&reg; (requires application)
+bitwarden=bitwarden&reg;
 doNotManageMyPasswords=Don't manage my passwords
 usePDFJS=Enable HTML5 PDF reader (requires browser restart)
 enableFlash=Enable Adobe Flash support

--- a/docs/state.md
+++ b/docs/state.md
@@ -196,6 +196,7 @@ AppStore
     'search.offer-search-suggestions': boolean, // true if suggestions should be offered from the default search engine when available.
     'security.flash.installed': boolean,
     'security.passwords.active-password-manager': string, // name of active password manager
+    'security.passwords.bitwarden-enabled': boolean, // true if the bitwarden extension should be enabled
     'security.passwords.dashlane-enabled': boolean, // true if the Dashlane extension should be enabled
     'security.passwords.enpass-enabled': boolean, // true if the Enpass extension should be enabled
     'security.passwords.last-pass-enabled': boolean, // true if the Last password extension should be enabled

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -1023,6 +1023,7 @@ class SecurityTab extends ImmutableComponent {
             <option data-l10n-id='onePassword' value={passwordManagers.ONE_PASSWORD} />
             <option data-l10n-id='dashlane' value={passwordManagers.DASHLANE} />
             <option data-l10n-id='lastPass' value={passwordManagers.LAST_PASS} />
+            <option data-l10n-id='bitwarden' value={passwordManagers.BITWARDEN} />
             { /* <option data-l10n-id='enpass' value={passwordManagers.ENPASS} /> */ }
             <option data-l10n-id='doNotManageMyPasswords' value={passwordManagers.UNMANAGED} />
           </SettingDropdown>

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -155,6 +155,7 @@ module.exports = {
     'security.passwords.dashlane-enabled': false,
     'security.passwords.last-pass-enabled': false,
     'security.passwords.enpass-enabled': false,
+    'security.passwords.bitwarden-enabled': false,
     'security.fullscreen.content': fullscreenOption.ALWAYS_ASK,
     'security.flash.installed': false,
     // sync

--- a/js/constants/passwordManagers.js
+++ b/js/constants/passwordManagers.js
@@ -8,6 +8,7 @@ const passwordManagers = {
   DASHLANE: 'Dashlane',
   LAST_PASS: 'LastPass',
   ENPASS: 'Enpass',
+  BITWARDEN: 'bitwarden',
   UNMANAGED: 'Unmanaged'
 }
 
@@ -19,6 +20,7 @@ extensionIds[passwordManagers.ONE_PASSWORD] = 'aomjjhallfgjeglblehebfpbcfeobpgk'
 extensionIds[passwordManagers.DASHLANE] = 'fdjamakpfbbddfjaooikfcpapjohcfmg'
 extensionIds[passwordManagers.LAST_PASS] = 'hdokiejnpimakedhajhdlcegeplioahd'
 extensionIds[passwordManagers.ENPASS] = 'kmcfomidfpdkfieipokbalgegidffkal'
+extensionIds[passwordManagers.BITWARDEN] = 'nngceckbapebfimnlniiiahkandclblb'
 extensionIds[passwordManagers.UNMANAGED] = null
 
 let displayNames = {}
@@ -27,6 +29,7 @@ displayNames[passwordManagers.ONE_PASSWORD] = '1Password'
 displayNames[passwordManagers.DASHLANE] = 'Dashlane'
 displayNames[passwordManagers.LAST_PASS] = 'LastPass'
 displayNames[passwordManagers.ENPASS] = 'Enpass'
+displayNames[passwordManagers.BITWARDEN] = 'bitwarden'
 displayNames[passwordManagers.UNMANAGED] = null
 
 module.exports = {

--- a/js/constants/settings.js
+++ b/js/constants/settings.js
@@ -84,6 +84,7 @@ const settings = {
   DASHLANE_ENABLED: 'security.passwords.dashlane-enabled',
   LAST_PASS_ENABLED: 'security.passwords.last-pass-enabled',
   ENPASS_ENABLED: 'security.passwords.enpass-enabled',
+  BITWARDEN_ENABLED: 'security.passwords.bitwarden-enabled',
   // > phased out with 0.12.6
   SHOW_BOOKMARKS_TOOLBAR_FAVICON: 'bookmarks.toolbar.showFavicon',
   SHOW_BOOKMARKS_TOOLBAR_ONLY_FAVICON: 'bookmarks.toolbar.showOnlyFavicon',

--- a/js/settings.js
+++ b/js/settings.js
@@ -21,6 +21,9 @@ const passwordManagerDefault = (settingKey, settingsCollection) => {
   const enpassEnabled = resolveValue(settings.ENPASS_ENABLED, settingsCollection) === true
   if (enpassEnabled) return passwordManagers.ENPASS
 
+  const bitwardenEnabled = resolveValue(settings.BITWARDEN_ENABLED, settingsCollection) === true
+  if (bitwardenEnabled) return passwordManagers.BITWARDEN
+
   const disabled = resolveValue(settings.PASSWORD_MANAGER_ENABLED, settingsCollection) === false
   if (disabled) return passwordManagers.UNMANAGED
 

--- a/test/about/extensionsTest.js
+++ b/test/about/extensionsTest.js
@@ -105,4 +105,18 @@ describe('about:extensions', function () {
         .waitForVisible(`[data-extension-id="${extensionIds[passwordManagers.ENPASS]}"]`, extensionDownloadWaitTime)
     })
   })
+  describe.skip('bitwarden installs when enabled', function () {
+    Brave.beforeAll(this)
+    before(function * () {
+      yield setup(this.app.client)
+    })
+    it('installs', function * () {
+      yield this.app.client
+        .windowByUrl(Brave.browserWindowUrl)
+        .changeSetting(settingsConst.ACTIVE_PASSWORD_MANAGER, passwordManagers.BITWARDEN)
+        .waitForVisible(`.extensionBrowserAction[data-button-value="${extensionIds[passwordManagers.BITWARDEN]}"]`)
+        .tabByIndex(0)
+        .waitForVisible(`[data-extension-id="${extensionIds[passwordManagers.BITWARDEN]}"]`, extensionDownloadWaitTime)
+    })
+  })
 })

--- a/test/unit/settingsTest.js
+++ b/test/unit/settingsTest.js
@@ -82,13 +82,19 @@ describe('settings unit test', function () {
           assert.equal(response, passwordManagers.ENPASS)
         })
 
+        it('returns `bitwarden` if BITWARDEN_ENABLED was true', function () {
+          settingsCollection[settingsConst.BITWARDEN_ENABLED] = true
+          const response = settings.getSetting(settingsConst.ACTIVE_PASSWORD_MANAGER, settingsCollection)
+          assert.equal(response, passwordManagers.BITWARDEN)
+        })
+
         it('returns `BuiltIn` if PASSWORD_MANAGER_ENABLED was true', function () {
           settingsCollection[settingsConst.PASSWORD_MANAGER_ENABLED] = true
           const response = settings.getSetting(settingsConst.ACTIVE_PASSWORD_MANAGER, settingsCollection)
           assert.equal(response, passwordManagers.BUILT_IN)
         })
 
-        it('returns `1Password`/`Dashlane`/`LastPass`/`Enpass`, even if PASSWORD_MANAGER_ENABLED was true', function () {
+        it('returns `1Password`/`Dashlane`/`LastPass`/`Enpass`/`bitwarden`, even if PASSWORD_MANAGER_ENABLED was true', function () {
           // 1Password
           settingsCollection[settingsConst.ONE_PASSWORD_ENABLED] = true
           settingsCollection[settingsConst.PASSWORD_MANAGER_ENABLED] = true
@@ -112,6 +118,12 @@ describe('settings unit test', function () {
           settingsCollection[settingsConst.PASSWORD_MANAGER_ENABLED] = true
           response = settings.getSetting(settingsConst.ACTIVE_PASSWORD_MANAGER, settingsCollection)
           assert.equal(response, passwordManagers.ENPASS)
+          // bitwarden
+          settingsCollection = {}
+          settingsCollection[settingsConst.BITWARDEN_ENABLED] = true
+          settingsCollection[settingsConst.PASSWORD_MANAGER_ENABLED] = true
+          response = settings.getSetting(settingsConst.ACTIVE_PASSWORD_MANAGER, settingsCollection)
+          assert.equal(response, passwordManagers.BITWARDEN)
         })
 
         it('returns `Unmanaged` if PASSWORD_MANAGER_ENABLED was false', function () {


### PR DESCRIPTION
This change adds support for bitwarden password manager using the compatible Chrome extension:

https://chrome.google.com/webstore/detail/bitwarden-free-password-m/nngceckbapebfimnlniiiahkandclblb?hl=en

bitwarden does not require any external desktop application to be installed. It is similar to LastPass.

resolves #4776 

------------------------

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

## Test Plan:

- New tests added following the same pattern from all other password managers
- Tests seem to pass properly when running, though overall build is broken right now for unrelated reasons.