### PR TITLE
Remove unnecessary separator from browser's `Help` menu.

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -427,7 +427,6 @@ const createWindowSubmenu = () => {
 
 const createHelpSubmenu = () => {
   const submenu = [
-    CommonMenu.separatorMenuItem,
     CommonMenu.submitFeedbackMenuItem(),
     {
       label: locale.translation('spreadTheWord'),


### PR DESCRIPTION
Seems that additional separator that was left in the menu code slips through because there's a Search component added to the menu dropdown. So I just removed it since I don't think we can fix it here.

Fixes #7109

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
