### PR TITLE
Remove command line flag which caused blurriness and missing pixels on Windows

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -82,8 +82,6 @@ const privacy = require('../js/state/privacy')
 const async = require('async')
 const settings = require('../js/constants/settings')
 
-// temporary fix for #4517, #4518 and #4472
-app.commandLine.appendSwitch('enable-use-zoom-for-dsf', 'false')
 app.commandLine.appendSwitch('enable-features', 'BlockSmallPluginContent,PreferHtmlOverPlugins')
 
 // Used to collect the per window state when shutting down the application


### PR DESCRIPTION
This was originally added to fix #4517, #4518, and #4472... but is no longer needed (I confirmed all those situations work).

Fixes https://github.com/brave/browser-laptop/issues/6462
Fixes https://github.com/brave/browser-laptop/issues/6777
Fixes https://github.com/brave/browser-laptop/issues/6144
Fixes https://github.com/brave/browser-laptop/issues/3556
Fixes https://github.com/brave/browser-laptop/issues/2089

Auditors: @bridiver, @bbondy, @darkdh

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

## Verify there are no regressions

### verify #4517 (Unable to select text on a page opened in a new tab following a link)

1. Open brianbondy.com
2. Click on Twitter image to open the twitter page in a new tab
3. Try selecting any text, not possible to select, text selection flickers when mouse is dragged across the text

### verify #4518 (Link hover indicators flicker when moving the cursor across links on tabs opened from links)
1. Set DPI to > 100 (125%, 200%)
2. Visit https://github.com/brave/browser-laptop/issues
3. Move mouse over various links. You should not see flickering in other (unrelated) divs


### verify #4472 (Mouse scrolling wheel issues)
1. go to http://jsbin.com/gesayaqoho/edit?html,output
2. click link shown in UI on right (has target=_blank)
3. notice you can scroll just fine

## Test plan
1. Set DPI to 125%, 150%, 175% by right clicking desktop and picking display settings
2. Launch Brave
3. Visit about:autofill
4. Click "Add Address" to bring up the modal
5. Verify there are no missing pixels, as seen in #6462
6. Close the modal and visit Brave.com
7. Hit Ctrl + D to bookmark page
8. Notice bookmark hanger is not blurry