### PR TITLE
Replace float:right with flex model on alert dialogs

### DIFF
--- a/app/renderer/components/messageBox.js
+++ b/app/renderer/components/messageBox.js
@@ -154,7 +154,8 @@ const styles = StyleSheet.create({
     '-webkit-user-select': 'text'
   },
   buttons: {
-    float: 'right',
+    display: 'flex',
+    justifyContent: 'flex-end',
     marginTop: '1.5em',
     marginBottom: '0.5em'
   }


### PR DESCRIPTION
## Test Plan:
1. Visit http://jsbin.com/fiyojusahu/edit?html,output
2. In the `output` area, click the `Click me to test an alert` button
3. Make sure the buttons are aligned to the right
4. Visit http://jsbin.com/sadunogefu/edit?html,output
5. In the `output` area, click the `Click me to test a confirm` button
6. Make sure the buttons are aligned to the right


## Description
Follow-up of #7107 (https://github.com/brave/browser-laptop/pull/7107#issuecomment-277942100)

Closes #7673

Auditors: @bsclifton, @cezaraugusto 

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).