### PR TITLE
Improve flash hidden element detection

### DIFF
--- a/app/extensions/brave/content/scripts/flashListener.js
+++ b/app/extensions/brave/content/scripts/flashListener.js
@@ -71,12 +71,23 @@ function hasHiddenFlashElement (elem) {
   })
 }
 
-
 // If Flash is enabled but not runnable, show a permission notification for small
 // Flash elements
-if (chrome.contentSettings.flashEnabled == 'allow' && chrome.contentSettings.plugins != 'allow' && hasHiddenFlashElement(document.documentElement)) {
-  chrome.ipcRenderer.send('dispatch-action', JSON.stringify([{
-    actionType: 'app-flash-permission-requested',
-    location: window.location.href
-  }]))
+if (chrome.contentSettings.flashEnabled == 'allow' && chrome.contentSettings.flashAllowed != 'allow') {
+  const maxFlashAttempts = 3
+  let flashAttempts = 0
+  const intervalId = window.setInterval(() => {
+    if (flashAttempts >= maxFlashAttempts) {
+      window.clearInterval(intervalId)
+      return
+    }
+    flashAttempts = flashAttempts + 1
+    if (hasHiddenFlashElement(document.documentElement)) {
+      chrome.ipcRenderer.send('dispatch-action', JSON.stringify([{
+        actionType: 'app-flash-permission-requested',
+        location: window.location.href
+      }]))
+      window.clearInterval(intervalId)
+    }
+  }, 1000)
 }

--- a/js/state/contentSettings.js
+++ b/js/state/contentSettings.js
@@ -97,8 +97,12 @@ const getDefaultUserPrefContentSettings = (braveryDefaults, appSettings, appConf
       setting: 'block',
       primaryPattern: '*'
     }],
-    flashEnabled: [{
+    flashEnabled: [{ // whether flash is installed and enabled
       setting: braveryDefaults.get('flash') ? 'allow' : 'block',
+      primaryPattern: '*'
+    }],
+    flashAllowed: [{ // whether user has expressed intent to run flash
+      setting: 'block',
       primaryPattern: '*'
     }],
     popups: [{
@@ -268,6 +272,7 @@ const siteSettingsToContentSettings = (currentSiteSettings, defaultContentSettin
     }
     if (typeof siteSetting.get('flash') === 'number' && braveryDefaults.get('flash')) {
       contentSettings = addContentSettings(contentSettings, 'plugins', primaryPattern, '*', 'allow', getFlashResourceId())
+      contentSettings = addContentSettings(contentSettings, 'flashAllowed', primaryPattern, '*', 'allow', getFlashResourceId())
     }
     if (typeof siteSetting.get('widevine') === 'number' && braveryDefaults.get('widevine')) {
       contentSettings = addContentSettings(contentSettings, 'plugins', primaryPattern, '*', 'allow', appConfig.widevine.resourceId)


### PR DESCRIPTION
Separates plugin content setting from flashEnabled setting so that shields down
allows tiny flash elements to be detected. Also improves hidden element detection
for slow/delayed element loads.

Fix #4020

Auditors: @srirambv @bbondy

## Test Plan:
1. go to reverso.net with flash enabled in about:preferences and shields down
2. enter something in the box and click translate
3. you should see a flash notification bar. click 'allow'
4. click on the copy-paste icon in the results box. the page should tell you that the text was copied.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
