### PR TITLE
Fix bookmarks order in menubar

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -24,7 +24,7 @@ const {fileUrl} = require('../../js/lib/appUrlUtil')
 const menuUtil = require('../common/lib/menuUtil')
 const getSetting = require('../../js/settings').getSetting
 const locale = require('../locale')
-const {isSiteBookmarked} = require('../../js/state/siteUtil')
+const {isSiteBookmarked, siteSort} = require('../../js/state/siteUtil')
 const isDarwin = process.platform === 'darwin'
 const aboutUrl = 'https://brave.com/'
 
@@ -365,7 +365,7 @@ const createBookmarksSubmenu = () => {
     CommonMenu.importBrowserDataMenuItem()
   ]
 
-  const bookmarks = menuUtil.createBookmarkTemplateItems(appStore.getState().get('sites'))
+  const bookmarks = menuUtil.createBookmarkTemplateItems(appStore.getState().get('sites').toList().sort(siteSort))
   if (bookmarks.length > 0) {
     submenu.push(CommonMenu.separatorMenuItem)
     submenu = submenu.concat(bookmarks)


### PR DESCRIPTION
fix #7048

Auditors: @bsclifton, @bbondy

Test Plan:
1. Import a bookmark file
2. Check the bookmarks menu
3. Order should be consitent as bookmark toolbar

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
