### PR TITLE
Minimum publisher visit default now 1

### DIFF
--- a/app/ledger.js
+++ b/app/ledger.js
@@ -761,7 +761,7 @@ var enable = (paymentsEnabled) => {
 
       value = getSetting(settings.MINIMUM_VISITS)
       if (!value) {
-        value = 5
+        value = 1
         appActions.changeSetting(settings.MINIMUM_VISITS, value)
       }
       if (value > 0) synopsis.options.minPublisherVisits = value

--- a/app/renderer/components/preferences/paymentsTab.js
+++ b/app/renderer/components/preferences/paymentsTab.js
@@ -251,9 +251,9 @@ class PaymentsTab extends ImmutableComponent {
             <SettingItem>
               <SettingDropdown
                 data-test-id='visitSelector'
-                defaultValue={minPublisherVisits || 5}
+                defaultValue={minPublisherVisits || 1}
                 onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.MINIMUM_VISITS)}>>>
-                <option value='2'>2 visits</option>
+                <option value='1'>1 visits</option>
                 <option value='5'>5 visits</option>
                 <option value='10'>10 visits</option>
               </SettingDropdown>

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -155,7 +155,7 @@ module.exports = {
     'advanced.send-usage-statistics': false,
     'advanced.hide-excluded-sites': false,
     'advanced.minimum-visit-time': 8,
-    'advanced.minimum-visits': 5,
+    'advanced.minimum-visits': 1,
     'advanced.minimum-percentage': false,
     'advanced.auto-suggest-sites': true,
     'shutdown.clear-history': false,


### PR DESCRIPTION
Fixes #6941

## Test Plan

1. start the browser with a new session, verify that the advanced settings shows '1' for relevancy
2. change the value, close the window, open it again, verify the change took.
3. quit the browser, start the browser, verify the change is still there.
