### PR TITLE
Default order in torrent list should be numerical order

### DIFF
--- a/js/webtorrent/components/torrentFileList.js
+++ b/js/webtorrent/components/torrentFileList.js
@@ -19,7 +19,7 @@ class TorrentFileList extends React.Component {
           defaultHeading='num'
           defaultHeadingSortOrder='asc'
           rows={files.map((file, i) => [
-            String(i + 1),
+            i + 1,
             {cell: this.renderFileLink(file, false)},
             {cell: this.renderFileLink(file, true)},
             prettierBytes(file.length)


### PR DESCRIPTION
Use numerical sort instead of alphanumerical sort.

Fixes: https://github.com/brave/browser-laptop/issues/7361

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

## Test Plan:

1. Start the WIRED CD magnet link from https://codepen.io/ferossity/full/qaezaB/
2. Look at the list.
3. Ensure that the list is sorted in the order 1, 2, 3, 4, 5, 6, 7, etc. instead of 1, 10, 11, 12, 13, etc.