### PR TITLE
Use pseudo-element for audio indicator

### DIFF
--- a/app/renderer/components/styles/tab.js
+++ b/app/renderer/components/styles/tab.js
@@ -41,9 +41,16 @@ const styles = StyleSheet.create({
   },
 
   narrowViewPlayIndicator: {
-    borderWidth: '2px 1px 0',
-    borderStyle: 'solid',
-    borderColor: `lightskyblue ${globalStyles.color.chromeControlsBackground} transparent transparent`
+    '::before': {
+      content: `''`,
+      display: 'block',
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      height: '2px',
+      background: 'lightskyblue'
+    }
   },
 
   tabNarrowestView: {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #8033 

Test Plan:
1. Navigate to https://www.youtube.com/watch?v=WsSPW2oC7pI
2. Open enough tabs to have 10 on-screen and reduce window-width to reveal player
3. Toggle video pause/play state
4. Tab contents should not shift when displaying the audio indicator