### PR TITLE
Perserve order for siteUtils.getFolders

### DIFF
--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -538,7 +538,7 @@ module.exports.isHistoryEntry = function (siteDetail) {
 module.exports.getFolders = function (sites, folderId, parentId, labelPrefix) {
   parentId = parentId || 0
   let folders = []
-  sites.forEach((site) => {
+  sites.toList().sort(module.exports.siteSort).forEach((site) => {
     if ((site.get('parentFolderId') || 0) === parentId && module.exports.isFolder(site)) {
       if (site.get('folderId') === folderId) {
         return


### PR DESCRIPTION
Test Plan:
---
1. Create folder A, B, C
2. Move folder C between A and B as order A, C, B
3. Bookmark a site and choose parent folder from dialog
4. The select drop down list order should be A, C, B


fix #7170

Auditors: @bbondy

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
