### PR TITLE
Instantly show newTab title instead of location

### DIFF
--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -85,6 +85,8 @@ class Tab extends ImmutableComponent {
     // to wait for the title to be parsed.
     if (this.props.tab.get('location') === 'about:blank') {
       return locale.translation('aboutBlankTitle')
+    } else if (this.props.tab.get('location') === 'about:newtab') {
+      return locale.translation('newTab')
     }
     // YouTube tries to change the title to add a play icon when
     // there is audio. Since we have our own audio indicator we get

--- a/test/components/tabTest.js
+++ b/test/components/tabTest.js
@@ -74,6 +74,16 @@ describe('tab tests', function () {
       yield this.app.client
         .waitForVisible('webview[partition="persist:default"]')
     })
+
+    it('shows new tab title instead of about:newtab', function * () {
+      yield this.app.client
+        .ipcSend(messages.SHORTCUT_NEW_FRAME)
+        .waitForExist('[data-test-id="tab"][data-frame-key="2"]')
+        .waitUntil(function () {
+          return this.getText('[data-test-id="tab"][data-frame-key="2"]')
+            .then((title) => title === 'New Tab')
+        })
+    })
   })
 
   describe('new tab button', function () {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bbondy

Fix #7724

Test Plan: covered by automated test
```
npm run test -- --grep="shows new tab title instead of about:newtab"
```

## QA steps:

1. Open a new tab by any means (shortcut, plus button, menu)
2. Newtab title should be "New Tab" instead of "about:newtab"