### PR TITLE
Update logic for publishers

### DIFF
--- a/app/renderer/components/publisherToggle.js
+++ b/app/renderer/components/publisherToggle.js
@@ -3,7 +3,6 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const React = require('react')
-const tldjs = require('tldjs')
 const ImmutableComponent = require('../../../js/components/immutableComponent')
 const appActions = require('../../../js/actions/appActions')
 const settings = require('../../../js/constants/settings')
@@ -11,6 +10,8 @@ const getSetting = require('../../../js/settings').getSetting
 const {StyleSheet, css} = require('aphrodite')
 const globalStyles = require('./styles/global')
 const commonStyles = require('./styles/commonStyles')
+const {getHostPattern, isHttpOrHttps} = require('../../../js/lib/urlutil')
+const {getBaseUrl} = require('../../../js/lib/appUrlUtil')
 
 const noFundVerifiedPublisherImage = require('../../extensions/brave/img/urlbar/browser_URL_fund_no_verified.svg')
 const fundVerifiedPublisherImage = require('../../extensions/brave/img/urlbar/browser_URL_fund_yes_verified.svg')
@@ -23,97 +24,89 @@ class PublisherToggle extends ImmutableComponent {
     this.onAuthorizePublisher = this.onAuthorizePublisher.bind(this)
   }
 
-  get publisherId () {
-// @cezaraugusto: publisherIds aren't limited to a domain name
-// when this runs, do you think that app/extensions/brave/content/scripts/pageInformation.js has already run?
-
-    return tldjs.getDomain(this.props.url)
+  get locationId () {
+    return getBaseUrl(this.props.location)
   }
 
-  get hostPattern () {
-    return `https?://${this.publisherId}`
+  get publisherId () {
+    return this.props.locationInfo.getIn([this.locationId, 'publisher'])
   }
 
   get hostSettings () {
-    // hostPattern defines it's own identifier for authorized publishers
-    // sites that do not match criteria would populate siteSettings
-    // with their default protocol, not hostPattern
-    return this.props.hostSettings.get(this.hostPattern)
+    const hostPattern = getHostPattern(this.publisherId)
+    return this.props.siteSettings.get(hostPattern)
   }
 
   get validPublisherSynopsis () {
-    // If session is clear then siteSettings is undefined and icon will never be shown,
-    // but synopsis may not be empty. In such cases let's check if synopsis matches current publisherId
-    return this.props.synopsis.map(entry => entry.get('site')).includes(this.publisherId)
+    // If session is clear then siteSettings is undefined and icon
+    // will never be shown, but synopsis may not be empty.
+    // In such cases let's check if synopsis matches current publisherId
+    return !!this.props.synopsis.map(entry => entry.get('site')).includes(this.publisherId)
   }
 
-  get authorizedPublisher () {
-    // If we can't get ledgerPayments, then it's likely that we are
-    // on a clean session. Let's then check for publisher's synopsis
+  get enabledForPaymentsPublisher () {
+    // All publishers will be enabled by default if AUTO_SUGGEST is ON,
+    // excluding publishers defined on ledger's exclusion list
+    const excluded = this.props.locationInfo.getIn([this.locationId, 'exclude'])
+    const autoSuggestSites = getSetting(settings.AUTO_SUGGEST_SITES)
+
+      // hostSettings is undefined until user hit addFunds button.
+      // For such cases check autoSuggestSites for eligibility.
     return this.hostSettings
       ? this.hostSettings.get('ledgerPayments') !== false
-      : this.validPublisherSynopsis
+      : this.validPublisherSynopsis || (autoSuggestSites && !excluded)
   }
 
   get verifiedPublisher () {
-// @cezaraugusto: should call `verifiedP` in ledger.js and return the 2nd parameter of the callback
-
-    let verifiedPublisher
-    this.props.synopsis.map(publisher => {
-      if (publisher.get('site') === this.publisherId && publisher.get('verified') === true) {
-        verifiedPublisher = !!publisher
-        return false
-      }
-      return true
-    })
-    return verifiedPublisher
+    return this.props.locationInfo.getIn([this.locationId, 'verified'])
   }
 
   get visiblePublisher () {
-    // ledgerPaymentsShown is undefined by default until user decide to permanently hide the publisher
+    // ledgerPaymentsShown is undefined by default until
+    // user decide to permanently hide the publisher,
     // so for icon to be shown it can be everything but false
     const ledgerPaymentsShown = this.hostSettings && this.hostSettings.get('ledgerPaymentsShown')
-    return ledgerPaymentsShown !== false
+    return typeof ledgerPaymentsShown === 'boolean'
+      ? ledgerPaymentsShown
+      : true
   }
 
   get shouldShowAddPublisherButton () {
-    if ((!!this.hostSettings || !!this.validPublisherSynopsis) && this.visiblePublisher) {
-      // Only show publisher icon if ledger is enabled
-      return getSetting(settings.PAYMENTS_ENABLED)
-    }
-    return false
+    return getSetting(settings.PAYMENTS_ENABLED) &&
+      isHttpOrHttps(this.props.location) &&
+      this.visiblePublisher
   }
 
   get l10nString () {
-    if (this.verifiedPublisher && !this.authorizedPublisher) {
-      return 'verifiedPublisher'
-    } else if (this.authorizedPublisher) {
-      return 'enabledPublisher'
+    let l10nData = 'disabledPublisher'
+    if (this.verifiedPublisher && !this.enabledForPaymentsPublisher) {
+      l10nData = 'verifiedPublisher'
+    } else if (this.enabledForPaymentsPublisher) {
+      l10nData = 'enabledPublisher'
     }
-    return 'disabledPublisher'
+    return l10nData
   }
 
   onAuthorizePublisher () {
-    this.authorizedPublisher
-      ? appActions.changeSiteSetting(this.hostPattern, 'ledgerPayments', false)
-      : appActions.changeSiteSetting(this.hostPattern, 'ledgerPayments', true)
+    const hostPattern = getHostPattern(this.publisherId)
+    appActions.changeSiteSetting(hostPattern, 'ledgerPayments', !this.enabledForPaymentsPublisher)
   }
 
   render () {
     return this.shouldShowAddPublisherButton
       ? <span
         data-test-id='publisherButton'
-        data-test-authorized={this.authorizedPublisher}
+        data-test-authorized={this.enabledForPaymentsPublisher}
         data-test-verified={this.verifiedPublisher}
         className={css(styles.addPublisherButtonContainer)}>
         <button
           className={
           css(
             commonStyles.browserButton,
-            !this.authorizedPublisher && this.verifiedPublisher && styles.noFundVerified,
-            this.authorizedPublisher && this.verifiedPublisher && styles.fundVerified,
-            !this.authorizedPublisher && !this.verifiedPublisher && styles.noFundUnverified,
-            this.authorizedPublisher && !this.verifiedPublisher && styles.fundUnverified
+            !this.enabledForPaymentsPublisher && this.verifiedPublisher && styles.noFundVerified,
+            this.enabledForPaymentsPublisher && this.verifiedPublisher && styles.fundVerified,
+            !this.enabledForPaymentsPublisher && !this.verifiedPublisher && styles.noFundUnverified,
+            this.enabledForPaymentsPublisher && !this.verifiedPublisher && styles.fundUnverified
             )
           }
           data-l10n-id={this.l10nString}

--- a/docs/appActions.md
+++ b/docs/appActions.md
@@ -337,6 +337,16 @@ Updates ledger information for the payments pane
 
 
 
+### updateLocationInfo(locationInfo) 
+
+Updates location information for the URL bar
+
+**Parameters**
+
+**locationInfo**: `object`, the current location synopsis
+
+
+
 ### updatePublisherInfo(publisherInfo) 
 
 Updates publisher information for the payments pane

--- a/docs/state.md
+++ b/docs/state.md
@@ -558,6 +558,15 @@ WindowStore
     top: number // the top position of the popup window
   },
   previewFrameKey: number,
+  locationInfo: {
+    [url]: {
+      publisher: string, // url of the publisher in question
+      verified: boolean, // wheter or not site is a verified publisher
+      exclude: boolean, // wheter or not site is in the excluded list
+      stickyP: boolean, // wheter or not site was added using addFunds urlbar toggle
+      timestamp: number // timestamp in milliseconds
+    }
+  },
   publisherInfo: {
     synopsis: [{
       daysSpent: number, // e.g., 1

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -413,6 +413,17 @@ const appActions = {
   },
 
   /**
+   * Updates location information for the URL bar
+   * @param {object} locationInfo - the current location synopsis
+   */
+  updateLocationInfo: function (locationInfo) {
+    AppDispatcher.dispatch({
+      actionType: appConstants.APP_UPDATE_LOCATION_INFO,
+      locationInfo
+    })
+  },
+
+  /**
    * Updates publisher information for the payments pane
    * @param {object} publisherInfo - the current publisher synopsis
    */

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -1014,6 +1014,7 @@ class Main extends ImmutableComponent {
                 siteSettings={this.props.appState.get('siteSettings')}
                 synopsis={this.props.appState.getIn(['publisherInfo', 'synopsis']) || new Immutable.Map()}
                 activeTabShowingMessageBox={activeTabShowingMessageBox}
+                locationInfo={this.props.appState.get('locationInfo')}
               />
               <div className='topLevelEndButtons'>
                 <div className={cx({

--- a/js/constants/appConstants.js
+++ b/js/constants/appConstants.js
@@ -42,6 +42,7 @@ const appConstants = {
   APP_IMPORT_BROWSER_DATA: _,
   APP_UPDATE_LEDGER_INFO: _,
   APP_LEDGER_RECOVERY_STATUS_CHANGED: _,
+  APP_UPDATE_LOCATION_INFO: _,
   APP_UPDATE_PUBLISHER_INFO: _,
   APP_SHOW_NOTIFICATION: _, /** @param {Object} detail */
   APP_HIDE_NOTIFICATION: _, /** @param {string} message */

--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -344,6 +344,24 @@ const UrlUtil = {
     } catch (e) {
       return url
     }
+  },
+
+  /**
+   * Gets the hostPattern from an URL.
+   * @param {string} url The URL to get the hostPattern from
+   * @return {string} url The URL formmatted as an hostPattern
+   */
+  getHostPattern: function (url) {
+    return `https?://${url}`
+  },
+
+  /**
+   * Checks if URL is based on http protocol.
+   * @param {string} url The URL to get the hostPattern from
+   * @return {string} url The URL formmatted as an hostPattern
+   */
+  isHttpOrHttps: function (url) {
+    return url.startsWith('https://') || url.startsWith('http://')
   }
 }
 

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -706,6 +706,9 @@ const handleAppAction = (action) => {
     case appConstants.APP_UPDATE_LEDGER_INFO:
       appState = appState.set('ledgerInfo', Immutable.fromJS(action.ledgerInfo))
       break
+    case appConstants.APP_UPDATE_LOCATION_INFO:
+      appState = appState.set('locationInfo', Immutable.fromJS(action.locationInfo))
+      break
     case appConstants.APP_UPDATE_PUBLISHER_INFO:
       appState = appState.set('publisherInfo', Immutable.fromJS(action.publisherInfo))
       break

--- a/test/unit/app/renderer/publisherToggleTest.js
+++ b/test/unit/app/renderer/publisherToggleTest.js
@@ -3,30 +3,39 @@ const mockery = require('mockery')
 const {shallow} = require('enzyme')
 const assert = require('assert')
 const Immutable = require('immutable')
-const tldjs = require('tldjs')
 const fakeElectron = require('../../lib/fakeElectron')
 const settingsConst = require('../../../../js/constants/settings')
+const {getHostPattern} = require('../../../../js/lib/urlutil')
 let PublisherToggle
 require('../../braveUnit')
 
 describe('PublisherToggle component', function () {
-  const getDomain = (url) => tldjs.getDomain(url)
-  const getPattern = (pattern) => `https?://${getDomain(pattern)}`
-  const getHostPattern = (pattern, isEnabled, shouldShow) => Immutable.fromJS({
-    [pattern]: {
+  const getUrlOrigin = url => url.split('/').slice(0, 3).join('/')
+  const getHostName = url => getUrlOrigin(url).split('/').slice(2).join('/')
+  const getPattern = pattern => getHostPattern(getHostName(pattern))
+
+  const locationInfo = (url, exclude, verified) => Immutable.fromJS({
+    [url]: {
+      'publisher': getHostName(url),
+      'exclude': exclude,
+      'verified': verified
+    }
+  })
+  const hostPattern = (pattern, isEnabled, shouldShow) => Immutable.fromJS({
+    [getPattern(pattern)]: {
       'ledgerPayments': isEnabled,
       'ledgerPaymentsShown': shouldShow
     }
   })
-  const getPublisherSynopsis = (url, verified) => Immutable.fromJS([{
-    'site': getDomain(url),
+  const publisherSynopsis = (url, verified) => Immutable.fromJS([{
+    'site': getHostName(url),
     'publisherURL': url,
     'verified': verified
   }])
-
+  const paymentsEnabled = settingsConst.PAYMENTS_ENABLED
+  const autoSuggestSites = settingsConst.AUTO_SUGGEST_SITES
   const url1 = 'https://clifton.io/sharing-my-passion-for-mercedes-benz'
-  const domain1 = getDomain(url1)
-  const pattern1 = getPattern(domain1)
+  const aboutPage = 'about:preferences'
 
   before(function () {
     mockery.enable({
@@ -39,7 +48,7 @@ describe('PublisherToggle component', function () {
     mockery.registerMock('../../extensions/brave/img/urlbar/browser_URL_fund_no.svg')
     mockery.registerMock('../../extensions/brave/img/urlbar/browser_URL_fund_yes.svg')
     mockery.registerMock('../../../js/settings', { getSetting: (settingKey, settingsCollection, value) => {
-      if (settingKey === settingsConst.PAYMENTS_ENABLED) {
+      if (settingKey === paymentsEnabled || settingKey === autoSuggestSites) {
         return true
       }
       return false
@@ -52,71 +61,105 @@ describe('PublisherToggle component', function () {
     mockery.disable()
   })
 
-  describe('criteria to be shown', function () {
-    it('render if domain match synopsis criteria (siteSettings is empty)', function () {
+  describe('default behaviour (when autoSuggest is ON)', function () {
+    it('show as enabled if site is on synopsis list (siteSettings is empty)', function () {
       const wrapper = shallow(
         <PublisherToggle
-          url={url1}
-          hostSettings={Immutable.Map()}
-          synopsis={getPublisherSynopsis(domain1, false)} />
+          location={url1}
+          locationInfo={Immutable.Map()}
+          siteSettings={Immutable.Map()}
+          synopsis={publisherSynopsis(url1, false)} />
       )
       assert.equal(wrapper.find('[data-test-id="publisherButton"]').length, 1)
+      assert.equal(wrapper.props()['data-test-authorized'], true)
     })
-    it('render if hostPattern match siteSettings (synopsis is empty)', function () {
+    it('show as enabled if hostPattern is on siteSettings list (synopsis is empty)', function () {
       const wrapper = shallow(
         <PublisherToggle
-          url={url1}
-          hostSettings={getHostPattern(pattern1, true, true)}
+          location={url1}
+          locationInfo={Immutable.Map()}
+          siteSettings={hostPattern(url1, true, true)}
           synopsis={Immutable.List()} />
       )
       assert.equal(wrapper.find('[data-test-id="publisherButton"]').length, 1)
+      assert.equal(wrapper.props()['data-test-authorized'], true)
     })
-    it('do not render for unauthorized publishers (no siteSettings and no synopsis)', function () {
+    it('show as enabled if url exists in locationInfo (both synopsis and siteSettings are empty)', function () {
       const wrapper = shallow(
         <PublisherToggle
-          url={url1}
-          hostSettings={Immutable.Map()}
+          location={url1}
+          locationInfo={locationInfo(url1, false, false)}
+          siteSettings={Immutable.Map()}
+          synopsis={Immutable.List()} />
+      )
+      assert.equal(wrapper.find('[data-test-id="publisherButton"]').length, 1)
+      assert.equal(wrapper.props()['data-test-authorized'], true)
+    })
+    it('Show as disabled if publisher is on exclusion list', function () {
+      const wrapper = shallow(
+        <PublisherToggle
+          location={url1}
+          locationInfo={locationInfo(url1, true, false)}
+          siteSettings={Immutable.Map()}
+          synopsis={Immutable.List()} />
+      )
+      assert.equal(wrapper.find('[data-test-id="publisherButton"]').length, 1)
+      assert.equal(wrapper.props()['data-test-authorized'], false)
+    })
+    it('Show as verified if publisher is shown as verified on locationInfo list', function () {
+      const wrapper = shallow(
+        <PublisherToggle
+          location={url1}
+          locationInfo={locationInfo(url1, false, true)}
+          siteSettings={Immutable.Map()}
+          synopsis={Immutable.List()} />
+      )
+      assert.equal(wrapper.find('[data-test-id="publisherButton"]').length, 1)
+      assert.equal(wrapper.props()['data-test-verified'], true)
+    })
+    it('do not render if about page', function () {
+      const wrapper = shallow(
+        <PublisherToggle
+          location={aboutPage}
+          locationInfo={Immutable.Map()}
+          siteSettings={Immutable.Map()}
           synopsis={Immutable.List()} />
       )
       assert.equal(wrapper.find('[data-test-id="publisherButton"]').length, 0)
     })
+  })
+
+  describe('user interaction behaviour', function () {
     it('do not render if publisher is permanently hidden', function () {
       const wrapper = shallow(
         <PublisherToggle
-          url={url1}
-          hostSettings={getHostPattern(pattern1, true, false)}
-          synopsis={Immutable.List()} />
+          location={url1}
+          locationInfo={locationInfo(url1, false, true)}
+          siteSettings={hostPattern(url1, true, false)}
+          synopsis={publisherSynopsis(url1, false)} />
       )
       assert.equal(wrapper.find('[data-test-id="publisherButton"]').length, 0)
     })
     it('show as enabled if ledgerPayments is true for that publisher', function () {
       const wrapper = shallow(
         <PublisherToggle
-          url={url1}
-          hostSettings={getHostPattern(pattern1, true, true)}
+          location={url1}
+          locationInfo={Immutable.Map()}
+          siteSettings={hostPattern(url1, true, true)}
           synopsis={Immutable.List()} />
       )
+      assert.equal(wrapper.find('[data-test-id="publisherButton"]').length, 1)
       assert.equal(wrapper.props()['data-test-authorized'], true)
     })
     it('Show as disabled if ledgerPayments is false for that publisher', function () {
       const wrapper = shallow(
         <PublisherToggle
-          url={url1}
-          hostSettings={getHostPattern(pattern1, false, true)}
-          synopsis={Immutable.List()} />
+          location={url1}
+          locationInfo={locationInfo(url1, false, true)}
+          siteSettings={hostPattern(url1, false, true)}
+          synopsis={publisherSynopsis(url1, false)} />
       )
-      assert.equal(wrapper.find('[data-test-id="publisherButton"]').length, 1)
       assert.equal(wrapper.props()['data-test-authorized'], false)
-    })
-    it('Show as verified if publisher is a verified publisher', function () {
-      const wrapper = shallow(
-        <PublisherToggle
-          url={url1}
-          hostSettings={Immutable.Map()}
-          synopsis={getPublisherSynopsis(domain1, true)} />
-      )
-      assert.equal(wrapper.find('[data-test-id="publisherButton"]').length, 1)
-      assert.equal(wrapper.props()['data-test-verified'], true)
     })
   })
 })


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @mrose17, @bsclifton 

Fix #7435 
Fix #7089
Fix #7429

Test Plan:

Despite when autoSuggest is OFF, all steps covered by automated test:
```
npm run test -- --grep="PublisherToggle component"
```

## QA Steps

### addFunds toggle is shown by default when
  * Ledger is **on**
  * Publisher **is not** permanently removed by user (deleted from publishers list)

### addFunds toggle is shown as enabled by default when
  * Auto-suggest is **on**
  * **Not** on excluded list (i.e. Google)
  
### addFunds toggle is shown as verified when
  * Site is on verified list (i.e. brianbondy.com)

### addFunds toggle is set to ON when
  * Publisher **is not** enabled for payments

### addFunds toggle is set to OFF when
  * Publisher is enabled for payments