### PR TITLE
Strengthen the download toolbar visible condition just like main.js

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -1404,7 +1404,8 @@ function onShowUsernameMenu (usernames, origin, action, boundingRect,
 
 function onShowAutofillMenu (suggestions, boundingRect, frame) {
   const menuTemplate = autofillTemplateInit(suggestions, frame)
-  const downloadsBarOffset = windowStore.getState().getIn(['ui', 'downloadsToolbar', 'isVisible']) ? getDownloadsBarHeight() : 0
+  const downloadsBarOffset = windowStore.getState().getIn(['ui', 'downloadsToolbar', 'isVisible']) &&
+    appStore.state.get('downloads') && appStore.state.get('downloads').size ? getDownloadsBarHeight() : 0
   const offset = {
     x: (window.innerWidth - boundingRect.clientWidth),
     y: (window.innerHeight - boundingRect.clientHeight)


### PR DESCRIPTION
fix #3758
fix #7033

Auditors: @bbondy

Test Plan:

1. Toggle clear download history when close Brave
2. Download something to make download tool bar shows
3. Quit Brave when downloading
4. After relaunch brave go to https://github.com/brave/browser-laptop/issues
5. Search something on filter to make autofill popup
6. The popup shouldn't be shifted

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).