### PR TITLE
Apply cursor:default and -webkit-user-select:none to .notificationBar…

### DIFF
--- a/less/findbar.less
+++ b/less/findbar.less
@@ -14,6 +14,11 @@
   justify-content: center;
   padding: 5px 10px;
   animation: slideIn 25ms;
+  cursor: default;
+
+  * {
+    -webkit-user-select: none;
+  }
 
   .findMatchText {
     margin: 0 10px;
@@ -23,7 +28,6 @@
 
   label {
     color: @mediumGray;
-    -webkit-user-select: none;
   }
 
   span.findButton {
@@ -49,7 +53,6 @@
     margin-right: 0;
     opacity: 0.5;
     transform: rotate(45deg);
-    -webkit-user-select: none;
   }
 
   .searchContainer {
@@ -96,10 +99,11 @@
   }
 
   .caseSensitivityContainer {
+    color: @gray;
+    margin-top: 6px;
+
     input {
       margin-right: 6px;
     }
-    color: @gray;
-    margin-top: 6px;
   }
 }

--- a/less/notificationBar.less
+++ b/less/notificationBar.less
@@ -8,6 +8,8 @@
 .notificationBar {
   display: inline-block;
   width: 100%;
+  cursor: default;
+  -webkit-user-select: none;
 
   .notificationItem {
     background-color: #ffefc0;
@@ -52,7 +54,6 @@
       font-size: 15px;
       padding: 0 10px 0 0;
       color: #666;
-      -webkit-user-select: none;
     }
 
     input[type="checkbox"] {
@@ -65,7 +66,6 @@
       padding: 2px 15px;
       text-transform: capitalize;
       width: auto;
-      -webkit-user-select: none;
     }
 
     .greeting {
@@ -73,7 +73,6 @@
       font-size: 16px;
       margin: auto 10px auto 0;
       user-select: none;
-      -webkit-user-select: none;
     }
 
     .message {
@@ -81,7 +80,6 @@
       font-size: 15px;
       margin: auto 0;
       user-select: none;
-      -webkit-user-select: none;
       cursor: default;
 
       &.secondary {


### PR DESCRIPTION
… and .findBar

Also redundant decralations under .notificationBar and .findBar were removed

Closes #6812

Auditors: @bsclifton 

Test Plan:
1. Open https://google.com
2. Move your mouse on the notification bar, keep pushing your mouse button
3. Make sure the shape of the cursor does not change
4. Open the find bar with CTRL+F
5. Move your mouse on the find bar, keep pushing your mouse button
6. Make sure the shape of the cursor does not change
7. Input a string on the find bar
8. Make sure the found results count and "Match case" is not selectable

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
