### PR TITLE
convert download-sync-client to node script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "clean-tp-data": "node ./tools/clean.js userData TrackingProtection.dat",
     "docs": "jsdox js/actions/appActions.js js/actions/windowActions.js --output docs",
     "download-languages": "node ./tools/downloadLanguages",
-    "download-sync-client": "./tools/downloadSyncClient",
+    "download-sync-client": "node ./tools/downloadSyncClient",
     "electron-rebuild": "electron-rebuild",
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
     "lint": "standard",

--- a/tools/downloadSyncClient
+++ b/tools/downloadSyncClient
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# stop on errors (nonzero exit codes), uninitialized vars
-set -eu
-
-SYNC_PATH=app/extensions/brave/content/scripts/sync.js
-
-curl -L -o $SYNC_PATH $(curl -s https://api.github.com/repos/brave/sync/releases/latest | grep \/bundle.js | head -n 1 | cut -d '"' -f 4)

--- a/tools/downloadSyncClient.js
+++ b/tools/downloadSyncClient.js
@@ -1,0 +1,42 @@
+'use strict'
+
+const path = require('path')
+const fs = require('fs')
+const request = require('request')
+
+const filename = path.join(__dirname, '..',
+  'app', 'extensions', 'brave', 'content', 'scripts', 'sync.js')
+const releaseUrl = 'https://api.github.com/repos/brave/sync/releases/latest'
+
+request({
+  url: releaseUrl,
+  headers: { 'User-Agent': 'request' }
+}, function (error, response, body) {
+  if (error || response.statusCode !== 200) {
+    console.log('could not get', releaseUrl)
+    return
+  }
+  try {
+    const assets = JSON.parse(body).assets
+    for (let i = 0; i < assets.length; i++) {
+      if (assets[i].name === 'bundle.js') {
+        const downloadUrl = assets[i].browser_download_url
+        request({
+          url: downloadUrl,
+          headers: { 'User-Agent': 'request' }
+        }, function (error, response, body) {
+          if (error || response.statusCode !== 200) {
+            console.log('could not get', downloadUrl)
+            return
+          }
+          // Save the sync bundle
+          console.log('writing sync bundle to ' + filename)
+          fs.writeFileSync(filename, body)
+        })
+        break
+      }
+    }
+  } catch (e) {
+    console.log('got error parsing download URL', e)
+  }
+})


### PR DESCRIPTION
Auditors: @bbondy

Test Plan: npm run download-sync client, then start browser and sync should work
