### PR TITLE
do not delete objectIds when sync is reset

### DIFF
--- a/app/sync.js
+++ b/app/sync.js
@@ -176,6 +176,7 @@ module.exports.onSyncReady = (isFirstRun, e) => {
   }
   const appState = AppStore.getState()
   const sites = appState.get('sites') || new Immutable.List()
+  const seed = appState.get('seed') || new Immutable.List()
 
   /**
    * Sync a bookmark that has not been synced yet, first syncing the parent
@@ -187,7 +188,8 @@ module.exports.onSyncReady = (isFirstRun, e) => {
    */
   const folderToObjectId = {}
   const syncBookmark = (site) => {
-    if (!site || site.get('objectId') || folderToObjectId[site.get('folderId')] || !syncUtil.isSyncable('bookmark', site)) {
+    if (!site || (site.get('objectId') && seed.equals(site.get('originalSeed'))) ||
+      folderToObjectId[site.get('folderId')] || !syncUtil.isSyncable('bookmark', site)) {
       return
     }
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -224,6 +224,7 @@ AppStore
       lastAccessedTime: number, // datetime.getTime()
       location: string,
       objectId: Array.<number>,
+      originalSeed: Array.<number>, // only set for bookmarks that have been synced before a sync profile reset
       parentFolderId: number, // set for bookmarks and bookmark folders only
       partitionNumber: number, // optionally specifies a specific session
       tags: [string], // empty, 'bookmark', 'bookmark-folder', 'pinned', or 'reader'


### PR DESCRIPTION
save the original seed for bookmarks, so they can be synced to a profile with
a different seed if needed. fix #7405.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. create a bookmark and a bookmark folder in pyramid 0 and enable sync.
2. sync pyramid 1 to pyramid 0. wait for the bookmark and folder to appear.
3. reset sync in pyramid 1
4. re-sync pyramid 1 to pyramid 0
5. in pyramid 1, move the bookmark into the folder. **this change should sync correctly to pyramid 0**.
6. reset sync again in pyramid 1
7. delete pyramid 0 completely
8. choose 'i am new to sync' in pyramid 1
9. start pyramid 0. it should have no bookmarks. sync it to pyramid 1's new profile
10. the bookmarks from pyramid 1 should appear in pyramid 0