### PR TITLE
Torrent Viewer CSP rule blocks <iframe> content

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -166,22 +166,23 @@ let generateTorrentManifest = () => {
   let cspDirectives = {
     'default-src': '\'self\'',
     // TODO(bridiver) - remove example.com when webtorrent no longer requires it
+    //                  (i.e. once Brave uses webpack v2)
     'connect-src': '\'self\' https://example.com',
     'media-src': '\'self\' http://localhost:*',
     'form-action': '\'none\'',
     'referrer': 'no-referrer',
     'style-src': '\'self\' \'unsafe-inline\'',
-    'frame-src': '\'self\''
+    'frame-src': '\'self\' http://localhost:*'
   }
 
   if (process.env.NODE_ENV === 'development') {
     // allow access to webpack dev server resources
     let devServer = 'localhost:' + process.env.npm_package_config_port
-    cspDirectives['default-src'] = '\'self\' http://' + devServer
+    cspDirectives['default-src'] += ' http://' + devServer
     cspDirectives['connect-src'] += ' http://' + devServer + ' ws://' + devServer
-    cspDirectives['media-src'] = '\'self\' http://localhost:* http://' + devServer
-    cspDirectives['frame-src'] = '\'self\' http://' + devServer
-    cspDirectives['style-src'] = '\'self\' \'unsafe-inline\' http://' + devServer
+    cspDirectives['media-src'] += ' http://' + devServer
+    cspDirectives['frame-src'] += ' http://' + devServer
+    cspDirectives['style-src'] += ' http://' + devServer
   }
 
   return {


### PR DESCRIPTION
Torrent content is rendered into <iframe> when it's not video or audio
content. For example, a .jpg or a .pdf file. This is because we're
using a viewer page that includes the content; we're not returning the
content directly.

This is because the torrent may not be active and in that case, we show
the "Start Download?" page.

When this occurs, CSP prevents the iframe from loading content from the
webtorrent server at http://localhost:port

This is because we only make a CSP exception for media elements, not
iframe elements. This is an easy fix.

Fixes: https://github.com/brave/browser-laptop/issues/7243

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

1. Load the WIRED CD torrent from https://codepen.io/ferossity/full/qaezaB/
2. Start the torrent
3. Click on a non-media file like `poster.jpg` or `README.md` to view it in Brave.
4. It should load and display correctly.

Since this touches CSP, I'd appreciate if @diracdeltas could take a look 🔐 ✅ 