### PR TITLE
Adjust bookmarksToolbarBtn to avoid clipped text

### DIFF
--- a/less/bookmarksToolbar.less
+++ b/less/bookmarksToolbar.less
@@ -20,7 +20,7 @@
   box-sizing: border-box;
   display: flex;
   flex: 1;
-  padding: 3px var(--bookmarks-toolbar-padding);
+  padding: 0 var(--bookmarks-toolbar-padding);
   height: @bookmarksToolbarHeight;
 
   &.allowDragging {
@@ -44,7 +44,7 @@
     color: @mediumGray;
     cursor: default;
     font-size: 11px;
-    line-height: 12px;
+    line-height: 1.3;
     margin: auto var(--bookmark-item-margin);
     padding: 2px var(--bookmark-item-padding);
     text-overflow: ellipsis;


### PR DESCRIPTION
Fix #7034

Auditors: @bbondy

Test Plan:

Bookmarks inside toolbar shouldn't have a clipped text for DPI > 100%