### PR TITLE
Change .desktop entry name from `brave` to `Brave`

### DIFF
--- a/res/linuxPackaging.json
+++ b/res/linuxPackaging.json
@@ -1,24 +1,44 @@
 {
+  "productName": "Brave",
+  "genericName": "Web Browser",
+  "homepage": "https://brave.com/",
   "icon": "res/app.png",
   "section": "web",
-  "categories": ["Network","WebBrowser"],
-  "mimeType": ["text/html", "text/xml", "application/xhtml_xml", "image/webp","x-scheme-handler/http", "x-scheme-handler/https", "x-scheme-handler/ftp"],
-  "requires": [ "GConf2", "libXScrnSaver" , "lsb" ],
-  "depends": [  "git",
- "gconf2",
- "gconf-service",
- "gvfs-bin",
- "libc6",
- "libcap2",
- "libgtk2.0-0",
- "libudev0 | libudev1",
- "libgcrypt11 | libgcrypt20",
- "libnotify4",
- "libnss3",
- "libxtst6",
- "libxss1",
- "python",
- "xdg-utils",
- "gir1.2-gnomekeyring-1.0",
- "libgnome-keyring0"]
+  "categories": [
+    "Network",
+    "WebBrowser"
+  ],
+  "mimeType": [
+    "text/html",
+    "text/xml",
+    "application/xhtml_xml",
+    "image/webp",
+    "x-scheme-handler/http",
+    "x-scheme-handler/https",
+    "x-scheme-handler/ftp"
+  ],
+  "requires": [
+    "GConf2",
+    "libXScrnSaver",
+    "lsb"
+  ],
+  "depends": [
+    "git",
+    "gconf2",
+    "gconf-service",
+    "gvfs-bin",
+    "libc6",
+    "libcap2",
+    "libgtk2.0-0",
+    "libudev0 | libudev1",
+    "libgcrypt11 | libgcrypt20",
+    "libnotify4",
+    "libnss3",
+    "libxtst6",
+    "libxss1",
+    "python",
+    "xdg-utils",
+    "gir1.2-gnomekeyring-1.0",
+    "libgnome-keyring0"
+  ]
 }


### PR DESCRIPTION
Capitalize product name without changing name of the executable. All changes apply to the the brave.desktop file which holds the name used in the application menu and other points of desktop integration (app switchers, etc.).

(Please forgive me for fixing up the inconsistent whitespacing.)

Test Plan (may need to be adjusted as this is the "paranoid" edition and nothing is actually likely to brake from this change):

1. Compare brave.desktop in builds before and after the change.
2. Install Brave, use your favorite Linux desktop environment and open up it’s application menu. Should now say “Brave” rather than “brave”. 
3. Open Brave from the application menu, look at whatever metaphor for how windows are organized in whatever desktop environment you’re using: Window titles, “taskbar”, and app switchers should all now say “Brave” and not “brave”.
4. Set Brave as the default web browser. Go to GNOME Settings/Plasma System Settings/whatever, and look into your default programs. Brave should be listed as the default web browser with correct capitalization.
5. On a system with an old build installed and already set as the default browser, upgrade to this build, and double-check that Brave remains the default browser. Check both GNOME and KDE’s settings thingies.