### PR TITLE
Do not sanitize `labelDataBind` as invalid entry

### DIFF
--- a/app/common/lib/menuUtil.js
+++ b/app/common/lib/menuUtil.js
@@ -153,7 +153,7 @@ const isItemValid = (currentItem, previousItem) => {
   }
 
   return currentItem && (typeof currentItem.l10nLabelId === 'string' || typeof currentItem.label === 'string' ||
-    currentItem.type === 'separator' || typeof currentItem.slice === 'function')
+    currentItem.type === 'separator' || typeof currentItem.slice === 'function' || typeof currentItem.labelDataBind === 'string')
 }
 
 const sanitizeTemplateItems = (template) => {

--- a/test/unit/app/common/lib/menuUtilTest.js
+++ b/test/unit/app/common/lib/menuUtilTest.js
@@ -257,9 +257,9 @@ describe('menuUtil tests', function () {
     })
     it('checks submenus recursively', function () {
       const template = [separator, {test: 'test'}, {label: 'lol'},
-        { label: 'submenu', submenu: [separator, {label: 'foo'}] }]
+        { label: 'submenu', submenu: [separator, {label: 'foo'}, {labelDataBind: 'zoomLevel'}] }]
       const result = menuUtil.sanitizeTemplateItems(template)
-      const expectedResult = [{label: 'lol'}, {label: 'submenu', submenu: [{label: 'foo'}]}]
+      const expectedResult = [{label: 'lol'}, {label: 'submenu', submenu: [{label: 'foo'}, {labelDataBind: 'zoomLevel'}]}]
 
       assert.deepEqual(result, expectedResult)
     })


### PR DESCRIPTION
Test Plan: 
---
Covered by automatic test

fix #7188

Auditors: @bsclifton

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).