### PR TITLE
Add setting to block all cookies

### DIFF
--- a/app/extensions/brave/content/scripts/block3rdPartyContent.js
+++ b/app/extensions/brave/content/scripts/block3rdPartyContent.js
@@ -2,34 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/**
- * Whether this is running in a third-party document.
- */
-function is3rdPartyDoc () {
-  try {
-    // Try accessing an element that cross-origin frames aren't supposed to
-    window.top.document
-  } catch (e) {
-    if (e.name === 'SecurityError') {
-      return true
-    } else {
-      console.log('got unexpected error accessing window.top.document', e)
-      // Err on the safe side and assume this is a third-party frame
-      return true
-    }
-  }
-  return false
-}
-
 function blockReferer () {
-  if (document.referrer) {
-    // Blocks cross-origin referer
-    var parser = document.createElement('a')
-    parser.href = document.referrer
-    if (parser.origin !== document.location.origin) {
-      window.Document.prototype.__defineGetter__('referrer', () => { return document.location.origin })
-    }
-  }
+  window.Document.prototype.__defineGetter__('referrer', () => { return document.location.origin })
 }
 
 function blockCookie () {
@@ -50,6 +24,6 @@ if (chrome.contentSettings.referer != 'allow' &&
     document.location.origin && document.location.origin !== 'https://youtube.googleapis.com') {
   executeScript(getBlockRefererScript())
 }
-if (chrome.contentSettings.cookies != 'allow' && is3rdPartyDoc()) {
+if (chrome.contentSettings.cookies != 'allow') {
   executeScript(getBlockCookieScript())
 }

--- a/app/extensions/brave/locales/en-US/bravery.properties
+++ b/app/extensions/brave/locales/en-US/bravery.properties
@@ -10,6 +10,7 @@ fingerprintingProtection=Fingerprinting Protection
 adControl=Ad Control
 cookieControl=Cookie Control
 allowAllCookies=Allow all cookies
+blockAllCookies=Block all cookies
 adBlock=Ad Block
 showBraveAds=Show Brave Ads
 adsBlocked={[plural(blockedAdCount)]}

--- a/docs/state.md
+++ b/docs/state.md
@@ -67,6 +67,9 @@ AppStore
   cookieblock: {
     enabled: boolean // enable 3p cookie/referer blocking
   },
+  cookieblockAll: {
+    enabled: boolean // enable all cookie/referer blocking
+  },
   defaultBrowserCheckComplete: boolean, // true to indicate default browser check is complete
   defaultWindowHeight: number, // DEPRECATED (0.12.7); replaced w/ defaultWindowParams.height
   defaultWindowParams: {
@@ -237,7 +240,7 @@ AppStore
   siteSettings: {
     [hostPattern]: {
       adControl: string, // (showBraveAds | blockAds | allowAdsAndTracking)
-      cookieControl: string, // (block3rdPartyCookie | allowAllCookies)
+      cookieControl: string, // (block3rdPartyCookie | allowAllCookies | blockAllCookies)
       fingerprintingProtection: boolean,
       flash: (number|boolean), // approval expiration time if allowed, false if never allow
       fullscreenPermission: boolean,

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -38,6 +38,7 @@ const searchProviders = require('../data/searchProviders')
 
 const adblock = appConfig.resourceNames.ADBLOCK
 const cookieblock = appConfig.resourceNames.COOKIEBLOCK
+const cookieblockAll = appConfig.resourceNames.COOKIEBLOCK_ALL
 const adInsertion = appConfig.resourceNames.AD_INSERTION
 const trackingProtection = appConfig.resourceNames.TRACKING_PROTECTION
 const httpsEverywhere = appConfig.resourceNames.HTTPS_EVERYWHERE
@@ -494,6 +495,7 @@ class ShieldsTab extends ImmutableComponent {
   }
   onChangeCookieControl (e) {
     aboutActions.setResourceEnabled(cookieblock, e.target.value === 'block3rdPartyCookie')
+    aboutActions.setResourceEnabled(cookieblockAll, e.target.value === 'blockAllCookies')
   }
   onToggleSetting (setting, e) {
     aboutActions.setResourceEnabled(setting, e.target.value)
@@ -517,6 +519,7 @@ class ShieldsTab extends ImmutableComponent {
             onChange={this.onChangeCookieControl}>
             <option data-l10n-id='block3rdPartyCookie' value='block3rdPartyCookie' />
             <option data-l10n-id='allowAllCookies' value='allowAllCookies' />
+            <option data-l10n-id='blockAllCookies' value='blockAllCookies' />
           </SettingDropdown>
         </SettingItem>
         <SettingCheckbox checked={this.props.braveryDefaults.get('httpsEverywhere')} dataL10nId='httpsEverywhere' onChange={this.onToggleHTTPSE} />

--- a/js/components/braveryPanel.js
+++ b/js/components/braveryPanel.js
@@ -304,6 +304,7 @@ class BraveryPanel extends ImmutableComponent {
                   <FormDropdown data-test-id='cookieControl' value={this.props.braverySettings.cookieControl} onChange={this.onToggleCookieControl} disabled={!shieldsUp}>
                     <option data-l10n-id='block3rdPartyCookie' value='block3rdPartyCookie' />
                     <option data-l10n-id='allowAllCookies' value='allowAllCookies' />
+                    <option data-l10n-id='blockAllCookies' value='blockAllCookies' />
                   </FormDropdown>
                   <SwitchControl onClick={this.onToggleFp} rightl10nId='fingerprintingProtection' checkedOn={fpEnabled} disabled={!shieldsUp} onInfoClick={this.onInfoClick} infoTitle={config.fingerprintingInfoUrl} className='fingerprintingProtectionSwitch' />
                   <SwitchControl onClick={this.onToggleSafeBrowsing} rightl10nId='safeBrowsing' checkedOn={this.props.braverySettings.safeBrowsing} disabled={!shieldsUp} className='safeBrowsingSwitch' />

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -27,12 +27,16 @@ module.exports = {
     FLASH: 'flash',
     WIDEVINE: 'widevine',
     COOKIEBLOCK: 'cookieblock', // block 3p cookies and referer
+    COOKIEBLOCK_ALL: 'cookieblockAll', // block all cookies and referer
     SITEHACK: 'siteHacks',
     WEBTORRENT: 'webtorrent'
     // ... other optional resource files are identified by uuid such as for regional adblock
   },
   cookieblock: {
     enabled: true
+  },
+  cookieblockAll: {
+    enabled: false
   },
   noScript: {
     enabled: false

--- a/js/state/siteSettings.js
+++ b/js/state/siteSettings.js
@@ -16,6 +16,7 @@ module.exports.braveryDefaults = (appState, appConfig) => {
   let blockAds = defaults[appConfig.resourceNames.ADBLOCK] || false
   let blockTracking = defaults[appConfig.resourceNames.TRACKING_PROTECTION] || false
   let blockCookies = defaults[appConfig.resourceNames.COOKIEBLOCK] || false
+  let blockCookiesAll = defaults[appConfig.resourceNames.COOKIEBLOCK_ALL] || false
   defaults.adControl = 'allowAdsAndTracking'
   if (blockAds && replaceAds && blockTracking) {
     defaults.adControl = 'showBraveAds'
@@ -23,6 +24,9 @@ module.exports.braveryDefaults = (appState, appConfig) => {
     defaults.adControl = 'blockAds'
   }
   defaults.cookieControl = blockCookies ? 'block3rdPartyCookie' : 'allowAllCookies'
+  if (blockCookiesAll) {
+    defaults.cookieControl = 'blockAllCookies'
+  }
 
   // TODO(bridiver) this should work just like the other bravery settings
   let fingerprintingProtection = appState.get('settings').get('privacy.block-canvas-fingerprinting')

--- a/js/state/syncUtil.js
+++ b/js/state/syncUtil.js
@@ -110,7 +110,8 @@ const applySiteSettingRecord = (record) => {
   }
   const cookieControlEnum = {
     0: 'block3rdPartyCookie',
-    1: 'allowAllCookies'
+    1: 'allowAllCookies',
+    2: 'blockAllCookies'
   }
   const getValue = (key, value) => {
     if (key === 'adControl') {
@@ -437,7 +438,8 @@ module.exports.createSiteSettingsData = (hostPattern, setting) => {
   }
   const cookieControlEnum = {
     block3rdPartyCookie: 0,
-    allowAllCookies: 1
+    allowAllCookies: 1,
+    blockAllCookies: 2
   }
   const objectData = {hostPattern}
 

--- a/test/fixtures/cookies.html
+++ b/test/fixtures/cookies.html
@@ -1,0 +1,71 @@
+<body>
+local storage:
+<div id='localstorage'>
+</div>
+session storage:
+<div id='sessionstorage'>
+</div>
+indexeddb:
+<div id='idb'>
+</div>
+cookies:
+<div id='cookies'>
+</div>
+websql:
+<div id='websql'>
+</div>
+filesystem API:
+<div id='fs'>
+</div>
+
+<script>
+function setText (id, result) {
+    document.getElementById(id).innerText = JSON.stringify(result)
+}
+
+// If storage is not blocked, these item values change on every page load.
+// Otherwise they stay at 0.
+try {
+  localStorage['a'] = localStorage['a'] ? localStorage['a'] + 0 : 0
+    setText('localstorage', localStorage.getItem('a'))
+} catch (e) {}
+try {
+  sessionStorage.setItem('b', sessionStorage['b'] ? sessionStorage['b'] + 0 : 0)
+  setText('sessionstorage', sessionStorage['b'])
+} catch (e) {}
+try {
+    document.cookie = 'abc=123'
+    setText('cookies', document.cookie)
+} catch (e) {}
+
+try {
+var idb = indexedDB.open('idb', 1)
+idb.onsuccess = function () {
+   indexedDB.webkitGetDatabaseNames().onsuccess = (sender) => {
+      setText('idb', sender.target.result)
+   }
+}
+} catch (e) {}
+
+try {
+var wdb = openDatabase("wdb", "0.1", "test", 1024 * 1024)
+if (wdb.transaction) {
+wdb.transaction(function (tx) {
+  tx.executeSql("CREATE TABLE IF NOT EXISTS " +
+                "todo(ID INTEGER PRIMARY KEY ASC, todo TEXT, added_on DATETIME)", [])
+});
+wdb.transaction(function(tx) {
+  tx.executeSql("SELECT tbl_name from sqlite_master WHERE type = 'table'", [], function (t, rs) {
+    setText('websql', rs.rows)
+  });
+});
+}
+} catch (e) {}
+
+try {
+webkitRequestFileSystem(PERSISTENT, 1024*1024, (fs) => {
+    setText('fs', fs.name)
+})
+} catch (e) {}
+</script>
+</body>

--- a/test/lib/selectors.js
+++ b/test/lib/selectors.js
@@ -41,6 +41,7 @@ module.exports = {
   blockAdsOption: '[data-l10n-id="blockAds"]',
   cookieControl: '[data-test-id="cookieControl"]',
   allowAllCookiesOption: '[data-l10n-id="allowAllCookies"]',
+  blockAllCookiesOption: '[data-l10n-id="blockAllCookies"]',
   braveryPanel: '.braveryPanel',
   httpsEverywhereStat: '.braveryStat.redirectedResourcesStat',
   httpsEverywhereSwitch: '.httpsEverywhereSwitch .switchMiddle',


### PR DESCRIPTION
fix #1987

Test Plan:
1. automated cookies tests should pass
2. go to https://jsfiddle.net/7ke9r14a/9/ with default cookie settings
3. the page should show blank or "" for all result values
4. in the brave panel, set cookies to "Block all cookies"
5. the page should not load
6. now set cookies to Allow All
7. the page should display non-empty result values

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
