### PR TITLE
Add dummy buildConfig.js

### DIFF
--- a/app/channel.js
+++ b/app/channel.js
@@ -5,12 +5,7 @@
 'use strict'
 
 // The package npm task builds this module
-let config = {}
-try {
-  config = require('../js/constants/buildConfig')
-} catch (e) {
-  // noop here - the buildConfig may not exist in dev mode
-}
+const config = require('../js/constants/buildConfig')
 
 // The current channel is retrieved first from the environment,
 // then the buildConfig constants file and finally defaults to dev

--- a/app/crash-herald.js
+++ b/app/crash-herald.js
@@ -3,16 +3,8 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const appConfig = require('../js/constants/appConfig')
+const buildConfig = require('../js/constants/buildConfig')
 const crashReporter = require('electron').crashReporter
-
-// buildConfig.js is built at package time, we need to require it in a try/catch
-// block to trap for it not existing yet.
-var buildConfig
-try {
-  buildConfig = require('../js/constants/buildConfig')
-} catch (e) {
-  buildConfig = {}
-}
 
 exports.init = () => {
   const options = {

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -9,13 +9,7 @@ const winUpdateHost = process.env.BRAVE_WIN_UPDATE_HOST || 'https://brave-downlo
 const crashURL = process.env.BRAVE_CRASH_URL || 'https://brave-laptop-updates.herokuapp.com/1/crashes'
 const adHost = process.env.AD_HOST || 'https://oip.brave.com'
 
-var buildConfig
-try {
-  buildConfig = require('./buildConfig')
-} catch (e) {
-  buildConfig = {}
-}
-
+const buildConfig = require('./buildConfig')
 const isProduction = buildConfig.nodeEnv === 'production'
 const {fullscreenOption} = require('../../app/common/constants/settingsEnums')
 

--- a/js/constants/buildConfig.js
+++ b/js/constants/buildConfig.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/tools/buildPackage.js
+++ b/tools/buildPackage.js
@@ -141,5 +141,6 @@ execute(cmds, env, (err) => {
     process.exit(1)
     return
   }
+  config.clearBuildConfig()
   console.log('done')
 })

--- a/tools/lib/config.js
+++ b/tools/lib/config.js
@@ -16,3 +16,7 @@ exports.writeBuildConfig = (config, filename) => {
   fs.writeFileSync(path.join(__dirname, '..', '..', 'js', 'constants', filename), buf)
   return config
 }
+
+exports.clearBuildConfig = (filename) => {
+  return exports.writeBuildConfig({}, filename)
+}


### PR DESCRIPTION
Fix #7269

Auditors: @bbondy @aekeus

Test Plan:
1. Reset js/constants/buildConfig.js to the og state (exports = {}).
2. `npm run watch` should emit no warnings "Compiled successfully".
3. `CHANNEL=dev npm run build-package`
4. After it finishes, js/constants/buildConfig.js should still look like exports = {}.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
