### PR TITLE
Hide HelpfulHints if window height is too small

### DIFF
--- a/app/renderer/components/preferences/helpfulHints.js
+++ b/app/renderer/components/preferences/helpfulHints.js
@@ -42,12 +42,12 @@ const styles = StyleSheet.create({
   helpfulHints: {
     cursor: 'default',
     padding: '20px 0 0',
-    overflowY: 'auto',
+    visibility: 'hidden',
 
-    '@media (min-height: 620px)': {
+    '@media (min-height: 680px)': {
       position: 'absolute',
       bottom: '0',
-      overflowY: 'none'
+      visibility: 'visible'
     }
   },
 


### PR DESCRIPTION
Fix #7404

Auditors: @luixxiul

Test Plan:

Per https://github.com/brave/browser-laptop/issues/7404#issuecomment-282808433, `helpfulHints` should not be visible if window height is too small.

**Note:** breakpoint was increased to allow an extra menu (upcoming extensions tab).