### PR TITLE
Fix zoom level on browser restore

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -262,7 +262,7 @@ AppStore
       savePasswords: boolean, // only false or undefined/null
       shieldsUp: boolean,
       widevine: (number|boolean), // false = block widevine, 0 = allow once, 1 = allow always
-      zoomLevel: number
+      zoomLevel: number // deprecated
     }
   },
   sync: {

--- a/js/lib/zoom.js
+++ b/js/lib/zoom.js
@@ -8,6 +8,11 @@ const {zoom} = require('../constants/config')
 module.exports.getZoomValuePercentage = (zoomLevel) =>
   100 + (20 * zoomLevel)
 
+// Convert zoom percentage to zoom level
+module.exports.getZoomLevel = (percentage) => {
+  return (percentage - 100) / 20
+}
+
 module.exports.getNextZoomLevel = (currentZoom, zoomIn) => {
   const zoomLevels = zoom.zoomLevels
   // First find the closet value to what we allow

--- a/js/state/frameStateUtil.js
+++ b/js/state/frameStateUtil.js
@@ -343,7 +343,6 @@ function addFrame (windowState, tabs, frameOpts, newKey, partitionNumber, active
   }
 
   const frame = Immutable.fromJS(Object.assign({
-    zoomLevel: config.zoom.defaultValue,
     audioMuted: false, // frame is muted
     location,
     aboutDetails: undefined,

--- a/js/state/syncUtil.js
+++ b/js/state/syncUtil.js
@@ -29,7 +29,7 @@ module.exports.CATEGORY_MAP = CATEGORY_MAP
 
 const siteSettingDefaults = {
   hostPattern: '',
-  zoomLevel: 0,
+  zoomLevel: 0, // deprecated
   shieldsUp: true,
   adControl: 1,
   cookieControl: 0,

--- a/test/unit/lib/zoomTest.js
+++ b/test/unit/lib/zoomTest.js
@@ -1,6 +1,6 @@
 /* global describe, it */
 
-const {getZoomValuePercentage, getNextZoomLevel} = require('../../../js/lib/zoom')
+const {getZoomValuePercentage, getZoomLevel, getNextZoomLevel} = require('../../../js/lib/zoom')
 const {zoom} = require('../../../js/constants/config')
 const assert = require('assert')
 
@@ -14,6 +14,17 @@ describe('zoom', function () {
     })
     it('formats negative 20% decrements', function * () {
       assert.equal(getZoomValuePercentage(-3.75), 25)
+    })
+  })
+  describe('getZoomLevel', function () {
+    it('formats 100 to 0', function * () {
+      assert.equal(getZoomLevel(100), 0)
+    })
+    it('formats positive value', function * () {
+      assert.equal(getZoomLevel(120), 1)
+    })
+    it('formats negative value', function * () {
+      assert.equal(getZoomLevel(25), -3.75)
     })
   })
   describe('getNextZoomLevel', function () {


### PR DESCRIPTION
and remove deprecated zoom level site setting.

fix https://github.com/brave/browser-laptop/issues/7832

Test Plan:
1. launch clean instance of brave
2. go to example.com and change the zoom level
3. close brave
4. reopen brave
5. example.com should load with the previous zoom setting

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
