### PR TITLE
Add internal terminology defining and routines

### DIFF
--- a/app/ledger.js
+++ b/app/ledger.js
@@ -1545,6 +1545,8 @@ var runTimeoutId = false
 
 var run = (delayTime) => {
   if (clientOptions.verboseP) {
+    var entries
+
     console.log('\nledger client run: clientP=' + (!!client) + ' delayTime=' + delayTime)
 
     var line = (fields) => {
@@ -1573,7 +1575,8 @@ var run = (delayTime) => {
            'contribP',
            'duration', 'visits'
          ])
-    synopsis.topN().forEach((entry) => {
+    entries = synopsis.topN() || []
+    entries.forEach((entry) => {
       var publisher = entry.publisher
 
       line([ publisher,


### PR DESCRIPTION
and some extra verbose output

Fixes #6531

## Test Plan
1. run with LEDGER_VERBOSE=true
2. visit some sites, etc.
3. go to `about:preferences#payments`
4. some time later you'll see something that looks like the output below (sorry, it doesn't look "nice" in a variable-width font).
5. verify that things look "right" according to https://github.com/brave/browser-laptop/blob/issue-6531/app/ledger.js#L22 et. seq.

````
    ledger client run: clientP=true delayTime=582412
              publisher  blockedP   stickyP  verified  excluded eligibleP  visibleP  contribP  duration    visits
            wikihow.com     false      true      true     false      true      true      true    117448        28
            archive.org     false     false      true     false      true      true      true     22729         8
          wikipedia.org     false     false     false     false      true      true      true     13709        10
           coindesk.com     false      true      true     false      true      true      true       841        19
           usesthis.com     false     false      true     false      true      true      true       172        10
       scotthelme.co.uk     false     false      true     false      true      true      true       130         7
             github.com     false     false     false      true      true     false     false       565         3
           facebook.com     false     false     false      true      true     false     false       546         1
             google.com     false     false     false      true      true     false     false        97         2
````

