### PR TITLE
Restore ability to delete bookmark custom title

### DIFF
--- a/app/renderer/components/addEditBookmarkHanger.js
+++ b/app/renderer/components/addEditBookmarkHanger.js
@@ -38,7 +38,7 @@ class AddEditBookmarkHanger extends ImmutableComponent {
   get displayBookmarkName () {
     const customTitle = this.props.currentDetail.get('customTitle')
     if (customTitle !== undefined && customTitle !== '') {
-      return this.props.currentDetail.get('customTitle')
+      return customTitle || ''
     }
     return this.props.currentDetail.get('title') || ''
   }
@@ -109,7 +109,11 @@ class AddEditBookmarkHanger extends ImmutableComponent {
     if (currentDetail.get('title') === name && name) {
       currentDetail = currentDetail.delete('customTitle')
     } else {
-      currentDetail = currentDetail.set('customTitle', name)
+      // '' is reserved for the default customTitle value of synced bookmarks,
+      // so replace '' with 0 if the user is deleting the customTitle.
+      // Note that non-string bookmark titles fail bookmarkNameValid so they
+      // are not saved.
+      currentDetail = currentDetail.set('customTitle', name || 0)
     }
     windowActions.setBookmarkDetail(currentDetail, this.props.originalDetail, this.props.destinationDetail, this.props.shouldShowLocation, !this.props.isModal)
   }

--- a/test/components/bookmarksTest.js
+++ b/test/components/bookmarksTest.js
@@ -58,6 +58,15 @@ describe('bookmark tests', function () {
           .getValue('#bookmarkName input').should.eventually.be.equal('Custom Page 1')
           .click(doneButton)
       })
+      it('can delete custom title', function * () {
+        yield this.app.client
+          .activateURLMode()
+          .waitForVisible(navigatorBookmarked)
+          .click(navigatorBookmarked)
+          .waitForVisible(doneButton)
+          .keys(Brave.keys.BACKSPACE)
+          .getValue('#bookmarkName input').should.eventually.be.equal('')
+      })
       it('display punycode custom title and location', function * () {
         yield this.app.client
           .activateURLMode()

--- a/test/unit/state/syncUtilTest.js
+++ b/test/unit/state/syncUtilTest.js
@@ -52,6 +52,21 @@ describe('syncUtil', () => {
       }
       assert.deepEqual(syncUtil.createSiteData(bookmark), expectedBookmark)
     })
+
+    it('bookmark with undefined custom title', () => {
+      const bookmark = Object.assign({}, site, {tags: ['bookmark'], customTitle: undefined})
+      const newValue = Object.assign({}, expectedSite.value, {customTitle: undefined})
+      const expectedBookmark = {
+        name: 'bookmark',
+        objectId,
+        value: {
+          site: newValue,
+          isFolder: false,
+          parentFolderObjectId: undefined
+        }
+      }
+      assert.deepEqual(syncUtil.createSiteData(bookmark), expectedBookmark)
+    })
   })
 
   describe('ipcSafeObject()', () => {


### PR DESCRIPTION
Fix #7691

Test Plan:
1. automated bookmark tests should pass
2. try editing a bookmark and fully deleting the title. the title field should be empty.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
