### PR TITLE
View certificate on padlock

### DIFF
--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -224,6 +224,7 @@ dismissDenyRunInsecureContent=Stay Insecure
 denyRunInsecureContent=Stop Loading Unsafe Scripts
 runInsecureContentWarning=This page is trying to load scripts from insecure sources. If you allow this content to run, it may transmit unencrypted data to other sites.
 denyRunInsecureContentWarning=Your connection is not private. This page is currently loading scripts from insecure sources.
+viewCertificate=View Certificate
 windowCaptionButtonMinimize=Minimize
 windowCaptionButtonMaximize=Maximize
 windowCaptionButtonRestore=Restore Down

--- a/js/actions/webviewActions.js
+++ b/js/actions/webviewActions.js
@@ -42,6 +42,16 @@ const webviewActions = {
   },
 
   /**
+   * Shows the certificate infomation
+   */
+  showCertificate: function () {
+    const webview = getWebview()
+    if (webview) {
+      webview.showCertificate()
+    }
+  },
+
+  /**
    * Shows the definition of the selected text in a pop-up window (macOS only)
    */
   showDefinitionForSelection: function () {

--- a/js/components/siteInfo.js
+++ b/js/components/siteInfo.js
@@ -9,14 +9,17 @@ const cx = require('../lib/classSet')
 const Dialog = require('./dialog')
 const Button = require('./button')
 const appActions = require('../actions/appActions')
+const webviewActions = require('../actions/webviewActions')
 const messages = require('../constants/messages')
 const siteUtil = require('../state/siteUtil')
+const platformUtil = require('../../app/common/lib/platformUtil')
 
 class SiteInfo extends ImmutableComponent {
   constructor () {
     super()
     this.onAllowRunInsecureContent = this.onAllowRunInsecureContent.bind(this)
     this.onDenyRunInsecureContent = this.onDenyRunInsecureContent.bind(this)
+    this.onViewCertificate = this.onViewCertificate.bind(this)
   }
   onAllowRunInsecureContent () {
     appActions.changeSiteSetting(siteUtil.getOrigin(this.location),
@@ -29,6 +32,10 @@ class SiteInfo extends ImmutableComponent {
       'runInsecureContent', this.isPrivate)
     ipc.emit(messages.SHORTCUT_ACTIVE_FRAME_LOAD_URL, {}, this.location)
     this.props.onHide()
+  }
+  onViewCertificate () {
+    this.props.onHide()
+    webviewActions.showCertificate()
   }
   get isExtendedValidation () {
     return this.props.frameProps.getIn(['security', 'isExtendedValidation'])
@@ -80,6 +87,12 @@ class SiteInfo extends ImmutableComponent {
     }
 
     let connectionInfo = null
+    let viewCertificateButton = null
+    // TODO(Anthony): Hide it until muon support linux
+    if (!platformUtil.isLinux()) {
+      viewCertificateButton =
+        <Button l10nId='viewCertificate' className='primaryButton viewCertificate' onClick={this.onViewCertificate} />
+    }
     if (this.isBlockedRunInsecureContent) {
       connectionInfo =
         <li>
@@ -104,10 +117,16 @@ class SiteInfo extends ImmutableComponent {
         </li>
     } else if (this.isSecure === true) {
       connectionInfo =
+        <div>
         <div className='connectionInfo' data-l10n-id='secureConnectionInfo' />
+        {viewCertificateButton}
+        </div>
     } else if (this.isSecure === 1) {
       connectionInfo =
+        <div>
         <div className='connectionInfo' data-l10n-id='partiallySecureConnectionInfo' />
+        {viewCertificateButton}
+        </div>
     } else {
       connectionInfo =
         <div className='connectionInfo' data-l10n-id='insecureConnectionInfo' />


### PR DESCRIPTION
Test Plan:
---
(on Mac and Windows)
1. Open https site
2. Click padlock
3. Click view certificate
4. certificate detail will show up in dialog

fix #6157

requires https://github.com/brave/muon/pull/162

Auditors: @bridiver, @bbondy

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
