### PR TITLE
Checks for extension path before using

### DIFF
--- a/app/common/state/extensionState.js
+++ b/app/common/state/extensionState.js
@@ -89,7 +89,7 @@ const extensionState = {
     tabId = tabId ? tabId.toString() : '-1'
     let path = browserAction.get('path')
     let basePath = browserAction.get('base_path')
-    if (basePath) {
+    if (path && basePath) {
       // Older extensions may provide a string path
       if (typeof path === 'string') {
         return `-webkit-image-set(


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Fixes #7775 

Auditors: @bridiver 

Test Plan:

Install any extension that lacks a `manifest.browser_action.default_icon` property. Ensure that Brave loads entirely, in spite of the missing `default_icon` and/or `browser_action` property. One extension that lacks these properties is the Mercury Reader extension (it sets default icons via script).
