### PR TITLE
Refactor about:adblock with Aphrodite

### DIFF
--- a/js/about/adblock.js
+++ b/js/about/adblock.js
@@ -13,11 +13,12 @@ const ImmutableComponent = require('../components/immutableComponent')
 const SwitchControl = require('../components/switchControl')
 const {DefaultTextArea} = require('../../app/renderer/components/textbox')
 
+const {StyleSheet, css} = require('aphrodite/no-important')
+
 const ipc = window.chrome.ipcRenderer
 
 // Stylesheets
 require('../../less/switchControls.less')
-require('../../less/about/itemList.less')
 require('../../less/about/adblock.less')
 
 class AdBlockItem extends ImmutableComponent {
@@ -64,33 +65,33 @@ class AboutAdBlock extends React.Component {
   }
   render () {
     const lastUpdateDate = new Date(this.state.adblock.get('lastCheckDate'))
-    return <div className='adblockDetailsPage'>
-      <h2 data-l10n-id='adblock' />
+    return <div className={css(styles.adblockDetailsPage)}>
+      <h2 className={css(styles.adblockDetailsPage__h2)} data-l10n-id='adblock' />
       <list>
         <div role='listitem'>
-          <div className='adblockDetailsPageContent'>
-            <div className='adblockCount'><span data-l10n-id='blockedCountLabel' /> <span className='blockedCountTotal'>{this.state.adblock.get('count') || 0}</span></div>
+          <div className={css(styles.adblockDetailsPageContent)}>
+            <div><span data-l10n-id='blockedCountLabel' /> <span data-test-id='blockedCountTotal'>{this.state.adblock.get('count') || 0}</span></div>
             {
               Number.isNaN(lastUpdateDate.getTime())
               ? null
-              : <div className='adblockLastChecked'><span data-l10n-id='lastUpdateCheckDateLabel' /> <span>{lastUpdateDate.toLocaleDateString()}</span></div>
+              : <div><span data-l10n-id='lastUpdateCheckDateLabel' /> <span>{lastUpdateDate.toLocaleDateString()}</span></div>
             }
             {
               this.state.adblock.get('etag')
-              ? <div className='adblockLastETag'><span data-l10n-id='lastCheckETagLabel' /> <span>{this.state.adblock.get('etag')}</span></div>
+              ? <div><span data-l10n-id='lastCheckETagLabel' /> <span>{this.state.adblock.get('etag')}</span></div>
               : null
             }
-            <h3 data-l10n-id='additionalFilterLists' />
-            <div className='adblockSubtext' data-l10n-id='adblockTooManyListsWarning' />
-            <div className='adblockLists'>
+            <h3 className={css(styles.adblockDetailsPage__h3)} data-l10n-id='additionalFilterLists' />
+            <div className={css(styles.adblockSubtext)} data-l10n-id='adblockTooManyListsWarning' />
+            <div className={css(styles.adblockLists)}>
               {
                 this.state.resources.map((resource) =>
                   <AdBlockItem resource={resource}
                     settings={this.state.settings} />)
               }
             </div>
-            <h3 data-l10n-id='customFilters' />
-            <div className='adblockSubtext' data-l10n-id='customFilterDescription' />
+            <h3 className={css(styles.adblockDetailsPage__h3)} data-l10n-id='customFilters' />
+            <div className={css(styles.adblockSubtext)} data-l10n-id='customFilterDescription' />
             <DefaultTextArea
               onChange={this.onChangeCustomFilters}
               value={getSetting(ADBLOCK_CUSTOM_RULES, this.state.settings) || ''}
@@ -110,5 +111,30 @@ class AboutAdBlock extends React.Component {
     aboutActions.updateCustomAdblockRules(e.target.value)
   }
 }
+
+const styles = StyleSheet.create({
+  adblockDetailsPage: {
+    margin: '20px',
+    minWidth: '704px'
+  },
+  adblockDetailsPage__h2: {
+    marginBottom: '10px'
+  },
+  adblockDetailsPage__h3: {
+    marginTop: '20px',
+    marginBottom: '10px'
+  },
+  adblockDetailsPageContent: {
+    marginBottom: '10px'
+  },
+  adblockLists: {
+    marginTop: '10px'
+  },
+  adblockSubtext: {
+    fontSize: 'smaller',
+    fontWeight: 'bold',
+    marginBottom: '10px'
+  }
+})
 
 module.exports = <AboutAdBlock />

--- a/less/about/adblock.less
+++ b/less/about/adblock.less
@@ -1,38 +1,8 @@
-@import "./itemList.less";
+@import "./common.less";
 
-.adblockDetailsPage {
-  margin: 20px;
-  min-width: 704px;
-
-  h2 {
-    margin-bottom: 10px;
-  }
-
-  h3 {
-    margin-top: 20px;
-    margin-bottom: 10px;
-  }
-
-  list .listItem {
-    display: flex;
-    -webkit-user-select: text;
-  }
-
-  .adblockDetailsPageContent {
-    margin-bottom: 10px;
-  }
-
-  .adblockLists {
-    margin-top: 10px;
-  }
-
+// TODO: refactor SwitchControl to remove this
+div[class^="adblockDetailsPage"] {
   .switchControlRightText {
     margin-left: 15px;
-  }
-
-  .adblockSubtext {
-    font-size: smaller;
-    font-weight: bold;
-    margin-bottom: 10px;
   }
 }

--- a/test/about/adblockTest.js
+++ b/test/about/adblockTest.js
@@ -19,6 +19,6 @@ describe('about:adblock', function () {
 
   it('lists adblock count', function * () {
     yield this.app.client
-      .getText('.blockedCountTotal').should.eventually.be.equal('0')
+      .getText('[data-test-id="blockedCountTotal"]').should.eventually.be.equal('0')
   })
 })


### PR DESCRIPTION
Closes #7320

itemList.less is removed as it has not been used
TODO: refactor SwitchControl to remove .switchControlRightText in adblock.less: #7321

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan: make sure about:adblock is properly displayed
