### PR TITLE
Prevent session from being destroyed when errors are raised during cleanAppData

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "file-loader": "^0.8.5",
     "font-awesome": "^4.5.0",
     "font-awesome-webpack": "0.0.4",
+    "fs-extra": "^2.1.2",
     "immutable": "^3.7.5",
     "immutablediff": "^0.4.2",
     "immutablepatch": "brave/immutable-js-patch",

--- a/test/unit/lib/fakeElectron.js
+++ b/test/unit/lib/fakeElectron.js
@@ -30,7 +30,8 @@ const fakeElectron = {
     },
     getPath: (param) => `${process.cwd()}/${param}`,
     getVersion: () => '0.14.0',
-    setLocale: (locale) => {}
+    setLocale: (locale) => {},
+    exit: () => {}
   },
   clipboard: {
     writeText: function () {


### PR DESCRIPTION
Taking a step towards https://github.com/brave/browser-laptop/issues/5512

## unit test coverage
Before
% Stmts: 52.65
% Branch: 45.77
% Funcs: 54.05
% Lines: 53.21

After
% Stmts: 55.33
% Branch: 48.59
% Funcs: 56.41
% Lines: 56.41

## overview
Losing your session sucks- every report by a user means they lost all of their bookmarks and likely didn't have a backup.  This PR takes a small step to help prevent session from being destroyed.  Here's how it works

1. App starts up; loadAppState() is called
2. Data loaded is passed into cleanAppData()
3. If an error occurs (and isn't caught), loadAppState will default to a fresh profile (meaning the user lost their work)
4. This PR will catch specific errors and continue on
  - errors cleaning window state are logged and window state is deleted
  - errors cleaning tab state are logged and tab state is deleted
  - errors clearing history are logged (nothing is deleted)
  - errors while clearing autofill are logged, nothing deleted
5. If something else happens which isn't caught by these handlers, the catch handler will rename the current session file (instead of doing nothing and overwriting it)

Auditors: @lukemulks, @diracdeltas, @bridiver, @bbondy 