### PR TITLE
Allow empty folder when exporting bookmarks

### DIFF
--- a/app/browser/bookmarksExporter.js
+++ b/app/browser/bookmarksExporter.js
@@ -58,13 +58,10 @@ function createBookmarkArray (sites, parentFolderId, first = true, depth = 1) {
       payload.push(`${indentNext}<DT><A HREF="${site.get('location')}">${title}</A>`)
     } else if (siteUtil.isFolder(site)) {
       const folderId = site.get('folderId')
-      const submenuItems = sites.filter((bookmark) => bookmark.get('parentFolderId') === folderId)
 
-      if (submenuItems.count() > 0) {
-        title = site.get('customTitle') || site.get('title')
-        payload.push(`${indentNext}<DT><H3>${title}</H3>`)
-        payload = payload.concat(createBookmarkArray(sites, folderId, true, (depth + 1)))
-      }
+      title = site.get('customTitle') || site.get('title')
+      payload.push(`${indentNext}<DT><H3>${title}</H3>`)
+      payload = payload.concat(createBookmarkArray(sites, folderId, true, (depth + 1)))
     }
   })
 

--- a/test/fixtures/bookmarkExport.html
+++ b/test/fixtures/bookmarkExport.html
@@ -21,11 +21,17 @@
       </DL><p>
     </DL><p>
     <DT><A HREF="https://brave.com/6">Website 6</A>
+    <DT><H3>folder 4</H3>
+    <DL><p>
+    </DL><p>
   </DL><p>
   <DT><A HREF="https://brave.com/7">Website 7</A>
-  <DT><H3>folder 4</H3>
+  <DT><H3>folder 5</H3>
     <DL><p>
       <DT><A HREF="https://brave.com/8">Website 8</A>
       <DT><A HREF="https://brave.com/9">Website 9</A>
+    </DL><p>
+  <DT><H3>folder 6</H3>
+    <DL><p>
     </DL><p>
 </DL><p>

--- a/test/unit/app/browser/exportBookmarksTest.js
+++ b/test/unit/app/browser/exportBookmarksTest.js
@@ -34,13 +34,14 @@ describe('Bookmarks export', function () {
    * +++ website 4
    * ++ folder 3
    * +++ website 5
-   * +website 6
-   *
+   * + website 6
+   * + folder 4
    * Other
    * + website 7
-   * + folder 4
+   * + folder 5
    * ++ website 8
    * ++ website 9
+   * + folder 6
    */
   const sites = Immutable.fromJS([
     { tags: [], title: 'Fake', location: 'https://brave.com' },
@@ -53,10 +54,12 @@ describe('Bookmarks export', function () {
     { tags: [siteTags.BOOKMARK_FOLDER], title: 'folder 3', folderId: 3, parentFolderId: 1 },
     { tags: [siteTags.BOOKMARK], title: 'Website 5', location: 'https://brave.com/5', parentFolderId: 3 },
     { tags: [siteTags.BOOKMARK], title: 'Website 6', location: 'https://brave.com/6' },
+    { tags: [siteTags.BOOKMARK_FOLDER], title: 'folder 4', folderId: 4 },
     { tags: [siteTags.BOOKMARK], title: 'Website 7', location: 'https://brave.com/7', parentFolderId: -1 },
-    { tags: [siteTags.BOOKMARK_FOLDER], title: 'folder 4', folderId: 4, parentFolderId: -1 },
-    { tags: [siteTags.BOOKMARK], title: 'Website 8', location: 'https://brave.com/8', parentFolderId: 4 },
-    { tags: [siteTags.BOOKMARK], title: 'Website 9', location: 'https://brave.com/9', parentFolderId: 4 }
+    { tags: [siteTags.BOOKMARK_FOLDER], title: 'folder 5', folderId: 5, parentFolderId: -1 },
+    { tags: [siteTags.BOOKMARK], title: 'Website 8', location: 'https://brave.com/8', parentFolderId: 5 },
+    { tags: [siteTags.BOOKMARK], title: 'Website 9', location: 'https://brave.com/9', parentFolderId: 5 },
+    { tags: [siteTags.BOOKMARK_FOLDER], title: 'folder 6', folderId: 6, parentFolderId: -1 }
   ])
 
   const personalArray = [
@@ -76,15 +79,21 @@ describe('Bookmarks export', function () {
     '      </DL><p>',
     '    </DL><p>',
     '    <DT><A HREF="https://brave.com/6">Website 6</A>',
+    '    <DT><H3>folder 4</H3>',
+    '    <DL><p>',
+    '    </DL><p>',
     '  </DL><p>'
   ]
 
   const otherArray = [
     '  <DT><A HREF="https://brave.com/7">Website 7</A>',
-    '  <DT><H3>folder 4</H3>',
+    '  <DT><H3>folder 5</H3>',
     '    <DL><p>',
     '      <DT><A HREF="https://brave.com/8">Website 8</A>',
     '      <DT><A HREF="https://brave.com/9">Website 9</A>',
+    '    </DL><p>',
+    '  <DT><H3>folder 6</H3>',
+    '    <DL><p>',
     '    </DL><p>'
   ]
 


### PR DESCRIPTION
## Test Plan
Covered by automatic test
`npm run unittest -- --grep="Bookmarks export"`

## Description
fix #7193

Auditors: @bsclifton, @NejcZdovc

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).