### PR TITLE
Make private tab color predominant

### DIFF
--- a/app/renderer/components/styles/global.js
+++ b/app/renderer/components/styles/global.js
@@ -18,7 +18,8 @@ const globalStyles = {
   color: {
     linkColor: '#0099CC',
     highlightBlue: '#37A9FD',
-    privateTabBackground: '#392e54',
+    privateTabBackground: '#665296',
+    privateTabBackgroundActive: '#4b3c6e',
     bitcoinOrange: '#f7931a',
     chromePrimary: '#F3F3F3',
     chromeSecondary: '#d3d3d3',

--- a/app/renderer/components/styles/tab.js
+++ b/app/renderer/components/styles/tab.js
@@ -99,16 +99,16 @@ const styles = StyleSheet.create({
   },
 
   activePrivateTab: {
-    background: 'rgb(247, 247, 247)',
-    color: 'black'
+    background: globalStyles.color.privateTabBackgroundActive,
+    color: '#fff'
   },
 
   private: {
-    background: '#9c8dc1', // (globalStyles.color.privateTabBackground, 40%)
+    background: globalStyles.color.privateTabBackground,
     color: '#fff',
 
     ':hover': {
-      background: '#665296', // (globalStyles.color.privateTabBackground, 20%)
+      background: globalStyles.color.privateTabBackgroundActive,
       color: '#fff'
     }
   },

--- a/app/renderer/components/tabContent.js
+++ b/app/renderer/components/tabContent.js
@@ -205,7 +205,9 @@ class TabTitle extends ImmutableComponent {
   get themeColor () {
     const themeColor = this.props.tabProps.get('themeColor') || this.props.tabProps.get('computedThemeColor')
     const defaultColor = this.props.tabProps.get('isPrivate') ? globalStyles.color.white100 : globalStyles.color.black100
-    return this.props.isActive && this.props.paintTabs && themeColor
+    const activeNonPrivateTab = !this.props.tabProps.get('isPrivate') && this.props.isActive
+
+    return activeNonPrivateTab && this.props.paintTabs && !!themeColor
       ? getTextColorForBackground(themeColor)
       : defaultColor
   }

--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -262,6 +262,9 @@ class Tab extends ImmutableComponent {
         this.props.isActive && this.props.tab.get('isPrivate') && styles.activePrivateTab,
         playIndicatorBreakpoint && this.canPlayAudio && styles.narrowViewPlayIndicator,
         this.props.isActive && this.themeColor && perPageStyles.themeColor,
+        // Private color should override themeColor
+        this.props.tab.get('isPrivate') && styles.private,
+        this.props.isActive && this.props.tab.get('isPrivate') && styles.activePrivateTab,
         !this.isPinned && this.narrowView && styles.tabNarrowView,
         !this.isPinned && this.narrowestView && styles.tabNarrowestView,
         !this.isPinned && this.props.tab.get('breakpoint') === 'smallest' && styles.tabMinAllowedSize


### PR DESCRIPTION
Auditors: @bsclifton

Fix #7720
Fix #7715 

![purple_is_the_new_private](https://cloud.githubusercontent.com/assets/4672033/23930594/fec96d18-090b-11e7-8dbe-7b10b5e12955.gif)

/cc @bradleyrichter 

Test Plan:
* If a tab is private, it should be purple even if themeColor is defined