### PR TITLE
Enhance icon path in extension page

### DIFF
--- a/js/about/extensions.js
+++ b/js/about/extensions.js
@@ -25,8 +25,15 @@ class ExtensionItem extends ImmutableComponent {
   onContextMenu (e) {
     aboutActions.contextMenu(this.props.extension.toJS(), 'extensions', e)
   }
+  get icon () {
+    return this.props.extension.getIn(['manifest', 'icons', '128']) ||
+      this.props.extension.getIn(['manifest', 'icons', '64']) ||
+      this.props.extension.getIn(['manifest', 'icons', '48']) ||
+      this.props.extension.getIn(['manifest', 'icons', '16']) ||
+      null
+  }
   render () {
-    const icon = this.props.extension.getIn(['manifest', 'icons', '48'])
+    const icon = this.icon
     const permissions = this.props.extension.getIn(['manifest', 'permissions'])
     return <div role='listitem'
       disabled={!this.props.extension.get('enabled')}


### PR DESCRIPTION
fix #7093

Auditors: @bbondy, @jonathansampson

Test Plan:
1. Select Dashlane as password manager in about:preferences#security
2. Go to about:extensions
3. Dashlane icon should display

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
