### PR TITLE
Send rev hash to crash reports

### DIFF
--- a/app/crash-herald.js
+++ b/app/crash-herald.js
@@ -4,6 +4,7 @@
 
 const appConfig = require('../js/constants/appConfig')
 const crashReporter = require('electron').crashReporter
+const buildConfig = require('../js/constants/buildConfig')
 
 exports.init = () => {
   const options = {
@@ -12,7 +13,8 @@ exports.init = () => {
     submitURL: appConfig.crashes.crashSubmitUrl,
     autoSubmit: true,
     extra: {
-      node_env: process.env.NODE_ENV
+      node_env: process.env.NODE_ENV,
+      rev: buildConfig.BROWSER_LAPTOP_REV || 'unknown'
     }
   }
   crashReporter.start(options)


### PR DESCRIPTION
Add rev. hash to the extra parameter send with crash reports.

Auditors: @bbondy, @bridiver, @alexwykoff

Fixes: #7123 

- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [X] Ran `git rebase -i` to squash commits (if needed).

Test Plan: No QA required. This was tested with the production crash server.

<img width="643" alt="screen shot 2017-02-07 at 9 05 40 pm" src="https://cloud.githubusercontent.com/assets/210240/22720501/3f076fb4-ed79-11e6-9cb1-4eea9226f285.png">

