### PR TITLE
Transition added to DownloadItem's progress bar

### DIFF
--- a/less/downloadBar.less
+++ b/less/downloadBar.less
@@ -77,6 +77,7 @@
 
       .downloadProgress {
         background-color: @highlightBlue;
+        transition: width 0.5s;
         left: 0;
         opacity: 0.5;
         position: absolute;
@@ -150,5 +151,3 @@
     }
   }
 }
-
-


### PR DESCRIPTION
Fixes #7248

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Before the patch:
![download-no-trans](https://cloud.githubusercontent.com/assets/347657/22958724/6d56b416-f331-11e6-840c-83d7e124f18e.gif)

After the patch:
![download-trans](https://cloud.githubusercontent.com/assets/347657/22958733/7ad4bbf6-f331-11e6-8c12-975857890e58.gif)

This tiny patch makes downloading items with Brave a little more captivating.