### PR TITLE
Ensure audio icon on tab is vertically centered 

### DIFF
--- a/app/renderer/components/tabContent.js
+++ b/app/renderer/components/tabContent.js
@@ -290,7 +290,8 @@ const styles = StyleSheet.create({
   },
 
   audioIcon: {
-    color: globalStyles.color.highlightBlue
+    color: globalStyles.color.highlightBlue,
+    fontSize: '16px'
   },
 
   newSession: {


### PR DESCRIPTION
## Test Plan:
1. Be on a Windows machine which is set at 125% DPI
2. Launch Brave and visit youtube.com
3. Click the first link you see and let the video play
4. Ensure you're at a # of tabs where audio icon is showing (if not, close some tabs)
5. Audio icon should look vertically centered now

## Description
Ensure audio icon on tab is vertically centered  (it only seemed to be a problem on Windows, > 100% DPI)

Fixes https://github.com/brave/browser-laptop/issues/7815

Auditors: @cezaraugusto, @srirambv

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

## Screenshot
<img width="321" alt="screen shot 2017-03-23 at 1 21 22 am" src="https://cloud.githubusercontent.com/assets/4733304/24238731/804f18e4-0f68-11e7-970d-f269475f0489.png">
