### PR TITLE
Bump webtorrent-remote dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "tracking-protection": "1.1.x",
     "underscore": "1.8.3",
     "url-loader": "^0.5.7",
-    "webtorrent-remote": "0.0.9"
+    "webtorrent-remote": "^1.0.0"
   },
   "devDependencies": {
     "asar": "^0.11.0",


### PR DESCRIPTION
Fixes: https://github.com/brave/browser-laptop/issues/6737

Updating to the newer `webtorrent-remote` dependency lets us pull in a looser range of webtorrent versions (0.x) and inherit this fix (https://github.com/feross/webtorrent/pull/1039), as well as future other fixes for free.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

Download from any torrent magnet link
Click on the save file button in the torrent viewer
Save dialogue prompt should contain the actual filename