### PR TITLE
Focus active webview when closing downloads-bar

### DIFF
--- a/app/renderer/components/downloadsBar.js
+++ b/app/renderer/components/downloadsBar.js
@@ -7,6 +7,7 @@ const ImmutableComponent = require('../../../js/components/immutableComponent')
 const Button = require('../../../js/components/button')
 const contextMenus = require('../../../js/contextMenus')
 const windowActions = require('../../../js/actions/windowActions')
+const webviewActions = require('../../../js/actions/webviewActions')
 const DownloadItem = require('./downloadItem')
 
 class DownloadsBar extends ImmutableComponent {
@@ -16,6 +17,7 @@ class DownloadsBar extends ImmutableComponent {
   }
   onHideDownloadsToolbar () {
     windowActions.setDownloadsToolbarVisible(false)
+    webviewActions.setWebviewFocused()
   }
   render () {
     const getComputedStyle = require('../getComputedStyle')


### PR DESCRIPTION
Fixes #3219

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
Webview now correctly gain focus after closing `DownloadsBar` (for instance up and down keys work, like on the attached gif).
![focus-on-download](https://cloud.githubusercontent.com/assets/347657/22604386/a888ccca-ea4b-11e6-996c-cdf3cfc7dee3.gif)
