### PR TITLE
Add small text style to match small slider style

### DIFF
--- a/app/renderer/components/settings.js
+++ b/app/renderer/components/settings.js
@@ -4,6 +4,7 @@
 
 const React = require('react')
 const ImmutableComponent = require('../../../js/components/immutableComponent')
+const {StyleSheet, css} = require('aphrodite')
 const aboutActions = require('../../../js/about/aboutActions')
 const getSetting = require('../../../js/settings').getSetting
 const {changeSetting} = require('../lib/settingsUtil')
@@ -64,11 +65,17 @@ class SettingCheckbox extends ImmutableComponent {
         disabled={this.props.disabled}
         onClick={this.onClick}
         checkedOn={this.props.checked !== undefined ? this.props.checked : getSetting(this.props.prefKey, this.props.settings)} />
-      <label data-l10n-id={this.props.dataL10nId} htmlFor={this.props.prefKey} />
+      <label className={css(this.props.small && settingCheckboxStyles.label)} data-l10n-id={this.props.dataL10nId} htmlFor={this.props.prefKey} />
       {this.props.options}
     </div>
   }
 }
+
+const settingCheckboxStyles = StyleSheet.create({
+  label: {
+    fontSize: 'smaller'
+  }
+})
 
 class SiteSettingCheckbox extends ImmutableComponent {
   constructor () {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bsclifton

Resolve #7241

Test Plan:

A small toggle (slider) button should have a smaller label font-size. 

<img width="315" alt="screen shot 2017-02-14 at 10 32 03 pm" src="https://cloud.githubusercontent.com/assets/4672033/22955726/f34a7166-f304-11e6-8f50-9c8e5a5fc8ce.png">
