### PR TITLE
set active tab in the browser process

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -467,6 +467,11 @@ const createDebugSubmenu = () => {
         process.crash()
       }
     }, {
+      label: 'Send memory pressure alert',
+      click: function () {
+        app.sendMemoryPressureAlert()
+      }
+    }, {
       label: 'Relaunch',
       accelerator: 'Command+Alt+R',
       click: function () {

--- a/app/browser/reducers/tabsReducer.js
+++ b/app/browser/reducers/tabsReducer.js
@@ -47,6 +47,9 @@ const tabsReducer = (state, action) => {
     case windowConstants.WINDOW_CLOSE_FRAME:
       state = tabState.closeFrame(state, action)
       break
+    case windowConstants.WINDOW_SET_ACTIVE_FRAME:
+      state = tabs.setActive(state, action)
+      break
     case appConstants.APP_TAB_TOGGLE_DEV_TOOLS:
       state = tabs.toggleDevTools(state, action)
       break

--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -183,6 +183,19 @@ const api = {
     return state
   },
 
+  setActive: (state, action) => {
+    action = makeImmutable(action)
+    let frameProps = action.get('frameProps')
+    let tabId = frameProps.get('tabId')
+    let tab = api.getWebContents(tabId)
+    if (tab && !tab.isDestroyed()) {
+      tab.setActive(true)
+      let tabValue = getTabValue(tabId)
+      return tabState.updateTab(state, { tabValue })
+    }
+    return state
+  },
+
   setAudioMuted: (state, action) => {
     action = makeImmutable(action)
     let frameProps = action.get('frameProps')


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
Tabs currently only discard on memory pressure so this isn't easily testable as-is
Will add a dev menu item to simulate a memory pressure event

NOT BACKWARDS COMPATIBLE WITH 2.57.7
Depends on https://github.com/brave/muon/pull/173