### PR TITLE
Check for initialized client in timeout callback

### DIFF
--- a/app/ledger.js
+++ b/app/ledger.js
@@ -711,6 +711,8 @@ var initialize = (paymentsEnabled) => {
 
         // speed-up browser start-up by delaying the first synchronization action
         setTimeout(() => {
+          if (!client) return
+
           if (client.sync(callback) === true) run(random.randomInt({ min: msecs.minute, max: 10 * msecs.minute }))
           cacheRuleSet(state.ruleset)
         }, 3 * msecs.second)


### PR DESCRIPTION
Fixes #7031
Auditor @bsclifton 

Test Plan:
- Enable Brave payments and wait till the wallet is created
- Disable payments and enable it immediately
- Repeat it for 4-5 times, brave should not crash