### PR TITLE
allow sites to detect flash when shields are down

### DIFF
--- a/js/state/contentSettings.js
+++ b/js/state/contentSettings.js
@@ -266,6 +266,7 @@ const siteSettingsToContentSettings = (currentSiteSettings, defaultContentSettin
       contentSettings = addContentSettings(contentSettings, 'adInsertion', primaryPattern, '*', 'block')
       contentSettings = addContentSettings(contentSettings, 'javascript', primaryPattern, '*', 'allow')
       contentSettings = addContentSettings(contentSettings, 'referer', primaryPattern, '*', 'allow')
+      contentSettings = addContentSettings(contentSettings, 'plugins', primaryPattern, '*', 'allow')
     }
   })
   return contentSettings


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/7549

Auditors: @bridiver

Test Plan:
0. enable flash in preferences
1. go to http://tv-trwam.pl/na-zywo
2. turn off shields. the flash placeholder should appear.

