### PR TITLE
Prevent windows from being opened off-screen

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -511,6 +511,10 @@ class Main extends ImmutableComponent {
 
     const onWindowMove = debounce(function (event) {
       const position = event.sender.getPosition()
+      // Windows may be placed off-screen
+      // See https://github.com/brave/browser-laptop/issues/3558
+      position[0] = Math.max(0, position[0])
+      position[1] = Math.max(0, position[1])
       // NOTE: the default window position is whatever the last window move was
       appActions.defaultWindowParamsChanged(undefined, position)
       windowActions.savePosition(position)

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -155,8 +155,10 @@ const createWindow = (browserOpts, defaults, frameOpts, windowState) => {
     const maxX = Math.max(...displays.map((display) => { return display.bounds.x + display.bounds.width }))
     const maxY = Math.max(...displays.map((display) => { return display.bounds.y + display.bounds.height }))
 
-    browserOpts.x = Math.min(browserOpts.x, maxX - defaults.windowOffset)
-    browserOpts.y = Math.min(browserOpts.y, maxY - defaults.windowOffset)
+    // Windows may be placed off-screen
+    // See https://github.com/brave/browser-laptop/issues/3558
+    browserOpts.x = Math.min(Math.max(0, browserOpts.x), maxX - defaults.windowOffset)
+    browserOpts.y = Math.min(Math.max(0, browserOpts.y), maxY - defaults.windowOffset)
   }
 
   const minWidth = isModal(browserOpts) ? defaults.minModalWidth : defaults.minWidth


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
Close Brave when the browser is positioned at a negative x or y offset. For example, move the left half of the browser off the left of the screen, leaving only the right-side of the browser visible. Close the browser. Re-open the browser. The window should not be opened to a negative x or y coordinate.

Resolves #3558 