### PR TITLE
don’t handle `set-active` because the active state is set in response…

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -347,13 +347,17 @@ class Frame extends ImmutableComponent {
     }
   }
 
-  componentDidMount () {
-    const cb = () => {
-      this.webview.setActive(this.props.isActive)
-      this.webview.setTabIndex(this.props.tabIndex)
-      this.updateAboutDetails({})
+  onPropsChanged (prevProps = {}) {
+    this.webview.setActive(this.props.isActive)
+    this.webview.setTabIndex(this.props.tabIndex)
+    if (this.frame && this.props.isActive && isFocused()) {
+      windowActions.setFocusedFrame(this.frame)
     }
-    this.updateWebview(cb)
+    this.updateAboutDetails(prevProps)
+  }
+
+  componentDidMount () {
+    this.updateWebview(this.onPropsChanged)
   }
 
   get zoomLevel () {
@@ -412,11 +416,10 @@ class Frame extends ImmutableComponent {
     }
 
     const cb = () => {
+      this.onPropsChanged(prevProps)
       if (this.getWebRTCPolicy(prevProps) !== this.getWebRTCPolicy(this.props)) {
         this.webview.setWebRTCIPHandlingPolicy(this.getWebRTCPolicy(this.props))
       }
-      this.webview.setActive(this.props.isActive)
-      this.webview.setTabIndex(this.props.tabIndex)
       if (prevProps.activeShortcut !== this.props.activeShortcut) {
         this.handleShortcut()
       }
@@ -435,7 +438,6 @@ class Frame extends ImmutableComponent {
           this.exitHtmlFullScreen()
         }
       }
-      this.updateAboutDetails(prevProps)
     }
 
     // For cross-origin navigation, clear temp approvals
@@ -672,17 +674,6 @@ class Frame extends ImmutableComponent {
       let mouseOnLeft = e.x < (window.innerWidth / 2)
       let showOnRight = nearBottom && mouseOnLeft
       windowActions.setLinkHoverPreview(e.url, showOnRight)
-    })
-    this.webview.addEventListener('set-active', (e) => {
-      if (this.frame.isEmpty()) {
-        return
-      }
-      if (e.active && isFocused()) {
-        windowActions.setFocusedFrame(this.frame)
-      }
-      if (e.active && !this.props.isActive) {
-        windowActions.setActiveFrame(this.frame)
-      }
     })
     this.webview.addEventListener('focus', this.onFocus)
     this.webview.addEventListener('mouseenter', (e) => {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.  https://github.com/brave/browser-laptop/issues/7138
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
This can be hard to replicate reliably, but often happens when switching tabs while one is still loading