### PR TITLE
Multiple home page URL

### DIFF
--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -142,6 +142,7 @@ newTabHomePage=Home page
 newTabDefaultSearchEngine=Default search engine
 newTabEmpty=Blank page
 myHomepage=My home page is
+multipleHomePages.title=Multiple home pages
 aboutBlank=about:blank
 default=Default
 searchEngine=Search Engine

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -683,7 +683,14 @@ class GeneralTab extends ImmutableComponent {
             <option data-l10n-id='newTabEmpty' value={newTabMode.EMPTY_NEW_TAB} />
           </SettingDropdown>
         </SettingItem>
-        <SettingItem dataL10nId='myHomepage'>
+        <div className='iconTitle'>
+          <span data-l10n-id='myHomepage' />
+          <span className='fa fa-info-circle iconLink' onClick={aboutActions.newFrame.bind(null, {
+            location: 'https://github.com/brave/browser-laptop/wiki/End-User-FAQ#how-to-set-up-multiple-home-pages'
+          }, true)}
+            data-l10n-id='multipleHomePages' />
+        </div>
+        <SettingItem>
           <SettingTextbox
             spellCheck='false'
             data-l10n-id='homepageInput'

--- a/js/lib/appUrlUtil.js
+++ b/js/lib/appUrlUtil.js
@@ -234,7 +234,8 @@ module.exports.newFrameUrl = function () {
 
   switch (settingValue) {
     case newTabMode.HOMEPAGE:
-      return getSetting(settings.HOMEPAGE) || 'about:blank'
+      const homePage = (getSetting(settings.HOMEPAGE) || 'about:blank').split('|')
+      return homePage[0]
 
     case newTabMode.DEFAULT_SEARCH_ENGINE:
       const searchProviders = require('../data/searchProviders').providers

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -395,7 +395,7 @@ const handleAppAction = (action) => {
 
       // initialize frames state
       let frames = []
-      if (frameOpts) {
+      if (frameOpts && Object.keys(frameOpts).length > 0) {
         if (frameOpts.forEach) {
           frames = frameOpts
         } else {

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -317,7 +317,6 @@ span.settingsListCopy {
 
 .settingsList {
   .settingItem {
-
     > *:not(.switchControl) {
       margin-bottom: 10px;
       min-width: 160px;
@@ -364,6 +363,22 @@ span.settingsListCopy {
 
   .subtext {
     font-size: 0.95em;
+  }
+
+  .iconTitle {
+    margin: 1.2em 2px 7px;
+    color: #444444;
+    font-size: 0.9em;
+
+    span {
+      display: inline-block;
+    }
+
+    .iconLink {
+      margin-left: 5px;
+      cursor: pointer;
+      vertical-align: middle;
+    }
   }
 }
 

--- a/test/about/newTabTest.js
+++ b/test/about/newTabTest.js
@@ -6,6 +6,7 @@ const {getTargetAboutUrl} = require('../../js/lib/appUrlUtil')
 const settings = require('../../js/constants/settings')
 const {newTabMode} = require('../../app/common/constants/settingsEnums')
 const aboutNewTabUrl = getTargetAboutUrl('about:newtab')
+const messages = require('../../js/constants/messages')
 
 describe('about:newtab tests', function () {
   function * setup (client) {
@@ -84,6 +85,25 @@ describe('about:newtab tests', function () {
       yield waitForPageLoad(this.app.client)
 
       yield this.app.client.waitForExist('.empty')
+    })
+  })
+
+  describe('with NEWTAB_MODE === HOMEPAGE', function () {
+    const page1 = 'https://start.duckduckgo.com/'
+    const page2 = 'https://brave.com/'
+
+    Brave.beforeAll(this)
+
+    before(function * () {
+      yield setup(this.app.client)
+      yield this.app.client.changeSetting(settings.NEWTAB_MODE, newTabMode.HOMEPAGE)
+      yield this.app.client.changeSetting(settings.HOMEPAGE, `${page1}|${page2}`)
+    })
+
+    it('multiple homepages', function * () {
+      yield this.app.client
+        .ipcSend(messages.SHORTCUT_NEW_FRAME)
+        .waitForUrl(page1)
     })
   })
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

## Description
Resolves #6913

This problem was introduced with c44b0eb, because `{}` was added as default value to  `frameOpts`.

## Auditors
@bsclifton, @bradleyrichter 

## Test Plan
1 plan:
- set home page url with multiple url's value for example `file:///index.htmlhttps://start.duckduckgo.com/|https://google.com/`
- restart browser and home page URL's should be opened correctly

2 plan:
- set home page url with multiple url's value for example `https://start.duckduckgo.com/|file:///index.htm|https://google.com/`
- click on new tab
- only first item should be opened (in this case `https://start.duckduckgo.com`)

## Automated tests
- `npm run watch-test`
- `npm run unittest -- --grep="multiple homepages"`
- `npm run unittest -- --grep="homepage multiple"`

