### PR TITLE
Provide popup coords on keypress

### DIFF
--- a/app/renderer/components/browserAction.js
+++ b/app/renderer/components/browserAction.js
@@ -23,9 +23,17 @@ class BrowserAction extends ImmutableComponent {
       windowActions.setPopupWindowDetail()
       return
     }
+    let centerX
+    let centerY
+    if (!e.nativeEvent.x || !e.nativeEvent.y) {
+      // Handles case where user focuses button, and presses Enter
+      let { top: offsetTop, left: offsetLeft } = e.target.getBoundingClientRect()
+      centerX = offsetLeft + (e.target.offsetWidth * 0.5)
+      centerY = offsetTop + (e.target.offsetHeight * 0.5)
+    }
     let props = {
-      x: e.nativeEvent.x,
-      y: e.nativeEvent.y,
+      x: e.nativeEvent.x || centerX,
+      y: e.nativeEvent.y || centerY,
       screenX: e.nativeEvent.screenX,
       screenY: e.nativeEvent.screenY,
       offsetX: e.nativeEvent.offsetX,


### PR DESCRIPTION
## Test Plan
1. Use Preferences > Security to change password manager to LastPass
2. Tab focus from address-bar to LastPass icon
3. Press Enter
4. Popup should open beneath extension icon

## Description
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes #8034 