### PR TITLE
Make alignment for tabTitle consistent across OSes

### DIFF
--- a/app/renderer/components/tabContent.js
+++ b/app/renderer/components/tabContent.js
@@ -6,7 +6,7 @@ const React = require('react')
 const ImmutableComponent = require('../../../js/components/immutableComponent')
 const {StyleSheet, css} = require('aphrodite/no-important')
 const globalStyles = require('./styles/global')
-const {isWindows, isLinux} = require('../../common/lib/platformUtil')
+const {isWindows} = require('../../common/lib/platformUtil')
 
 /**
  * Boilerplate component for all tab icons
@@ -174,9 +174,7 @@ class TabTitle extends ImmutableComponent {
       styles.tabTitle,
       this.props.tabProps.get('hoverState') && titleStyles.reduceTitleSize,
       // Windows specific style
-      isWindows() && styles.tabTitleForWindows,
-      // Linux specific style
-      isLinux() && styles.tabTitleForLinux
+      isWindows() && styles.tabTitleForWindows
     )}>
       {this.props.pageTitle}
     </div>
@@ -259,18 +257,13 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-    height: '15px',
+    lineHeight: '1.6',
     padding: globalStyles.spacing.defaultTabPadding
   },
 
   tabTitleForWindows: {
     fontWeight: '500',
-    fontSize: globalStyles.fontSize.tabTitle,
-    height: '18px'
-  },
-
-  tabTitleForLinux: {
-    height: globalStyles.fontSize.tabTitle
+    fontSize: globalStyles.fontSize.tabTitle
   }
 })
 


### PR DESCRIPTION
Auditors: @luixxiul

/cc @NejcZdovc @bsclifton for review

Fix #7304
Fix #7312

Main issue is that we had title's height defined and no line-height declared. Removing the former and adding an unitless line-height solved the issue and let us keep it consistent across OSes.

Test Plan:

1. Tab title should keep vertically centered when website's title has tall characters such as https://github.com/vadimdemedes/trevor
2. Tab title should keep vertically centered on Windows/Linux distros/Mac
3. Tab title should keep vertically centered **and not cropped** if DPI is higher than 100%
