### PR TITLE
Resize favicon when tabs are too small

### DIFF
--- a/app/renderer/components/styles/global.js
+++ b/app/renderer/components/styles/global.js
@@ -111,6 +111,7 @@ const globalStyles = {
     defaultTabPadding: '0 4px',
     defaultIconPadding: '2px',
     iconSize: '16px',
+    narrowIconSize: '12px',
     dialogTopOffset: '30px',
     paymentsMargin: '20px',
     modalPanelHeaderMarginBottom: '.5em',

--- a/app/renderer/components/tabContent.js
+++ b/app/renderer/components/tabContent.js
@@ -65,6 +65,10 @@ class Favicon extends ImmutableComponent {
       : null
   }
 
+  get narrowView () {
+    return this.props.tabProps.get('breakpoint') === 'smallest'
+  }
+
   render () {
     const iconStyles = StyleSheet.create({
       favicon: {backgroundImage: `url(${this.favicon})`}
@@ -73,7 +77,11 @@ class Favicon extends ImmutableComponent {
       ? <TabIcon
         data-test-favicon={this.favicon}
         data-test-id={this.loadingIcon ? 'loading' : 'defaultIcon'}
-        className={css(styles.icon, this.favicon && iconStyles.favicon)}
+        className={css(
+          styles.icon,
+          this.favicon && iconStyles.favicon,
+          this.narrowView && styles.faviconNarrowView
+        )}
         symbol={this.loadingIcon || this.defaultIcon} />
       : null
   }
@@ -272,6 +280,15 @@ const styles = StyleSheet.create({
 
   iconNarrowView: {
     padding: 0
+  },
+
+  faviconNarrowView: {
+    minWidth: globalStyles.spacing.narrowIconSize,
+    width: globalStyles.spacing.narrowIconSize,
+    backgroundSize: globalStyles.spacing.narrowIconSize,
+    padding: '0',
+    fontSize: '10px',
+    backgroundPosition: 'center center'
   },
 
   audioIcon: {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bbondy

Fix #7656

Test Plan:
* Have 20 tabs
* Resize window
* Favicon should be resized when window is too small