### PR TITLE
tweak on narrow view audio indicator

### DIFF
--- a/app/renderer/components/styles/global.js
+++ b/app/renderer/components/styles/global.js
@@ -127,7 +127,8 @@ const globalStyles = {
     transitionFastEase: 'all 100ms ease',
     transitionSlowEase: 'all 1s ease',
     switchBGTransition: 'background-color 100ms',
-    switchNubTransition: 'right 100ms'
+    switchNubTransition: 'right 100ms',
+    tabBackgroundTransition: 'background-color 100ms linear'
   },
   zindex: {
     zindexWindowNotActive: '900',

--- a/app/renderer/components/styles/tab.js
+++ b/app/renderer/components/styles/tab.js
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
     display: 'flex',
     height: '23px',
     marginTop: '2px',
-    transition: 'transform 200ms ease',
+    transition: `transform 200ms ease, ${globalStyles.transition.tabBackgroundTransition}`,
     left: '0',
     opacity: '1',
     width: '100%',
@@ -43,9 +43,13 @@ const styles = StyleSheet.create({
   },
 
   narrowViewPlayIndicator: {
-    borderWidth: '2px 0 0',
+    borderWidth: '2px 1px 0',
     borderStyle: 'solid',
-    borderColor: 'lightskyblue'
+    borderColor: 'lightskyblue transparent transparent'
+  },
+
+  activeTabNarrowViewPlayIndicator: {
+    borderColor: `lightskyblue ${globalStyles.color.chromeControlsBackground} ${globalStyles.color.chromeControlsBackground}`
   },
 
   tabNarrowestView: {

--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -250,6 +250,7 @@ class Tab extends ImmutableComponent {
         this.props.tab.get('isPrivate') && styles.private,
         this.props.isActive && this.props.tab.get('isPrivate') && styles.activePrivateTab,
         this.narrowView && this.canPlayAudio && styles.narrowViewPlayIndicator,
+        this.props.isActive && this.narrowView && this.canPlayAudio && styles.activeTabNarrowViewPlayIndicator,
         this.props.isActive && this.themeColor && perPageStyles.themeColor,
         !this.isPinned && this.narrowView && styles.tabNarrowView,
         !this.isPinned && this.narrowestView && styles.tabNarrowestView,


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bbondy
/cc @srirambv

Fix #7219

This PR addresses two issues for narrow view audio indicator:
* Adds Transition for active/inactive states
* Fix border issue that made unpinned tabs shrink

**Note for QA:** Toggling audio ON/OFF cause tab icon to be pushed down (see screenshot). I left it as-is as it makes it visible that user interacted with the audio state.

Screenshot:

![narrow_audio_indicator](https://cloud.githubusercontent.com/assets/4672033/22906297/ff6b9d4c-f22a-11e6-9871-9d054a87409b.gif)


Test Plan:

* Replicate screenshot steps:
  * Have a tab pinned with audio playing
  * Have at least one unpinned tab
  * Toggle audio between muted/unmuted
  * Unpinned tab should not have its position changed
  * Close unpinned tab
  * Wait pinned tab with audio playing be active
  * Open a new tab
  * There should be a smooth background color transition for active state change