### PR TITLE
Do not override themeColor if platform is Windows

### DIFF
--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -245,6 +245,8 @@ class Tab extends ImmutableComponent {
       onMouseLeave={this.onMouseLeave}>
       <div className={css(
         styles.tab,
+        // Windows specific style
+        isWindows() && styles.tabForWindows,
         this.isPinned && styles.isPinned,
         this.props.isActive && styles.active,
         this.props.tab.get('isPrivate') && styles.private,
@@ -253,9 +255,7 @@ class Tab extends ImmutableComponent {
         this.props.isActive && this.themeColor && perPageStyles.themeColor,
         !this.isPinned && this.narrowView && styles.tabNarrowView,
         !this.isPinned && this.narrowestView && styles.tabNarrowestView,
-        !this.isPinned && this.props.tab.get('breakpoint') === 'smallest' && styles.tabMinAllowedSize,
-        // Windows specific style
-        isWindows() && styles.tabForWindows
+        !this.isPinned && this.props.tab.get('breakpoint') === 'smallest' && styles.tabMinAllowedSize
         )}
         data-test-active-tab={this.props.isActive}
         data-test-pinned-tab={this.isPinned}


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bbondy

Fix #7216

The main issue was that Windows specific style was being declared after themeColor and late declared classes take precedence so themeColor was being overridden on Windows.

Test plan:
* Test it on Windows
* Enable themeColor for tabs on settings
* Go to https://facebook.com
* Title color should be visible based on tab's background (`getTextColorForBackground()`) and not `#555` (Windows specific color)