### PR TITLE
Set customTitle before setBookmarkDetail on navigation bar

### DIFF
--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -52,6 +52,7 @@ class NavigationBar extends ImmutableComponent {
 
     if (key !== null) {
       siteDetail = siteDetail.set('parentFolderId', this.props.sites.getIn([key, 'parentFolderId']))
+      siteDetail = siteDetail.set('customTitle', this.props.sites.getIn([key, 'customTitle']))
     }
     windowActions.setBookmarkDetail(siteDetail, siteDetail, null, editing, true)
   }

--- a/test/components/bookmarksTest.js
+++ b/test/components/bookmarksTest.js
@@ -41,6 +41,22 @@ describe('bookmark tests', function () {
           .waitForExist('#bookmarkLocation input')
           .waitForBookmarkDetail(this.page1Url, 'Page 1')
       })
+      it('add custom title', function * () {
+        yield this.app.client
+          .waitForExist('#bookmarkName input')
+          .waitForBookmarkDetail(this.page1Url, 'Page 1')
+          .setValue('#bookmarkName input', 'Custom Page 1')
+          .waitForEnabled(doneButton)
+          .click(doneButton)
+      })
+      it('check custom title', function * () {
+        yield this.app.client
+          .activateURLMode()
+          .waitForVisible(navigatorBookmarked)
+          .click(navigatorBookmarked)
+          .waitForVisible(doneButton)
+          .getValue('#bookmarkName input').should.eventually.be.equal('Custom Page 1')
+      })
     })
 
     describe('pages with title', function () {


### PR DESCRIPTION
fix #7056

Auditors: @bbondy

Test Plan: covered by automatic test

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

