### PR TITLE
Focus webview when ESC pressed on UrlBar

### DIFF
--- a/app/renderer/components/urlBar.js
+++ b/app/renderer/components/urlBar.js
@@ -7,6 +7,7 @@ const urlParse = require('../../common/urlParse')
 
 const ImmutableComponent = require('../../../js/components/immutableComponent')
 const windowActions = require('../../../js/actions/windowActions')
+const webviewActions = require('../../../js/actions/webviewActions')
 const appActions = require('../../../js/actions/appActions')
 const KeyCodes = require('../../common/constants/keyCodes')
 const cx = require('../../../js/lib/classSet')
@@ -335,9 +336,11 @@ class UrlBar extends ImmutableComponent {
 
   onKeyUp (e) {
     switch (e.keyCode) {
+      case KeyCodes.ESC:
+        webviewActions.setWebviewFocused()
+        return
       case KeyCodes.UP:
       case KeyCodes.DOWN:
-      case KeyCodes.ESC:
         return
     }
     if (this.isSelected()) {


### PR DESCRIPTION
Fixes #3248

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
  - Focus the URL bar
  - Press `ESC`
  - notice the focus returned to the webview