### PR TITLE
Preserve order when exporting bookmarks

### DIFF
--- a/app/browser/bookmarksExporter.js
+++ b/app/browser/bookmarksExporter.js
@@ -52,7 +52,7 @@ function createBookmarkArray (sites, parentFolderId, first = true, depth = 1) {
 
   if (first) payload.push(`${indentFirst}<DL><p>`)
 
-  filteredBookmarks.forEach((site) => {
+  filteredBookmarks.toList().sort(siteUtil.siteSort).forEach((site) => {
     if (site.get('tags').includes(siteTags.BOOKMARK) && site.get('location')) {
       title = site.get('customTitle') || site.get('title') || site.get('location')
       payload.push(`${indentNext}<DT><A HREF="${site.get('location')}">${title}</A>`)


### PR DESCRIPTION
Test Plan:
---
1. Import a lot of bookmarks.
2. Export bookmarks to a file. (file A)
3. Delete all the bookmarks
4. Import from file A
5. The bookmarks order should be the same as step 1
---
fix #7189

Auditors: @bbondy, @NejcZdovc

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
