### PR TITLE
Preserved order when constructing pinned sites

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -1186,7 +1186,6 @@ class Main extends ImmutableComponent {
           previewTabPageIndex={this.props.windowState.getIn(['ui', 'tabs', 'previewTabPageIndex'])}
           fixTabWidth={this.props.windowState.getIn(['ui', 'tabs', 'fixTabWidth'])}
           tabs={this.props.windowState.get('tabs')}
-          sites={appStateSites}
           key='tab-bar'
           activeFrameKey={activeFrame && activeFrame.get('key') || undefined}
           onMenu={this.onHamburgerMenu}

--- a/js/components/tabsToolbar.js
+++ b/js/components/tabsToolbar.js
@@ -45,7 +45,7 @@ class TabsToolbar extends ImmutableComponent {
       onContextMenu={this.onContextMenu}>
       {
         pinnedTabs.size > 0
-        ? <PinnedTabs sites={this.props.sites}
+        ? <PinnedTabs
           activeFrameKey={this.props.activeFrameKey}
           paintTabs={this.props.paintTabs}
           previewTabs={this.props.previewTabs}

--- a/js/components/window.js
+++ b/js/components/window.js
@@ -13,6 +13,7 @@ const Main = require('./main')
 const SiteTags = require('../constants/siteTags')
 const cx = require('../lib/classSet')
 const {getPlatformStyles} = require('../../app/common/lib/platformUtil')
+const {siteSort} = require('../state/siteUtil')
 
 class Window extends React.Component {
   constructor (props) {
@@ -103,7 +104,7 @@ class Window extends React.Component {
       return
     }
 
-    const sites = this.appState.get('sites')
+    const sites = this.appState.get('sites').toList().sort(siteSort)
     const frames = this.windowState.get('frames')
 
     // Check for new pinned sites which we don't already know about

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -342,17 +342,19 @@ module.exports.moveSite = function (sites, sourceDetail, destinationDetail, prep
     destinationSiteIndex = sites.getIn([destinationKey, 'order'])
   }
 
-  const newIndex = destinationSiteIndex + (prepend ? 0 : 1)
   let sourceSite = sites.get(sourceKey)
   if (!sourceSite) {
     return sites
   }
+  const newIndex = destinationSiteIndex + (prepend ? 0 : 1)
   const destinationSite = sites.get(destinationKey)
   sites = sites.delete(sourceKey)
   sites = sites.map((site) => {
     const siteOrder = site.get('order')
     if (siteOrder >= newIndex && siteOrder < sourceSiteIndex) {
       return site.set('order', siteOrder + 1)
+    } else if (siteOrder <= newIndex && siteOrder > sourceSiteIndex) {
+      return site.set('order', siteOrder - 1)
     }
     return site
   })


### PR DESCRIPTION
fix #7091

Auditors: @bbondy, @bsclifton

Test Plan:
1. Open site A, B, C
2. Pinned site A, B, C
3. Move pinned tab A to the place between B & C
4. Relaunch Brave
5. Pinned tab order should be preserved

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
