### PR TITLE
Advance settings not being clickable

### DIFF
--- a/app/renderer/components/preferences/helpfulHints.js
+++ b/app/renderer/components/preferences/helpfulHints.js
@@ -41,10 +41,9 @@ const styles = StyleSheet.create({
 
   helpfulHints: {
     cursor: 'default',
-    padding: '20px 0 0',
     visibility: 'hidden',
 
-    '@media (min-height: 680px)': {
+    '@media (min-height: 700px)': {
       position: 'absolute',
       bottom: '0',
       visibility: 'visible'


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #7452

## Auditors
@bsclifton @cezaraugusto

## Test Plan
- go to about:preferences
- switch to Russian
- advance settings should always be clickable (wait for a long text)