### PR TITLE
Preserved order when constructing pinned sites

### DIFF
--- a/js/components/window.js
+++ b/js/components/window.js
@@ -13,6 +13,7 @@ const Main = require('./main')
 const SiteTags = require('../constants/siteTags')
 const cx = require('../lib/classSet')
 const {getPlatformStyles} = require('../../app/common/lib/platformUtil')
+const {siteSort} = require('../state/siteUtil')
 
 class Window extends React.Component {
   constructor (props) {
@@ -115,7 +116,7 @@ class Window extends React.Component {
             frame.get('pinnedLocation') === site.get('location') &&
             (frame.get('partitionNumber') || 0) === (site.get('partitionNumber') || 0))
       })
-    sitesToAdd.forEach((site) => {
+    sitesToAdd.toList().sort(siteSort).forEach((site) => {
       windowActions.newFrame({
         location: site.get('location'),
         partitionNumber: site.get('partitionNumber'),

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -342,10 +342,13 @@ module.exports.moveSite = function (sites, sourceDetail, destinationDetail, prep
     destinationSiteIndex = sites.getIn([destinationKey, 'order'])
   }
 
-  const newIndex = destinationSiteIndex + (prepend ? 0 : 1)
   let sourceSite = sites.get(sourceKey)
   if (!sourceSite) {
     return sites
+  }
+  let newIndex = destinationSiteIndex + (prepend ? 0 : 1)
+  if (destinationSiteIndex > sourceSiteIndex) {
+    --newIndex
   }
   const destinationSite = sites.get(destinationKey)
   sites = sites.delete(sourceKey)
@@ -353,6 +356,8 @@ module.exports.moveSite = function (sites, sourceDetail, destinationDetail, prep
     const siteOrder = site.get('order')
     if (siteOrder >= newIndex && siteOrder < sourceSiteIndex) {
       return site.set('order', siteOrder + 1)
+    } else if (siteOrder <= newIndex && siteOrder > sourceSiteIndex) {
+      return site.set('order', siteOrder - 1)
     }
     return site
   })

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -595,98 +595,195 @@ describe('siteUtil', function () {
 
   describe('moveSite', function () {
     describe('order test', function () {
-      const destinationDetail = {
-        location: testUrl1,
-        partitionNumber: 0,
-        parentFolderId: 0,
-        order: 0
-      }
-      const sourceDetail = {
-        location: testUrl2 + '4',
-        partitionNumber: 0,
-        parentFolderId: 0,
-        order: 3
-      }
-      const sites = {
-        'https://brave.com/|0|0': destinationDetail,
-        'http://example.com/0|0': {
-          location: testUrl2,
+      describe('back to front', function () {
+        const destinationDetail = {
+          location: testUrl1,
           partitionNumber: 0,
           parentFolderId: 0,
-          order: 1
-        },
-        'https://brave.com/3|0|0': {
-          location: testUrl1 + '3',
+          order: 0
+        }
+        const sourceDetail = {
+          location: testUrl2 + '4',
           partitionNumber: 0,
           parentFolderId: 0,
-          order: 2
-        },
-        'http://example.com/4|0|0': sourceDetail
-      }
+          order: 3
+        }
+        const sites = {
+          'https://brave.com/|0|0': destinationDetail,
+          'http://example.com/0|0': {
+            location: testUrl2,
+            partitionNumber: 0,
+            parentFolderId: 0,
+            order: 1
+          },
+          'https://brave.com/3|0|0': {
+            location: testUrl1 + '3',
+            partitionNumber: 0,
+            parentFolderId: 0,
+            order: 2
+          },
+          'http://example.com/4|0|0': sourceDetail
+        }
 
-      it('prepend target', function () {
-        const expectedSites = {
-          'http://example.com/4|0|0': {
-            location: testUrl2 + '4',
-            partitionNumber: 0,
-            parentFolderId: 0,
-            order: 0
-          },
-          'https://brave.com/|0|0': {
-            location: testUrl1,
-            partitionNumber: 0,
-            parentFolderId: 0,
-            order: 1
-          },
-          'http://example.com/0|0': {
-            location: testUrl2,
-            partitionNumber: 0,
-            parentFolderId: 0,
-            order: 2
-          },
-          'https://brave.com/3|0|0': {
-            location: testUrl1 + '3',
-            partitionNumber: 0,
-            parentFolderId: 0,
-            order: 3
+        it('prepend target', function () {
+          const expectedSites = {
+            'http://example.com/4|0|0': {
+              location: testUrl2 + '4',
+              partitionNumber: 0,
+              parentFolderId: 0,
+              order: 0
+            },
+            'https://brave.com/|0|0': {
+              location: testUrl1,
+              partitionNumber: 0,
+              parentFolderId: 0,
+              order: 1
+            },
+            'http://example.com/0|0': {
+              location: testUrl2,
+              partitionNumber: 0,
+              parentFolderId: 0,
+              order: 2
+            },
+            'https://brave.com/3|0|0': {
+              location: testUrl1 + '3',
+              partitionNumber: 0,
+              parentFolderId: 0,
+              order: 3
+            }
           }
-        }
-        const processedSites = siteUtil.moveSite(Immutable.fromJS(sites),
-          Immutable.fromJS(sourceDetail),
-          Immutable.fromJS(destinationDetail), true, false, true)
-        assert.deepEqual(processedSites.toJS(), expectedSites)
+          const processedSites = siteUtil.moveSite(Immutable.fromJS(sites),
+            Immutable.fromJS(sourceDetail),
+            Immutable.fromJS(destinationDetail), true, false, true)
+          assert.deepEqual(processedSites.toJS(), expectedSites)
+        })
+        it('not prepend target', function () {
+          const expectedSites = {
+            'http://example.com/4|0|0': {
+              location: testUrl2 + '4',
+              partitionNumber: 0,
+              parentFolderId: 0,
+              order: 1
+            },
+            'https://brave.com/|0|0': {
+              location: testUrl1,
+              partitionNumber: 0,
+              parentFolderId: 0,
+              order: 0
+            },
+            'http://example.com/0|0': {
+              location: testUrl2,
+              partitionNumber: 0,
+              parentFolderId: 0,
+              order: 2
+            },
+            'https://brave.com/3|0|0': {
+              location: testUrl1 + '3',
+              partitionNumber: 0,
+              parentFolderId: 0,
+              order: 3
+            }
+          }
+          const processedSites = siteUtil.moveSite(Immutable.fromJS(sites),
+            Immutable.fromJS(sourceDetail),
+            Immutable.fromJS(destinationDetail), false, false, true)
+          assert.deepEqual(processedSites.toJS(), expectedSites)
+        })
       })
-      it('not prepend target', function () {
-        const expectedSites = {
-          'http://example.com/4|0|0': {
-            location: testUrl2 + '4',
-            partitionNumber: 0,
-            parentFolderId: 0,
-            order: 1
-          },
-          'https://brave.com/|0|0': {
-            location: testUrl1,
-            partitionNumber: 0,
-            parentFolderId: 0,
-            order: 0
-          },
+      describe('front to back', function () {
+        const sourceDetail = {
+          location: testUrl1,
+          partitionNumber: 0,
+          parentFolderId: 0,
+          order: 0
+        }
+        const destinationDetail = {
+          location: testUrl2 + '4',
+          partitionNumber: 0,
+          parentFolderId: 0,
+          order: 3
+        }
+        const sites = {
+          'https://brave.com/|0|0': sourceDetail,
           'http://example.com/0|0': {
             location: testUrl2,
             partitionNumber: 0,
             parentFolderId: 0,
-            order: 2
+            order: 1
           },
           'https://brave.com/3|0|0': {
             location: testUrl1 + '3',
             partitionNumber: 0,
             parentFolderId: 0,
-            order: 3
-          }
+            order: 2
+          },
+          'http://example.com/4|0|0': destinationDetail
         }
-        const processedSites = siteUtil.moveSite(Immutable.fromJS(sites),
-          Immutable.fromJS(sourceDetail),
-          Immutable.fromJS(destinationDetail), false, false, true)
-        assert.deepEqual(processedSites.toJS(), expectedSites)
+
+        it('prepend target', function () {
+          const expectedSites = {
+            'http://example.com/0|0': {
+              location: testUrl2,
+              partitionNumber: 0,
+              parentFolderId: 0,
+              order: 0
+            },
+            'https://brave.com/3|0|0': {
+              location: testUrl1 + '3',
+              partitionNumber: 0,
+              parentFolderId: 0,
+              order: 1
+            },
+            'https://brave.com/|0|0': {
+              location: testUrl1,
+              partitionNumber: 0,
+              parentFolderId: 0,
+              order: 2
+            },
+            'http://example.com/4|0|0': {
+              location: testUrl2 + '4',
+              partitionNumber: 0,
+              parentFolderId: 0,
+              order: 3
+            }
+          }
+          const processedSites = siteUtil.moveSite(Immutable.fromJS(sites),
+            Immutable.fromJS(sourceDetail),
+            Immutable.fromJS(destinationDetail), true, false, true)
+          assert.deepEqual(processedSites.toJS(), expectedSites)
+        })
+        it('not prepend target', function () {
+          const expectedSites = {
+            'http://example.com/0|0': {
+              location: testUrl2,
+              partitionNumber: 0,
+              parentFolderId: 0,
+              order: 0
+            },
+            'https://brave.com/3|0|0': {
+              location: testUrl1 + '3',
+              partitionNumber: 0,
+              parentFolderId: 0,
+              order: 1
+            },
+            'http://example.com/4|0|0': {
+              location: testUrl2 + '4',
+              partitionNumber: 0,
+              parentFolderId: 0,
+              order: 2
+            },
+            'https://brave.com/|0|0': {
+              location: testUrl1,
+              partitionNumber: 0,
+              parentFolderId: 0,
+              order: 3
+            }
+          }
+          const processedSites = siteUtil.moveSite(Immutable.fromJS(sites),
+            Immutable.fromJS(sourceDetail),
+            Immutable.fromJS(destinationDetail), false, false, true)
+          assert.deepEqual(processedSites.toJS(), expectedSites)
+        })
       })
     })
     it('destination is parent', function () {


### PR DESCRIPTION
Also fix moveSite calulating index which covered by automatic test

fix #7091

Auditors: @bbondy, @bsclifton

Test Plan:
1. Open site A, B, C
2. Pinned site A, B, C
3. Move pinned tab A to the place between B & C
4. Relaunch Brave
5. Pinned tab order should be preserved

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
