### PR TITLE
Prepare Sync for packaging

### DIFF
--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -9,7 +9,14 @@ const winUpdateHost = process.env.BRAVE_WIN_UPDATE_HOST || 'https://brave-downlo
 const crashURL = process.env.BRAVE_CRASH_URL || 'https://brave-laptop-updates.herokuapp.com/1/crashes'
 const adHost = process.env.AD_HOST || 'https://oip.brave.com'
 
-const isProduction = process.env.NODE_ENV === 'production'
+var buildConfig
+try {
+  buildConfig = require('./buildConfig')
+} catch (e) {
+  buildConfig = {}
+}
+
+const isProduction = buildConfig.nodeEnv === 'production'
 const {fullscreenOption} = require('../../app/common/constants/settingsEnums')
 
 module.exports = {
@@ -104,7 +111,7 @@ module.exports = {
   sync: {
     apiVersion: '0',
     serverUrl: isProduction ? 'https://sync.brave.com' : 'https://sync-staging.brave.com',
-    debug: true,
+    debug: !isProduction,
     s3Url: isProduction ? 'https://brave-sync.s3.dualstack.us-west-2.amazonaws.com' : 'https://brave-sync-staging.s3.dualstack.us-west-2.amazonaws.com',
     fetchInterval: 1000 * 60
   },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "electron-rebuild": "electron-rebuild",
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
     "lint": "standard",
-    "postinstall": "webpack",
+    "postinstall": "npm run download-sync-client && webpack",
     "preload-httpse": "node ./preload-httpse.js",
     "start-log": "node ./tools/start.js --user-data-dir=brave-development --debug=5858 --enable-logging=stderr --v=1 --enable-extension-activity-logging --enable-sandbox-logging --enable-dcheck",
     "start": "node ./tools/start.js --user-data-dir=brave-development --debug=5858 --enable-logging --v=0 --enable-extension-activity-logging --enable-sandbox-logging --enable-dcheck",

--- a/tools/buildPackage.js
+++ b/tools/buildPackage.js
@@ -41,7 +41,8 @@ console.log('Writing buildConfig.js...')
 config.writeBuildConfig(
   {
     channel: env.CHANNEL,
-    BROWSER_LAPTOP_REV: require('git-rev-sync').long()
+    BROWSER_LAPTOP_REV: require('git-rev-sync').long(),
+    nodeEnv: env.NODE_ENV
   },
   'buildConfig.js'
 )


### PR DESCRIPTION
- Add download sync client to package.json postinstall
- Fix sync endpoints to be prod for packaged apps

Auditors: @diracdeltas @bsclifton

Test Plan:
- Remove `node_modules`.
- `npm install`.
- `CHANNEL=dev npm run build-package` / `CHANNEL=dev npm run build-installer`.
- Open the built app.
- Preferences > Sync should be present.
- Enable Sync.
- Sync should connect to `https://sync.brave.com` and `https://brave-sync.s3.dualstack.us-west-2.amazonaws.com`. (You could check this with Little Snitch for MacOS)