### PR TITLE
Remove Brave software links from urlbar suggestions

### DIFF
--- a/js/data/newTabData.js
+++ b/js/data/newTabData.js
@@ -80,3 +80,5 @@ module.exports.topSites = [
       "title": "Brave Browser: Fast AdBlock – Apps para Android no Google Play"
   }
 ]
+
+module.exports.topSiteLocations = module.exports.topSites.map((site) => site.location)

--- a/js/data/newTabData.js
+++ b/js/data/newTabData.js
@@ -10,18 +10,7 @@ const iconPath = getBraveExtUrl('img/newtab/defaultTopSitesIcon')
  */
 const now = Date.now()
 
-module.exports.pinnedTopSites = [
-    {
-      "count": 1,
-      "favicon": `${iconPath}/twitter.png`,
-      "lastAccessedTime": now,
-      "location": "https://twitter.com/brave",
-      "partitionNumber": 0,
-      "tags": [],
-      "themeColor": "rgb(255, 255, 255)",
-      "title": "Brave Software (@brave) | Twitter"
-  }
-]
+module.exports.pinnedTopSites = []
 
 module.exports.topSites = [
   {

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -34,6 +34,7 @@ const Filtering = require('../../app/filtering')
 const basicAuth = require('../../app/browser/basicAuth')
 const webtorrent = require('../../app/browser/webtorrent')
 const windows = require('../../app/browser/windows')
+const { topSiteLocations } = require('../data/newTabData')
 const assert = require('assert')
 
 // state helpers
@@ -421,9 +422,20 @@ const handleAppAction = (action) => {
       appState = appState.set('passwords', new Immutable.List())
       break
     case appConstants.APP_CHANGE_NEW_TAB_DETAIL:
+      // If a site is pinned, add it to the sites if it isn't already there.
+      if (action.newTabPageDetail) {
+        let pinnedTopSites = action.newTabPageDetail.get('pinnedTopSites')
+        if (pinnedTopSites) {
+          pinnedTopSites.forEach((site) => {
+            if (site && topSiteLocations.includes(site.get('location'))) {
+              appState = appState.set('sites', siteUtil.addSite(appState.get('sites'), site))
+            }
+          })
+        }
+      }
       appState = aboutNewTabState.mergeDetails(appState, action)
       if (action.refresh) {
-        appState = aboutNewTabState.setSites(appState, action)
+        appState = aboutNewTabState.setSites(appState)
       }
       break
     case appConstants.APP_POPULATE_HISTORY:


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/7655

Auditors: @bsclifton

Test Plan:
1. open a clean instance of brave
2. type 'face' into the urlbar
3. it should autocomplete to facebook instead of Brave's facebook page

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
