### PR TITLE
only display time range in statement PDF when range is available (#6896, #6897)

### DIFF
--- a/js/about/contributionStatement.js
+++ b/js/about/contributionStatement.js
@@ -262,12 +262,19 @@ class ContributionStatement extends ImmutableComponent {
     return pages
   }
 
+  get contributionDateRangeString () {
+    if (this.lastContributionHumanFormattedDate !== '') {
+      return (this.lastContributionHumanFormattedDate + ' - ' + this.thisContributionHumanFormattedDate)
+    }
+    return null
+  }
+
   ContributionStatementDetailTable (page, pageIdx, totalPages) {
     return (
       <div className='contributionStatementDetailTableContainer'>
         <div>
           <span className='statementDatesCoveredText pull-right'>
-            { this.lastContributionHumanFormattedDate } - { this.thisContributionHumanFormattedDate }
+            { this.contributionDateRangeString }
           </span>
           <table className='contributionStatementDetailTable'>
             <tbody>

--- a/tools/lib/utilApp/index.js
+++ b/tools/lib/utilApp/index.js
@@ -54,7 +54,7 @@ app.on('ready', () => {
       cleanUserData(process.argv[3])
       break
     case 'addSimulatedLedgerTransactions':
-      addSimulatedLedgerTransactions(process.argv[3])
+      addSimulatedLedgerTransactions(parseInt(process.argv[3]))
       break
     case 'addSimulatedSynopsisVisits':
       addSimulatedSynopsisVisits(process.argv[3])

--- a/tools/utilAppRunner.js
+++ b/tools/utilAppRunner.js
@@ -14,7 +14,7 @@ function runUtilApp (cmd, file, stdioOptions) {
   }
   cmd = cmd.split(' ')
   if (process.env.NODE_ENV === 'development') {
-    cmd.push('--user-data-dir=brave-development')
+    cmd.push('--user-data-dir=../../../brave-development')
   }
   const utilApp = proc.spawnSync('electron', [utilAppDir].concat(cmd), options)
   if (utilApp.error) {


### PR DESCRIPTION
for #6896 
(replaces and comes from discussion in #6897 and in https://github.com/willy-b/browser-laptop/commit/a510c87d1598b6e75043bf2924e36643355e4e7e#commitcomment-20667505 , where @mrose17 reviewed this change)

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.

Test Plan:
- either have a payment history or generate one with `npm run add-simulated-payment-history`
- open Brave -> Preferences -> Payments (or navigate to `about:preferences#payments`)
- click "View Payment History"
- open your first payment receipt PDF
- observe there is no date range present
- open a later payment receipt PDF
- observe a time range is present

Example: Two consecutive statements
-  where 1st has no time range (since 1st payment):
![statementpdf_norange](https://cloud.githubusercontent.com/assets/6969859/22410269/07897a62-e664-11e6-8a05-b748a6aa12ad.png)

- 2nd does have a time range (begins with date of last statement):
![statementpdf_yesrange](https://cloud.githubusercontent.com/assets/6969859/22410270/0e246c88-e664-11e6-9a00-440de35eefd4.png)