### PR TITLE
make urlbar borderRadius match addFunds toggle

### DIFF
--- a/js/components/navigationBar.js
+++ b/js/components/navigationBar.js
@@ -130,11 +130,13 @@ class NavigationBar extends ImmutableComponent {
     const hostPattern = UrlUtil.getHostPattern(this.publisherId)
     const hostSettings = this.props.siteSettings.get(hostPattern)
     const ledgerPaymentsShown = hostSettings && hostSettings.get('ledgerPaymentsShown')
-    return ledgerPaymentsShown !== false
+    return typeof ledgerPaymentsShown === 'boolean'
+      ? ledgerPaymentsShown
+      : true
   }
 
   get isPublisherButtonEnabled () {
-    getSetting(settings.PAYMENTS_ENABLED) && this.visiblePublisher
+    return UrlUtil.isHttpOrHttps(this.props.location) && this.visiblePublisher
   }
 
   componentDidMount () {


### PR DESCRIPTION
Auditors: @bbondy, @bsclifton 

Fix #7449
Fix #7447

## Test Plan (for #7449):

**Go to a valid publisher url (i.e. brianbondy.com)**
 - urlbar **shouldn't** have right borderRadius

**Exclude that publisher**
- urlbar should have right borderRadius

**Disable payments**
- urlbar should have right borderRadius

**Go to an about page or other pages that shouldn't have publisherToggle (protocols other than HTTP)**
- urlbar should have right borderRadius

> This also addressed #7447 

## Test plan (for #7447)

* Clear `session-store` and `ledger-synopsis` file
* Enable payments, wait till the payments menu is opened
* Open a new tab by clicking on the + button
* New tab should open immediately
* URL bar should be accessible