### PR TITLE
Change addFunds toggle criteria to be visible

### DIFF
--- a/app/renderer/components/publisherToggle.js
+++ b/app/renderer/components/publisherToggle.js
@@ -73,8 +73,8 @@ class PublisherToggle extends ImmutableComponent {
 
   get shouldShowAddPublisherButton () {
     if ((!!this.hostSettings || !!this.validPublisherSynopsis) && this.visiblePublisher) {
-      // Only show publisher icon if autoSuggest option is OFF
-      return !getSetting(settings.AUTO_SUGGEST_SITES)
+      // Only show publisher icon if ledger is enabled
+      return getSetting(settings.PAYMENTS_ENABLED)
     }
     return false
   }
@@ -89,11 +89,6 @@ class PublisherToggle extends ImmutableComponent {
   }
 
   onAuthorizePublisher () {
-    // if payments disabled, enable it
-    if (!getSetting(settings.AUTO_SUGGEST_SITES)) {
-      appActions.changeSetting(settings.PAYMENTS_ENABLED, true)
-    }
-
     this.authorizedPublisher
       ? appActions.changeSiteSetting(this.hostPattern, 'ledgerPayments', false)
       : appActions.changeSiteSetting(this.hostPattern, 'ledgerPayments', true)

--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -116,7 +116,7 @@ class NavigationBar extends ImmutableComponent {
     const validPublisherSynopsis = this.props.synopsis.map(entry => entry.get('site')).includes(domain)
 
     if ((hostSettings || validPublisherSynopsis) && visiblePublisher !== false) {
-      return !getSetting(settings.AUTO_SUGGEST_SITES) && !isSourceAboutUrl(this.props.location)
+      return getSetting(settings.PAYMENTS_ENABLED) && !isSourceAboutUrl(this.props.location)
     }
     return false
   }

--- a/test/unit/app/renderer/publisherToggleTest.js
+++ b/test/unit/app/renderer/publisherToggleTest.js
@@ -39,10 +39,10 @@ describe('PublisherToggle component', function () {
     mockery.registerMock('../../extensions/brave/img/urlbar/browser_URL_fund_no.svg')
     mockery.registerMock('../../extensions/brave/img/urlbar/browser_URL_fund_yes.svg')
     mockery.registerMock('../../../js/settings', { getSetting: (settingKey, settingsCollection, value) => {
-      if (settingKey === settingsConst.AUTO_SUGGEST_SITES) {
-        return false
+      if (settingKey === settingsConst.PAYMENTS_ENABLED) {
+        return true
       }
-      return true
+      return false
     }})
     mockery.registerMock('electron', fakeElectron)
     window.chrome = fakeElectron


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bsclifton

/cc @mrose17

Fix #7012

## Test Plan

1. If ledger is disabled, addFunds button should not be visible
2. addFunds button should be visible either if auto-suggest is on or off

**Note**: Previous criteria per publisher site hasn't changed

## Automated tests
covered by automated tests (tweaked to match new criteria)
```
npm run test -- --grep="PublisherToggle component" 
```