### PR TITLE
Adding decimal place for time saved stats

### DIFF
--- a/js/about/newTabComponents/stats.js
+++ b/js/about/newTabComponents/stats.js
@@ -33,11 +33,13 @@ class Stats extends ImmutableComponent {
       counter = Math.ceil(estimatedMillisecondsSaved / 1000 / 60)
       text = 'minutes'
     } else if (hours) {
-      counter = Math.ceil(estimatedMillisecondsSaved / 1000 / 60 / 60)
+      // Refer to http://stackoverflow.com/a/12830454/2950032 for the detailed reasoning behind the + after
+      // toFixed is applied. In a nutshell, + is used to discard unnecessary trailing 0s after calling toFixed
+      counter = +((estimatedMillisecondsSaved / 1000 / 60 / 60).toFixed(1))
       text = 'hours'
     } else {
       // Otherwise the output is in days
-      counter = Math.ceil(estimatedMillisecondsSaved / 1000 / 60 / 60 / 24)
+      counter = +((estimatedMillisecondsSaved / 1000 / 60 / 60 / 24).toFixed(2))
       text = 'days'
     }
 


### PR DESCRIPTION
Fixes #6650 

Time saved in hours will now have 1 decimal place. And time saved
in days will have 2 decimal places

Auditors: @bbondy @bsclifton 

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

## Test Plan
1. Make sure all instances of Brave are closed
2. Open your session file (`~/Libraries/Application Support/brave/session-state-1` on macOS, `%appdata%\brave\session-state-1` on Windows) in an editor such as Sublime, vim, notepad, etc.  If you have a JSON formatting plugin, you may wish to use it (so that it's easier to edit)
3. Edit the JSON for`adblock` > `count` to be `555555` (six fives)
![screen shot 2017-03-10 at 4 58 46 pm](https://cloud.githubusercontent.com/assets/4733304/23817814/4415668a-05b3-11e7-8ae5-7cfe46a75e6c.png)
4. Save the file and then launch Brave
5. Verify it shows hours with 1 decimal point of precision, like so:
![screen shot 2017-03-10 at 4 58 12 pm](https://cloud.githubusercontent.com/assets/4733304/23817831/6c5caf68-05b3-11e7-8fb0-c29ecc175243.png)
6. Close Brave and re-open your session file in your editor of choice
7. Edit the `adblock` > `count` value to be `55555555` (eight fives)
8. Save the file and then launch Brave
9. Verify it shows the days with two digits of precision, like so:
![image](https://cloud.githubusercontent.com/assets/4733304/23817875/ce6cbc98-05b3-11e7-84a0-ed1521ccb601.png)