### PR TITLE
Fix regression of about:styles

### DIFF
--- a/js/about/styles.js
+++ b/js/about/styles.js
@@ -4,7 +4,7 @@
 
 const React = require('react')
 const ImmutableComponent = require('../components/immutableComponent')
-const {StyleSheet, css} = require('aphrodite')
+const {StyleSheet, css} = require('aphrodite/no-important')
 const globalStyles = require('../../app/renderer/components/styles/global')
 
 // Stylesheets go here
@@ -87,23 +87,23 @@ class AboutStyle extends ImmutableComponent {
         </Code></Pre>
       </Container>
 
-      <div className='container'>
+      <Container>
         <h2>Plain textarea</h2>
         <TextArea placeholder='TextArea' />
-        <pre><code>
+        <Pre><Code>
           const { '{TextArea}' } = require('../../app/renderer/components/textbox'){'\n'}
           &lt;TextArea />
-        </code></pre>
-      </div>
+        </Code></Pre>
+      </Container>
 
-      <div className='container'>
+      <Container>
         <h2>Default textarea; font size is specified</h2>
         <DefaultTextArea placeholder='DefaultTextArea' />
-        <pre><code>
+        <Pre><Code>
           const { '{DefaultTextArea}' } = require('../../app/renderer/components/textbox'){'\n'}
           &lt;DefaultTextArea />
-        </code></pre>
-      </div>
+        </Code></Pre>
+      </Container>
 
       <hr />
 


### PR DESCRIPTION
Fixes #7201

including
- aphrodite/no-important

Auditors:

Test Plan:
1. Open about:styles
2. Make sure the code snippets of TextArea and DefaultTextArea are no longer unstyled

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
