### PR TITLE
'hide sites with <1% usage' should be default on in about:preferences#payments

### DIFF
--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -176,7 +176,7 @@ module.exports = {
     'advanced.hide-excluded-sites': false,
     'advanced.minimum-visit-time': 8,
     'advanced.minimum-visits': 1,
-    'advanced.minimum-percentage': false,
+    'advanced.minimum-percentage': true,
     'advanced.auto-suggest-sites': true,
     'shutdown.clear-history': false,
     'shutdown.clear-downloads': false,


### PR DESCRIPTION
Fixes #7520

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
- bring up a brand new browser with no state
- go to about:preferences#payments
- click on 'Advanced Settings'
- verify that 'Hide sites with less than 1% usage' is enabled