### PR TITLE
Simplify badge icon logic

### DIFF
--- a/app/common/state/extensionState.js
+++ b/app/common/state/extensionState.js
@@ -31,10 +31,8 @@ const extensionState = {
     tabId = tabId ? tabId.toString() : '-1'
     let extension = extensionState.getExtensionById(state, extensionId)
     if (extension && extension.get('browserAction')) {
-      let icons = extension.getIn(['manifest', 'icons'])
-      let defaultIcons = extension.getIn(['manifest', 'browser_action', 'default_icon'])
       let tabBrowserAction = extension.getIn(['tabs', tabId]) || Immutable.Map()
-      return extension.get('browserAction').merge({icons, defaultIcons}).merge(tabBrowserAction).merge({base_path: extension.get('base_path')})
+      return extension.get('browserAction').merge(tabBrowserAction).merge({base_path: extension.get('base_path')})
     }
     return null
   },
@@ -89,35 +87,20 @@ const extensionState = {
 
   browserActionBackgroundImage: (browserAction, tabId) => {
     tabId = tabId ? tabId.toString() : '-1'
+    let path = browserAction.get('path')
     let basePath = browserAction.get('base_path')
     if (basePath) {
-      let baseIcons19 = browserAction.getIn(['icons', '19'])
-      let baseIcons38 = browserAction.getIn(['icons', '38'])
-      if (baseIcons19 && baseIcons38) {
+      // Older extensions may provide a string path
+      if (typeof path === 'string') {
         return `-webkit-image-set(
-                  url(${basePath}/${baseIcons19}) 1x,
-                  url(${basePath}/${baseIcons38}) 2x`
+                  url(${basePath}/${path}) 1x`
       }
-      let tabsPath19 = browserAction.getIn(['tabs', tabId, 'path', '19'])
-      let tabsPath38 = browserAction.getIn(['tabs', tabId, 'path', '38'])
-      if (tabsPath19 && tabsPath38) {
-        return `-webkit-image-set(
-                  url(${basePath}/${tabsPath19}) 1x,
-                  url(${basePath}/${tabsPath38}) 2x`
-      }
-      let basePath19 = browserAction.getIn(['path', '19'])
-      let basePath38 = browserAction.getIn(['path', '38'])
+      let basePath19 = path.get('19')
+      let basePath38 = path.get('38')
       if (basePath19 && basePath38) {
         return `-webkit-image-set(
                   url(${basePath}/${basePath19}) 1x,
                   url(${basePath}/${basePath38}) 2x`
-      }
-      let baseIcons16 = browserAction.getIn(['icons', '16'])
-      let baseIcons48 = browserAction.getIn(['icons', '48'])
-      if (baseIcons16 && baseIcons48) {
-        return `-webkit-image-set(
-                  url(${basePath}/${baseIcons16}) 1x,
-                  url(${basePath}/${baseIcons48}) 2x`
       }
     }
     return ''


### PR DESCRIPTION
Removes redundant lookups, invalid considerations, and handles older patterns.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Fixes #6193 

Test Plan:

An extension's manifest file may contain a `browser_action.default_icon` property. This property usually holds an object, but may (in older extensions) hold a string. String paths to images were not being handled by Brave, which caused some extensions (such as Vimium) to have no displayed icon.

To test this, [install the Vimium extension](https://blog.brave.com/loading-chrome-extensions-in-brave/) in your development build of Brave. Vimium's extension ID is dbepggeogbaibhgnhhndojpepiihcmeb. With this extension registered and loaded, running Brave should reveal the Vimium icon near the Brave Shield icon.

This commit also prevents the redundant look-up of `manifest.browser_action.default_icon` (`path` is already [a reference](https://github.com/brave/muon/blob/ef80be0e321a0d8b799a9cc8a577a93c0f21103d/lib/browser/api/extensions.js#L42) to `browser_action.default_icon`). Also, `manifest.icons` should not be the source for browser action icons.