### PR TITLE
Remove string from tab on persistent partition

### DIFF
--- a/app/renderer/components/tabContent.js
+++ b/app/renderer/components/tabContent.js
@@ -147,7 +147,13 @@ class NewSessionIcon extends ImmutableComponent {
   }
 
   get partitionNumber () {
-    return this.props.tabProps.get('partitionNumber')
+    let partition = this.props.tabProps.get('partitionNumber')
+    // Persistent partitions opened by `target="_blank"` will have
+    // *partition-* string first, which causes bad UI. We don't need it for tabs
+    if (typeof partition === 'string') {
+      partition = partition.replace('partition-', '')
+    }
+    return partition
   }
 
   get partitionIndicator () {

--- a/app/renderer/components/tabContent.js
+++ b/app/renderer/components/tabContent.js
@@ -151,7 +151,7 @@ class NewSessionIcon extends ImmutableComponent {
     // Persistent partitions opened by `target="_blank"` will have
     // *partition-* string first, which causes bad UI. We don't need it for tabs
     if (typeof partition === 'string') {
-      partition = partition.replace('partition-', '')
+      partition = partition.replace(/^partition-/i, '')
     }
     return partition
   }

--- a/test/unit/app/renderer/tabContentTest.js
+++ b/test/unit/app/renderer/tabContentTest.js
@@ -264,6 +264,17 @@ describe('tabContent components', function () {
       )
       assert.equal(wrapper.props().symbolContent, 3)
     })
+    it('should read and show partition number for sessions with number set by opener (ex: clicking target=_blank)', function () {
+      const wrapper = shallow(
+        <NewSessionIcon
+          tabProps={
+            Immutable.Map({
+              partitionNumber: 'partition-3'
+            })}
+        />
+      )
+      assert.equal(wrapper.props().symbolContent, 3)
+    })
     it('should show max partition number even if session is bigger', function () {
       const wrapper = shallow(
         <NewSessionIcon


### PR DESCRIPTION
Auditors: @bsclifton

Fix #7716

Issue was caused by persistent partitions being set as string instead of number

Test Plan:
* Open new session tab
* Click on a `target="_blank"` link
* New tab should have only numbers and not `partition-` string on its tab