### PR TITLE
Show Flash notification bar if page loads small/hidden Flash elements

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -75,7 +75,8 @@ let generateBraveManifest = () => {
         js: [
           'content/scripts/adInsertion.js',
           'content/scripts/passwordManager.js',
-          'content/scripts/pageInformation.js'
+          'content/scripts/pageInformation.js',
+          'content/scripts/flashListener.js'
         ]
       },
       {

--- a/app/extensions/brave/content/scripts/flashListener.js
+++ b/app/extensions/brave/content/scripts/flashListener.js
@@ -1,0 +1,82 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Whether a src is a .swf file.
+ * If so, returns the origin of the file. Otherwise returns false.
+ * @param {string} src
+ * @return {boolean|string}
+ */
+function isSWF (src) {
+  if (!src) {
+    return false
+  }
+  let a = document.createElement('a')
+  a.href = src
+  if (a.pathname && a.pathname.toLowerCase().endsWith('.swf')) {
+    return a.origin
+  } else {
+    return false
+  }
+}
+
+/**
+ * Whether an element is invisible or very small.
+ * @param {Element} elem
+ * @return {boolean}
+ */
+function isHiddenElement (el) {
+  if (!el) {
+    return false
+  }
+  const minSize = 20
+  if (el.offsetWidth < minSize || el.offsetHeight < minSize) {
+    return true
+  }
+  if (!el.getClientRects().length) {
+    return true
+  }
+  return false
+}
+
+/**
+ * Whether there is a small/hidden flash object on the page
+ * Reference:
+ * https://helpx.adobe.com/flash/kb/flash-object-embed-tag-attributes.html
+ * @param {Element} elem - HTML element to search
+ * @return {Array.<string>}
+ */
+function hasHiddenFlashElement (elem) {
+  let foundElement = Array.from(elem.getElementsByTagName('embed')).some((el) => {
+    return isSWF(el.getAttribute('src')) && isHiddenElement(el)
+  })
+
+  if (foundElement) {
+    return true
+  }
+
+  return Array.from(elem.getElementsByTagName('object')).some((el) => {
+    if (!isHiddenElement(el)) {
+      return false
+    }
+    let origin = isSWF(el.getAttribute('data'))
+    return origin
+      ? true
+      : Array.from(el.getElementsByTagName('param')).some((param) => {
+        let name = param.getAttribute('name')
+        let origin = isSWF(param.getAttribute('value'))
+        return name && ['movie', 'src'].includes(name.toLowerCase()) && origin
+      })
+  })
+}
+
+
+// If Flash is enabled but not runnable, show a permission notification for small
+// Flash elements
+if (chrome.contentSettings.flashEnabled == 'allow' && chrome.contentSettings.plugins != 'allow' && hasHiddenFlashElement(document.documentElement)) {
+  chrome.ipcRenderer.send('dispatch-action', JSON.stringify([{
+    actionType: 'app-flash-permission-requested',
+    location: window.location.href
+  }]))
+}

--- a/test/components/flashTest.js
+++ b/test/components/flashTest.js
@@ -47,4 +47,26 @@ describe('flash install interception', function () {
         return this.getText(notificationBar).then((val) => val.includes('run Flash Player'))
       })
   })
+  it('shows flash notification bar when small element is loaded', function * () {
+    const flashUrl = Brave.server.url('flash_small.html')
+    yield this.app.client
+      .tabByIndex(0)
+      .loadUrl(flashUrl)
+      .windowByUrl(Brave.browserWindowUrl)
+      .waitForExist(notificationBar)
+      .waitUntil(function () {
+        return this.getText(notificationBar).then((val) => val.includes('run Flash Player'))
+      })
+  })
+  it('shows flash notification bar when invisible element is loaded', function * () {
+    const flashUrl = Brave.server.url('flash_invisible.html')
+    yield this.app.client
+      .tabByIndex(0)
+      .loadUrl(flashUrl)
+      .windowByUrl(Brave.browserWindowUrl)
+      .waitForExist(notificationBar)
+      .waitUntil(function () {
+        return this.getText(notificationBar).then((val) => val.includes('run Flash Player'))
+      })
+  })
 })

--- a/test/fixtures/flash_invisible.html
+++ b/test/fixtures/flash_invisible.html
@@ -1,0 +1,5 @@
+<body>
+<div align="center"><object classid="clsid:D27CDB6E-AE6D-11cf-96B8-444553540000" codebase="http://download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=5,0,0,0" width="550" height="200">
+    <object data="nonexistent.swf" width="100" height="100" style="display:none;"></object>
+  </object></div>
+</body>

--- a/test/fixtures/flash_small.html
+++ b/test/fixtures/flash_small.html
@@ -1,0 +1,3 @@
+<body>
+<embed src="https://example.com/nonexistent.swf" width="10" height="10"></embed>
+</body>


### PR DESCRIPTION
Fix https://github.com/brave/browser-laptop/issues/7523

Test Plan:
1. automated flash tests should pass
2. go to a site that has an invisible Flash object. If Flash is globally enabled, it should show the notification bar. @srirambv or @alexwykoff may have an example of such a site.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).