### PR TITLE
Sanitize PDF url before saving to site data

### DIFF
--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -170,6 +170,7 @@ class NewTabPage extends React.Component {
   onToggleBookmark (siteProps) {
     const siteDetail = siteUtil.getDetailFromFrame(siteProps, siteTags.BOOKMARK)
     const editing = this.isBookmarked(siteProps)
+    // PDFJS will not show up in new tab
     aboutActions.setBookmarkDetail(siteDetail, siteDetail, null, editing)
   }
 

--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -20,6 +20,7 @@ const {isSourceAboutUrl} = require('../lib/appUrlUtil')
 const AddEditBookmarkHanger = require('../../app/renderer/components/addEditBookmarkHanger')
 const siteUtil = require('../state/siteUtil')
 const eventUtil = require('../lib/eventUtil')
+const UrlUtil = require('../lib/urlutil')
 const getSetting = require('../settings').getSetting
 const windowStore = require('../stores/windowStore')
 const contextMenus = require('../contextMenus')
@@ -54,6 +55,7 @@ class NavigationBar extends ImmutableComponent {
       siteDetail = siteDetail.set('parentFolderId', this.props.sites.getIn([key, 'parentFolderId']))
       siteDetail = siteDetail.set('customTitle', this.props.sites.getIn([key, 'customTitle']))
     }
+    siteDetail = siteDetail.set('location', UrlUtil.getLocationIfPDF(siteDetail.get('location')))
     windowActions.setBookmarkDetail(siteDetail, siteDetail, null, editing, true)
   }
 

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -54,6 +54,7 @@ const addBookmarkMenuItem = (label, siteDetail, closestDestinationDetail, isPare
       if (isParent) {
         siteDetail = siteDetail.set('parentFolderId', closestDestinationDetail && (closestDestinationDetail.get('folderId') || closestDestinationDetail.get('parentFolderId')))
       }
+      siteDetail = siteDetail.set('location', urlUtil.getLocationIfPDF(siteDetail.get('location')))
       windowActions.setBookmarkDetail(siteDetail, siteDetail, closestDestinationDetail, true)
     }
   }

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -61,10 +61,11 @@ module.exports.getSiteKey = function (siteDetail) {
     return null
   }
   const folderId = siteDetail.get('folderId')
-  const location = siteDetail.get('location')
+  let location = siteDetail.get('location')
   if (folderId) {
     return folderId.toString()
   } else if (location) {
+    location = UrlUtil.getLocationIfPDF(location)
     return location + '|' +
       (siteDetail.get('partitionNumber') || 0) + '|' +
       (siteDetail.get('parentFolderId') || 0)
@@ -86,7 +87,7 @@ module.exports.isSiteBookmarked = function (sites, siteDetail) {
 
   const site = sites.find((site) =>
     isBookmark(site.get('tags')) &&
-    site.get('location') === siteDetail.get('location') &&
+    site.get('location') === UrlUtil.getLocationIfPDF(siteDetail.get('location')) &&
     (site.get('partitionNumber') || 0) === (siteDetail.get('partitionNumber') || 0)
   )
 
@@ -237,6 +238,8 @@ module.exports.addSite = function (sites, siteDetail, tag, originalSiteDetail) {
   if (oldSite) {
     sites = sites.delete(oldKey)
   }
+
+  site = site.set('location', UrlUtil.getLocationIfPDF(site.get('location')))
 
   const key = module.exports.getSiteKey(site)
   if (key === null) {

--- a/test/components/bookmarksTest.js
+++ b/test/components/bookmarksTest.js
@@ -221,6 +221,48 @@ describe('bookmark tests', function () {
         })
       })
     })
+    describe('bookmark pdf', function () {
+      Brave.beforeAll(this)
+
+      before(function * () {
+        yield setup(this.app.client)
+      })
+      it('load pdf', function * () {
+        const page1Url = Brave.server.url('img/test.pdf')
+        yield this.app.client
+          .windowByUrl(Brave.browserWindowUrl)
+          .waitUntil(function () {
+            return this.getAppState().then((val) => {
+              return val.value.extensions['jdbefljfgobbmcidnmpjamcbhnbphjnb']
+            })
+          })
+        yield this.app.client.tabByIndex(0).url(page1Url).windowParentByUrl(page1Url)
+        yield this.app.client
+          .activateURLMode()
+          .waitUntil(function () {
+            return this.getValue(urlInput).then((val) => {
+              return val === page1Url
+            })
+          })
+      })
+      it('check location', function * () {
+        const page1Url = Brave.server.url('img/test.pdf')
+        yield this.app.client
+          .windowParentByUrl(page1Url)
+          .activateURLMode()
+          .waitForVisible(navigatorNotBookmarked)
+          .click(navigatorNotBookmarked)
+          .waitForVisible(doneButton)
+          .waitForBookmarkDetail(page1Url, 'test.pdf')
+          .waitForEnabled(doneButton)
+          .click(doneButton)
+          .activateURLMode()
+          .waitForVisible(navigatorBookmarked)
+          .click(navigatorBookmarked)
+          .waitForVisible(doneButton)
+          .getValue('#bookmarkLocation input').should.eventually.be.equal(page1Url)
+      })
+    })
   })
 
   describe('menu behavior', function () {


### PR DESCRIPTION
## Test Plan
Covered by automatic test
`npm run uitest -- --grep="bookmark pdf"`

## Description
fix #7190

Auditors: @bsclfton, @bbondy

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).