### PR TITLE
Fixes automated test failures on sessionStore

### DIFF
--- a/test/app/sessionStoreTest.js
+++ b/test/app/sessionStoreTest.js
@@ -34,7 +34,7 @@ describe('sessionStore', function () {
         .waitUntil(function () {
           return this.getAppState().then((val) => {
             let state = val.value
-            return Immutable.fromJS(state.sites).size === 1 && state.sites[key].location === page1Url
+            return siteUtil.getBookmarks(Immutable.fromJS(state.sites)).size === 1 && state.sites[key].location === page1Url
           })
         })
       yield Brave.stopApp(false)


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #7839

**Note**
This test was failing because we were getting all sites, not just bookmarked sites.

### Auditors
@bsclifton @bridiver

### Test Plan
- npm run test -- --grep="sessionStore"
