### PR TITLE
Add field separators to getSiteKey

### DIFF
--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -65,8 +65,8 @@ module.exports.getSiteKey = function (siteDetail) {
   if (folderId) {
     return folderId.toString()
   } else if (location) {
-    return location +
-      (siteDetail.get('partitionNumber') || 0) +
+    return location + '|' +
+      (siteDetail.get('partitionNumber') || 0) + '|' +
       (siteDetail.get('parentFolderId') || 0)
   }
   return null

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -59,19 +59,49 @@ describe('siteUtil', function () {
           partitionNumber: 0
         })
         const key = siteUtil.getSiteKey(siteDetail)
-        assert.equal(key, testUrl1 + '00')
+        assert.equal(key, testUrl1 + '|0|0')
       })
       it('returns key if location matches and partitionNumber is NOT present', function () {
         const siteDetail = Immutable.fromJS({
           location: testUrl1
         })
         const key = siteUtil.getSiteKey(siteDetail)
-        assert.equal(key, testUrl1 + '00')
+        assert.equal(key, testUrl1 + '|0|0')
       })
       it('returns null if location is missing', function () {
         const siteDetail = new Immutable.Map()
         const key = siteUtil.getSiteKey(siteDetail)
         assert.equal(key, null)
+      })
+    })
+    describe('prevent collision', function () {
+      it('partition number', function () {
+        const siteA = Immutable.fromJS({
+          location: testUrl1 + '1',
+          partitionNumber: 0
+        })
+        const siteB = Immutable.fromJS({
+          location: testUrl1,
+          partitionNumber: 10
+        })
+        const keyA = siteUtil.getSiteKey(siteA)
+        const keyB = siteUtil.getSiteKey(siteB)
+        assert.notEqual(keyA, keyB)
+      })
+      it('parent folder id', function () {
+        const siteA = Immutable.fromJS({
+          location: testUrl1 + '1',
+          partitionNumber: 0,
+          parentFolderId: 0
+        })
+        const siteB = Immutable.fromJS({
+          location: testUrl1,
+          partitionNumber: 10,
+          parentFolderId: 0
+        })
+        const keyA = siteUtil.getSiteKey(siteA)
+        const keyB = siteUtil.getSiteKey(siteB)
+        assert.notEqual(keyA, keyB)
       })
     })
   })


### PR DESCRIPTION
fix #6936

Auditors: @diracdeltas, @bbondy

Test Plan: Covered by automation test

Note: No migration for old sites data due to still not releasing

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
