### PR TITLE
Correct Fedora to include importing GPG key. and others:

### DIFF
--- a/docs/linuxInstall.md
+++ b/docs/linuxInstall.md
@@ -47,16 +47,15 @@ sudo dpkg -i ./brave.deb
 To install brave using dnf:
 
 ```
-dnf config-manager --add-repo dnf config-manager --add-repo https://s3-us-west-2.amazonaws.com/brave-rpm-release/x86_64/
-dnf check-update
-dnf install brave
+sudo dnf config-manager --add-repo https://s3-us-west-2.amazonaws.com/brave-rpm-release/x86_64/
+sudo rpm --import https://s3-us-west-2.amazonaws.com/brave-rpm-release/keys.asc 
+sudo dnf install brave
 ```
 
 To update brave using dnf:
 
 ```
-dnf check-update
-dnf update brave
+dnf upgrade brave
 ```
 
 


### PR DESCRIPTION
- Correct duplicate `dnf config-manager --add-repo`
- `sudo` is as important here as it is above for Debian/Ubuntu - add for
  consistency's sake
- Since you have a GPG key available, let's use it by importing it into the RPM
  keyring. Currently, the instructions fail at install time due to not importing
  this key, coupled with the fact that `dnf config-manager` does not set
  `gpgcheck=0` by default, thus we need to import the gpg key as `gpgcheck=1` is
  set by default by fedora in `/etc/dnf/dnf.conf`
- The `dnf check-update` step is unnecessary, dnf will update dependencies and
  check new repositories by default. Removed
- `dnf update` is a deprecated alias for the true command, `dnf upgrade`. Replace