### PR TITLE
Show default bookmark title for synced bookmarks

### DIFF
--- a/app/renderer/components/addEditBookmarkHanger.js
+++ b/app/renderer/components/addEditBookmarkHanger.js
@@ -36,7 +36,8 @@ class AddEditBookmarkHanger extends ImmutableComponent {
       : (typeof location === 'string' && location.trim().length > 0)
   }
   get displayBookmarkName () {
-    if (this.props.currentDetail.get('customTitle') !== undefined) {
+    const customTitle = this.props.currentDetail.get('customTitle')
+    if (customTitle !== undefined && customTitle !== '') {
       return this.props.currentDetail.get('customTitle')
     }
     return this.props.currentDetail.get('title') || ''


### PR DESCRIPTION
Fix #7291

Test plan:
1. open pyramid 0, enable sync, bookmark something.
2. open pyramid 1, sync to pyramid 0, wait for the synced bookmark to appear.
3. click 'edit bookmark...' on the synced bookmark in pyramid 1. the title field should not be empty.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

