### PR TITLE
Avoid tab title overflow if tab is being hovered

### DIFF
--- a/app/renderer/components/styles/global.js
+++ b/app/renderer/components/styles/global.js
@@ -105,7 +105,8 @@ const globalStyles = {
     sideBarWidth: '190px',
     aboutPageSectionPadding: '24px',
     defaultTabPadding: '0 4px',
-    defaultIconPadding: '0 2px'
+    defaultIconPadding: '2px',
+    iconSize: '16px'
   },
   shadow: {
     switchShadow: 'inset 0 1px 4px rgba(0, 0, 0, 0.35)',

--- a/app/renderer/components/styles/tab.js
+++ b/app/renderer/components/styles/tab.js
@@ -82,7 +82,8 @@ const styles = StyleSheet.create({
   },
 
   isPinned: {
-    padding: globalStyles.spacing.defaultIconPadding
+    paddingLeft: globalStyles.spacing.defaultIconPadding,
+    paddingRight: globalStyles.spacing.defaultIconPadding
   },
 
   active: {

--- a/app/renderer/components/tabContent.js
+++ b/app/renderer/components/tabContent.js
@@ -19,8 +19,8 @@ class TabIcon extends ImmutableComponent {
       fontSize: 'inherit',
       display: 'flex',
       alignSelf: 'center',
-      width: '16px',
-      height: '16px',
+      width: globalStyles.spacing.iconSize,
+      height: globalStyles.spacing.iconSize,
       alignItems: 'center',
       justifyContent: 'center'
     }
@@ -147,17 +147,32 @@ class TabTitle extends ImmutableComponent {
     return this.props.tabProps.get('audioPlaybackActive') || this.props.tabProps.get('audioMuted')
   }
 
+  get hoveredOnNarrowView () {
+    const sizes = ['mediumSmall', 'small', 'extraSmall', 'smallest']
+    return this.props.tabProps.get('hoverState') && sizes.includes(this.props.tabProps.get('breakpoint'))
+  }
+
   get shouldHideTitle () {
     return (this.props.tabProps.get('breakpoint') === 'largeMedium' && this.pageCanPlayAudio && this.locationHasSecondaryIcon) ||
       (this.props.tabProps.get('breakpoint') === 'mediumSmall' && this.locationHasSecondaryIcon) ||
-      this.props.tabProps.get('breakpoint') === 'extraSmall' || this.props.tabProps.get('breakpoint') === 'smallest'
+      this.props.tabProps.get('breakpoint') === 'extraSmall' || this.props.tabProps.get('breakpoint') === 'smallest' ||
+      this.hoveredOnNarrowView
   }
 
   render () {
+    const titleStyles = StyleSheet.create({
+      reduceTitleSize: {
+        // include a margin gutter with same size
+        // as closeTabIcon to avoid title overflow
+        // when hovering over a tab
+        marginRight: `calc(${globalStyles.spacing.iconSize} + ${globalStyles.spacing.defaultIconPadding})`
+      }
+    })
     return !this.isPinned && !this.shouldHideTitle
     ? <div data-test-id='tabTitle'
       className={css(
       styles.tabTitle,
+      this.props.tabProps.get('hoverState') && titleStyles.reduceTitleSize,
       // Windows specific style
       isWindows() && styles.tabTitleForWindows,
       // Linux specific style
@@ -192,10 +207,10 @@ class CloseTabIcon extends ImmutableComponent {
 
 const styles = StyleSheet.create({
   icon: {
-    width: '16px',
-    minWidth: '16px',
-    height: '16px',
-    backgroundSize: '16px',
+    width: globalStyles.spacing.iconSize,
+    minWidth: globalStyles.spacing.iconSize,
+    height: globalStyles.spacing.iconSize,
+    backgroundSize: globalStyles.spacing.iconSize,
     fontSize: globalStyles.fontSize.tabIcon,
     backgroundPosition: 'center',
     backgroundRepeat: 'no-repeat',
@@ -204,7 +219,8 @@ const styles = StyleSheet.create({
     position: 'relative',
     textAlign: 'center',
     justifyContent: 'center',
-    padding: globalStyles.spacing.defaultIconPadding
+    paddingLeft: globalStyles.spacing.defaultIconPadding,
+    paddingRight: globalStyles.spacing.defaultIconPadding
   },
 
   iconNarrowView: {
@@ -225,8 +241,8 @@ const styles = StyleSheet.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    fontSize: '16px',
-    width: '16px',
+    fontSize: globalStyles.spacing.iconSize,
+    width: globalStyles.spacing.iconSize,
     height: '100%',
     border: '0',
     zIndex: globalStyles.zindex.zindexTabs,


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

If tab is being hovered, title should respect closeTab size and don't oveflow

![tab-title-no-overflow](https://cloud.githubusercontent.com/assets/4672033/22892525/0cdeb8fa-f1fa-11e6-94c1-b574f97767e5.gif)
