### PR TITLE
show origin for downloaded URLs

### DIFF
--- a/app/renderer/components/downloadItem.js
+++ b/app/renderer/components/downloadItem.js
@@ -10,6 +10,7 @@ const downloadStates = require('../../../js/constants/downloadStates')
 const {PAUSE, RESUME, CANCEL} = require('../../common/constants/electronDownloadItemActions')
 const appActions = require('../../../js/actions/appActions')
 const downloadUtil = require('../../../js/state/downloadUtil')
+const {getOrigin} = require('../../../js/state/siteUtil')
 const cx = require('../../../js/lib/classSet')
 
 class DownloadItem extends ImmutableComponent {
@@ -71,6 +72,7 @@ class DownloadItem extends ImmutableComponent {
     return this.props.download.get('state') === downloadStates.PAUSED
   }
   render () {
+    const origin = getOrigin(this.props.download.get('url'))
     const progressStyle = {
       width: downloadUtil.getPercentageComplete(this.props.download)
     }
@@ -149,6 +151,15 @@ class DownloadItem extends ImmutableComponent {
               this.props.download.get('filename')
             }
           </div>
+          {
+            origin
+              ? <div className={cx({
+                downloadOrigin: true,
+                isSecure: origin.startsWith('https://'),
+                isInsecure: origin.startsWith('http://')
+              })} title={origin}>{origin}</div>
+              : null
+          }
           {
             this.isCancelled || this.isInterrupted || this.isCompleted || this.isPaused || this.isInProgress
             ? <div className='downloadState' data-l10n-id={downloadUtil.getL10nId(this.props.download)} data-l10n-args={JSON.stringify(l10nStateArgs)} />

--- a/less/downloadBar.less
+++ b/less/downloadBar.less
@@ -36,7 +36,7 @@
       display: flex;
       font-size: 11px;
       flex-direction: column;
-      height: 36px;
+      height: 46px;
       padding: 0 14px;
       position: relative;
       margin: auto var(--download-item-margin) auto 0;
@@ -44,7 +44,7 @@
       min-width: var(--download-item-width);
 
       &:hover {
-        height: 62px;
+        height: 72px;
         top: -23px;
 
         .downloadInfo .downloadArrow {
@@ -97,7 +97,7 @@
       .downloadInfo {
         display: flex;
         margin: auto 0;
-        .downloadFilename, .downloadState {
+        .downloadFilename, .downloadState, .downloadOrigin {
           margin: auto 0;
           white-space: nowrap;
           overflow: hidden;
@@ -108,6 +108,14 @@
         .downloadArrow {
           width: 14px;
           margin: auto 0 auto auto;
+        }
+
+        .isSecure {
+          color: #15b106;
+        }
+
+        .isInsecure {
+          color: red;
         }
 
         >span {

--- a/less/variables.less
+++ b/less/variables.less
@@ -76,7 +76,7 @@
 @switchNubTransition: right 100ms;
 
 @navbarHeight: 36px;
-@downloadsBarHeight: 50px;
+@downloadsBarHeight: 60px;
 @tabsToolbarHeight: 24px;
 @tabPagesHeight: 7px;
 @bookmarksToolbarHeight: 24px;

--- a/test/unit/app/renderer/downloadItemTest.js
+++ b/test/unit/app/renderer/downloadItemTest.js
@@ -62,6 +62,10 @@ describe('downloadItem component', function () {
         assert.equal(this.result.find('.downloadFilename').text(), this.download.get('filename'))
       })
 
+      it('origin exists and matches download origin', function () {
+        assert.equal(this.result.find('.downloadOrigin').text(), 'http://www.bradrichter.com')
+      })
+
       const shouldProgressBarExist = [downloadStates.IN_PROGRESS, downloadStates.PAUSED].includes(state)
       it(shouldProgressBarExist ? 'progress bar should exist' : 'progress bar should not exist', function () {
         assert.equal(this.result.find('.downloadProgress').length, shouldProgressBarExist ? 1 : 0)


### PR DESCRIPTION
## test plan:
1. go to https://bing.com, download any of the images. the download bar should appear and show 'https://bing.com' in green.
2. go to http://thehill.com, download any image. the download bar should show 'http://thehill.com' in red.

![screen shot 2017-04-03 at 11 01 37 am](https://cloud.githubusercontent.com/assets/4733304/24623380/0aa07c70-185d-11e7-91fe-5bdee8a7e376.png)


## Description
fix https://github.com/brave/browser-laptop/issues/7468

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
