### PR TITLE
Make Payments FAQ link obvious

### DIFF
--- a/app/renderer/components/preferences/payment/disabledContent.js
+++ b/app/renderer/components/preferences/payment/disabledContent.js
@@ -30,7 +30,7 @@ class DisabledContent extends ImmutableComponent {
         <div className={css(styles.text)}data-l10n-id='paymentsWelcomeText5' />
         <div className={css(styles.text)}>
           <span data-l10n-id='paymentsWelcomeText6' />&nbsp;
-          <a href='https://brave.com/Payments_FAQ.html' target='_blank' data-l10n-id='paymentsWelcomeLink' />&nbsp;
+          <a className='linkText' href='https://brave.com/Payments_FAQ.html' target='_blank' data-l10n-id='paymentsWelcomeLink' />&nbsp;
           <span data-l10n-id='paymentsWelcomeText7' />
         </div>
       </div>


### PR DESCRIPTION
## Test plan
1. With a new session, launch Brave, open preferences, and go to Payments
2. The FAQ link should be orange (per screenshot below) and very obviously be a link
3. Click link, confirm it goes to FAQ

## Description
Fixes #7487

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan: See issue #7487 for QA steps.

Screenshot:
![image](https://cloud.githubusercontent.com/assets/19424103/23576763/199c0a56-0074-11e7-8abb-b30d2ba8a71e.png)
