### PR TITLE
Added tab press to select autocomplete

### DIFF
--- a/js/components/contextMenu.js
+++ b/js/components/contextMenu.js
@@ -276,7 +276,11 @@ class ContextMenu extends ImmutableComponent {
 
     switch (e.keyCode) {
       case keyCodes.ENTER:
-        e.preventDefault()
+      case KeyCodes.TAB:
+        if (e.keyCode === keyCodes.ENTER) {
+          e.preventDefault()
+        }
+
         e.stopPropagation()
         if (currentIndex !== null) {
           const action = selectedTemplate.getIn([currentIndex, 'click'])
@@ -288,7 +292,6 @@ class ContextMenu extends ImmutableComponent {
         break
 
       case KeyCodes.ESC:
-      case KeyCodes.TAB:
         windowActions.resetMenuState()
         break
 


### PR DESCRIPTION
## Test Plan
- Ensure you have auto complete suggestion for on an input filed
- Press down on the input field to highlight the suggestion
- Once highlighted press tab, field should be filled

## Details
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #7132

## Auditors
@srirambv @bsclifton