### PR TITLE
remove about:preferences from web_accessible_resources

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -126,10 +126,7 @@ let generateBraveManifest = () => {
       ]
     },
     web_accessible_resources: [
-      'img/favicon.ico',
-      'about-blank.html',
-      'about-newtab.html',
-      'about-preferences.html'
+      'img/favicon.ico'
     ],
     incognito: 'spanning',
     key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAupOLMy5Fd4dCSOtjcApsAQOnuBdTs+OvBVt/3P93noIrf068x0xXkvxbn+fpigcqfNamiJ5CjGyfx9zAIs7zcHwbxjOw0Uih4SllfgtK+svNTeE0r5atMWE0xR489BvsqNuPSxYJUmW28JqhaSZ4SabYrRx114KcU6ko7hkjyPkjQa3P+chStJjIKYgu5tWBiMJp5QVLelKoM+xkY6S7efvJ8AfajxCViLGyDQPDviGr2D0VvIBob0D1ZmAoTvYOWafcNCaqaejPDybFtuLFX3pZBqfyOCyyzGhucyCmfBXJALKbhjRAqN5glNsUmGhhPK87TuGATQfVuZtenMvXMQIDAQAB'


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/4913

Auditors: @bridiver

Test Plan:
1. open about:preferences and open devtools
2. the top-level HTTP response should not show an 'Access-Control-Allow-Origin' header

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).