### PR TITLE
Do not update tab size if user enters fullscreen

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -1190,6 +1190,11 @@ class Main extends ImmutableComponent {
           key='tab-bar'
           activeFrameKey={activeFrame && activeFrame.get('key') || undefined}
           onMenu={this.onHamburgerMenu}
+          hasTabInFullScreen={
+            sortedFrames
+              .map((frame) => frame.get('isFullScreen'))
+              .some(fullScreenMode => fullScreenMode === true)
+          }
         />
 
         {

--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -193,11 +193,8 @@ class Tab extends ImmutableComponent {
 
   onUpdateTabSize () {
     const currentSize = getTabBreakpoint(this.tabSize)
-    // Avoid changing state on unmounted component
-    // when user switch to a new tabSet
-    if (this.tabNode) {
-      windowActions.setTabBreakpoint(this.frame, currentSize)
-    }
+    // Avoid updating breakpoint when user enters fullscreen (see #7301)
+    !this.props.hasTabInFullScreen && windowActions.setTabBreakpoint(this.frame, currentSize)
   }
 
   componentWillMount () {

--- a/js/components/tabs.js
+++ b/js/components/tabs.js
@@ -142,6 +142,7 @@ class Tabs extends ImmutableComponent {
                 isActive={this.props.activeFrameKey === tab.get('frameKey')}
                 onTabClosedWithMouse={this.onTabClosedWithMouse}
                 tabWidth={this.props.fixTabWidth}
+                hasTabInFullScreen={this.props.hasTabInFullScreen}
                 partOfFullPageSet={this.props.partOfFullPageSet} />)
         }
         {(() => {

--- a/js/components/tabsToolbar.js
+++ b/js/components/tabsToolbar.js
@@ -65,6 +65,7 @@ class TabsToolbar extends ImmutableComponent {
         tabsPerTabPage={this.props.tabsPerTabPage}
         activeFrameKey={this.props.activeFrameKey}
         tabPageIndex={this.props.tabPageIndex}
+        hasTabInFullScreen={this.props.hasTabInFullScreen}
         tabBreakpoint={this.props.tabBreakpoint}
         currentTabs={currentTabs}
         previewTabPageIndex={this.props.previewTabPageIndex}

--- a/test/components/tabTest.js
+++ b/test/components/tabTest.js
@@ -4,7 +4,7 @@ const Brave = require('../lib/brave')
 const messages = require('../../js/constants/messages')
 const assert = require('assert')
 const settings = require('../../js/constants/settings')
-const {urlInput, backButton, forwardButton, activeTabTitle, activeTabFavicon, newFrameButton} = require('../lib/selectors')
+const {urlInput, backButton, forwardButton, activeTab, activeTabTitle, activeTabFavicon, newFrameButton, notificationBar} = require('../lib/selectors')
 
 describe('tab tests', function () {
   function * setup (client) {
@@ -354,6 +354,38 @@ describe('tab tests', function () {
         .waitForVisible('[data-test-id="tab"][data-frame-key="2"]')
         // This should not be converted to a waitUntil
         .getText('[data-test-id="tab"][data-frame-key="2"]').then((val) => assert.equal(val, 'Untitled'))
+    })
+  })
+
+  describe('webview in fullscreen mode', function () {
+    Brave.beforeAll(this)
+    before(function * () {
+      yield setup(this.app.client)
+    })
+
+    it('keep favicon and title after exiting fullscreen mode', function * () {
+      const url1 = Brave.server.url('fullscreen.html')
+
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(url1)
+        .tabByUrl(url1)
+        .waitForExist('#fullscreenImg')
+        .click('#fullscreenImg')
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist(notificationBar)
+        .waitForExist('button=Allow')
+        .click('button=Allow')
+        .tabByUrl(url1)
+        .waitForExist('#fullscreenImg')
+        .click('#fullscreenImg')
+        .windowByUrl(Brave.browserWindowUrl)
+        .moveToObject(activeTab)
+        .waitForExist(activeTabFavicon)
+        .waitUntil(function () {
+          return this.getText(activeTabTitle)
+            .then((title) => title === 'fullscreenPage')
+        })
     })
   })
 })

--- a/test/fixtures/fullscreen.html
+++ b/test/fixtures/fullscreen.html
@@ -1,0 +1,18 @@
+<html>
+<head>
+  <title>fullscreenPage</title>
+  <link rel="shortcut icon" href="img/test.ico">
+</head>
+<body>
+  <img id="fullscreenImg" src="img/test.ico">
+  <script>
+    const elm = document.getElementById('fullscreenImg')
+    const toggleFullscreen = () => {
+      !document.webkitFullscreenElement
+        ? elm.webkitRequestFullscreen()
+        : document.webkitExitFullscreen()
+    }
+    elm.addEventListener('click', () => toggleFullscreen())
+  </script>
+</body>
+</html>

--- a/test/lib/selectors.js
+++ b/test/lib/selectors.js
@@ -4,6 +4,7 @@ module.exports = {
   closeButton: '.close-btn',
   urlInput: '#urlInput',
   activeWebview: '.frameWrapper.isActive webview',
+  activeTab: '[data-test-active-tab]',
   activeTabTitle: '[data-test-active-tab] [data-test-id="tabTitle"]',
   activeTabFavicon: '[data-test-active-tab] [data-test-favicon]',
   pinnedTabsTabs: '.pinnedTabs [data-test-id="tab"]',


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors:  @bsclifton

Fix #7301 

Test Plan: covered by automated test
```
npm run test -- --grep="keep favicon and title after exiting fullscreen mode"
```

![keep_tab_size_fs](https://cloud.githubusercontent.com/assets/4672033/23136295/da54be58-f77a-11e6-9296-1120d08c389f.gif)


QA steps:

* Open website with fullscreen option
* Allow fullscreen
* Watch website going fullscreen
* Keep an eye on tab elements (favicon and title - optionally audio)
* Press `esc` /click on element to exit fullscreen
* Tab elements should not update (keep same state as before allowing fullscreen)