### PR TITLE
Fixes automated test failures on urlBarSuggestions

### DIFF
--- a/app/renderer/reducers/urlBarSuggestionsReducer.js
+++ b/app/renderer/reducers/urlBarSuggestionsReducer.js
@@ -129,7 +129,7 @@ const generateNewSuggestionsList = (state) => {
   if (sites) {
     // Filter out Brave default newtab sites and sites with falsey location
     sites = sites.filterNot((site) =>
-      Immutable.is(site.get('tags'), (new Immutable.List(['default'])) &&
+      (Immutable.is(site.get('tags'), new Immutable.List(['default'])) &&
       site.get('lastAccessedTime') === 1) ||
       !site.get('location')
     )


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #7837

**Note**
Bug was introduced with this commit https://github.com/brave/browser-laptop/commit/b2618c911863b7930b054b3f6562224d6acf3cbe#diff-98a3c7cee990c3f0f8c000990a02a2f7R132

### Auditors
@diracdeltas @cezaraugusto

### Test Plan
- `npm run test -- --grep="urlBarSuggestions"`
