### PR TITLE
block media device enumeration when fingerprinting protection is on

### DIFF
--- a/test/bravery-components/braveryPanelTest.js
+++ b/test/bravery-components/braveryPanelTest.js
@@ -518,6 +518,31 @@ describe('Bravery Panel', function () {
             .then((stat) => stat === '2' || stat === '3')
         })
     })
+    it('block device enumeration', function * () {
+      const url = Brave.server.url('enumerate_devices.html')
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(url)
+        .waitUntil(function () {
+          return this.getText('body')
+            .then((body) => {
+              return body.includes('default')
+            })
+        })
+        .openBraveMenu(braveMenu, braveryPanel)
+        .click(fpSwitch)
+        .waitUntil(function () {
+          return this.getText(fpStat)
+            .then((stat) => stat === '1')
+        })
+        .tabByUrl(url)
+        .waitUntil(function () {
+          return this.getText('body')
+            .then((body) => {
+              return body === ''
+            })
+        })
+    })
     it('allows fingerprinting when setting is off in private tab', function * () {
       const url = Brave.server.url('fingerprinting.html')
       yield this.app.client

--- a/test/fixtures/enumerate_devices.html
+++ b/test/fixtures/enumerate_devices.html
@@ -1,0 +1,14 @@
+<body>
+<div id='results'></div>
+<script>
+let results = document.getElementById('results')
+navigator.mediaDevices.enumerateDevices()
+.then(function(devices) {
+  devices.forEach(function(device) {
+    let li = document.createElement('li')
+    li.textContent = [device.label, device.deviceId].join(': ')
+    results.appendChild(li)
+  });
+})
+</script>
+</body>


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/7462

Test Plan:
1. automated bravery panel tests should pass
2. go to https://browserleaks.com/webrtc with fingerprinting protection enabled
3. media device information should not be available

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
