### PR TITLE
add us-east-1 region to sync CSP

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -227,13 +227,14 @@ let generateSyncManifest = () => {
   }
   cspDirectives['connect-src'] = ['\'self\'',
     appConfig.sync.serverUrl,
+    appConfig.sync.s3Url.replace('us-west-2', 'us-east-1'),
     appConfig.sync.s3Url].join(' ')
 
   if (process.env.NODE_ENV === 'development') {
     // allow access to webpack dev server resources
     let devServer = 'localhost:' + process.env.npm_package_config_port
     cspDirectives['default-src'] += ' http://' + devServer
-    cspDirectives['connect-src'] += ' http://' + devServer + ' ws://' + devServer + ' ' + appConfig.sync.testS3Url
+    cspDirectives['connect-src'] += ' http://' + devServer + ' ws://' + devServer + ' ' + appConfig.sync.testS3Url + ' ' + appConfig.sync.testS3Url.replace('us-west-2', 'us-east-1')
   }
 
   return {


### PR DESCRIPTION
fix #7965

Auditors: @ayumi

Test Plan:
1. enable sync
2. turn off wifi
3. open chrome-extension://cjnmeadmgmiihncdidmfiabhenbggfjm/_generated_background_page.html
4. wait around a minute
5. you should not see any errors that start with "Refused to connect to 'https://brave-sync.s3.dualstack.us-east-1.amazonaws.com...'"

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
