### PR TITLE
Background for new tab is now toggleable via prefs

### DIFF
--- a/app/common/lib/randomUtil.js
+++ b/app/common/lib/randomUtil.js
@@ -1,0 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+module.exports.random = () => Math.random()

--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -311,3 +311,5 @@ notDefaultBrowser=Brave is not your default browser.
 setAsDefault=Set as default…
 checkDefaultOnStartup=Always check on startup
 useTorrentViewer=Enable Torrent Viewer (requires browser restart)
+dashboardSettingsTitle=Dashboard
+dashboardShowImages=Show images

--- a/js/about/entry.js
+++ b/js/about/entry.js
@@ -74,7 +74,7 @@ switch (getBaseUrl(getSourceAboutUrl(window.location.href))) {
     element = require('./history')
     break
   case 'about:newtab':
-    element = require('./newtab')
+    element = require('./newtab').AboutNewTab
     break
   case 'about:passwords':
     element = require('./passwords')

--- a/js/about/newTabComponents/footerInfo.js
+++ b/js/about/newTabComponents/footerInfo.js
@@ -8,15 +8,18 @@ const {aboutUrls} = require('../../lib/appUrlUtil')
 
 class FooterInfo extends ImmutableComponent {
   render () {
-    if (!this.props.backgroundImage.name) {
-      return null
-    }
     return <footer className='footerContainer'>
       <div className='copyrightNotice'>
-        <div className='copyrightCredits'>
-          <span className='photoBy' data-l10n-id='photoBy' /> <a className='copyrightOwner' href={this.props.backgroundImage.link} target='_blank'>{this.props.backgroundImage.author}</a>
-        </div>
-        <span className='photoName'>{this.props.backgroundImage.name}</span>
+        {
+          this.props.backgroundImage && this.props.backgroundImage.name
+          ? <div>
+            <div className='copyrightCredits'>
+              <span className='photoBy' data-l10n-id='photoBy' /> <a className='copyrightOwner' href={this.props.backgroundImage.link} target='_blank'>{this.props.backgroundImage.author}</a>
+            </div>
+            <span className='photoName'>{this.props.backgroundImage.name}</span>
+          </div>
+          : null
+        }
       </div>
       <nav className='shortcutsContainer'>
         <a className='shortcutIcon settingsIcon' href={aboutUrls.get('about:preferences')} data-l10n-id='preferencesPage' />

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -859,6 +859,9 @@ class TabsTab extends ImmutableComponent {
         <SettingCheckbox dataL10nId='switchToNewTabs' prefKey={settings.SWITCH_TO_NEW_TABS} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
         <SettingCheckbox dataL10nId='paintTabs' prefKey={settings.PAINT_TABS} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
         <SettingCheckbox dataL10nId='showTabPreviews' prefKey={settings.SHOW_TAB_PREVIEWS} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
+        <SettingItem dataL10nId='dashboardSettingsTitle'>
+          <SettingCheckbox dataL10nId='dashboardShowImages' prefKey={settings.SHOW_DASHBOARD_IMAGES} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
+        </SettingItem>
       </SettingsList>
     </div>
   }

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -165,8 +165,11 @@ class Frame extends ImmutableComponent {
           prevProps.adblockCount !== this.props.adblockCount ||
           prevProps.httpsUpgradedCount !== this.props.httpsUpgradedCount ||
           !Immutable.is(prevProps.newTabDetail, this.props.newTabDetail)) {
+        const showEmptyPage = getSetting(settings.NEWTAB_MODE) === newTabMode.EMPTY_NEW_TAB
+        const showImages = getSetting(settings.SHOW_DASHBOARD_IMAGES) && !showEmptyPage
         this.webview.send(messages.NEWTAB_DATA_UPDATED, {
-          showEmptyPage: getSetting(settings.NEWTAB_MODE) === newTabMode.EMPTY_NEW_TAB,
+          showEmptyPage,
+          showImages,
           trackedBlockersCount: this.props.trackedBlockersCount,
           adblockCount: this.props.adblockCount,
           httpsUpgradedCount: this.props.httpsUpgradedCount,

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -120,6 +120,7 @@ module.exports = {
     'tabs.tabs-per-page': 10,
     'tabs.close-action': 'parent',
     'tabs.show-tab-previews': true,
+    'tabs.show-dashboard-images': true,
     'privacy.history-suggestions': true,
     'privacy.bookmark-suggestions': true,
     'privacy.opened-tab-suggestions': true,

--- a/js/constants/settings.js
+++ b/js/constants/settings.js
@@ -25,6 +25,7 @@ const settings = {
   PAINT_TABS: 'tabs.paint-tabs',
   TABS_PER_PAGE: 'tabs.tabs-per-page',
   SHOW_TAB_PREVIEWS: 'tabs.show-tab-previews',
+  SHOW_DASHBOARD_IMAGES: 'tabs.show-dashboard-images',
   // Privacy Tab
   HISTORY_SUGGESTIONS: 'privacy.history-suggestions',
   BOOKMARK_SUGGESTIONS: 'privacy.bookmark-suggestions',

--- a/less/about/newtab.less
+++ b/less/about/newtab.less
@@ -20,14 +20,13 @@ body {
   background: #fff;
 }
 
-body, .dynamicBackground {
+body, .dynamicBackground, bgGradient {
   opacity: 0;
   animation: fadeIn 200ms;
   animation-fill-mode: forwards;
 }
 
 .copyrightNotice {
-  visibility: hidden !important;
   -webkit-user-select: none;
   cursor: default;
 }
@@ -43,10 +42,6 @@ ul {
     vertical-align: middle;
     list-style-type: none;
   }
-}
-
-#appContainer > div {
-  height: auto; // overrides default #appContainer > div: 100%
 }
 
 .dynamicBackground {
@@ -67,6 +62,15 @@ ul {
   position: absolute;
   top: 0;
   width: 100%;
+}
+
+.bgGradient {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  background: linear-gradient(rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
+  height: 400px;
 }
 
 .content {

--- a/test/about/newTabTest.js
+++ b/test/about/newTabTest.js
@@ -72,22 +72,6 @@ describe('about:newtab tests', function () {
       .tabByIndex(0)
   }
 
-  describe('with NEWTAB_MODE === EMPTY_NEW_TAB', function () {
-    Brave.beforeAll(this)
-
-    before(function * () {
-      yield setup(this.app.client)
-      yield this.app.client.changeSetting(settings.NEWTAB_MODE, newTabMode.EMPTY_NEW_TAB)
-      yield reloadNewTab(this.app.client)
-    })
-
-    it('returns an empty page', function * () {
-      yield waitForPageLoad(this.app.client)
-
-      yield this.app.client.waitForExist('.empty')
-    })
-  })
-
   describe('with NEWTAB_MODE === HOMEPAGE', function () {
     const page1 = 'https://start.duckduckgo.com/'
     const page2 = 'https://brave.com/'
@@ -108,36 +92,6 @@ describe('about:newtab tests', function () {
   })
 
   describe.skip('with NEWTAB_MODE === NEW_TAB_PAGE', function () {
-    describe('page content', function () {
-      Brave.beforeAll(this)
-
-      before(function * () {
-        yield setup(this.app.client)
-      })
-
-      it('displays a clock', function * () {
-        yield waitForPageLoad(this.app.client)
-
-        yield this.app.client
-          .windowByUrl(Brave.browserWindowUrl)
-          .waitForExist('[data-test-id="tab"][data-frame-key="1"]')
-          .tabByIndex(0)
-          .waitForVisible('.clock .time')
-          .waitUntil(function () {
-            return this.getText('.clock .time')
-              .then((clockTime) => {
-                return !!clockTime.match(/^\d{1,2}.*\d{2}.*/)
-              })
-          })
-      })
-
-      // TODO(bsclifton):
-      // - link check
-      // has link to settings
-      // has link to bookmarks
-      // has link to history
-    })
-
     describe('when displaying stats', function () {
       Brave.beforeEach(this)
       beforeEach(function * () {

--- a/test/unit/about/newTabPageTest.js
+++ b/test/unit/about/newTabPageTest.js
@@ -1,0 +1,193 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* global describe, before, beforeEach, after, it */
+
+const React = require('react')
+const mockery = require('mockery')
+const {shallow} = require('enzyme')
+const sinon = require('sinon')
+const assert = require('assert')
+const Immutable = require('immutable')
+const fakeElectron = require('../lib/fakeElectron')
+let NewTabPage, randomSpy, Clock, Stats, FooterInfo
+require('../braveUnit')
+
+const randomWrapper = {
+  random: () => Math.random()
+}
+
+describe('NewTab component unit tests', function () {
+  before(function () {
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    })
+    mockery.registerMock('../../less/about/newtab.less', {})
+    mockery.registerMock('../../node_modules/font-awesome/css/font-awesome.css', {})
+    randomSpy = sinon.spy(randomWrapper, 'random')
+    mockery.registerMock('../../app/common/lib/randomUtil', randomWrapper)
+    window.chrome = fakeElectron
+    window.CustomEvent = {}
+    NewTabPage = require('../../../js/about/newtab').component
+    Clock = require('../../../js/about/newTabComponents/clock')
+    Stats = require('../../../js/about/newTabComponents/stats')
+    FooterInfo = require('../../../js/about/newTabComponents/footerInfo')
+  })
+
+  after(function () {
+    mockery.disable()
+    randomSpy.restore()
+  })
+
+  let wrapper
+  const backgroundImage = {
+    style: {
+      backgroundImage: 'url(testing123.jpg)'
+    }
+  }
+
+  beforeEach(function () {
+    wrapper = shallow(
+      <NewTabPage />
+    )
+  })
+
+  describe('Object properties', function () {
+    describe('showImages', function () {
+      it('returns true when `showImages` and `backgroundImage` are true', function () {
+        wrapper.setState({showImages: true, backgroundImage})
+        const instance = wrapper.instance()
+        assert.equal(instance.showImages, true)
+      })
+
+      it('returns false when `showImages` is falsey', function () {
+        wrapper.setState({showImages: false, backgroundImage})
+        const instance = wrapper.instance()
+        assert.equal(instance.showImages, false)
+      })
+
+      it('returns false when `backgroundImage` is falsey', function () {
+        wrapper.setState({showImages: true, backgroundImage: undefined})
+        const instance = wrapper.instance()
+        assert.equal(instance.showImages, false)
+      })
+    })
+
+    describe('randomBackgroundImage', function () {
+      it('calls random to get a random index', function () {
+        randomSpy.reset()
+        const instance = wrapper.instance()
+        instance.randomBackgroundImage
+        assert.equal(randomSpy.calledOnce, true)
+      })
+
+      it('returns an object which has a value set for `style.backgroundImage`', function () {
+        const instance = wrapper.instance()
+        const result = instance.randomBackgroundImage
+        assert.notEqual(result, undefined)
+        assert.notEqual(result.style, undefined)
+        assert.notEqual(result.style.backgroundImage, undefined)
+        assert.equal(!!result.style.backgroundImage.match(/^url\(/), true)
+      })
+    })
+    describe('fallbackImage', function () {
+      it('returns an object which has a value set for `style.backgroundImage`', function () {
+        const instance = wrapper.instance()
+        const result = instance.fallbackImage
+        assert.notEqual(result, undefined)
+        assert.notEqual(result.style, undefined)
+        assert.notEqual(result.style.backgroundImage, undefined)
+        assert.equal(!!result.style.backgroundImage.match(/^url\(/), true)
+      })
+    })
+    describe('topSites', function () {
+    })
+    describe('pinnedTopSites', function () {
+    })
+    describe('ignoredTopSites', function () {
+    })
+    describe('gridLayoutSize', function () {
+    })
+    describe('gridLayout', function () {
+    })
+  })
+
+  describe('Rendering', function () {
+    describe('empty new tab', function () {
+      it('renders an empty div if `this.state.showEmptyPage` is true', function () {
+        wrapper.setState({showEmptyPage: true})
+        assert.equal(wrapper.find('div.empty').length, 1)
+      })
+    })
+
+    describe('dashboard', function () {
+      const emptyNewTabData = Immutable.fromJS({})
+
+      it('returns null if newTabData is not set', function () {
+        wrapper.setState({showEmptyPage: false})
+        assert.equal(wrapper.node, null)
+      })
+
+      it('renders the Stats component', function () {
+        wrapper.setState({showEmptyPage: false, newTabData: emptyNewTabData})
+        assert.equal(wrapper.find(Stats).length, 1)
+      })
+
+      it('renders the Clock component', function () {
+        wrapper.setState({showEmptyPage: false, newTabData: emptyNewTabData})
+        assert.equal(wrapper.find(Clock).length, 1)
+      })
+
+      it('renders the FooterInfo component', function () {
+        wrapper.setState({showEmptyPage: false, newTabData: emptyNewTabData})
+        assert.equal(wrapper.find(FooterInfo).length, 1)
+      })
+
+      describe('when `this.showImages` is true', function () {
+        beforeEach(function () {
+          wrapper.setState({
+            showEmptyPage: false,
+            showImages: true,
+            newTabData: emptyNewTabData,
+            backgroundImage
+          })
+        })
+
+        it('sets backgroundImage for root element to the URL of the image', function () {
+          const node = wrapper.find('.dynamicBackground').node
+          assert.notEqual(node, undefined)
+          assert.deepEqual(node.props.style, backgroundImage.style)
+        })
+
+        it('includes div element with class bgGradient', function () {
+          assert.equal(wrapper.find('.bgGradient').length, 1)
+        })
+
+        it('includes img element (used to detect onError)', function () {
+          assert.equal(wrapper.find('img[data-test-id="backgroundImage"]').length, 1)
+        })
+      })
+
+      describe('when `this.showImages` is false', function () {
+        beforeEach(function () {
+          wrapper.setState({
+            showEmptyPage: false,
+            showImages: false,
+            newTabData: emptyNewTabData,
+            backgroundImage: undefined
+          })
+        })
+
+        it('includes element with class gradient', function () {
+          assert.equal(wrapper.find('.gradient').length, 1)
+        })
+
+        it('does NOT include img element (used to detect onError)', function () {
+          assert.equal(wrapper.find('img[data-test-id="backgroundImage"]').length, 0)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Test plan
1. Launch Brave and visit about:preferences#tabs
2. Default setting should be true
3. Open new tab; verify backgrounds are shown
4. Close new tab and change setting to false
5. Open new tab; verify gradients are shown

## Automated tests
```
npm run unittest -- --grep="NewTab component unit tests"
```

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes https://github.com/brave/browser-laptop/issues/6965

Noteable items include:
- New setting is called `Show images` and defaults to `true`
- Much of new tab is now unit tested. Redundant (and also slower) webdriver tests removed

Auditors: @cezaraugusto, @bbondy 


![screen shot 2017-02-10 at 1 49 58 am](https://cloud.githubusercontent.com/assets/4733304/22820313/6fcf86f2-ef33-11e6-9f57-782404a34245.png)