### PR TITLE
Update lint style for Standard@9.0.0 - 2nd patch

### DIFF
--- a/app/common/lib/formatUtil.js
+++ b/app/common/lib/formatUtil.js
@@ -106,5 +106,5 @@ module.exports.toLocaleString = (epoch, defaultValue) => {
  */
 module.exports.wrappingClamp = (value, min, max) => {
   const range = (max - min) + 1
-  return value - Math.floor((value - min) / range) * range
+  return value - (Math.floor((value - min) / range) * range)
 }

--- a/app/dataFile.js
+++ b/app/dataFile.js
@@ -69,7 +69,7 @@ module.exports.shouldRedownloadFirst = (resourceName, version) => {
   const lastCheckDate = AppStore.getState().getIn([resourceName, 'lastCheckDate'])
   const lastCheckVersion = AppStore.getState().getIn([resourceName, 'lastCheckVersion'])
   return lastCheckVersion !== version ||
-    lastCheckDate && (new Date().getTime() - lastCheckDate) > appConfig[resourceName].msBetweenRechecks
+    (lastCheckDate && (new Date().getTime() - lastCheckDate) > appConfig[resourceName].msBetweenRechecks)
 }
 
 /**

--- a/app/dates.js
+++ b/app/dates.js
@@ -2,9 +2,9 @@
 var isoWeek = function () {
   var date = new Date()
   date.setHours(0, 0, 0, 0)
-  date.setDate(date.getDate() + 3 - (date.getDay() + 6) % 7)
+  date.setDate(date.getDate() + 3 - ((date.getDay() + 6) % 7))
   var jan4 = new Date(date.getFullYear(), 0, 4)
-  return 1 + Math.round(((date.getTime() - jan4.getTime()) / 86400000 - 3 + (jan4.getDay() + 6) % 7) / 7)
+  return 1 + Math.round((((date.getTime() - jan4.getTime()) / 86400000) - 3 + ((jan4.getDay() + 6) % 7) / 7))
 }
 
 // Local data yyyy-mm-dd (with zero padding)

--- a/app/filtering.js
+++ b/app/filtering.js
@@ -107,7 +107,8 @@ function registerForBeforeRequest (session, partition) {
 
     for (let i = 0; i < beforeRequestFilteringFns.length; i++) {
       let results = beforeRequestFilteringFns[i](details, isPrivate)
-      const isAdBlock = results.resourceName === appConfig.resourceNames.ADBLOCK || appConfig[results.resourceName] && appConfig[results.resourceName].resourceType === adBlockResourceName
+      const isAdBlock = (results.resourceName === appConfig.resourceNames.ADBLOCK) ||
+        (appConfig[results.resourceName] && appConfig[results.resourceName].resourceType === adBlockResourceName)
       const isHttpsEverywhere = results.resourceName === appConfig.resourceNames.HTTPS_EVERYWHERE
       const isTracker = results.resourceName === appConfig.resourceNames.TRACKING_PROTECTION
 
@@ -481,7 +482,7 @@ function updateDownloadState (downloadId, item, state) {
     startTime: downloadItemStartTime || new Date().getTime(),
     savePath: item.getSavePath(),
     url: item.getURL(),
-    filename: item.getSavePath() && path.basename(item.getSavePath()) || item.getFilename(),
+    filename: (item.getSavePath() && path.basename(item.getSavePath())) || item.getFilename(),
     totalBytes: item.getTotalBytes(),
     receivedBytes: item.getReceivedBytes(),
     state
@@ -694,9 +695,9 @@ module.exports.isResourceEnabled = (resourceName, url, isPrivate) => {
   }
 
   if (resourceName === appConfig.resourceNames.ADBLOCK ||
-      appConfig[resourceName] &&
+      (appConfig[resourceName] &&
         appConfig[resourceName].enabled &&
-        appConfig[resourceName].resourceType === adBlockResourceName ||
+        appConfig[resourceName].resourceType === adBlockResourceName) ||
       resourceName === appConfig.resourceNames.TRACKING_PROTECTION) {
     // Check the resource vs the ad control setting
     if (braverySettings.adControl === 'allowAdsAndTracking') {

--- a/app/ledger.js
+++ b/app/ledger.js
@@ -2027,7 +2027,7 @@ const showEnabledNotifications = () => {
   if (reconcileStamp - underscore.now() < msecs.day) {
     if (sufficientBalanceToReconcile()) {
       if (shouldShowNotificationReviewPublishers()) {
-        showNotificationReviewPublishers(reconcileStamp + (ledgerInfo.reconcileFrequency - 2) * msecs.day)
+        showNotificationReviewPublishers(reconcileStamp + ((ledgerInfo.reconcileFrequency - 2) * msecs.day))
       }
     } else if (shouldShowNotificationAddFunds()) {
       showNotificationAddFunds()
@@ -2052,7 +2052,7 @@ const shouldShowNotificationAddFunds = () => {
 }
 
 const showNotificationAddFunds = () => {
-  const nextTime = underscore.now() + 3 * msecs.day
+  const nextTime = underscore.now() + (3 * msecs.day)
   appActions.changeSetting(settings.PAYMENTS_NOTIFICATION_ADD_FUNDS_TIMESTAMP, nextTime)
 
   addFundsMessage = addFundsMessage || locale.translation('addFundsNotification')

--- a/app/renderer/components/bookmarksToolbar.js
+++ b/app/renderer/components/bookmarksToolbar.js
@@ -386,7 +386,7 @@ class BookmarksToolbar extends ImmutableComponent {
   }
   onContextMenu (e) {
     const closest = dnd.closestFromXOffset(this.bookmarkRefs.filter((x) => !!x), e.clientX).selectedRef
-    contextMenus.onTabsToolbarContextMenu(this.activeFrame, closest && closest.props.bookmark || undefined, closest && closest.isDroppedOn, e)
+    contextMenus.onTabsToolbarContextMenu(this.activeFrame, (closest && closest.props.bookmark) || undefined, closest && closest.isDroppedOn, e)
   }
   render () {
     let showFavicon = this.props.showFavicon

--- a/app/renderer/components/urlBar.js
+++ b/app/renderer/components/urlBar.js
@@ -183,7 +183,8 @@ class UrlBar extends ImmutableComponent {
           if (!isLocationUrl && e.ctrlKey) {
             windowActions.loadUrl(this.activeFrame, `www.${location}.com`)
           } else if (this.shouldRenderUrlBarSuggestions &&
-              (typeof this.activeIndex === 'number' && this.activeIndex >= 0 || this.locationValueSuffix && this.autocompleteEnabled)) {
+              ((typeof this.activeIndex === 'number' && this.activeIndex >= 0) ||
+              (this.locationValueSuffix && this.autocompleteEnabled))) {
             // Hack to make alt enter open a new tab for url bar suggestions when hitting enter on them.
             const isDarwin = process.platform === 'darwin'
             if (e.altKey) {
@@ -407,8 +408,8 @@ class UrlBar extends ImmutableComponent {
         (this.props.hasLocationValueSuffix !== prevProps.hasLocationValueSuffix ||
          this.props.urlbar.get('location') !== prevProps.urlbar.get('location'))) {
         this.showAutocompleteResult()
-      } else if (this.props.titleMode !== prevProps.titleMode ||
-          !this.isActive && !this.isFocused) {
+      } else if ((this.props.titleMode !== prevProps.titleMode) ||
+          (!this.isActive && !this.isFocused)) {
         this.setValue(this.locationValue)
       } else if (this.props.urlbar.get('location') !== prevProps.urlbar.get('location') &&
           this.urlInput.value !== this.props.urlbar.get('location')) {

--- a/app/renderer/reducers/urlBarSuggestionsReducer.js
+++ b/app/renderer/reducers/urlBarSuggestionsReducer.js
@@ -129,8 +129,8 @@ const generateNewSuggestionsList = (state) => {
   if (sites) {
     // Filter out Brave default newtab sites and sites with falsey location
     sites = sites.filterNot((site) =>
-      Immutable.is(site.get('tags'), new Immutable.List(['default'])) &&
-      site.get('lastAccessedTime') === 1 ||
+      Immutable.is(site.get('tags'), (new Immutable.List(['default'])) &&
+      site.get('lastAccessedTime') === 1) ||
       !site.get('location')
     )
   }
@@ -278,8 +278,11 @@ const generateNewSuggestionsList = (state) => {
       formatUrl: (frame) => frame.get('location'),
       filterValue: (frame) => !isSourceAboutUrl(frame.get('location')) &&
         frame.get('key') !== activeFrameKey &&
-        (frame.get('title') && frame.get('title').toLowerCase().includes(urlLocationLower) ||
-        frame.get('location') && frame.get('location').toLowerCase().includes(urlLocationLower))}))
+        (
+          (frame.get('title') && frame.get('title').toLowerCase().includes(urlLocationLower)) ||
+          (frame.get('location') && frame.get('location').toLowerCase().includes(urlLocationLower))
+        )
+    }))
   }
 
   // Search suggestions

--- a/app/renderer/suggestionClickHandlers.js
+++ b/app/renderer/suggestionClickHandlers.js
@@ -15,7 +15,7 @@ const navigateSiteClickHandler = (formatUrl) => (site, isForSecondaryAction, shi
   if (isForSecondaryAction) {
     windowActions.newFrame({
       location,
-      partitionNumber: site && site.get && site.get('partitionNumber') || undefined
+      partitionNumber: (site && site.get && site.get('partitionNumber')) || undefined
     }, !!shiftKey)
   } else {
     const activeFrame = getActiveFrame(windowStore.state)

--- a/app/siteHacks.js
+++ b/app/siteHacks.js
@@ -65,8 +65,8 @@ module.exports.init = () => {
 
     if (hack && hack.onBeforeRequest &&
         (hack.enableForAll ||
-         hack.enableForAdblock && Filtering.isResourceEnabled(appConfig.resourceNames.ADBLOCK, mainFrameUrl, isPrivate) ||
-         hack.enableForTrackingProtection && Filtering.isResourceEnabled(appConfig.resourceNames.TRACKING_PROTECTION, mainFrameUrl, isPrivate))) {
+         (hack.enableForAdblock && Filtering.isResourceEnabled(appConfig.resourceNames.ADBLOCK, mainFrameUrl, isPrivate)) ||
+         (hack.enableForTrackingProtection && Filtering.isResourceEnabled(appConfig.resourceNames.TRACKING_PROTECTION, mainFrameUrl, isPrivate)))) {
       const result = hack.onBeforeRequest.call(this, details)
       if (result && result.redirectURL) {
         redirectURL = result.redirectURL

--- a/app/trackingProtection.js
+++ b/app/trackingProtection.js
@@ -36,7 +36,7 @@ const startTrackingProtection = (wnd) => {
     if (firstPartyUrl.protocol && firstPartyUrl.protocol.startsWith('http')) {
       if (!cachedFirstParty.get(firstPartyUrlHost)) {
         let firstPartyHosts = trackingProtection.findFirstPartyHosts(firstPartyUrlHost)
-        cachedFirstParty.set(firstPartyUrlHost, firstPartyHosts && firstPartyHosts.split(',') || [])
+        cachedFirstParty.set(firstPartyUrlHost, (firstPartyHosts && firstPartyHosts.split(',')) || [])
       }
     }
     const urlHost = urlParse(details.url).hostname

--- a/js/about/bookmarks.js
+++ b/js/about/bookmarks.js
@@ -383,8 +383,8 @@ class AboutBookmarks extends React.Component {
     }
     ipc.on(messages.BOOKMARKS_UPDATED, (e, detail) => {
       this.setState({
-        bookmarks: Immutable.fromJS(detail && detail.bookmarks || {}),
-        bookmarkFolders: Immutable.fromJS(detail && detail.bookmarkFolders || {})
+        bookmarks: Immutable.fromJS((detail && detail.bookmarks) || {}),
+        bookmarkFolders: Immutable.fromJS((detail && detail.bookmarkFolders) || {})
       })
     })
   }

--- a/js/about/brave.js
+++ b/js/about/brave.js
@@ -59,7 +59,7 @@ class AboutBrave extends React.Component {
             },
             {
               html: entry.get('name') === 'rev'
-                ? <a target='_blank' href={`https://github.com/brave/browser-laptop/commit/${entry.get('version')}`}>{entry.get('version') && entry.get('version').substring(0, 7) || ''}</a>
+                ? <a target='_blank' href={`https://github.com/brave/browser-laptop/commit/${entry.get('version')}`}>{(entry.get('version') && entry.get('version').substring(0, 7)) || ''}</a>
                 : entry.get('version'),
               value: entry.get('version')
             }

--- a/js/about/downloads.js
+++ b/js/about/downloads.js
@@ -66,7 +66,7 @@ class AboutDownloads extends React.Component {
     }
     ipc.on(messages.DOWNLOADS_UPDATED, (e, detail) => {
       this.setState({
-        downloads: Immutable.fromJS(detail && detail.downloads || {})
+        downloads: Immutable.fromJS((detail && detail.downloads) || {})
           .sort((x, y) => y.get('startTime') - x.get('startTime'))
       })
     })

--- a/js/actions/bookmarkActions.js
+++ b/js/actions/bookmarkActions.js
@@ -32,7 +32,7 @@ const bookmarkActions = {
       if (eventUtil.isForSecondaryAction(e)) {
         windowActions.newFrame({
           location: bookmarkItem.get('location'),
-          partitionNumber: bookmarkItem && bookmarkItem.get && bookmarkItem.get('partitionNumber') || undefined
+          partitionNumber: (bookmarkItem && bookmarkItem.get && bookmarkItem.get('partitionNumber')) || undefined
         }, !!e.shiftKey || getSetting(SWITCH_TO_NEW_TABS))
       } else {
         windowActions.loadUrl(activeFrame, bookmarkItem.get('location'))

--- a/js/components/findbar.js
+++ b/js/components/findbar.js
@@ -87,7 +87,7 @@ class FindBar extends ImmutableComponent {
 
   componentWillUpdate (nextProps) {
     if (nextProps.frameKey !== this.props.frameKey) {
-      this.searchInput.value = nextProps.findDetail && nextProps.findDetail.get('searchString') || ''
+      this.searchInput.value = (nextProps.findDetail && nextProps.findDetail.get('searchString')) || ''
     }
   }
 

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -1025,8 +1025,8 @@ class Frame extends ImmutableComponent {
           return
         }
         windowActions.setFindDetail(this.frame, Immutable.fromJS({
-          numberOfMatches: e.result.matches || this.props.findDetail && this.props.findDetail.get('numberOfMatches') || 0,
-          activeMatchOrdinal: e.result.activeMatchOrdinal || this.props.findDetail && this.props.findDetail.get('activeMatchOrdinal')
+          numberOfMatches: e.result.matches || (this.props.findDetail && this.props.findDetail.get('numberOfMatches')) || 0,
+          activeMatchOrdinal: e.result.activeMatchOrdinal || (this.props.findDetail && this.props.findDetail.get('activeMatchOrdinal'))
         }))
       }
     })
@@ -1119,7 +1119,7 @@ class Frame extends ImmutableComponent {
     }
     const searchString = this.props.findDetail && this.props.findDetail.get('searchString')
     if (searchString) {
-      webviewActions.findInPage(searchString, this.props.findDetail && this.props.findDetail.get('caseSensitivity') || undefined, forward, this.props.findDetail.get('internalFindStatePresent'), this.webview)
+      webviewActions.findInPage(searchString, (this.props.findDetail && this.props.findDetail.get('caseSensitivity')) || undefined, forward, this.props.findDetail.get('internalFindStatePresent'), this.webview)
     }
   }
 

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -341,8 +341,8 @@ class Main extends ImmutableComponent {
     this.loadSearchProviders()
     const activeFrame = frameStateUtil.getActiveFrame(this.props.windowState)
     const activeFramePrev = frameStateUtil.getActiveFrame(prevProps.windowState)
-    const activeFrameTitle = activeFrame && (activeFrame.get('title') || activeFrame.get('location')) || ''
-    const activeFramePrevTitle = activeFramePrev && (activeFramePrev.get('title') || activeFramePrev.get('location')) || ''
+    const activeFrameTitle = (activeFrame && (activeFrame.get('title') || activeFrame.get('location'))) || ''
+    const activeFramePrevTitle = (activeFramePrev && (activeFramePrev.get('title') || activeFramePrev.get('location'))) || ''
     if (activeFrameTitle !== activeFramePrevTitle) {
       currentWindow.setTitle(activeFrameTitle)
     }
@@ -404,7 +404,7 @@ class Main extends ImmutableComponent {
 
       self.props.windowState.get('frames').forEach((frame, i) => {
         if (!frame.get('pinnedLocation') &&
-            (i < currentIndex && isCloseLeft || i > currentIndex && isCloseRight)) {
+            ((i < currentIndex && isCloseLeft) || (i > currentIndex && isCloseRight))) {
           windowActions.closeFrame(self.props.windowState.get('frames'), frame)
         }
       })
@@ -576,7 +576,7 @@ class Main extends ImmutableComponent {
     const height = navigator.getBoundingClientRect().bottom
     if (this.pageY < height && this.props.windowState.getIn(['ui', 'mouseInTitlebar']) !== true) {
       windowActions.setMouseInTitlebar(true)
-    } else if (this.pageY === undefined || this.pageY >= height && this.props.windowState.getIn(['ui', 'mouseInTitlebar']) !== false) {
+    } else if (this.pageY === undefined || (this.pageY >= height && this.props.windowState.getIn(['ui', 'mouseInTitlebar']) !== false)) {
       windowActions.setMouseInTitlebar(false)
     }
   }
@@ -646,7 +646,7 @@ class Main extends ImmutableComponent {
 
   onHamburgerMenu (e) {
     const activeFrame = frameStateUtil.getActiveFrame(this.props.windowState)
-    contextMenus.onHamburgerMenu(activeFrame && activeFrame.get('location') || '', e)
+    contextMenus.onHamburgerMenu((activeFrame && activeFrame.get('location')) || '', e)
   }
 
   onHideSiteInfo () {
@@ -1017,17 +1017,17 @@ class Main extends ImmutableComponent {
                 navbar={activeFrame && activeFrame.get('navbar')}
                 sites={appStateSites}
                 canGoForward={activeTab && activeTab.get('canGoForward')}
-                activeFrameKey={activeFrame && activeFrame.get('key') || undefined}
-                location={activeFrame && activeFrame.get('location') || ''}
-                title={activeFrame && activeFrame.get('title') || ''}
+                activeFrameKey={(activeFrame && activeFrame.get('key')) || undefined}
+                location={(activeFrame && activeFrame.get('location')) || ''}
+                title={(activeFrame && activeFrame.get('title')) || ''}
                 scriptsBlocked={activeFrame && activeFrame.getIn(['noScript', 'blocked'])}
-                partitionNumber={activeFrame && activeFrame.get('partitionNumber') || 0}
-                history={activeFrame && activeFrame.get('history') || emptyList}
-                suggestionIndex={activeFrame && activeFrame.getIn(['navbar', 'urlbar', 'suggestions', 'selectedIndex']) || 0}
+                partitionNumber={(activeFrame && activeFrame.get('partitionNumber')) || 0}
+                history={(activeFrame && activeFrame.get('history')) || emptyList}
+                suggestionIndex={(activeFrame && activeFrame.getIn(['navbar', 'urlbar', 'suggestions', 'selectedIndex'])) || 0}
                 isSecure={activeFrame ? activeFrame.getIn(['security', 'isSecure']) : null}
                 hasLocationValueSuffix={activeFrame && activeFrame.getIn(['navbar', 'urlbar', 'suggestions', 'urlSuffix'])}
-                startLoadTime={activeFrame && activeFrame.get('startLoadTime') || undefined}
-                endLoadTime={activeFrame && activeFrame.get('endLoadTime') || undefined}
+                startLoadTime={(activeFrame && activeFrame.get('startLoadTime')) || undefined}
+                endLoadTime={(activeFrame && activeFrame.get('endLoadTime')) || undefined}
                 loading={activeFrame && activeFrame.get('loading')}
                 bookmarkDetail={this.props.windowState.get('bookmarkDetail')}
                 mouseInTitlebar={this.props.windowState.getIn(['ui', 'mouseInTitlebar'])}
@@ -1185,7 +1185,7 @@ class Main extends ImmutableComponent {
             showFavicon={showFavicon}
             showOnlyFavicon={showOnlyFavicon}
             shouldAllowWindowDrag={shouldAllowWindowDrag && !isWindows}
-            activeFrameKey={activeFrame && activeFrame.get('key') || undefined}
+            activeFrameKey={(activeFrame && activeFrame.get('key')) || undefined}
             windowWidth={window.innerWidth}
             contextMenuDetail={contextMenuDetail}
             sites={appStateSites}
@@ -1219,7 +1219,7 @@ class Main extends ImmutableComponent {
           tabs={this.props.windowState.get('tabs')}
           sites={appStateSites}
           key='tab-bar'
-          activeFrameKey={activeFrame && activeFrame.get('key') || undefined}
+          activeFrameKey={(activeFrame && activeFrame.get('key')) || undefined}
           onMenu={this.onHamburgerMenu}
           hasTabInFullScreen={
             sortedFrames

--- a/js/components/tabPages.js
+++ b/js/components/tabPages.js
@@ -97,7 +97,7 @@ class TabPages extends ImmutableComponent {
         Array.from(new Array(tabPageCount)).map((x, i) =>
           <TabPage
             key={`tabPage-${i}`}
-            frames={this.props.frames.slice(i * this.props.tabsPerTabPage, i * this.props.tabsPerTabPage + this.props.tabsPerTabPage)}
+            frames={this.props.frames.slice(i * this.props.tabsPerTabPage, (i * this.props.tabsPerTabPage) + this.props.tabsPerTabPage)}
             previewTabPage={this.props.previewTabPage}
             index={i}
             sourceDragFromPageIndex={sourceDragFromPageIndex}

--- a/js/components/updateBar.js
+++ b/js/components/updateBar.js
@@ -169,7 +169,7 @@ class UpdateBar extends ImmutableComponent {
     const verbose = this.props.updates.get('verbose')
     let updateStatus = this.props.updates.get('status')
     if (!updateStatus ||
-        !verbose && updateStatus !== UpdateStatus.UPDATE_AVAILABLE ||
+        (!verbose && updateStatus !== UpdateStatus.UPDATE_AVAILABLE) ||
         updateStatus === UpdateStatus.UPDATE_NONE ||
         updateStatus === UpdateStatus.UPDATE_APPLYING_RESTART ||
         updateStatus === UpdateStatus.UPDATE_APPLYING_NO_RESTART) {

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -1299,7 +1299,7 @@ function onNewTabContextMenu (target) {
   const containerRect = target.parentNode.getBoundingClientRect()
   const rect = target.getBoundingClientRect()
 
-  const contextMenuMaxVisibleWidth = rect.right + contextMenuSize / 2
+  const contextMenuMaxVisibleWidth = rect.right + (contextMenuSize / 2)
   const contextMenuHasOverflow = contextMenuMaxVisibleWidth > containerRect.right
 
   const menuTemplate = [

--- a/js/dnd.js
+++ b/js/dnd.js
@@ -58,14 +58,14 @@ module.exports.onDragOver = (dragType, sourceBoundingRect, draggingOverKey, drag
     return
   }
 
-  if (e.clientX > sourceBoundingRect.left && e.clientX < sourceBoundingRect.left + sourceBoundingRect.width / 5 &&
+  if (e.clientX > sourceBoundingRect.left && e.clientX < sourceBoundingRect.left + (sourceBoundingRect.width / 5) &&
     (!draggingOverDetail || !draggingOverDetail.get('draggingOverLeftHalf'))) {
     windowActions.setIsBeingDraggedOverDetail(dragType, draggingOverKey, {
       draggingOverLeftHalf: true,
       draggingOverRightHalf: false
     })
     windowActions.setContextMenuDetail()
-  } else if (e.clientX < sourceBoundingRect.right && e.clientX >= sourceBoundingRect.left + sourceBoundingRect.width / 5 &&
+  } else if (e.clientX < sourceBoundingRect.right && e.clientX >= sourceBoundingRect.left + (sourceBoundingRect.width / 5) &&
     (!draggingOverDetail || !draggingOverDetail.get('draggingOverRightHalf'))) {
     windowActions.setIsBeingDraggedOverDetail(dragType, draggingOverKey, {
       draggingOverLeftHalf: false,
@@ -88,7 +88,7 @@ module.exports.closestFromXOffset = (refs, x) => {
       }
     }
     const rect = refNode.getBoundingClientRect()
-    let currentDistance = Math.abs(x - rect.left + (rect.right - rect.left) / 2)
+    let currentDistance = Math.abs(x - rect.left + ((rect.right - rect.left) / 2))
     if (currentDistance < smallestValue) {
       smallestValue = currentDistance
       selectedRef = ref
@@ -102,13 +102,13 @@ module.exports.closestFromXOffset = (refs, x) => {
 
 module.exports.isLeftSide = (domNode, clientX) => {
   const boundingRect = domNode.getBoundingClientRect()
-  return clientX < boundingRect.left + (boundingRect.right - boundingRect.left) / 2
+  return clientX < boundingRect.left + ((boundingRect.right - boundingRect.left) / 2)
 }
 
 module.exports.isMiddle = (domNode, clientX) => {
   const boundingRect = domNode.getBoundingClientRect()
-  const isLeft = clientX < boundingRect.left + (boundingRect.right - boundingRect.left) / 3
-  const isRight = clientX > boundingRect.right - (boundingRect.right - boundingRect.left) / 3
+  const isLeft = clientX < boundingRect.left + ((boundingRect.right - boundingRect.left) / 3)
+  const isRight = clientX > boundingRect.right - ((boundingRect.right - boundingRect.left) / 3)
   return !isLeft && !isRight
 }
 

--- a/js/dndData.js
+++ b/js/dndData.js
@@ -28,5 +28,5 @@ module.exports.setupDataTransferBraveData = (dataTransfer, dragType, data) => {
 
 module.exports.shouldPrependVerticalItem = (target, clientY) => {
   const boundingRect = target.getBoundingClientRect()
-  return clientY < boundingRect.top + (boundingRect.bottom - boundingRect.top) / 2
+  return clientY < boundingRect.top + ((boundingRect.bottom - boundingRect.top) / 2)
 }

--- a/js/flash.js
+++ b/js/flash.js
@@ -72,7 +72,7 @@ module.exports.showFlashMessageBox = (location, tabId) => {
       appActions.hideNotification(message)
       if (buttonIndex === 1) {
         if (persist) {
-          appActions.changeSiteSetting(origin, 'flash', Date.now() + 7 * 24 * 1000 * 3600)
+          appActions.changeSiteSetting(origin, 'flash', Date.now() + (7 * 24 * 1000 * 3600))
         } else {
           appActions.changeSiteSetting(origin, 'flash', 1)
         }

--- a/js/lib/color.js
+++ b/js/lib/color.js
@@ -16,6 +16,6 @@ module.exports.getTextColorForBackground = (color) => {
     return null
   }
   const [r, g, b] = rgb
-  const yiq = (r * 299 + g * 587 + b * 114) / 1000
+  const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000
   return yiq >= 128 ? 'black' : 'white'
 }

--- a/js/lib/zoom.js
+++ b/js/lib/zoom.js
@@ -6,7 +6,7 @@ const {zoom} = require('../constants/config')
 
 // Each zoomLevel is multiplied by 20 to get the percentage offset from 100
 module.exports.getZoomValuePercentage = (zoomLevel) =>
-  100 + 20 * zoomLevel
+  100 + (20 * zoomLevel)
 
 module.exports.getNextZoomLevel = (currentZoom, zoomIn) => {
   const zoomLevels = zoom.zoomLevels

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -22,8 +22,8 @@ const isBookmarkFolder = (tags) => {
   if (!tags) {
     return false
   }
-  return typeof tags === 'string' && tags === siteTags.BOOKMARK_FOLDER ||
-    tags && typeof tags !== 'string' && tags.includes(siteTags.BOOKMARK_FOLDER)
+  return (typeof tags === 'string' && tags === siteTags.BOOKMARK_FOLDER) ||
+    (tags && typeof tags !== 'string' && tags.includes(siteTags.BOOKMARK_FOLDER))
 }
 
 const isPinnedTab = (tags) => {
@@ -147,14 +147,14 @@ const mergeSiteLastAccessedTime = (oldSiteDetail, newSiteDetail, tag) => {
 // Some details can be copied from the existing siteDetail if null
 // ex: parentFolderId, partitionNumber, and favicon
 const mergeSiteDetails = (oldSiteDetail, newSiteDetail, tag, folderId, order) => {
-  let tags = oldSiteDetail && oldSiteDetail.get('tags') || new Immutable.List()
+  let tags = (oldSiteDetail && oldSiteDetail.get('tags')) || new Immutable.List()
   if (tag) {
     tags = tags.toSet().add(tag).toList()
   }
 
   const customTitle = typeof newSiteDetail.get('customTitle') === 'string'
     ? newSiteDetail.get('customTitle')
-    : (newSiteDetail.get('customTitle') || oldSiteDetail && oldSiteDetail.get('customTitle'))
+    : (newSiteDetail.get('customTitle') || (oldSiteDetail && oldSiteDetail.get('customTitle')))
 
   const lastAccessedTime = mergeSiteLastAccessedTime(oldSiteDetail, newSiteDetail, tag)
 
@@ -179,20 +179,20 @@ const mergeSiteDetails = (oldSiteDetail, newSiteDetail, tag, folderId, order) =>
   if (typeof customTitle === 'string') {
     site = site.set('customTitle', customTitle)
   }
-  if (newSiteDetail.get('parentFolderId') !== undefined || oldSiteDetail && oldSiteDetail.get('parentFolderId')) {
+  if (newSiteDetail.get('parentFolderId') !== undefined || (oldSiteDetail && oldSiteDetail.get('parentFolderId'))) {
     let parentFolderId = newSiteDetail.get('parentFolderId') !== undefined
       ? newSiteDetail.get('parentFolderId') : oldSiteDetail.get('parentFolderId')
     site = site.set('parentFolderId', Number(parentFolderId))
   }
-  if (newSiteDetail.get('partitionNumber') !== undefined || oldSiteDetail && oldSiteDetail.get('partitionNumber')) {
+  if (newSiteDetail.get('partitionNumber') !== undefined || (oldSiteDetail && oldSiteDetail.get('partitionNumber'))) {
     let partitionNumber = newSiteDetail.get('partitionNumber') !== undefined
     ? newSiteDetail.get('partitionNumber') : oldSiteDetail.get('partitionNumber')
     site = site.set('partitionNumber', Number(partitionNumber))
   }
-  if (newSiteDetail.get('favicon') || oldSiteDetail && oldSiteDetail.get('favicon')) {
+  if (newSiteDetail.get('favicon') || (oldSiteDetail && oldSiteDetail.get('favicon'))) {
     site = site.set('favicon', newSiteDetail.get('favicon') || oldSiteDetail.get('favicon'))
   }
-  if (newSiteDetail.get('themeColor') || oldSiteDetail && oldSiteDetail.get('themeColor')) {
+  if (newSiteDetail.get('themeColor') || (oldSiteDetail && oldSiteDetail.get('themeColor'))) {
     site = site.set('themeColor', newSiteDetail.get('themeColor') || oldSiteDetail.get('themeColor'))
   }
   if (site.get('tags').size === 0) {

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -570,7 +570,7 @@ const handleAppAction = (action) => {
     case appConstants.APP_ALLOW_FLASH_ALWAYS:
       {
         const propertyName = action.isPrivate ? 'temporarySiteSettings' : 'siteSettings'
-        const expirationTime = Date.now() + 7 * 24 * 3600 * 1000
+        const expirationTime = Date.now() + (7 * 24 * 3600 * 1000)
         appState = appState.set(propertyName,
           siteSettings.mergeSiteSetting(appState.get(propertyName), siteUtil.getOrigin(action.url), 'flash', expirationTime))
         break

--- a/test/app/sessionStoreTest.js
+++ b/test/app/sessionStoreTest.js
@@ -85,7 +85,7 @@ describe('sessionStore', function () {
           return this.getAppState().then((val) => {
             firstRunTimestamp = val.value.firstRunTimestamp
             return (
-              firstRunTimestamp > (timestamp - 30 * 1000) &&
+              firstRunTimestamp > (timestamp - (30 * 1000)) &&
               firstRunTimestamp <= timestamp
             )
           })

--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -333,8 +333,8 @@ var exports = {
       logVerbose('waitForAddressCount(' + addressCount + ')')
       return this.waitUntil(function () {
         return this.getAppState().then((val) => {
-          const ret = val.value && val.value && val.value.autofill &&
-            val.value.autofill.addresses && val.value.autofill.addresses.guid.length || 0
+          const ret = (val.value && val.value && val.value.autofill &&
+            val.value.autofill.addresses && val.value.autofill.addresses.guid.length) || 0
           logVerbose('waitForAddressCount(' + addressCount + ') => ' + ret)
           return ret
         })
@@ -377,7 +377,7 @@ var exports = {
         return this.getAppState().then((val) => {
           const ret = val.value && val.value.sites && Array.from(Object.values(val.value.sites)).find(
             (site) => site.location === location &&
-              (!waitForTitle || waitForTitle && site.title))
+              (!waitForTitle || (waitForTitle && site.title)))
           logVerbose('waitForSiteEntry("' + location + ', ' + waitForTitle + '") => ' + ret)
           return ret
         })
@@ -390,7 +390,7 @@ var exports = {
         return this.getAppState().then((val) => {
           const ret = val.value && val.value.sites && Array.from(Object.values(val.value.sites)).find(
             (site) => site.location === location &&
-              (!waitForTitle || waitForTitle && site.title))
+              (!waitForTitle || (waitForTitle && site.title)))
           logVerbose('sites:' + JSON.stringify(val.value.sites))
           logVerbose('waitForSiteEntry("' + location + '", ' + waitForTitle + ') => ' + ret)
           return ret
@@ -404,8 +404,8 @@ var exports = {
         return this.getWindowState().then((val) => {
           const bookmarkDetailLocation = val.value && val.value.bookmarkDetail &&
             val.value.bookmarkDetail.currentDetail && val.value.bookmarkDetail.currentDetail.location
-          const bookmarkDetailTitle = val.value && val.value.bookmarkDetail && val.value.bookmarkDetail.currentDetail &&
-            val.value.bookmarkDetail.currentDetail.customTitle || val.value.bookmarkDetail.currentDetail.title
+          const bookmarkDetailTitle = (val.value && val.value.bookmarkDetail && val.value.bookmarkDetail.currentDetail &&
+            val.value.bookmarkDetail.currentDetail.customTitle) || val.value.bookmarkDetail.currentDetail.title
           const ret = bookmarkDetailLocation === location && bookmarkDetailTitle === title
           logVerbose('waitForBookmarkDetail("' + location + '", "' + title + '") => ' + ret +
             ' (bookmarkDetailLocation = ' + bookmarkDetailLocation + ', bookmarkDetailTitle = ' + bookmarkDetailTitle + ')')

--- a/test/tab-components/tabPagesTest.js
+++ b/test/tab-components/tabPagesTest.js
@@ -88,7 +88,7 @@ describe('tab pages', function () {
         yield this.app.client
           .waitForExist(newFrameButton)
           .click(newFrameButton)
-          .waitForElementCount(tabsTabs, (i + 1) % tabsPerPage + 1)
+          .waitForElementCount(tabsTabs, ((i + 1) % tabsPerPage) + 1)
       }
       yield this.app.client
         .waitForElementCount(tabPage, 2)

--- a/tools/lib/simulateLedgerTransactions.js
+++ b/tools/lib/simulateLedgerTransactions.js
@@ -3,7 +3,7 @@ const TxHelpers = require('./transactionHelpers')
 let currentTimestamp = (new Date()).getTime()
 
 const getNthContributionPeriodBack = function (n) {
-  return currentTimestamp - (1000 * 3600 * 24 * 30) * n
+  return currentTimestamp - ((1000 * 3600 * 24 * 30) * n)
 }
 
 function simulateLedgerTransactions (numTx) {


### PR DESCRIPTION
Auditors: @bsclifton, @bbondy

Fix #7492
Follow-up of #7495

This PR addressed [`no-mixed-operators`](http://eslint.org/docs/rules/no-mixed-operators) rule

## Test plan (two steps):

### 1. With current `standard`, run

```
npm run lint
```

- There should be no linting errors

### 2. Install standard@9.0.0 globally

```
npm i -g standard@9.0.0
```

Checkout this PR, under browser-laptop folder, run
```
standard
```

- Lint errors should not include:
  - `Unexpected mix of` ...