### PR TITLE
Remove bold font-weight from ledger header text

### DIFF
--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -1293,7 +1293,6 @@ table.sortableTable {
         }
 
         .th-inner {
-          font-weight: bold;
           font-size: 14px;
 
           &:hover {


### PR DESCRIPTION
## Test Plan
- Open preferences and go to payments
- Enable payments (if needed)
- Ledger header text should not be bold

## Description
Auditors: @luixxiul

Close #7225

<img width="826" alt="screen shot 2017-02-16 at 12 01 06 am" src="https://cloud.githubusercontent.com/assets/4672033/23003806/4a0030d8-f3da-11e6-85c3-e16a38a4880b.png">
