### PR TITLE
Adjust min-threshold for closeTab

### DIFF
--- a/app/renderer/components/styles/global.js
+++ b/app/renderer/components/styles/global.js
@@ -11,7 +11,7 @@ const globalStyles = {
       medium: '66px',
       mediumSmall: '53px',
       small: '46px',
-      extraSmall: '33px',
+      extraSmall: '40px',
       smallest: '19px'
     }
   },

--- a/app/renderer/lib/tabUtil.js
+++ b/app/renderer/lib/tabUtil.js
@@ -25,3 +25,33 @@ module.exports.getTabBreakpoint = (tabWidth) => {
 
 // Execute resize handler at a rate of 15fps
 module.exports.tabUpdateFrameRate = 66
+
+/**
+ * Check whether or not current breakpoint match defined criteria
+ * @param {Object} props - Object that hosts the tab breakpoint
+ * @param {Array} arr - Array of Strings including breakpoint names to check against
+ * @returns {Boolean} Whether or not the sizing criteria was match
+ */
+module.exports.hasBreakpoint = (props, arr) => {
+  arr = Array.isArray(arr) ? arr : [arr]
+  return arr.includes(props.tab.get('breakpoint'))
+}
+
+/**
+ * Check whether or not closeTab icon is relative to hover state
+ * @param {Object} props - Object that hosts the tab props
+ * @returns {Boolean} Whether or not the tab has a relative closeTab icon
+ */
+module.exports.hasRelativeCloseIcon = (props) => {
+  return props.tab.get('hoverState') &&
+    !module.exports.hasBreakpoint(props, ['small', 'extraSmall', 'smallest'])
+}
+
+/**
+ * Check whether or not closeTab icon is always visible (fixed) in tab
+ * @param {Object} props - Object that hosts the tab props
+ * @returns {Boolean} Whether or not the close icon is always visible (fixed)
+ */
+module.exports.hasFixedCloseIcon = (props) => {
+  return props.isActive && module.exports.hasBreakpoint(props, ['small', 'extraSmall'])
+}

--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -289,7 +289,12 @@ class Tab extends ImmutableComponent {
           this.narrowView && styles.tabIdNarrowView,
           this.props.tab.get('breakpoint') === 'smallest' && styles.tabIdMinAllowedSize
           )}>
-          <Favicon tab={this.props.tab} isLoading={this.loading} isPinned={this.isPinned} />
+          <Favicon
+            isActive={this.props.isActive}
+            tab={this.props.tab}
+            isLoading={this.loading}
+            isPinned={this.isPinned}
+          />
           <AudioTabIcon
             tab={this.props.tab}
             onClick={this.onMuteFrame.bind(this, !this.props.tab.get('audioMuted'))}
@@ -310,6 +315,7 @@ class Tab extends ImmutableComponent {
           l10nId='sessionInfoTab'
         />
         <CloseTabIcon
+          isActive={this.props.isActive}
           tab={this.props.tab}
           onClick={this.onTabClosedWithMouse.bind(this)}
           l10nId='closeTabButton'

--- a/test/unit/app/renderer/tabContentTest.js
+++ b/test/unit/app/renderer/tabContentTest.js
@@ -376,14 +376,62 @@ describe('tabContent components', function () {
         <CloseTabIcon
           tab={
             Immutable.Map({
-              hoverState: false,
+              hoverState: true,
               pinnedLocation: true
             })}
         />
       )
       assert.notEqual(wrapper.props().symbol, globalStyles.appIcons.closeTab)
     })
-    it('should not show closeTab icon if tab size is too small', function () {
+    it('should show closeTab icon if tab size is small and tab is active', function () {
+      const wrapper = shallow(
+        <CloseTabIcon isActive
+          tab={
+            Immutable.Map({
+              hoverState: false,
+              breakpoint: 'small'
+            })}
+        />
+      )
+      assert.equal(wrapper.props().symbol, globalStyles.appIcons.closeTab)
+    })
+    it('should not show closeTab icon if tab size is small and tab is not active', function () {
+      const wrapper = shallow(
+        <CloseTabIcon isActive={false}
+          tab={
+            Immutable.Map({
+              hoverState: true,
+              breakpoint: 'small'
+            })}
+        />
+      )
+      assert.notEqual(wrapper.props().symbol, globalStyles.appIcons.closeTab)
+    })
+    it('should show closeTab icon if tab size is extraSmall and tab is active', function () {
+      const wrapper = shallow(
+        <CloseTabIcon isActive
+          tab={
+            Immutable.Map({
+              hoverState: false,
+              breakpoint: 'extraSmall'
+            })}
+        />
+      )
+      assert.equal(wrapper.props().symbol, globalStyles.appIcons.closeTab)
+    })
+    it('should not show closeTab icon if tab size is extraSmall and tab is not active', function () {
+      const wrapper = shallow(
+        <CloseTabIcon isActive={false}
+          tab={
+            Immutable.Map({
+              hoverState: true,
+              breakpoint: 'extraSmall'
+            })}
+        />
+      )
+      assert.notEqual(wrapper.props().symbol, globalStyles.appIcons.closeTab)
+    })
+    it('should not show closeTab icon if tab size is the smallest size', function () {
       const wrapper = shallow(
         <CloseTabIcon
           tab={


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bbondy, @bsclifton

Fix #5431

#### Note: PR also removed extra gutter for close icon. Now you can only close a tab if you really intent to close a tab  ❌ 👍  

Test plan:

automated tests must pass:

```
✓ npm run test -- --grep="should not show closeTab icon if tab size is small and tab is not active"
✓ npm run test -- --grep="should show closeTab icon if tab size is small and tab is active"
✓ npm run test -- --grep="should not show closeTab icon if tab size is extraSmall and tab is not active"
✓ npm run test -- --grep="should show closeTab icon if tab size is extraSmall and tab is active"
✓ npm run test -- --grep="should not show closeTab icon if tab size is the smallest size"
```

QA steps:

1. Try to close a tab by hitting an area next to icon (but not the icon itself)
- Expected: You can't

2. Have a lot of tabs up until tab is small enough to have two icons almost colliding. (<46px wide)
- Expected: Active tab **should** have closeTab icon always visible
- Expected: Inactive tabs **should not** have closeTab icon

3. Have a lot of tabs up until tab is small enough to have just one icon.
- Expected: Active tab **should** have closeTab icon always visible
- Expected: Inactive tabs **should not** have closeTab icon

4. Have a lot of tabs up until tab is small enough so favicon is resized to a smaller width
- Expected: Both active/inactive tabs **should not** have closeTab icon
