### PR TITLE
Remove top:1px from .urlbarForm > *

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -849,11 +849,6 @@
        -webkit-user-select: none;
     }
 
-    > * {
-      position: relative;
-      top: 1px;
-    }
-
     .inputbar-wrapper {
       //background: white;
       display: flex;


### PR DESCRIPTION
Closes #7805

The fix is no longer necessary as the header design became flat thanks to #7546 and #7739

Auditors:

Test Plan: make sure the URL bar looks like https://github.com/brave/browser-laptop/issues/7805#issue-215747638

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
