### PR TITLE
Add new regex for flash interception

### DIFF
--- a/app/extensions/brave/content/scripts/blockFlash.js
+++ b/app/extensions/brave/content/scripts/blockFlash.js
@@ -2,7 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const adobeRegex = new RegExp('//(get\\.adobe\\.com/([a-z_-]+/)*flashplayer|www\\.macromedia\\.com/go/getflash|www\\.adobe\\.com/go/getflash)', 'i')
+const adobeRegex =
+  new RegExp('//(get\\.adobe\\.com/([a-z_-]+/)*flashplayer|www\\.macromedia\\.com/go/getflash|www\\.adobe\\.com/go/getflash|helpx\\.adobe\\.com/flash-player/([a-z_-]+/)*flash-player)', 'i')
 
 function blockFlashDetection () {
   const handler = {


### PR DESCRIPTION
Test Plan:
---
1. Open http://www.y8.com/games/superfighters
2. Click "How to enable flash in chrome"
3. Ask for flash permission notification should show up

fix #7192

Auditors: @diracdeltas 

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
