### PR TITLE
Add short domains to url suggestions when long url is present

### DIFF
--- a/app/renderer/lib/suggestion.js
+++ b/app/renderer/lib/suggestion.js
@@ -187,7 +187,7 @@ module.exports.createVirtualHistoryItems = (historySites) => {
   })
   // find groups with more than 2 of the same host
   var multiGroupKeys = _.filter(_.keys(grouped), (k) => {
-    return grouped[k].length > 2
+    return grouped[k].length > 0
   })
   // potentially create virtual history items
   var virtualHistorySites = _.map(multiGroupKeys, (location) => {
@@ -196,5 +196,7 @@ module.exports.createVirtualHistoryItems = (historySites) => {
   virtualHistorySites = _.filter(virtualHistorySites, (site) => {
     return !!site
   })
-  return virtualHistorySites
+  return Immutable.fromJS(_.object(virtualHistorySites.map((site) => {
+    return [site.location, site]
+  })))
 }

--- a/test/unit/lib/urlSuggestionTest.js
+++ b/test/unit/lib/urlSuggestionTest.js
@@ -2,6 +2,7 @@
 const suggestion = require('../../../app/renderer/lib/suggestion')
 const assert = require('assert')
 const Immutable = require('immutable')
+const _ = require('underscore')
 
 require('../braveUnit')
 
@@ -68,13 +69,11 @@ const site3 = Immutable.Map({
 describe('suggestion', function () {
   it('shows virtual history item', function () {
     var history = Immutable.List([site1, site2, site3])
-    var virtual = suggestion.createVirtualHistoryItems(history)
-    assert.ok(virtual.length > 0, 'virtual location created')
-    assert.ok(virtual[0].get('location') === 'http://www.foo.com')
-    assert.ok(virtual[0].get('title') === 'www.foo.com')
-    assert.ok(virtual[0].get('lastAccessedTime') > 0)
-    history = Immutable.List([site1, site2])
-    virtual = suggestion.createVirtualHistoryItems(history)
-    assert.ok(virtual.length === 0, 'virtual location not created')
+    var virtual = suggestion.createVirtualHistoryItems(history).toJS()
+    var keys = _.keys(virtual)
+    assert.ok(keys.length > 0, 'virtual location created')
+    assert.ok(virtual[keys[0]].location === 'http://www.foo.com')
+    assert.ok(virtual[keys[0]].title === 'www.foo.com')
+    assert.ok(virtual[keys[0]].lastAccessedTime > 0)
   })
 })


### PR DESCRIPTION
Auditors: @bbondy

Test Plan:

  1. Clear history
  2. Visit http://www.github.com/brave
  3. Verify one history item in about:history
  4. Open new tab
  5. type 'github'
  6. Verify that http://www.github.com suggestion is present

Fixes: #7533

- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Ran `git rebase -i` to squash commits (if needed).

