### PR TITLE
Fix websockets bypass in Brave filtering

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -568,7 +568,7 @@ function initForPartition (partition) {
   fns.forEach((fn) => { fn(ses, partition, module.exports.isPrivate(partition)) })
 }
 
-const filterableProtocols = ['http:', 'https:']
+const filterableProtocols = ['http:', 'https:', 'ws:', 'wss:']
 
 function shouldIgnoreUrl (details) {
   // internal requests

--- a/test/components/braveryPanelTest.js
+++ b/test/components/braveryPanelTest.js
@@ -268,6 +268,24 @@ describe('Bravery Panel', function () {
         .click(blockAdsOption)
         .waitForTextValue(adsBlockedStat, '2')
     })
+    it('blocks websocket tracking', function * () {
+      const url = Brave.server.url('websockets.html')
+      yield this.app.client
+        .waitForDataFile('adblock')
+        .tabByIndex(0)
+        .loadUrl(url)
+        .waitForTextValue('#result', 'success')
+        .waitForTextValue('#error', 'error')
+        .openBraveMenu(braveMenu, braveryPanel)
+        .waitForTextValue(adsBlockedStat, '1')
+        .click(adsBlockedStat)
+        .waitUntil(function () {
+          return this.getText('.braveryPanelBody li')
+            .then((body) => {
+              return body[0] === 'ws://ag.innovid.com/dv/sync?tid=2'
+            })
+        })
+    })
     // TODO(bridiver) using slashdot won't provide reliable results so we should
     // create our own iframe page with urls we expect to be blocked
     it('detects blocked elements in iframe in private tab', function * () {

--- a/test/fixtures/websockets.html
+++ b/test/fixtures/websockets.html
@@ -1,0 +1,14 @@
+<div id='result'></div>
+<div id='error'></div>
+<script>
+  // This should get blocked by adblock if it is on
+  var exampleSocket = new WebSocket("ws://ag.innovid.com/dv/sync?tid=2");
+  exampleSocket.onerror = (e) => {
+    document.getElementById('error').innerText = 'error'
+  }
+  // This should be a valid connection
+  var ws = new WebSocket("wss://wss.websocketstest.com:443/service")
+  ws.onopen = function() {
+    document.getElementById('result').innerText = 'success'
+  }
+</script>


### PR DESCRIPTION
Fix #6997.
Requires https://github.com/brave/muon/pull/160

Auditors: @bridiver

Test Plan: covered by automated test

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

