### PR TITLE
Improvement of buttons on TorrentViewer

### DIFF
--- a/js/webtorrent/components/torrentViewer.js
+++ b/js/webtorrent/components/torrentViewer.js
@@ -46,14 +46,14 @@ class TorrentViewer extends React.Component {
           {titleElem}
           <div className='headerActions'>
             <Button
+              l10nId={mainButtonId}
+              className='primaryButton mainButton'
+              disabled={!!torrent}
+              onClick={() => dispatch('start')} />
+            <Button
               l10nId='saveTorrentFile'
               className='whiteButton saveTorrentFile'
               onClick={() => dispatch('saveTorrentFile')} />
-            <Button
-              l10nId={mainButtonId}
-              className='whiteButton mainButton'
-              disabled={!!torrent}
-              onClick={() => dispatch('start')} />
           </div>
         </div>
 

--- a/less/webtorrent.less
+++ b/less/webtorrent.less
@@ -10,16 +10,7 @@
   min-width: 704px;
 
   .siteDetailsPageHeader {
-    .headerActions > * {
-      float: right;
-    }
     .mainButton {
-      background: linear-gradient(@braveLightOrange, @braveOrange);
-      border: 2px solid transparent;
-      border-top: 2px solid @braveLightOrange;
-      border-bottom: 2px solid @braveOrange;
-      box-shadow: @buttonShadow;
-      color: white;
       font-weight: 400;
     }
   }


### PR DESCRIPTION
- Removed redundant rules, adding "primaryButton" class
- Removed float:right by aligning the buttons on the js file

Fixes #6735

Auditors:

Test Plan:
1. Visit https://codepen.io/ferossity/full/qaezaB/
2. Open any link on the page in a new tab
3. Make sure there is a gap between the buttons on the header


<img width="308" alt="screenshot 2017-03-13 17 44 29" src="https://cloud.githubusercontent.com/assets/3362943/23847211/bc9a2182-0814-11e7-8dfc-bace8a6b4bca.png">

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
