### PR TITLE
Filling in some unit testing gaps, add small checks to session code

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -251,7 +251,7 @@ module.exports.cleanAppData = (data, isShutdown) => {
   // Delete temp site settings
   data.temporarySiteSettings = {}
 
-  if (data.settings[settings.CHECK_DEFAULT_ON_STARTUP] === true) {
+  if (data.settings && data.settings[settings.CHECK_DEFAULT_ON_STARTUP] === true) {
     // Delete defaultBrowserCheckComplete state since this is checked on startup
     delete data.defaultBrowserCheckComplete
   }
@@ -272,10 +272,16 @@ module.exports.cleanAppData = (data, isShutdown) => {
   if (clearAutofillData) {
     autofill.clearAutofillData()
     const date = new Date().getTime()
-    data.autofill.addresses.guid = []
-    data.autofill.addresses.timestamp = date
-    data.autofill.creditCards.guid = []
-    data.autofill.creditCards.timestamp = date
+    data.autofill = {
+      addresses: {
+        guid: [],
+        timestamp: date
+      },
+      creditCards: {
+        guid: [],
+        timestamp: date
+      }
+    }
   }
   const clearSiteSettings = isShutdown && getSetting(settings.SHUTDOWN_CLEAR_SITE_SETTINGS) === true
   if (clearSiteSettings) {
@@ -305,8 +311,10 @@ module.exports.cleanAppData = (data, isShutdown) => {
     const clearHistory = isShutdown && getSetting(settings.SHUTDOWN_CLEAR_HISTORY) === true
     if (clearHistory) {
       data.sites = siteUtil.clearHistory(Immutable.fromJS(data.sites)).toJS()
-      delete data.about.history
-      delete data.about.newtab
+      if (data.about) {
+        delete data.about.history
+        delete data.about.newtab
+      }
     }
   }
   if (data.downloads) {

--- a/test/unit/app/sessionStoreTest.js
+++ b/test/unit/app/sessionStoreTest.js
@@ -1,0 +1,489 @@
+/* global describe, before, after, it */
+const mockery = require('mockery')
+const assert = require('assert')
+const sinon = require('sinon')
+const settings = require('../../../js/constants/settings')
+const {makeImmutable} = require('../../../app/common/state/immutableUtil')
+const downloadStates = require('../../../js/constants/downloadStates')
+const siteUtil = require('../../../js/state/siteUtil')
+
+require('../braveUnit')
+
+describe('sessionStore unit tests', function () {
+  let sessionStore
+  const fakeAutofill = {
+    init: () => {},
+    addAutofillAddress: () => {},
+    removeAutofillAddress: () => {},
+    addAutofillCreditCard: () => {},
+    removeAutofillCreditCard: () => {},
+    clearAutocompleteData: () => {},
+    clearAutofillData: () => {}
+  }
+  const fakeTabState = {
+    getPersistentState: (data) => { return makeImmutable(data) }
+  }
+  const fakeWindowState = {
+    getPersistentState: (data) => { return makeImmutable(data) }
+  }
+  const fakeFileSystem = {
+    readFileSync: (path) => {
+      return '{"cleanedOnShutdown": false}'
+    },
+    writeFile: (path, options, callback) => {
+      console.log('calling mocked fs.writeFile')
+      callback()
+    },
+    rename: (oldPath, newPath, callback) => {
+      console.log('calling mocked fs.rename')
+      callback()
+    }
+  }
+  const mockSiteUtil = {
+    clearHistory: (sites, syncCallback) => {
+      return siteUtil.clearHistory(sites, syncCallback)
+    },
+    getSiteKey: (siteDetail) => {
+      return siteUtil.getSiteKey(siteDetail)
+    }
+  }
+  const fakeLocale = {
+    init: (language) => {
+      return new Promise((resolve, reject) => {
+        resolve()
+      })
+    }
+  }
+
+  before(function () {
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    })
+    mockery.registerMock('fs', fakeFileSystem)
+    mockery.registerMock('electron', require('../lib/fakeElectron'))
+    mockery.registerMock('./locale', fakeLocale)
+    mockery.registerMock('../js/state/siteUtil', mockSiteUtil)
+    mockery.registerMock('./autofill', fakeAutofill)
+    mockery.registerMock('./common/state/tabState', fakeTabState)
+    mockery.registerMock('./common/state/windowState', fakeWindowState)
+    mockery.registerMock('../js/settings', { getSetting: (settingKey, settingsCollection, value) => {
+      switch (settingKey) {
+        default: return true
+      }
+    }})
+    sessionStore = require('../../../app/sessionStore')
+  })
+
+  after(function () {
+    mockery.disable()
+  })
+
+  describe('saveAppState', function () {
+    let cleanAppDataStub
+    let cleanSessionDataOnShutdownStub
+
+    before(function () {
+      cleanAppDataStub = sinon.stub(sessionStore, 'cleanAppData').returns({})
+      cleanSessionDataOnShutdownStub = sinon.stub(sessionStore, 'cleanSessionDataOnShutdown')
+    })
+
+    after(function () {
+      cleanAppDataStub.restore()
+      cleanSessionDataOnShutdownStub.restore()
+    })
+
+    it('calls cleanAppData', function () {
+      cleanAppDataStub.reset()
+      return sessionStore.saveAppState({})
+      .then(function (result) {
+        assert.equal(cleanAppDataStub.calledOnce, true)
+      }, function (result) {
+        console.log('failed: ', result)
+        assert.fail()
+      })
+    })
+
+    describe('with isShutdown', function () {
+      it('calls cleanSessionDataOnShutdown if true', function () {
+        cleanSessionDataOnShutdownStub.reset()
+        return sessionStore.saveAppState({}, true)
+        .then(() => {
+          assert.equal(cleanSessionDataOnShutdownStub.calledOnce, true)
+        }, function (result) {
+          console.log('failed: ', result)
+          assert.fail()
+        })
+      })
+
+      it('does not call cleanSessionDataOnShutdown if false', function () {
+        cleanSessionDataOnShutdownStub.reset()
+        return sessionStore.saveAppState({}, false)
+        .then(() => {
+          assert.equal(cleanSessionDataOnShutdownStub.notCalled, true)
+        }, function (result) {
+          console.log('failed: ', result)
+          assert.fail()
+        })
+      })
+    })
+  })
+
+  describe('cleanPerWindowData', function () {
+  })
+
+  describe('cleanAppData', function () {
+    it('clears notifications from the last session', function () {
+      const data = {notifications: ['message 1', 'message 2']}
+      const result = sessionStore.cleanAppData(data)
+      assert.deepEqual(result.notifications, [])
+    })
+
+    it('deletes temp site settings', function () {
+      const data = {temporarySiteSettings: {site1: {setting1: 'value1'}}}
+      const result = sessionStore.cleanAppData(data)
+      assert.deepEqual(result.temporarySiteSettings, {})
+    })
+
+    describe('when CHECK_DEFAULT_ON_STARTUP is true', function () {
+      it('clears defaultBrowserCheckComplete', function () {
+        const data = {
+          settings: {},
+          defaultBrowserCheckComplete: 'test_value'
+        }
+        data.settings[settings.CHECK_DEFAULT_ON_STARTUP] = true
+        const result = sessionStore.cleanAppData(data)
+        assert.equal(result.defaultBrowserCheckComplete, undefined)
+      })
+    })
+
+    describe('with recovery status', function () {
+      it('deletes status if present', function () {
+        const data = {
+          ui: {
+            about: {
+              preferences: { recoverySucceeded: true }
+            }
+          }
+        }
+        const result = sessionStore.cleanAppData(data)
+        assert.deepEqual(result.ui.about.preferences.recoverySucceeded, undefined)
+        assert.deepEqual(result.ui.about.preferences, {})
+      })
+
+      it('does not throw an exception if not present', function () {
+        const data = {
+          ui: {}
+        }
+        const result = sessionStore.cleanAppData(data)
+        assert.deepEqual(result.ui, {})
+      })
+    })
+
+    describe('if perWindowState is present', function () {
+      it('calls cleanPerWindowData for each item', function () {
+        const cleanPerWindowDataStub = sinon.stub(sessionStore, 'cleanPerWindowData')
+        const data = {
+          perWindowState: ['window1', 'window2']
+        }
+        sessionStore.cleanAppData(data, 'IS_SHUTDOWN_VALUE')
+        assert.equal(cleanPerWindowDataStub.withArgs('window1', 'IS_SHUTDOWN_VALUE').calledOnce, true)
+        assert.equal(cleanPerWindowDataStub.withArgs('window2', 'IS_SHUTDOWN_VALUE').calledOnce, true)
+        cleanPerWindowDataStub.restore()
+      })
+    })
+
+    describe('when clearAutocompleteData is true', function () {
+      it('calls autofill.clearAutocompleteData', function () {
+        const clearAutocompleteDataSpy = sinon.spy(fakeAutofill, 'clearAutocompleteData')
+        const data = {}
+        sessionStore.cleanAppData(data, true)
+        assert.equal(clearAutocompleteDataSpy.calledOnce, true)
+        clearAutocompleteDataSpy.restore()
+      })
+    })
+
+    describe('when clearAutofillData is true', function () {
+      describe('happy path', function () {
+        let clearAutofillDataSpy
+        let result
+        let clock
+        let now
+
+        before(function () {
+          clearAutofillDataSpy = sinon.spy(fakeAutofill, 'clearAutofillData')
+          clock = sinon.useFakeTimers()
+          now = new Date(0)
+          const data = {
+            autofill: {
+              addresses: {
+                guid: ['value1', 'value2'],
+                timestamp: 'time1'
+              },
+              creditCards: {
+                guid: ['value3', 'value4'],
+                timestamp: 'time2'
+              }
+            }
+          }
+          result = sessionStore.cleanAppData(data, true)
+        })
+
+        after(function () {
+          clearAutofillDataSpy.restore()
+          clock.restore()
+        })
+
+        it('calls autofill.clearAutofillData', function () {
+          assert.equal(clearAutofillDataSpy.calledOnce, true)
+        })
+
+        it('sets the guid for addresses to []', function () {
+          assert.deepEqual(result.autofill.addresses.guid, [])
+        })
+
+        it('sets the timestamp for addresses to now', function () {
+          assert.equal(result.autofill.addresses.timestamp, now.getTime())
+        })
+
+        it('sets the guid for creditCards to []', function () {
+          assert.deepEqual(result.autofill.creditCards.guid, [])
+        })
+
+        it('sets the timestamp for creditCards to now', function () {
+          assert.equal(result.autofill.creditCards.timestamp, now.getTime())
+        })
+      })
+
+      describe('malformed input', function () {
+        it('does not throw an exception', function () {
+          sessionStore.cleanAppData({}, true)
+          sessionStore.cleanAppData({autofill: 'stringValue'}, true)
+          sessionStore.cleanAppData({autofill: {}}, true)
+          sessionStore.cleanAppData({autofill: {addresses: 'stringValue'}}, true)
+          sessionStore.cleanAppData({autofill: {creditCards: 'stringValue'}}, true)
+        })
+      })
+    })
+
+    describe('when clearSiteSettings is true', function () {
+      it('clears siteSettings', function () {
+        const data = {siteSettings: {site1: {setting1: 'value1'}}}
+        const result = sessionStore.cleanAppData(data, true)
+        assert.deepEqual(result.siteSettings, {})
+      })
+    })
+
+    describe('with siteSettings', function () {
+      it('deletes Flash approval if expired', function () {
+        const data = {
+          siteSettings: {
+            site1: {flash: 1, test: 2}
+          }
+        }
+        const result = sessionStore.cleanAppData(data, false)
+        assert.equal(result.siteSettings.site1.flash, undefined)
+      })
+
+      it('leaves Flash approval alone if not expired', function () {
+        const data = {
+          siteSettings: {
+            site1: {flash: Infinity, test: 2}
+          }
+        }
+        const result = sessionStore.cleanAppData(data, false)
+        assert.equal(result.siteSettings.site1.flash, Infinity)
+      })
+
+      it('deletes NoScript approval if set', function () {
+        const data = {
+          siteSettings: {
+            site1: {noScript: 1, test: 2}
+          }
+        }
+        const result = sessionStore.cleanAppData(data, false)
+        assert.equal(result.siteSettings.noScript, undefined)
+      })
+
+      it('deletes NoScript exceptions', function () {
+        const data = {
+          siteSettings: {
+            site1: {noScriptExceptions: true, test: 2}
+          }
+        }
+        const result = sessionStore.cleanAppData(data, false)
+        assert.equal(result.siteSettings.site1.noScriptExceptions, undefined)
+      })
+
+      it('deletes runInsecureContent', function () {
+        const data = {
+          siteSettings: {
+            site1: {runInsecureContent: true, test: 2}
+          }
+        }
+        const result = sessionStore.cleanAppData(data, false)
+        assert.equal(result.siteSettings.site1.runInsecureContent, undefined)
+      })
+
+      it('deletes entry if empty', function () {
+        const data = {
+          siteSettings: {
+            site1: {}
+          }
+        }
+        const result = sessionStore.cleanAppData(data, false)
+        assert.equal(result.siteSettings.site1, undefined)
+      })
+    })
+
+    describe('when sites and clearHistory are truthy', function () {
+      it('calls siteUtil.clearHistory', function () {
+        const clearHistorySpy = sinon.spy(siteUtil, 'clearHistory')
+        const data = {
+          sites: {entry1: {}}
+        }
+        sessionStore.cleanAppData(data, true)
+        assert.equal(clearHistorySpy.calledOnce, true)
+        clearHistorySpy.restore()
+      })
+      it('deletes temporary entries used in about:history', function () {
+        const data = {
+          about: {history: true},
+          sites: {entry1: {}}
+        }
+        const result = sessionStore.cleanAppData(data, true)
+        assert.equal(result.about.history, undefined)
+      })
+      it('deletes top site entries used in about:newtab', function () {
+        const data = {
+          about: {newtab: true},
+          sites: {entry1: {}}
+        }
+        const result = sessionStore.cleanAppData(data, true)
+        assert.equal(result.about.newtab, undefined)
+      })
+    })
+
+    describe('when downloads is truthy', function () {
+      describe('when clearDownloads is true', function () {
+        it('deletes downloads', function () {
+          const data = {
+            downloads: {
+              entry1: {}
+            }
+          }
+          const result = sessionStore.cleanAppData(data, true)
+          assert.equal(result.downloads, undefined)
+        })
+      })
+
+      describe('when clearDownloads is falsey', function () {
+        it('deletes entries which are more than a week old', function () {
+          const data = {
+            downloads: {
+              entry1: {startTime: 1}
+            }
+          }
+          const result = sessionStore.cleanAppData(data, false)
+          assert.deepEqual(result.downloads, {})
+        })
+
+        it('leaves entries which are less than a week old', function () {
+          const data = {
+            downloads: {
+              entry1: {startTime: new Date().getTime()}
+            }
+          }
+          const result = sessionStore.cleanAppData(data, false)
+          assert.deepEqual(result.downloads, data.downloads)
+        })
+
+        describe('with download state', function () {
+          const getEntry = (state) => {
+            return {
+              downloads: {
+                entry1: {startTime: new Date().getTime(), state: state}
+              }
+            }
+          }
+
+          it('sets IN_PROGRESS to INTERRUPTED', function () {
+            const data = getEntry(downloadStates.IN_PROGRESS)
+            const result = sessionStore.cleanAppData(data, false)
+            assert.equal(result.downloads.entry1.state, downloadStates.INTERRUPTED)
+          })
+
+          it('sets PAUSED to INTERRUPTED', function () {
+            const data = getEntry(downloadStates.PAUSED)
+            const result = sessionStore.cleanAppData(data, false)
+            assert.equal(result.downloads.entry1.state, downloadStates.INTERRUPTED)
+          })
+
+          it('leaves other states alone', function () {
+            let data = getEntry(downloadStates.COMPLETED)
+            let result = sessionStore.cleanAppData(data, false)
+            assert.equal(result.downloads.entry1.state, downloadStates.COMPLETED)
+
+            data = getEntry(downloadStates.CANCELLED)
+            result = sessionStore.cleanAppData(data, false)
+            assert.equal(result.downloads.entry1.state, downloadStates.CANCELLED)
+
+            data = getEntry(downloadStates.PENDING)
+            result = sessionStore.cleanAppData(data, false)
+            assert.equal(result.downloads.entry1.state, downloadStates.PENDING)
+          })
+        })
+      })
+    })
+
+    it('calls tabState.getPersistentState', function () {
+      const getPersistentStateSpy = sinon.spy(fakeTabState, 'getPersistentState')
+      const data = {}
+      sessionStore.cleanAppData(data)
+      assert.equal(getPersistentStateSpy.calledOnce, true)
+      getPersistentStateSpy.restore()
+    })
+
+    it('calls windowState.getPersistentState', function () {
+      const getPersistentStateSpy = sinon.spy(fakeWindowState, 'getPersistentState')
+      const data = {}
+      sessionStore.cleanAppData(data)
+      assert.equal(getPersistentStateSpy.calledOnce, true)
+      getPersistentStateSpy.restore()
+    })
+
+    describe('with data.extensions', function () {
+    })
+  })
+
+  describe('cleanSessionDataOnShutdown', function () {
+  })
+
+  describe('loadAppState', function () {
+    let cleanAppDataStub
+    before(function () {
+      cleanAppDataStub = sinon.stub(sessionStore, 'cleanAppData')
+    })
+
+    after(function () {
+      cleanAppDataStub.restore()
+    })
+
+    it('calls cleanAppData if data.cleanedOnShutdown !== true', function () {
+      return sessionStore.loadAppState()
+      .then(function (result) {
+        assert.equal(cleanAppDataStub.calledOnce, true)
+      }, function (result) {
+        console.log('failed: ', result)
+        assert.fail()
+      })
+    })
+  })
+
+  describe('defaultAppState', function () {
+  })
+
+  describe('isProtocolHandled', function () {
+  })
+})

--- a/test/unit/js/components/frameTest.js
+++ b/test/unit/js/components/frameTest.js
@@ -1,0 +1,103 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* global describe, before, after, it */
+
+const mockery = require('mockery')
+const {shallow} = require('enzyme')
+const sinon = require('sinon')
+const assert = require('assert')
+let Frame
+require('../../braveUnit')
+
+describe('Frame component unit tests', function () {
+  const fakeWindowActions = {
+    setActiveFrameShortcut: () => {},
+    setFindbarShown: () => {}
+  }
+
+  before(function () {
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    })
+
+    mockery.registerMock('../../extensions/brave/img/urlbar/browser_URL_fund_no_verified.svg', {})
+    mockery.registerMock('../../extensions/brave/img/urlbar/browser_URL_fund_yes_verified.svg', {})
+    mockery.registerMock('../../extensions/brave/img/urlbar/browser_URL_fund_no.svg', {})
+    mockery.registerMock('../../extensions/brave/img/urlbar/browser_URL_fund_yes.svg', {})
+    mockery.registerMock('../../extensions/brave/img/caret_down_grey.svg', 'caret_down_grey.svg')
+    mockery.registerMock('electron', require('../../lib/fakeElectron'))
+    mockery.registerMock('../actions/windowActions', fakeWindowActions)
+    Frame = require('../../../../js/components/frame')
+  })
+
+  after(function () {
+    mockery.disable()
+  })
+
+  const expectCall = (shortcut, expectedCall, expectedArgs) => {
+    const wrapper = shallow(
+      <Frame activeShortcut={shortcut} />
+    )
+    const instance = wrapper.instance()
+    const expectedCallSpy = sinon.spy(instance, expectedCall)
+    instance.handleShortcut()
+    if (expectedArgs) {
+      assert.equal(expectedCallSpy.withArgs(expectedArgs).calledOnce, true)
+    } else {
+      assert.equal(expectedCallSpy.calledOnce, true)
+    }
+    expectedCallSpy.restore()
+  }
+
+  const expectWindowActionCall = (shortcut, expectedCall, expectNoCalls) => {
+    const wrapper = shallow(
+      <Frame activeShortcut={shortcut} />
+    )
+    const instance = wrapper.instance()
+    const expectedCallSpy = sinon.spy(fakeWindowActions, expectedCall)
+    instance.handleShortcut()
+    if (expectNoCalls) {
+      assert.equal(expectedCallSpy.notCalled, true)
+    } else {
+      assert.equal(expectedCallSpy.calledOnce, true)
+    }
+    expectedCallSpy.restore()
+  }
+
+  describe('handleShortcut', function () {
+    it('calls zoomIn when set to "zoom-in"', function () {
+      expectCall('zoom-in', 'zoomIn')
+    })
+
+    it('calls zoomOut when set to "zoom-out"', function () {
+      expectCall('zoom-out', 'zoomOut')
+    })
+
+    it('calls zoomReset when set to "zoom-reset"', function () {
+      expectCall('zoom-reset', 'zoomReset')
+    })
+
+    it('calls windowActions.setFindbarShown when set to "show-findbar"', function () {
+      expectWindowActionCall('show-findbar', 'setFindbarShown')
+    })
+
+    it('calls onFindAgain with true when set to "find-next"', function () {
+      expectCall('find-next', 'onFindAgain', true)
+    })
+
+    it('calls onFindAgain with false when set to "find-prev"', function () {
+      expectCall('find-prev', 'onFindAgain', false)
+    })
+
+    it('calls windowActions.setActiveFrameShortcut when truthy', function () {
+      expectWindowActionCall('not-a-real-value', 'setActiveFrameShortcut')
+    })
+
+    it('does not call windowActions.setActiveFrameShortcut if falsey', function () {
+      expectWindowActionCall(undefined, 'setActiveFrameShortcut', true)
+    })
+  })
+})

--- a/test/unit/js/components/mainTest.js
+++ b/test/unit/js/components/mainTest.js
@@ -8,7 +8,7 @@ const {shallow} = require('enzyme')
 const assert = require('assert')
 const Immutable = require('immutable')
 let Main, NavigationBar
-require('../braveUnit')
+require('../../braveUnit')
 
 describe('Main component unit tests', function () {
   before(function () {
@@ -22,9 +22,10 @@ describe('Main component unit tests', function () {
     mockery.registerMock('../../extensions/brave/img/urlbar/browser_URL_fund_no.svg', {})
     mockery.registerMock('../../extensions/brave/img/urlbar/browser_URL_fund_yes.svg', {})
     mockery.registerMock('../../extensions/brave/img/caret_down_grey.svg', 'caret_down_grey.svg')
-    mockery.registerMock('electron', require('../lib/fakeElectron'))
-    Main = require('../../../js/components/main')
-    NavigationBar = require('../../../js/components/navigationBar')
+    mockery.registerMock('../../extensions/brave/img/tabs/new_session.svg')
+    mockery.registerMock('electron', require('../../lib/fakeElectron'))
+    Main = require('../../../../js/components/main')
+    NavigationBar = require('../../../../js/components/navigationBar')
   })
 
   after(function () {

--- a/test/unit/js/components/navigationBarTest.js
+++ b/test/unit/js/components/navigationBarTest.js
@@ -9,7 +9,7 @@ const {shallow} = require('enzyme')
 const assert = require('assert')
 const Immutable = require('immutable')
 let NavigationBar, UrlBar
-require('../braveUnit')
+require('../../braveUnit')
 
 describe('NavigationBar component unit tests', function () {
   before(function () {
@@ -22,9 +22,9 @@ describe('NavigationBar component unit tests', function () {
     mockery.registerMock('../../extensions/brave/img/urlbar/browser_URL_fund_yes_verified.svg', {})
     mockery.registerMock('../../extensions/brave/img/urlbar/browser_URL_fund_no.svg', {})
     mockery.registerMock('../../extensions/brave/img/urlbar/browser_URL_fund_yes.svg', {})
-    mockery.registerMock('electron', require('../lib/fakeElectron'))
-    NavigationBar = require('../../../js/components/navigationBar')
-    UrlBar = require('../../../app/renderer/components/urlBar')
+    mockery.registerMock('electron', require('../../lib/fakeElectron'))
+    NavigationBar = require('../../../../js/components/navigationBar')
+    UrlBar = require('../../../../app/renderer/components/urlBar')
   })
 
   after(function () {

--- a/test/unit/lib/fakeElectron.js
+++ b/test/unit/lib/fakeElectron.js
@@ -28,7 +28,9 @@ const fakeElectron = {
   app: {
     on: function () {
     },
-    getPath: (param) => `${process.cwd()}/${param}`
+    getPath: (param) => `${process.cwd()}/${param}`,
+    getVersion: () => '0.14.0',
+    setLocale: (locale) => {}
   },
   clipboard: {
     writeText: function () {


### PR DESCRIPTION
Filling in some unit testing gaps, add small checks to session code (preventing exception from being thrown).

**This PR includes 43 unit tests for**:
- our session methods (where we have known issues with session being erased when it fails loading)
- frame component (specifically handleShortcut where @bradleyrichter saw an error- this isn't finished yet)

Currently, our unit test coverage for `app/sessionStore.js` is 0%
This PR brings that number up to (stats courtesy of Istanbul):
- % Stmts: 52.65
- % Branch: 45.77%
- % Funcs: 54.05
- % Lines: 53.21%

`js/components/frames.js` was at 5% statement coverage 0% branch coverage and now has:
- % Stmts: 10.94
- % Branch: 4.12%
- % Funcs: 8%
- % Lines: 11.13%

Auditors: @bridiver, @bbondy, @diracdeltas, @BrendanEich

Test Plan:
`npm run unittest -- --grep="sessionStore unit tests"`
`npm run unittest -- --grep="Frame component unit tests"`

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
