### PR TITLE
Update Standard@9.0.0

### DIFF
--- a/app/dataFile.js
+++ b/app/dataFile.js
@@ -55,7 +55,7 @@ module.exports.readDataFile = (resourceName, url) => {
     fs.readFile(storagePath(url), (err, data) => {
       if (err || !data || data.length === 0) {
         // console.log('rejecting for read for resource:', resourceName)
-        reject()
+        reject(new Error('unable to read data file'))
       } else {
         // console.log('resolving for read for resource:', resourceName)
         resolve(data)

--- a/app/dates.js
+++ b/app/dates.js
@@ -4,7 +4,10 @@ var isoWeek = function () {
   date.setHours(0, 0, 0, 0)
   date.setDate(date.getDate() + 3 - ((date.getDay() + 6) % 7))
   var jan4 = new Date(date.getFullYear(), 0, 4)
-  return 1 + Math.round((((date.getTime() - jan4.getTime()) / 86400000) - 3 + ((jan4.getDay() + 6) % 7) / 7))
+  return 1 + Math.round(
+      ((date.getTime() - jan4.getTime()) / 86400000) - 3 +
+      (((jan4.getDay() + 6) % 7) / 7)
+    )
 }
 
 // Local data yyyy-mm-dd (with zero padding)

--- a/app/ledger.js
+++ b/app/ledger.js
@@ -395,7 +395,7 @@ var recoverKeys = (appState, action) => {
     secondRecoveryKey = action.secondRecoveryKey
   }
 
-  const UUID_REGEX = /^[0-9a-z]{8}\-[0-9a-z]{4}\-[0-9a-z]{4}\-[0-9a-z]{4}\-[0-9a-z]{12}$/
+  const UUID_REGEX = /^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/
   if (typeof firstRecoveryKey !== 'string' || !firstRecoveryKey.match(UUID_REGEX) || typeof secondRecoveryKey !== 'string' || !secondRecoveryKey.match(UUID_REGEX)) {
     // calling logError sets the error object
     logError(true, 'recoverKeys')

--- a/app/renderer/components/bookmarksToolbar.js
+++ b/app/renderer/components/bookmarksToolbar.js
@@ -83,7 +83,6 @@ class BookmarkToolbarButton extends ImmutableComponent {
     if (this.isFolder) {
       e.target = ReactDOM.findDOMNode(this)
       if (dnd.isMiddle(e.target, e.clientX)) {
-        e.target.getBoundingClientRect
         this.props.showBookmarkFolderMenu(this.props.bookmark, e)
         windowActions.setIsBeingDraggedOverDetail(dragTypes.BOOKMARK, this.props.bookmark, {
           expanded: true

--- a/app/renderer/components/browserAction.js
+++ b/app/renderer/components/browserAction.js
@@ -8,7 +8,6 @@ const electron = require('electron')
 const ipc = electron.ipcRenderer
 const Button = require('../../../js/components/button')
 const BrowserActionBadge = require('../../renderer/components/browserActionBadge')
-const cx = require('../../../js/lib/classSet')
 const extensionState = require('../../common/state/extensionState')
 const windowActions = require('../../../js/actions/windowActions')
 const {StyleSheet, css} = require('aphrodite')

--- a/app/renderer/components/tabContent.js
+++ b/app/renderer/components/tabContent.js
@@ -119,10 +119,6 @@ class AudioTabIcon extends ImmutableComponent {
     return this.pageCanPlayAudio && this.props.tab.get('audioMuted')
   }
 
-  get unmutedState () {
-    this.props.tab.get('audioPlaybackActive') && !this.props.tab.get('audioMuted')
-  }
-
   get audioIcon () {
     return !this.mutedState
       ? globalStyles.appIcons.volumeOn

--- a/js/lib/imageUtil.js
+++ b/js/lib/imageUtil.js
@@ -6,7 +6,7 @@ module.exports.getBase64FromImageUrl = (url) => {
   return new Promise((resolve, reject) => {
     const img = new window.Image()
     img.onerror = function () {
-      reject()
+      reject(new Error('unable to load image'))
     }
     img.onload = function () {
       const canvas = document.createElement('canvas')

--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -104,16 +104,16 @@ const UrlUtil = {
       return true
     }
     // for cases where we have scheme and we dont want spaces in domain names
-    const caseDomain = /^[\w]{2,5}:\/\/[^\s\/]+\//
+    const caseDomain = /^[\w]{2,5}:\/\/[^\s/]+\//
     // for cases, quoted strings
     const case1Reg = /^".*"$/
     // for cases:
     // - starts with "?" or "."
     // - contains "? "
     // - ends with "." (and was not preceded by a domain or /)
-    const case2Reg = /(^\?)|(\?.+\s)|(^\.)|(^[^.+\..+]*[^\/]*\.$)/
+    const case2Reg = /(^\?)|(\?.+\s)|(^\.)|(^[^.+..+]*[^/]*\.$)/
     // for cases, pure string
-    const case3Reg = /[\?\.\/\s:]/
+    const case3Reg = /[?./\s:]/
     // for cases, data:uri, view-source:uri and about
     const case4Reg = /^(data|view-source|mailto|about|chrome-extension|magnet):.*/
 

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "sinon": "^1.17.6",
     "spectron": "brave/spectron#chromium56",
     "sqlite3": "^3.1.1",
-    "standard": "8.1.0",
+    "standard": "9.0.0",
     "style-loader": "^0.13.0",
     "uglify-js-harmony": "^2.7.5",
     "webdriverio": "4.2.5",

--- a/test/about/ledgerPanelAdvancedPanelTest.js
+++ b/test/about/ledgerPanelAdvancedPanelTest.js
@@ -88,7 +88,7 @@ function validateRecoveryFile (recoveryFileContents) {
   console.log(`recovered passphrase: ${passphrase}`)
 
   // validate that paymentId and passphrase are uuids here
-  const UUID_REGEX = /^[0-9a-z]{8}\-[0-9a-z]{4}\-[0-9a-z]{4}\-[0-9a-z]{4}\-[0-9a-z]{12}$/
+  const UUID_REGEX = /^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}$/
   assert.ok(paymentId.match(UUID_REGEX), 'paymentId should be a valid UUID')
   assert.ok(passphrase.match(UUID_REGEX), 'passphrase should be a valid UUID')
 

--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -742,7 +742,7 @@ var exports = {
         // Get the internal view instance ID from the selected webview
         var v8Util = process.atomBinding('v8_util')
         var internal = v8Util.getHiddenValue(webview, 'internal')
-        internal.viewInstanceId
+
         // This allows you to send more args than just the event itself like would only
         // be possible with dispatchEvent.
         devTools('electron').ipcRenderer.emit('ELECTRON_GUEST_VIEW_INTERNAL_DISPATCH_EVENT-' + internal.viewInstanceId, ...params)

--- a/test/misc-components/syncTest.js
+++ b/test/misc-components/syncTest.js
@@ -55,7 +55,7 @@ function * setupBrave (client) {
 }
 
 function * toggleSync (client, expectedState) {
-  if (typeof expectedState === undefined) {
+  if (typeof expectedState === 'undefined') {
     throw new Error('expectedState is required')
   }
   yield client

--- a/test/unit/about/newTabPageTest.js
+++ b/test/unit/about/newTabPageTest.js
@@ -109,6 +109,7 @@ describe('NewTab component unit tests', function () {
     describe('randomBackgroundImage', function () {
       it('calls random to get a random index', function () {
         randomSpy.reset()
+        wrapper.instance().randomBackgroundImage
         assert.equal(randomSpy.calledOnce, true)
       })
 

--- a/test/unit/about/newTabPageTest.js
+++ b/test/unit/about/newTabPageTest.js
@@ -109,8 +109,6 @@ describe('NewTab component unit tests', function () {
     describe('randomBackgroundImage', function () {
       it('calls random to get a random index', function () {
         randomSpy.reset()
-        const instance = wrapper.instance()
-        instance.randomBackgroundImage
         assert.equal(randomSpy.calledOnce, true)
       })
 

--- a/tools/lib/transactionHelpers.js
+++ b/tools/lib/transactionHelpers.js
@@ -4,7 +4,7 @@ let generateRandomHost = require('./randomHostname')
 const SATOSHIS_PER_BTC = Math.pow(10, 8)
 
 const VALID_CURRENCY_CODE_REGEX = /^[A-Z]+$/
-const VALID_HOSTNAME_REGEX = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/
+const VALID_HOSTNAME_REGEX = /^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9-]*[A-Za-z0-9])$/
 
 const transactionSchema = Joi.object().keys({
   viewingId: Joi.string().guid().required().description('a unique id for the transaction'),


### PR DESCRIPTION
Auditors: @bsclifton

Fix #7492
Follow-up of #7495 and #7785

Will also help with standard version inconsistency between repo/travis (#7794)

This PR addressed the following new rules:

```
no-mixed-operators (follow-up with 1 occurency)
no-unused-expressions
prefer-promise-reject-errors
valid-typeof
no-useless-escape
```

Test plan:

1. Run `npm run lint`
2. Should have no linting errors