### PR TITLE
always set title from tabData

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -396,7 +396,21 @@ class Frame extends ImmutableComponent {
     }
   }
 
+  setTitle (title) {
+    if (this.frame.isEmpty()) {
+      return
+    }
+    windowActions.setFrameTitle(this.frame, title)
+  }
+
   componentDidUpdate (prevProps, prevState) {
+    if (this.props.tabData) {
+      if (!prevProps.tabData ||
+            prevProps.tabData.get('title') !== this.props.tabData.get('title')) {
+        this.setTitle(this.props.tabData.get('title'))
+      }
+    }
+
     const cb = () => {
       if (this.getWebRTCPolicy(prevProps) !== this.getWebRTCPolicy(this.props)) {
         this.webview.setWebRTCIPHandlingPolicy(this.getWebRTCPolicy(this.props))
@@ -716,12 +730,6 @@ class Frame extends ImmutableComponent {
         })
       }
     })
-    this.webview.addEventListener('page-title-updated', ({title}) => {
-      if (this.frame.isEmpty()) {
-        return
-      }
-      windowActions.setFrameTitle(this.frame, title)
-    })
     this.webview.addEventListener('show-autofill-settings', (e) => {
       windowActions.newFrame({ location: 'about:autofill' }, true)
     })
@@ -833,7 +841,12 @@ class Frame extends ImmutableComponent {
       const isError = this.props.aboutDetails && this.props.aboutDetails.get('errorCode')
       if (!this.props.isPrivate && (protocol === 'http:' || protocol === 'https:') && !isError && savePage) {
         // Register the site for recent history for navigation bar
-        appActions.addSite(siteUtil.getDetailFromFrame(this.frame))
+        // calling with setTimeout is an ugly hack for a race condition
+        // with setTitle. We either need to delay this call until the title is
+        // or add a way to update it
+        setTimeout(() => {
+          appActions.addSite(siteUtil.getDetailFromFrame(this.frame))
+        }, 250)
       }
 
       if (url.startsWith(pdfjsOrigin)) {
@@ -928,13 +941,6 @@ class Frame extends ImmutableComponent {
       }
       // force temporary url display for tabnapping protection
       windowActions.setMouseInTitlebar(true)
-
-      // After navigating to the URL via back/forward buttons, set correct frame title
-      if (!e.isRendererInitiated) {
-        if (!this.frame.isEmpty() && this.props.tabData) {
-          windowActions.setFrameTitle(this.frame, this.props.tabData.get('title'))
-        }
-      }
     })
     this.webview.addEventListener('crashed', (e) => {
       if (this.frame.isEmpty()) {


### PR DESCRIPTION
requires https://github.com/brave/muon/commit/821bbe2108fec2d435b5bccacf36fa2258e498f5
fix #6927

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
