### PR TITLE
Do not sync siteData fields that are data: URLs

### DIFF
--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -203,7 +203,7 @@ const UrlUtil = {
    * @returns {Boolean} Whether or not this is a data url.
    */
   isDataUrl: function (url) {
-    return url.toLowerCase().startsWith('data:')
+    return typeof url === 'string' && url.toLowerCase().startsWith('data:')
   },
 
   /**

--- a/js/state/syncUtil.js
+++ b/js/state/syncUtil.js
@@ -7,6 +7,7 @@ const Immutable = require('immutable')
 const writeActions = require('../constants/sync/proto').actions
 const siteTags = require('../constants/siteTags')
 const siteUtil = require('./siteUtil')
+const {isDataUrl} = require('../lib/urlutil')
 
 const CATEGORY_MAP = {
   bookmark: {
@@ -394,7 +395,7 @@ module.exports.createSiteData = (site, appState) => {
     creationTime: 0
   }
   for (let field in site) {
-    if (field in siteData) {
+    if (field in siteData && !isDataUrl(site[field])) {
       siteData[field] = site[field]
     }
   }

--- a/test/unit/state/syncUtilTest.js
+++ b/test/unit/state/syncUtilTest.js
@@ -67,6 +67,21 @@ describe('syncUtil', () => {
       }
       assert.deepEqual(syncUtil.createSiteData(bookmark), expectedBookmark)
     })
+
+    it('bookmark containing data url', () => {
+      const bookmark = Object.assign({}, site, {tags: ['bookmark'], favicon: 'data:foo'})
+      const newValue = Object.assign({}, expectedSite.value, {favicon: ''})
+      const expectedBookmark = {
+        name: 'bookmark',
+        objectId,
+        value: {
+          site: newValue,
+          isFolder: false,
+          parentFolderObjectId: undefined
+        }
+      }
+      assert.deepEqual(syncUtil.createSiteData(bookmark), expectedBookmark)
+    })
   })
 
   describe('ipcSafeObject()', () => {


### PR DESCRIPTION
since they are likely to exceed the AWS upload limit.
fix https://github.com/brave/browser-laptop/issues/8023

Test Plan:
1. unit tests should pass
2. set up sync
3. Open about:about and bookmark it
4. Open chrome-extension://cjnmeadmgmiihncdidmfiabhenbggfjm/_generated_background_page.html and wait. you should not see any errors related to encodeDataToS3KeyArray.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
