### PR TITLE
Fixes Add Bookmarks in Bookmarks Manager

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -55,6 +55,9 @@ const addBookmarkMenuItem = (label, siteDetail, closestDestinationDetail, isPare
       if (isParent) {
         siteDetail = siteDetail.set('parentFolderId', closestDestinationDetail && (closestDestinationDetail.get('folderId') || closestDestinationDetail.get('parentFolderId')))
       }
+      if (siteDetail.constructor !== Immutable.Map) {
+        siteDetail = Immutable.fromJS(siteDetail)
+      }
       siteDetail = siteDetail.set('location', urlUtil.getLocationIfPDF(siteDetail.get('location')))
       windowActions.setBookmarkDetail(siteDetail, siteDetail, closestDestinationDetail, true)
     }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #7801

**Note**
Bug was introduced with this commit https://github.com/brave/browser-laptop/commit/583d178bcc6dae3be62ef28f71d30b7ae2e7bdae

## Auditors
@bsclifton @darkdh

### Test Plan
- go to Bookmarks Manager
- right click in a bookmarks area (right side)
- select Add bookmark
- bookmark dialog is opened