### PR TITLE
Include ytd-video-masthead-ad to removeEmptyElements.css

### DIFF
--- a/app/extensions/brave/content/styles/removeEmptyElements.css
+++ b/app/extensions/brave/content/styles/removeEmptyElements.css
@@ -8,6 +8,7 @@
   .ytp-ad-progress-list,
   .ad-container,
   #video-masthead,
-  #watch-channel-brand-div {
+  #watch-channel-brand-div,
+  ytd-video-masthead-ad {
     display: none !important;
 }


### PR DESCRIPTION
Addresses #7818

Auditors: @bbondy @lukemulks

Test Plan:
1. Open youtube.com in the experimental mode (try on the privade tab)
2. Make sure you do not see the div placeholder

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
