### PR TITLE
Partial refactoring of about:about with Aphrodite

### DIFF
--- a/js/about/about.js
+++ b/js/about/about.js
@@ -6,6 +6,9 @@ const React = require('react')
 const ImmutableComponent = require('../components/immutableComponent')
 const {aboutUrls, isNavigatableAboutPage} = require('../lib/appUrlUtil')
 
+const {StyleSheet, css} = require('aphrodite/no-important')
+const globalStyles = require('../../app/renderer/components/styles/global')
+
 require('../../less/about/history.less')
 require('../../node_modules/font-awesome/css/font-awesome.css')
 
@@ -16,9 +19,9 @@ class AboutAbout extends ImmutableComponent {
         <div data-l10n-id='aboutPages' className='sectionTitle' />
       </div>
 
-      <div className='siteDetailsPageContent aboutAbout'>
+      <div className='siteDetailsPageContent'>
         <div className='sectionTitle' data-l10n-id='listOfAboutPages' />
-        <ul>
+        <ul className={css(styles.list)}>
           {
             aboutUrls.keySeq().sort().filter((aboutSourceUrl) => isNavigatableAboutPage(aboutSourceUrl)).map((aboutSourceUrl) =>
               <li>
@@ -32,5 +35,11 @@ class AboutAbout extends ImmutableComponent {
     </div>
   }
 }
+
+const styles = StyleSheet.create({
+  list: {
+    marginLeft: `calc(${globalStyles.spacing.aboutPageSectionPadding} * 2)`
+  }
+})
 
 module.exports = <AboutAbout />

--- a/js/about/brave.js
+++ b/js/about/brave.js
@@ -41,7 +41,7 @@ class AboutBrave extends React.Component {
         <div data-l10n-id='aboutBrave' className='sectionTitle' />
       </div>
 
-      <div className='siteDetailsPageContent aboutAbout'>
+      <div className='siteDetailsPageContent aboutBrave'>
         <div className='title'>
           <span className='sectionTitle' data-l10n-id='versionInformation' />
           <ClipboardButton

--- a/less/about/history.less
+++ b/less/about/history.less
@@ -4,7 +4,7 @@
   min-width: 704px;
 
   .siteDetailsPageContent {
-    &.aboutAbout {
+    &.aboutBrave {
       .sortableTable {
         -webkit-user-select: text;
         margin-left: @aboutPageSectionPadding;
@@ -13,9 +13,6 @@
           cursor: auto;
           padding-left: 8px;
         }
-      }
-      ul {
-        margin-left: @aboutPageSectionPadding + @aboutPageSectionPadding;
       }
     }
     .sortableTable {


### PR DESCRIPTION
## Test Plan
1. open about:about

## Description
Addresses #7670

- 'aboutAbout' is replaced with 'aboutBrave' because styles under '.sortableTable' is not used on about:about

TODO: refactor less/about/history.less

Auditors: @cezaraugusto @bsclifton

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
