### PR TITLE
Follow-up of #7547

### DIFF
--- a/less/bookmarksToolbar.less
+++ b/less/bookmarksToolbar.less
@@ -14,12 +14,10 @@
 }
 
 .bookmarksToolbar {
-  margin-bottom: 5px;
   box-sizing: border-box;
   display: flex;
   flex: 1;
-  padding: 0 var(--bookmarks-toolbar-padding);
-  height: @bookmarksToolbarHeight;
+  padding: 0 var(--bookmarks-toolbar-padding) 8px;
 
   &.allowDragging {
     -webkit-app-region: drag;
@@ -28,13 +26,8 @@
     }
   }
 
-  &.showFavicon {
-    height: @bookmarksToolbarWithFaviconsHeight;
-  }
-
   &.showOnlyFavicon {
-    padding: 0px 0px 0px 10px;
-    margin: 0px;
+    padding: 0 0 7px 10px;
   }
 
   .bookmarkToolbarButton {

--- a/less/bookmarksToolbar.less
+++ b/less/bookmarksToolbar.less
@@ -17,7 +17,7 @@
   box-sizing: border-box;
   display: flex;
   flex: 1;
-  padding: 0 var(--bookmarks-toolbar-padding) 8px;
+  padding: 7px var(--bookmarks-toolbar-padding) 8px;
 
   &.allowDragging {
     -webkit-app-region: drag;
@@ -27,7 +27,18 @@
   }
 
   &.showOnlyFavicon {
-    padding: 0 0 7px 10px;
+    padding: 7px 0 7px 10px;
+  }
+
+  // PR #7740
+  + .tabPages {
+    &.singlePage {
+      height: 0;
+    }
+
+    &:not(.singlePage) {
+      padding-top: 0;
+    }
   }
 
   .bookmarkToolbarButton {

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -622,7 +622,7 @@
 .navigatorWrapper {
   justify-content: space-between;
   align-items: center;
-  margin: 7px 0;
+  margin-top: 7px;
   box-sizing: border-box;
 
   /**

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -622,8 +622,7 @@
 .navigatorWrapper {
   justify-content: space-between;
   align-items: center;
-  margin-top: 1px;
-  height: @navbarHeight;
+  margin: 7px 0;
   box-sizing: border-box;
 
   /**

--- a/less/tabs.less
+++ b/less/tabs.less
@@ -138,7 +138,7 @@
   background: none;
   display: flex;
   height: @tabPagesHeight;
-  padding: 0 0 7px;
+  padding: 7px 0;
   justify-content: center;
   position: relative;
   text-align: center;
@@ -153,7 +153,6 @@
   &.singlePage {
     margin: 0;
     padding: 0;
-    height: 0;
   }
 
   >div {

--- a/less/tabs.less
+++ b/less/tabs.less
@@ -138,7 +138,7 @@
   background: none;
   display: flex;
   height: @tabPagesHeight;
-  margin-bottom: 5px;
+  padding: 0 0 7px;
   justify-content: center;
   position: relative;
   text-align: center;
@@ -151,8 +151,9 @@
   }
 
   &.singlePage {
+    margin: 0;
+    padding: 0;
     height: 0;
-    margin-bottom: 2px;
   }
 
   >div {

--- a/less/variables.less
+++ b/less/variables.less
@@ -77,9 +77,9 @@
 @navbarHeight: 36px;
 @downloadsBarHeight: 50px;
 @tabsToolbarHeight: 24px;
-@tabPagesHeight: 9px;
+@tabPagesHeight: 7px;
 @bookmarksToolbarHeight: 24px;
-@bookmarksToolbarWithFaviconsHeight: 28px;
+@bookmarksToolbarWithFaviconsHeight: 24px;
 @bookmarksFileIconSize: 13px;
 @bookmarksFolderIconSize: 15px;
 


### PR DESCRIPTION
Closes #7739

Auditors:

Test Plan:

**Test case 1 - default status**
1. Clear your profile
2. Start the browser
3. Make sure that the area between the URL bar and the tabs bar is draggable

<img width="257" alt="screenshot 2017-03-16 11 47 29" src="https://cloud.githubusercontent.com/assets/3362943/23980079/d45aee04-0a40-11e7-85dd-c99bd76552e2.png">

**Test case 2 - text only**
4. Open https://github.com/ in a new tab
5. Open https://github.com/features in a new tab
6. Open https://github.com/explore in a new tab
7. Open https://github.com/pricing in a new tab
8. Display the bookmark toolbar
9. Bookmark them **by dragging the lock icon on the URL bar to the bookmark toolbar**
10. Make sure that the area between the bookmarked items and the URL bar is draggable
11. Make sure that the area between the bookmarked items and the tabs bar is draggable

<img width="273" alt="screenshot 2017-03-16 11 56 11" src="https://cloud.githubusercontent.com/assets/3362943/23980081/d46026a8-0a40-11e7-8cd7-0690abb11b79.png">

**Test case 3 - text only with tab sets**
12. Open about:preferences#tabs
13. Set the number of tabs per tab set to 6
14. Open several new tabs to create another tab page
15. Narrow the window size to place the tab page indicators under the bookmarked items
16. Make sure that the area between the tab page indicators and the bookmark bar is draggable (the tiny area between the indicators is NOT draggable)
17. Make sure that the area between the tab page indicators and the tabs bar is draggable

<img width="278" alt="screenshot 2017-03-16 11 57 14" src="https://cloud.githubusercontent.com/assets/3362943/23980082/d461f1f4-0a40-11e7-85e2-5cc197189d48.png">

**Test case 4 - text and favicons with tab sets**
18. Open about:preferences
19. Change "Text only" to "Text and Favicons"
20. Repeat the step 16 and 17
21. Close several tabs to clear the 2nd tab set
22. Make sure that the area around the bookmarks is draggable

<img width="271" alt="screenshot 2017-03-16 11 57 34" src="https://cloud.githubusercontent.com/assets/3362943/23980083/d468c60a-0a40-11e7-9dc6-95e18de4de8f.png">

<img width="270" alt="screenshot 2017-03-17 16 41 48" src="https://cloud.githubusercontent.com/assets/3362943/24033528/b7fb3ec6-0b30-11e7-867a-171cdc472fdc.png">


**Test case 5 - only tab sets**
23. Hide the bookmark toolbar
24. Make sure that the area around the tab page indicators is draggable

<img width="248" alt="screenshot 2017-03-16 11 50 55" src="https://cloud.githubusercontent.com/assets/3362943/23980080/d45bb3ac-0a40-11e7-9c1f-7d7fe605b54e.png">

**Test case 6 - favicon only with and without tab sets**
25. Bookmark several other GitHub pages
26. Open about:preferences
27. Change "Text and Favicons" to "Favicon only"
28. Change window size to place the tab page indicators under the bookmark favicons
29. Repeat the step 16 and 17
29. Close tabs to clear the 2nd tab set
30. Make sure that the area around favicons is draggable

<img width="152" alt="screenshot 2017-03-16 12 31 24" src="https://cloud.githubusercontent.com/assets/3362943/23980822/9a253f14-0a45-11e7-8e3a-e5adefc9c130.png"> <img width="134" alt="screenshot 2017-03-16 12 31 38" src="https://cloud.githubusercontent.com/assets/3362943/23980823/9a28c0d0-0a45-11e7-9a32-4067d51e6dcd.png">

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
