### PR TITLE
Revert "Disable payments panel tests too"; update names for tests to …

### DIFF
--- a/test/components/ledgerPanelAdvancedPanelTest.js
+++ b/test/components/ledgerPanelAdvancedPanelTest.js
@@ -130,7 +130,7 @@ let generateAndSaveRecoveryFile = function (recoveryFilePath, paymentId, passphr
   return
 }
 
-describe.skip('Payments Panel -> Advanced Panel', function () {
+describe.skip('Advanced payment panel tests', function () {
   let context = this
   Brave.beforeEach(this)
 

--- a/test/components/ledgerPanelTest.js
+++ b/test/components/ledgerPanelTest.js
@@ -14,7 +14,7 @@ function * setup (client) {
     .waitForVisible(urlInput)
 }
 
-describe.skip('Payments Panel', function () {
+describe('Regular payment panel tests', function () {
   describe('can setup payments', function () {
     Brave.beforeEach(this)
     beforeEach(function * () {


### PR DESCRIPTION
…make more grep-able (advanced vs regular)

This reverts commit 15e56280def6c48537f66026bd913eda753765ff.

Auditors: @bbondy, @willy-b

## Test plan
`npm run test -- --grep="Regular payment panel tests"`