### PR TITLE
Make sanitizeTemplateItems recursively check submenus in templates

### DIFF
--- a/app/common/lib/menuUtil.js
+++ b/app/common/lib/menuUtil.js
@@ -151,20 +151,19 @@ const isItemValid = (currentItem, previousItem) => {
       return false
     }
   }
-  return currentItem && (typeof currentItem.l10nLabelId === 'string' || typeof currentItem.label === 'string' || currentItem.type === 'separator')
+
+  return currentItem && (typeof currentItem.l10nLabelId === 'string' || typeof currentItem.label === 'string' ||
+    currentItem.type === 'separator' || typeof currentItem.slice === 'function')
 }
 
-/**
- * Remove invalid entries from a menu template:
- * - null or falsey entries
- * - extra menu separators
- * - entries which don't have a label (or l10nLabelId) if their type is not 'separator'
- */
-module.exports.sanitizeTemplateItems = (template) => {
+const sanitizeTemplateItems = (template) => {
   const reduced = template.reduce((result, currentValue, currentIndex, array) => {
     const previousItem = result.length > 0
       ? result[result.length - 1]
       : undefined
+    if (currentValue && currentValue.submenu) {
+      currentValue.submenu = sanitizeTemplateItems(currentValue.submenu)
+    }
     if (isItemValid(currentValue, previousItem)) {
       result.push(currentValue)
     }
@@ -185,3 +184,11 @@ module.exports.sanitizeTemplateItems = (template) => {
 
   return result
 }
+
+/**
+ * Remove invalid entries from a menu template:
+ * - null or falsey entries
+ * - extra menu separators
+ * - entries which don't have a label (or l10nLabelId) if their type is not 'separator'
+ */
+module.exports.sanitizeTemplateItems = sanitizeTemplateItems

--- a/test/unit/app/common/lib/menuUtilTest.js
+++ b/test/unit/app/common/lib/menuUtilTest.js
@@ -255,6 +255,14 @@ describe('menuUtil tests', function () {
       const expectedResult = [{l10nLabelId: 'lol1'}]
       assert.deepEqual(result, expectedResult)
     })
+    it('checks submenus recursively', function () {
+      const template = [separator, {test: 'test'}, {label: 'lol'},
+        { label: 'submenu', submenu: [separator, {label: 'foo'}] }]
+      const result = menuUtil.sanitizeTemplateItems(template)
+      const expectedResult = [{label: 'lol'}, {label: 'submenu', submenu: [{label: 'foo'}]}]
+
+      assert.deepEqual(result, expectedResult)
+    })
     it('removes items which are missing label or type', function () {
       const template = [{}, {test: 'test'}, {label: 'lol'}]
       const result = menuUtil.sanitizeTemplateItems(template)


### PR DESCRIPTION
Fixes #7098

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

## Automated tests
`npm run test -- --grep="menuUtil tests sanitizeTemplateItems checks submenus recursively"`