### PR TITLE
Don't auto-close Brave Payments statements

### DIFF
--- a/js/about/contributionStatement.js
+++ b/js/about/contributionStatement.js
@@ -98,11 +98,11 @@ class ContributionStatement extends ImmutableComponent {
     if (transaction) {
       this.setState({transaction: transaction})
 
+      // Pop up the save dialog (but don't close the statement)
       if (!this.state.savedPDF) {
         this.setState({savedPDF: true})
         setTimeout(function () {
           this.renderPdf()
-          window.close()
         }.bind(this), 250)
       }
 


### PR DESCRIPTION
## Test Plan:
1. Launch Brave, have payments enabled, and have a contribution history (if you don't have one, you can run `npm run add-simulated-payment-history` to add one)
2. Go to Preferences > Payments
3. Click the History icon (circle next to the gear) to bring up the contribution list
4. Click any of the contributions to open them
5. Notice it opens the contribution as an about:contributions page and stays open
6. Once the new Muon build is available, it will still prompt the user to save

## Description
It feels like bad UX to have the contribution statement open and then close really quick, especially when the statement itself looks great and has useful information.

This change only prevents the window from auto-closing; it will still prompt to save (we'll need a new Muon before that can be tested. See https://github.com/brave/browser-laptop/issues/7416 for more information)

Fixes https://github.com/brave/browser-laptop/issues/7698

Auditors: @willy-b, @bradleyrichter, @mrose17


- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
