### PR TITLE
Fix failling test for tab themeColor

### DIFF
--- a/test/components/navigationBarTest.js
+++ b/test/components/navigationBarTest.js
@@ -769,7 +769,7 @@ describe('navigationBar tests', function () {
       const page1Url = Brave.server.url('page1.html')
       yield this.app.client.tabByUrl(Brave.newTabUrl).url(page1Url).waitForUrl(page1Url).windowParentByUrl(page1Url)
       let background = yield this.app.client.getCssProperty('[data-test-active-tab]', 'background')
-      assert.equal(background.value, 'rgba(0,0,0,0)linear-gradient(rgb(255,255,255),rgb(243,243,243))repeatscroll0%0%/autopadding-boxborder-box')
+      assert.equal(background.value, 'rgb(255,255,255)nonerepeatscroll0%0%/autopadding-boxborder-box')
     })
 
     // We need a newer electron build first


### PR DESCRIPTION
Auditors: @luixxiul

Test Plan:
Automated test must pass:
✓ Uses the default tab color when one is not specified
```
npm run test -- --grep="Uses the default tab color when one is not specified"
```