### PR TITLE
Order the "recently closed" items in History menu in DESC order (top == last closed)

### DIFF
--- a/app/common/lib/menuUtil.js
+++ b/app/common/lib/menuUtil.js
@@ -3,7 +3,7 @@
 
 'use strict'
 
-const Immutable = require('immutable')
+const {makeImmutable} = require('../../common/state/immutableUtil')
 const CommonMenu = require('../../common/commonMenu')
 const messages = require('../../../js/constants/messages')
 const siteTags = require('../../../js/constants/siteTags')
@@ -64,7 +64,7 @@ module.exports.setTemplateItemChecked = (template, label, checked) => {
   const menuItem = getTemplateItem(menu, label)
   if (menuItem.checked !== checked) {
     menuItem.checked = checked
-    return Immutable.fromJS(menu)
+    return makeImmutable(menu)
   }
   return null
 }
@@ -120,6 +120,9 @@ module.exports.createBookmarkTemplateItems = (sites) => {
  */
 module.exports.createRecentlyClosedTemplateItems = (lastClosedFrames) => {
   const payload = []
+
+  lastClosedFrames = makeImmutable(lastClosedFrames)
+
   if (lastClosedFrames && lastClosedFrames.size > 0) {
     payload.push(
       CommonMenu.separatorMenuItem,
@@ -128,7 +131,7 @@ module.exports.createRecentlyClosedTemplateItems = (lastClosedFrames) => {
         enabled: false
       })
 
-    const lastTen = (lastClosedFrames.size < 10) ? lastClosedFrames : lastClosedFrames.slice(-10)
+    const lastTen = ((lastClosedFrames.size < 10) ? lastClosedFrames : lastClosedFrames.slice(-10)).reverse()
     lastTen.forEach((closedFrame) => {
       payload.push({
         label: closedFrame.get('title') || closedFrame.get('location'),

--- a/test/unit/app/common/lib/menuUtilTest.js
+++ b/test/unit/app/common/lib/menuUtilTest.js
@@ -214,7 +214,8 @@ describe('menuUtil tests', function () {
       assert.equal(menuItems[2].label, windowStateClosedFrames.first().get('title'))
       assert.equal(typeof menuItems[2].click === 'function', true)
     })
-    it('only shows the last 10 items', function () {
+
+    it('shows the last 10 items in reverse order (top == last closed)', function () {
       const windowStateClosedFrames = Immutable.fromJS([
         { title: 'site01', location: 'https://brave01.com' },
         { title: 'site02', location: 'https://brave02.com' },
@@ -231,8 +232,24 @@ describe('menuUtil tests', function () {
       const menuItems = menuUtil.createRecentlyClosedTemplateItems(windowStateClosedFrames)
 
       assert.equal(menuItems.length, 12)
-      assert.equal(menuItems[2].label, windowStateClosedFrames.get(1).get('title'))
-      assert.equal(menuItems[11].label, windowStateClosedFrames.get(10).get('title'))
+      assert.equal(menuItems[11].label, windowStateClosedFrames.get(1).get('title'))
+      assert.equal(menuItems[2].label, windowStateClosedFrames.get(10).get('title'))
+    })
+
+    it('returns an empty array if lastClosedFrames is null, empty, or undefined', function () {
+      assert.deepEqual(menuUtil.createRecentlyClosedTemplateItems(), [])
+      assert.deepEqual(menuUtil.createRecentlyClosedTemplateItems(null), [])
+      assert.deepEqual(menuUtil.createRecentlyClosedTemplateItems(Immutable.fromJS([])), [])
+    })
+
+    it('makes the input immutable if passed as mutable', function () {
+      const windowStateClosedFrames = [{
+        title: 'sample',
+        location: 'https://brave.com'
+      }]
+      const menuItems = menuUtil.createRecentlyClosedTemplateItems(windowStateClosedFrames)
+      assert.equal(Array.isArray(menuItems), true)
+      assert.equal(menuItems.length, 3)
     })
   })
 


### PR DESCRIPTION
## Test Plan:
1. Launch Brave and open 5 tabs, each to a unique page
2. Close 4 of the tabs, remembering the order you closed them in
3. Click the History menu
4. Under "Recently closed", the most recently closed tabs should be at the top

## Description
Fixes https://github.com/brave/browser-laptop/issues/7548

Auditors: @jhreis, @NejcZdovc

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).