### PR TITLE
Show bookmarks toolbar when bookmarks are synced for the first time

### DIFF
--- a/test/components/syncTest.js
+++ b/test/components/syncTest.js
@@ -361,8 +361,9 @@ describe('Syncing bookmarks', function () {
     // Finally start a fresh profile and setup sync
     yield Brave.stopApp()
     yield setup(this.seed)
+    // The bookmarks toolbar should appear automatically
     yield Brave.app.client
-      .changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, true)
+      .waitForSettingValue(settings.SHOW_BOOKMARKS_TOOLBAR, true)
   })
 
   after(function * () {
@@ -519,8 +520,9 @@ describe('Syncing bookmarks from an existing profile', function () {
     yield Brave.startApp()
     yield setupBrave(Brave.app.client)
     yield setupSync(Brave.app.client, this.seed)
+    // The bookmarks toolbar should appear automatically
     yield Brave.app.client
-      .changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, true)
+      .waitForSettingValue(settings.SHOW_BOOKMARKS_TOOLBAR, true)
   })
 
   after(function * () {


### PR DESCRIPTION
Fix #7282

Auditors: @ayumi

Test Plan:
1. automated syncing bookmarks tests should pass
2. open pyramid 0, enable sync
3. open pyramid 1, sync it with pyramid 0
4. add bookmarks to pyramid 0
5. toolbar should appear in pyramid 1 once bookmarks are synced

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
