### PR TITLE
Fix ADDFUNDS_URL button in payments

### DIFF
--- a/app/renderer/components/preferences/payment/bitcoinDashboard.js
+++ b/app/renderer/components/preferences/payment/bitcoinDashboard.js
@@ -95,7 +95,7 @@ class BitcoinDashboard extends ImmutableComponent {
           <div className={css(styles.settingsListTitle, styles.subTitle)} data-l10n-id='moneyAddSubTitle' />
         </div>
         <div className={css(styles.settingsPanelDivider, styles.settingsPanelDividerLast)}>
-          {this.bitcoinPurchaseButton}
+          {this.bitcoinPurchaseButton()}
           <div className={css(styles.settingsListTitle, styles.subTitle)} data-l10n-id='transferTime' />
         </div>
       </div>


### PR DESCRIPTION
Auditors: @bbondy, @mrose17

Test Plan:

  1. Launch browser with ADDFUNDS_URL pointing to a url i.e. http://www.github.com
  2. Open Preferences / Payments / Add Funds...
  3. Click on displayed button
  4. Ensure a new tab is opened with the URL above loaded

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
