### PR TITLE
Re-enable ping to stats server for linux

### DIFF
--- a/app/updater.js
+++ b/app/updater.js
@@ -36,7 +36,8 @@ var debug = function (contents) {
 var platforms = {
   'darwin': 'osx',
   'win32x64': 'winx64',
-  'win32ia32': 'winia32'
+  'win32ia32': 'winia32',
+  'linux': 'linux'
 }
 
 // We are storing this as a package variable because a number of functions need access
@@ -52,7 +53,7 @@ exports.updateUrl = function (updates, platform, arch) {
   }
   platformBaseUrl = `${updates.baseUrl}/${Channel.channel()}/${version}/${platforms[platform]}`
   debug(`platformBaseUrl = ${platformBaseUrl}`)
-  if (platform === 'darwin') {
+  if (platform === 'darwin' || platform === 'linux') {
     return platformBaseUrl
   } else {
     if (platform.match(/^win32/)) {


### PR DESCRIPTION
This change re-enables the update check, used to send anonymous stats, for Linux.

The update check does not show the update bar, even if there is a newer version
of the software available. This will be addressed in a later commit.

Testing:

Testing this change from a QA perspective is problematic. These are the steps
I used to test the functionality of the change.

A)

  * Change the version in package.json to a previous release version
  * Build the binary on Linux
  * Launch the browser ensuring:
    * The browser does not crash on update init
    * The updater scheduler is initiated
    * Metadata is retrieved from the updater
    * The updater bar is NOT shown
    * The browser does not crash
    * No attempt is made to update the browser binary

B)

  * Change the browser version in package.json to a non-existent version
  * Build on Linux and launch
  * Ensure no metadata is retrieved
  * Ensure that the ping is recorded in the dw.fc_usage table of stats

Auditors: @bbondy

Implements: #7562

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
