### PR TITLE
fix "Cannot read property 'size' of undefined" error when getting persistent state

### DIFF
--- a/app/common/state/tabState.js
+++ b/app/common/state/tabState.js
@@ -184,6 +184,9 @@ const api = {
     state = makeImmutable(state)
 
     let tabs = state.get('tabs')
+    if (!tabs) {
+      return state
+    }
     for (let i = 0; i < tabs.size; i++) {
       tabs = tabs.deleteIn([i, field])
     }

--- a/test/unit/app/common/state/tabStateTest.js
+++ b/test/unit/app/common/state/tabStateTest.js
@@ -483,6 +483,11 @@ describe('tabState unit tests', function () {
       const expectedAppState = defaultAppState.set('tabs', tabsWithoutField)
       assert.deepEqual(newAppState, expectedAppState)
     })
+    it('returns the state (unchanged) if tabs is falsey', function () {
+      const emptyTabState = defaultAppState.delete('tabs')
+      const newAppState = tabState.removeTabField(emptyTabState, 'loginRequiredDetail')
+      assert.equal(newAppState, emptyTabState)
+    })
   })
 
   describe('getPersistentState', function () {


### PR DESCRIPTION

When upgrading from 0.13.4 to 0.13.5, this was causing getting persistent state
to fail on startup, thereby losing session state. Fix #7466

Test Plan:
1. copy your session-store-1 from Brave 0.13.4 into the brave-development profile folder
2. npm start
3. Brave should show bookmarks, settings, pinned tabs, etc from the 0.13.4 profile

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

