### PR TITLE
Left-align interactive sound indicator

### DIFF
--- a/app/renderer/components/tabContent.js
+++ b/app/renderer/components/tabContent.js
@@ -30,7 +30,7 @@ class TabIcon extends ImmutableComponent {
       width: globalStyles.spacing.iconSize,
       height: globalStyles.spacing.iconSize,
       alignItems: 'center',
-      justifyContent: this.props.symbolContent ? 'flex-end' : 'center',
+      justifyContent: this.props.symbolContent ? 'flex-end' : 'left',
       fontWeight: this.props.symbolContent ? 'bold' : 'normal',
       color: this.props.symbolContent ? globalStyles.color.black100 : 'inherit'
     }


### PR DESCRIPTION
## Test Plan
1. Go to a YouTube video
2. Click/toggle the tab mute button
3. Button should not jump around


## Description
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #8041 