### PR TITLE
Improved dnd for bookmarks manager (dnd refactor)

### DIFF
--- a/app/renderer/components/urlBarIcon.js
+++ b/app/renderer/components/urlBarIcon.js
@@ -6,8 +6,6 @@ const React = require('react')
 const ImmutableComponent = require('../../../js/components/immutableComponent')
 const windowActions = require('../../../js/actions/windowActions')
 const cx = require('../../../js/lib/classSet')
-const dragTypes = require('../../../js/constants/dragTypes')
-const dndData = require('../../../js/dndData')
 const {isSourceAboutUrl} = require('../../../js/lib/appUrlUtil')
 const searchIconSize = 16
 
@@ -28,7 +26,6 @@ class UrlBarIcon extends ImmutableComponent {
   constructor () {
     super()
     this.onClick = this.onClick.bind(this)
-    this.onDragStart = this.onDragStart.bind(this)
   }
   get isSecure () {
     return this.props.isHTTPPage &&
@@ -94,14 +91,8 @@ class UrlBarIcon extends ImmutableComponent {
     }
     windowActions.setSiteInfoVisible(true)
   }
-  onDragStart (e) {
-    dndData.setupDataTransferURL(e.dataTransfer, this.props.location, this.props.title)
-    dndData.setupDataTransferBraveData(e.dataTransfer, dragTypes.TAB, this.activeFrame)
-  }
   render () {
     return <span
-      onDragStart={this.onDragStart}
-      draggable
       onClick={this.onClick}
       className={this.iconClasses}
       style={this.iconStyles} />


### PR DESCRIPTION
- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Resolves #6246 

Part of this PR is also a refactoring, so that we can use dnd in other components.

@bsclifton Can you please check out my first commit `Removed dnd in url bar`. In 5837fc5 you added dnd for URLIcon. I don't see why this should be here (couldn't find anything about it in parent issue). Is it ok to remove it? If you dnd search icon in the current release you get error like this:
![image](https://cloud.githubusercontent.com/assets/9574457/22732262/d9b70136-eded-11e6-89f6-f9b88ef29aa0.png)
