### PR TITLE
noscript info dialog improvements

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -1123,7 +1123,6 @@ class Main extends ImmutableComponent {
         {
           noScriptIsVisible
             ? <NoScriptInfo frameProps={activeFrame}
-              noScriptGlobalEnabled={this.props.appState.getIn(['noScript', 'enabled'])}
               onHide={this.onHideNoScript} />
             : null
         }

--- a/less/forms.less
+++ b/less/forms.less
@@ -504,6 +504,10 @@ select {
     }
     .noScriptCheckbox {
       text-align: left;
+      font-size: 110%;
+      input[type=checkbox] {
+        margin: 5px;
+      }
     }
     .clickable {
       text-align: left;


### PR DESCRIPTION

Test Plan:
* go to vox.com
* disable scripts in the brave panel
* hit the noscript icon, uncheck everything except vox and vox-cdn checkboxes. click inside the dialog and the dialog should not disappear.
* hit one of the allow buttons. the page should reload, and vox images should appear.

changes:
* make it easier to click the checkboxes. fix #7430.
* do not close the dialog unless clicking outside or on a button.
* make the dialog the same whether noscript is globally enabled or not.
* if no checkboxes are checked, clicking the button should be a no-op.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
