### PR TITLE
Fixes element blocking content on Washington Post

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -42,6 +42,14 @@ let generateBraveManifest = () => {
       {
         run_at: 'document_start',
         all_frames: true,
+        matches: ['https://www.washingtonpost.com/*'],
+        css: [
+          'content/styles/removeEmptyElements.css'
+        ]
+      },
+      {
+        run_at: 'document_start',
+        all_frames: true,
         matches: ['<all_urls>'],
         include_globs: [
           'http://*/*', 'https://*/*', 'file://*', 'data:*', 'about:srcdoc'

--- a/app/extensions/brave/content/styles/removeEmptyElements.css
+++ b/app/extensions/brave/content/styles/removeEmptyElements.css
@@ -1,0 +1,3 @@
+.ad-hideable {
+    display: none !important;
+}


### PR DESCRIPTION
## Test plan
1. Navigate to [any article](https://www.washingtonpost.com/news/food/wp/2017/03/02/a-dishwasher-becomes-a-partner-in-one-of-the-worlds-greatest-restaurants/?tid=pm_lifestyle_pop&utm_term=.f75e15d12fac) on washingtonpost.com
2. Scroll down to read the article
3. After scrolling down, there should NOT be a full-width bar across the top of the content (see screenshot below)
![large-empty-box-wapo](https://cloud.githubusercontent.com/assets/815158/23598278/1ed7e5c6-01ff-11e7-9e2f-974287cb03df.png)


## Description
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Fixes #7510 
