### PR TITLE
Fixes back/forward history middle click

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -1459,7 +1459,7 @@ function onBackButtonHistoryMenu (activeFrame, history, target) {
           if (eventUtil.isForSecondaryAction(e)) {
             windowActions.newFrame({
               location: url,
-              partitionNumber: activeFrame.props.frame.get('partitionNumber')
+              partitionNumber: activeFrame.props.partitionNumber
             }, !!e.shiftKey)
           } else {
             activeFrame.goToIndex(index)
@@ -1503,7 +1503,7 @@ function onForwardButtonHistoryMenu (activeFrame, history, target) {
           if (eventUtil.isForSecondaryAction(e)) {
             windowActions.newFrame({
               location: url,
-              partitionNumber: activeFrame.props.frame.get('partitionNumber')
+              partitionNumber: activeFrame.props.partitionNumber
             }, !!e.shiftKey)
           } else {
             activeFrame.goToIndex(index)

--- a/test/tab-components/tabTest.js
+++ b/test/tab-components/tabTest.js
@@ -4,7 +4,7 @@ const Brave = require('../lib/brave')
 const messages = require('../../js/constants/messages')
 const assert = require('assert')
 const settings = require('../../js/constants/settings')
-const {urlInput, backButton, forwardButton, activeTab, activeTabTitle, activeTabFavicon, newFrameButton, notificationBar} = require('../lib/selectors')
+const {urlInput, backButton, forwardButton, activeTab, activeTabTitle, activeTabFavicon, newFrameButton, notificationBar, contextMenu} = require('../lib/selectors')
 
 describe('tab tests', function () {
   function * setup (client) {
@@ -55,6 +55,40 @@ describe('tab tests', function () {
           return this.getText(activeTabTitle)
             .then((title) => title === 'Page 2')
         })
+    })
+
+    it('middle click opens in the new tab', function * () {
+      var page1 = Brave.server.url('page1.html')
+      var page2 = Brave.server.url('page2.html')
+
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(page1)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitUntil(function () {
+          return this.getText(activeTabTitle)
+            .then((title) => title === 'Page 1')
+        })
+        .tabByIndex(0)
+        .loadUrl(page2)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitUntil(function () {
+          return this.getText(activeTabTitle)
+            .then((title) => title === 'Page 2')
+        })
+        .waitForExist(backButton)
+        .click(backButton)
+        .waitForUrl(page1)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitUntil(function () {
+          return this.getText(activeTabTitle)
+            .then((title) => title === 'Page 1')
+        })
+        .waitForExist('.forwardButton')
+        .rightClick(forwardButton)
+        .waitForExist(contextMenu)
+        .middleClick(`${contextMenu} [data-index="0"]`)
+        .waitForTabCount(2)
     })
   })
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #7892

### Auditors
@bsclifton

### Test Plan
- Open page and some sub pages
- Right click on a back button
- Middle click on a history item