### PR TITLE
Update lint style for Standard@9.0.0 - first patch

### DIFF
--- a/app/browser/windows.js
+++ b/app/browser/windows.js
@@ -107,7 +107,6 @@ const api = {
               return
             case 'browser-forward':
               win.webContents.send(messages.SHORTCUT_ACTIVE_FRAME_FORWARD)
-              return
           }
         })
         win.webContents.on('crashed', (e) => {

--- a/app/common/lib/ledgerExportUtil.js
+++ b/app/common/lib/ledgerExportUtil.js
@@ -260,12 +260,13 @@ module.exports.getTransactionCSVRows = (transactions, viewingIds, addTotalRow, s
       throw new Error('ledgerExportUtil#getTransactionCSVRows does not support mixed currency data (yet)!')
     }
 
-    return [pub,
-            pubRow.votes,
-            pubRow.fraction,
-            rowBTC,
-            pubRow.contribution.fiat.toFixed(2) + ' ' + pubRow.contribution.currency
-           ].join(',')
+    return [
+      pub,
+      pubRow.votes,
+      pubRow.fraction,
+      rowBTC,
+      pubRow.contribution.fiat.toFixed(2) + ' ' + pubRow.contribution.currency
+    ].join(',')
   }))
 
   // note: do NOT add a total row if only header row is present (no data case)

--- a/app/dataFile.js
+++ b/app/dataFile.js
@@ -138,10 +138,10 @@ module.exports.init = (resourceName, startExtension, onInitDone, forceDownload) 
 }
 
 module.exports.debug = (resourceName, details, shouldBlock) => {
-  if (!shouldBlock) {
-    return
-  }
   /*
+  if (!shouldBlock) {
+
+  }
   console.log('-----')
   console.log(`${resourceName} should block: `, shouldBlock)
   console.log(details.url)

--- a/app/httpsEverywhere.js
+++ b/app/httpsEverywhere.js
@@ -179,7 +179,6 @@ function onBeforeRedirect (details, isPrivate) {
         console.log('blacklisting url from HTTPS Everywhere for too many 307s',
                     canonicalUrl)
         redirectBlacklist.push(canonicalUrl)
-        return
       }
     } else {
       recent307Counter[canonicalUrl] = 1

--- a/app/ledger.js
+++ b/app/ledger.js
@@ -90,11 +90,12 @@ const synopsisPath = 'ledger-synopsis.json'
 
 var bootP = false
 var client
-const clientOptions = { debugP: process.env.LEDGER_DEBUG,
-                        loggingP: process.env.LEDGER_LOGGING,
-                        verboseP: process.env.LEDGER_VERBOSE,
-                        server: process.env.LEDGER_SERVER_URL
-                      }
+const clientOptions = {
+  debugP: process.env.LEDGER_DEBUG,
+  loggingP: process.env.LEDGER_LOGGING,
+  verboseP: process.env.LEDGER_VERBOSE,
+  server: process.env.LEDGER_SERVER_URL
+}
 
 var doneTimer
 
@@ -117,12 +118,12 @@ var publishers = {}
  */
 
 const msecs = { year: 365 * 24 * 60 * 60 * 1000,
-                week: 7 * 24 * 60 * 60 * 1000,
-                day: 24 * 60 * 60 * 1000,
-                hour: 60 * 60 * 1000,
-                minute: 60 * 1000,
-                second: 1000
-              }
+  week: 7 * 24 * 60 * 60 * 1000,
+  day: 24 * 60 * 60 * 1000,
+  hour: 60 * 60 * 1000,
+  minute: 60 * 1000,
+  second: 1000
+}
 
 /*
  * notification state globals
@@ -1155,13 +1156,13 @@ var cacheRuleSet = (ruleset) => {
       if (rule.dom) {
         if (rule.dom.publisher) {
           entry.publisher = { selector: rule.dom.publisher.nodeSelector,
-                              consequent: acorn.parse(rule.dom.publisher.consequent)
-                            }
+            consequent: acorn.parse(rule.dom.publisher.consequent)
+          }
         }
         if (rule.dom.faviconURL) {
           entry.faviconURL = { selector: rule.dom.faviconURL.nodeSelector,
-                               consequent: acorn.parse(rule.dom.faviconURL.consequent)
-                             }
+            consequent: acorn.parse(rule.dom.faviconURL.consequent)
+          }
         }
       }
       if (!entry.publisher) entry.consequent = rule.consequent ? acorn.parse(rule.consequent) : rule.consequent
@@ -1385,7 +1386,7 @@ var updateLedgerInfo = () => {
   if (info) {
     underscore.extend(ledgerInfo,
                       underscore.pick(info, [ 'address', 'passphrase', 'balance', 'unconfirmed', 'satoshis', 'btc', 'amount',
-                                              'currency' ]))
+                        'currency' ]))
     if ((!info.buyURLExpires) || (info.buyURLExpires > now)) {
       ledgerInfo.buyURL = info.buyURL
       ledgerInfo.buyMaximumUSD = 6
@@ -1394,8 +1395,8 @@ var updateLedgerInfo = () => {
       ledgerInfo.buyURLFrame = true
       ledgerInfo.buyURL = process.env.ADDFUNDS_URL + '?' +
                           querystring.stringify({ currency: ledgerInfo.currency,
-                                                  amount: getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT),
-                                                  address: ledgerInfo.address })
+                            amount: getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT),
+                            address: ledgerInfo.address })
       ledgerInfo.buyMaximumUSD = false
     }
 
@@ -1482,9 +1483,9 @@ var callback = (err, result, delayTime) => {
     entries = []
     results.forEach((entry) => {
       entries.push({ type: 'put',
-                     key: entry.facet + ':' + entry.publisher,
-                     value: JSON.stringify(underscore.omit(entry, [ 'facet', 'publisher' ]))
-                   })
+        key: entry.facet + ':' + entry.publisher,
+        value: JSON.stringify(underscore.omit(entry, [ 'facet', 'publisher' ]))
+      })
     })
 
     v2RulesetDB.batch(entries, (err) => {
@@ -1500,9 +1501,9 @@ var callback = (err, result, delayTime) => {
     entries = []
     results.forEach((entry) => {
       entries.push({ type: 'put',
-                     key: entry.publisher,
-                     value: JSON.stringify(underscore.omit(entry, [ 'publisher' ]))
-                   })
+        key: entry.publisher,
+        value: JSON.stringify(underscore.omit(entry, [ 'publisher' ]))
+      })
       if ((synopsis.publishers[entry.publisher]) &&
           (synopsis.publishers[entry.publisher].options.verified !== entry.verified)) {
         synopsis.publishers[entry.publisher].options.verified = entry.verified
@@ -1616,20 +1617,20 @@ var run = (delayTime) => {
     }
 
     line([ 'publisher',
-           'blockedP', 'stickyP', 'verified',
-           'excluded', 'eligibleP', 'visibleP',
-           'contribP',
-           'duration', 'visits'
-         ])
+      'blockedP', 'stickyP', 'verified',
+      'excluded', 'eligibleP', 'visibleP',
+      'contribP',
+      'duration', 'visits'
+    ])
     entries = synopsis.topN() || []
     entries.forEach((entry) => {
       var publisher = entry.publisher
 
       line([ publisher,
-             blockedP(publisher), stickyP(publisher), synopsis.publishers[publisher].options.verified === true,
-             synopsis.publishers[publisher].options.exclude === true, eligibleP(publisher), visibleP(publisher),
-             contributeP(publisher),
-             Math.round(synopsis.publishers[publisher].duration / 1000), synopsis.publishers[publisher].visits ])
+        blockedP(publisher), stickyP(publisher), synopsis.publishers[publisher].options.verified === true,
+        synopsis.publishers[publisher].options.exclude === true, eligibleP(publisher), visibleP(publisher),
+        contributeP(publisher),
+        Math.round(synopsis.publishers[publisher].duration / 1000), synopsis.publishers[publisher].visits ])
     })
   }
 

--- a/app/pdf.js
+++ b/app/pdf.js
@@ -75,4 +75,3 @@ const renderUrlToPdf = (appState, action, testingMode) => {
 module.exports = {
   renderUrlToPdf
 }
-

--- a/app/renderer/components/bookmarksToolbar.js
+++ b/app/renderer/components/bookmarksToolbar.js
@@ -52,7 +52,6 @@ class BookmarkToolbarButton extends ImmutableComponent {
       }
       e.target = ReactDOM.findDOMNode(this)
       this.props.showBookmarkFolderMenu(this.props.bookmark, e)
-      return
     }
   }
 

--- a/app/renderer/components/menubar.js
+++ b/app/renderer/components/menubar.js
@@ -169,7 +169,6 @@ class Menubar extends ImmutableComponent {
 
       case keyCodes.UP:
         e.preventDefault()
-
     }
   }
   shouldComponentUpdate (nextProps, nextState) {

--- a/app/renderer/components/settings.js
+++ b/app/renderer/components/settings.js
@@ -113,9 +113,7 @@ class SiteSettingCheckbox extends ImmutableComponent {
   }
 
   onClick (e) {
-    if (this.props.disabled || !this.props.hostPattern) {
-      return
-    } else {
+    if (!this.props.disabled || this.props.hostPattern) {
       const value = !!e.target.value
       value === this.props.defaultValue
         ? aboutActions.removeSiteSetting(this.props.hostPattern,

--- a/app/renderer/lib/suggestion.js
+++ b/app/renderer/lib/suggestion.js
@@ -165,8 +165,6 @@ var virtualSite = (sites) => {
       title: sites[0].host,
       lastAccessedTime: (new Date()).getTime()
     })
-  } else {
-    return
   }
 }
 

--- a/app/telemetry.js
+++ b/app/telemetry.js
@@ -86,8 +86,6 @@ function deltaBetween (checkpoint1, checkpoint2) {
   var ts2 = telemetry.get(checkpoint2)
   if (_.isNumber(ts1) && _.isNumber(ts2)) {
     return Math.abs(ts2 - ts1)
-  } else {
-    return
   }
 }
 

--- a/js/about/contributionStatement.js
+++ b/js/about/contributionStatement.js
@@ -170,7 +170,7 @@ class ContributionStatement extends ImmutableComponent {
           <span className='sectionTitle smaller pull-right' data-l10n-id='contributionStatement' />
         </div>
       </div>
-     )
+    )
   }
 
   get contributionDate () {

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -425,10 +425,10 @@ class Main extends ImmutableComponent {
     })
 
     ipc.on(messages.BLOCKED_PAGE, (e, blockType, details) => {
-      const frameProps = frameStateUtil.getFrameByTabId(self.props.windowState, details.tabId)
-      if (!frameProps) {
-        return
-      }
+      // const frameProps = frameStateUtil.getFrameByTabId(self.props.windowState, details.tabId)
+      // if (!frameProps) {
+      //   return
+      // }
     })
 
     ipc.on(messages.HTTPSE_RULE_APPLIED, (e, ruleset, details) => {

--- a/js/components/modalOverlay.js
+++ b/js/components/modalOverlay.js
@@ -13,7 +13,6 @@ var globalInstanceCounter = 0
 var mountedInstances = []
 
 class ModalOverlay extends ImmutableComponent {
-
   componentWillMount () {
     this.instanceId = globalInstanceCounter++
 

--- a/js/components/popupWindow.js
+++ b/js/components/popupWindow.js
@@ -13,7 +13,6 @@ const windowActions = require('../actions/windowActions')
  * Represents a popup window
  */
 class PopupWindow extends ImmutableComponent {
-
   componentWillMount () {
     this.width = this.props.detail.get('width')
     this.height = this.props.detail.get('height')

--- a/js/dispatcher/appDispatcher.js
+++ b/js/dispatcher/appDispatcher.js
@@ -18,7 +18,6 @@ if (typeof chrome !== 'undefined') { // eslint-disable-line
 }
 
 class AppDispatcher {
-
   constructor () {
     this.callbacks = []
     this.promises = []

--- a/js/lib/request.js
+++ b/js/lib/request.js
@@ -27,9 +27,10 @@ module.exports.request = (options, callback) => {
   params = underscore.defaults(underscore.pick(options, [ 'method', 'headers' ]), { headers: {} })
   params.headers['accept-encoding'] = ''
   if (options.payload) {
-    underscore.extend(params, { payload: JSON.stringify(options.payload),
-                                payload_content_type: params.headers['content-type'] || 'application/json; charset=utf-8'
-                              })
+    underscore.extend(params, {
+      payload: JSON.stringify(options.payload),
+      payload_content_type: params.headers['content-type'] || 'application/json; charset=utf-8'
+    })
   }
 
   if (process.env.NODE_ENV === 'development' &&

--- a/preload-httpse.js
+++ b/preload-httpse.js
@@ -58,10 +58,11 @@ var db = new sqlite3.Database('httpse.sqlite', function (err) {
     throw new Error('FATAL: could not open db: ' + err)
   }
 
-  db.exec(['DROP TABLE IF EXISTS rulesets',
-          'CREATE TABLE rulesets (id INTEGER PRIMARY KEY, contents TEXT)',
-          'DROP TABLE IF EXISTS targets',
-          'CREATE TABLE targets (host TEXT UNIQUE, ids TEXT)'].join('; '), function (err) {
+  db.exec([
+    'DROP TABLE IF EXISTS rulesets',
+    'CREATE TABLE rulesets (id INTEGER PRIMARY KEY, contents TEXT)',
+    'DROP TABLE IF EXISTS targets',
+    'CREATE TABLE targets (host TEXT UNIQUE, ids TEXT)'].join('; '), function (err) {
     if (err !== null) {
       throw new Error('FATAL: could not create tables: ' + err)
     }

--- a/test/components/contextMenuTest.js
+++ b/test/components/contextMenuTest.js
@@ -128,7 +128,7 @@ describe('ContextMenu', function () {
         .getValue(this.input).should.eventually.be.equal(this.values[3])
     })
 
-    it('check left/right on non sub menu item', function *() {
+    it('check left/right on non sub menu item', function * () {
       yield this.app.client
         .tabByIndex(0)
         .loadUrl(this.formfill)

--- a/test/components/ledgerPanelAdvancedPanelTest.js
+++ b/test/components/ledgerPanelAdvancedPanelTest.js
@@ -35,7 +35,7 @@ function setup (client) {
     .waitForVisible(urlInput)
 }
 
-function* setupPaymentsTabAndOpenAdvancedSettings (client, tabAlreadyLoaded) {
+function * setupPaymentsTabAndOpenAdvancedSettings (client, tabAlreadyLoaded) {
   yield client
     .tabByIndex(0)
 
@@ -126,8 +126,6 @@ let generateAndSaveRecoveryFile = function (recoveryFilePath, paymentId, passphr
   }
 
   fs.writeFileSync(recoveryFilePath, recoveryFileContents)
-
-  return
 }
 
 describe.skip('Advanced payment panel tests', function () {

--- a/test/components/tabsToolbarTest.js
+++ b/test/components/tabsToolbarTest.js
@@ -13,11 +13,11 @@ describe('tabs toolbar tests', function () {
 
   describe('hamburgerMenu\'s contextMenu appearance test', function () {
     Brave.beforeAll(this)
-    before(function* () {
+    before(function * () {
       yield setup(this.app.client)
     })
 
-    beforeEach(function* () {
+    beforeEach(function * () {
       yield this.app.client
         .click(tabsToolbar)
     })

--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -52,7 +52,6 @@ const rmDir = (dirPath) => {
     fs.rmdirSync(dirPath)
   } catch (e) {
     console.error(e)
-    return
   }
 }
 

--- a/test/unit/app/common/urlParseTest.js
+++ b/test/unit/app/common/urlParseTest.js
@@ -41,4 +41,3 @@ describe('urlParse', function () {
     assert.deepEqual(result1, result2)
   })
 })
-

--- a/test/unit/lib/urlutilTest.js
+++ b/test/unit/lib/urlutilTest.js
@@ -209,17 +209,17 @@ describe('urlutil', function () {
     })
     it('gets subdomain hostname patterns', function () {
       assert.deepEqual(UrlUtil.getHostnamePatterns('https://bar.brave.com'),
-                       ['bar.brave.com',
-                        '*.brave.com',
-                        'bar.*.com',
-                        'bar.brave.*'])
+        ['bar.brave.com',
+          '*.brave.com',
+          'bar.*.com',
+          'bar.brave.*'])
       assert.deepEqual(UrlUtil.getHostnamePatterns('https://foo.bar.brave.com'),
-                       ['foo.bar.brave.com',
-                        '*.bar.brave.com',
-                        'foo.*.brave.com',
-                        'foo.bar.*.com',
-                        'foo.bar.brave.*',
-                        '*.brave.com'])
+        ['foo.bar.brave.com',
+          '*.bar.brave.com',
+          'foo.*.brave.com',
+          'foo.bar.*.com',
+          'foo.bar.brave.*',
+          '*.brave.com'])
     })
   })
 


### PR DESCRIPTION
Auditors: @bsclifton, @nejczdovc
Fix #7492

This PR addressed the following new rules:

```
no-multiple-empty-lines
no-useless-return
generator-star-spacing
padded-blocks
```

Test plan (two steps):

1. With current `standard`, run

```
npm run lint
```

- There should be no linting errors

2. Update standard@9.0.0

- Lint errors should not include:
  - `Too many blank lines at the end of file`...
  - `Unnecessary return statement`
  - `Expected indentation of`...
  - `Missing space after *`
  - `Block must not be padded by blank lines`

**Note:** Most files were updated running `standard --fix`. Below files that were updated manually:

```
main.js (code commented as a reference)
settings.js
dataFile.js
```