### PR TITLE
Change inactive private tab background to 30% of original color

### DIFF
--- a/app/renderer/components/styles/tab.js
+++ b/app/renderer/components/styles/tab.js
@@ -106,6 +106,14 @@ const styles = StyleSheet.create({
     }
   },
 
+  private: {
+    background: 'rgba(75, 60, 110, 0.3)',
+
+    ':hover': {
+      background: globalStyles.color.privateTabBackgroundActive
+    }
+  },
+
   dragging: {
     ':hover': {
       closeTab: {

--- a/app/renderer/components/tabContent.js
+++ b/app/renderer/components/tabContent.js
@@ -223,7 +223,7 @@ class TabTitle extends ImmutableComponent {
   get themeColor () {
     const themeColor = this.props.tab.get('themeColor') || this.props.tab.get('computedThemeColor')
     const activeNonPrivateTab = !this.props.tab.get('isPrivate') && this.props.isActive
-    const activePrivateTab = this.props.tab.get('isPrivate') && this.props.isActive
+    const activePrivateTab = (this.props.tab.get('isPrivate') && this.props.isActive) || this.props.isHover
     const defaultColor = activePrivateTab ? globalStyles.color.white100 : globalStyles.color.black100
 
     return activeNonPrivateTab && this.props.paintTabs && !!themeColor

--- a/app/renderer/components/tabContent.js
+++ b/app/renderer/components/tabContent.js
@@ -223,8 +223,8 @@ class TabTitle extends ImmutableComponent {
   get themeColor () {
     const themeColor = this.props.tab.get('themeColor') || this.props.tab.get('computedThemeColor')
     const activeNonPrivateTab = !this.props.tab.get('isPrivate') && this.props.isActive
-    const activePrivateTab = (this.props.tab.get('isPrivate') && this.props.isActive) || this.props.isHover
-    const defaultColor = activePrivateTab ? globalStyles.color.white100 : globalStyles.color.black100
+    const isPrivateTab = this.props.tab.get('isPrivate') && (this.props.isActive || this.props.tab.get('hoverState'))
+    const defaultColor = isPrivateTab ? globalStyles.color.white100 : globalStyles.color.black100
 
     return activeNonPrivateTab && this.props.paintTabs && !!themeColor
       ? getTextColorForBackground(themeColor)

--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -33,7 +33,6 @@ class Tab extends ImmutableComponent {
     this.onMouseEnter = this.onMouseEnter.bind(this)
     this.onMouseLeave = this.onMouseLeave.bind(this)
     this.onUpdateTabSize = this.onUpdateTabSize.bind(this)
-    this.isHover = false
   }
   get frame () {
     return windowStore.getFrame(this.props.tab.get('frameKey'))
@@ -140,8 +139,6 @@ class Tab extends ImmutableComponent {
       windowActions.setPreviewFrame(null)
     }
     windowActions.setTabHoverState(this.frame, false)
-
-    this.isHover = false
   }
 
   onMouseEnter (e) {
@@ -157,8 +154,6 @@ class Tab extends ImmutableComponent {
         window.setTimeout(windowActions.setPreviewFrame.bind(null, this.frame), previewMode ? 0 : 200)
     }
     windowActions.setTabHoverState(this.frame, true)
-
-    this.isHover = true
   }
 
   onAuxClick (e) {
@@ -306,7 +301,6 @@ class Tab extends ImmutableComponent {
           <TabTitle
             isActive={this.props.isActive}
             paintTabs={this.props.paintTabs}
-            isHover={this.isHover}
             tab={this.props.tab}
             pageTitle={this.displayValue}
           />

--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -33,6 +33,7 @@ class Tab extends ImmutableComponent {
     this.onMouseEnter = this.onMouseEnter.bind(this)
     this.onMouseLeave = this.onMouseLeave.bind(this)
     this.onUpdateTabSize = this.onUpdateTabSize.bind(this)
+    this.isHover = false
   }
   get frame () {
     return windowStore.getFrame(this.props.tab.get('frameKey'))
@@ -139,6 +140,8 @@ class Tab extends ImmutableComponent {
       windowActions.setPreviewFrame(null)
     }
     windowActions.setTabHoverState(this.frame, false)
+
+    this.isHover = false
   }
 
   onMouseEnter (e) {
@@ -154,6 +157,8 @@ class Tab extends ImmutableComponent {
         window.setTimeout(windowActions.setPreviewFrame.bind(null, this.frame), previewMode ? 0 : 200)
     }
     windowActions.setTabHoverState(this.frame, true)
+
+    this.isHover = true
   }
 
   onAuxClick (e) {
@@ -301,6 +306,7 @@ class Tab extends ImmutableComponent {
           <TabTitle
             isActive={this.props.isActive}
             paintTabs={this.props.paintTabs}
+            isHover={this.isHover}
             tab={this.props.tab}
             pageTitle={this.displayValue}
           />


### PR DESCRIPTION
- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

### Auditors
@bsclifton @cezaraugusto @bradleyrichter

### Test Plan
- open private tab
- open another private tab
- non active private tab should have light purple background
