### PR TITLE
Prevent loss of default browser on Windows during upgrade/reinstall/etc

### DIFF
--- a/res/braveDefaults.nsi
+++ b/res/braveDefaults.nsi
@@ -39,6 +39,7 @@ Function .onInit
 
   Push $EXEDIR
   Call GetParent
+  Call GetParent
   POP $0
 
   StrCpy $BraveEXEPath "$0\Brave.exe"

--- a/tools/buildPackage.js
+++ b/tools/buildPackage.js
@@ -95,9 +95,9 @@ cmds = cmds.concat([
     ' --build-version=' + VersionInfo.electronVersion +
     ' --protocol="http" --protocol-name="HTTP Handler"' +
     ' --protocol="https" --protocol-name="HTTPS Handler"' +
-    ' --version-string.CompanyName="Brave Inc."' +
+    ' --version-string.CompanyName="Brave Software"' +
     ' --version-string.ProductName="Brave"' +
-    ' --version-string.Copyright="Copyright 2016, Brave Inc."' +
+    ' --version-string.Copyright="Copyright 2017, Brave Software"' +
     ' --version-string.FileDescription="Brave"'
 ])
 


### PR DESCRIPTION
## Test plan
### Prevent loss of default browser on Windows during upgrade/reinstall/etc
This should be attempted on Windows 7 and 10
 
1. Install the official release of Brave 0.14.2 (at the time of writing, not available)
2. Set Brave as the default for all applications
  - Start menu
  - search "Default Programs"
  - Press enter
  - pick Brave
  - Windows 10 demo: 
  ![default-win10](https://cloud.githubusercontent.com/assets/4733304/24677686/797f2f6c-193c-11e7-9db4-5ef99a3d61e6.gif)
  - Windows 7 demo:
![default-win7](https://cloud.githubusercontent.com/assets/4733304/24677973/9664b90c-193d-11e7-9f0c-d8a74d6ded1c.gif)


## Description
### Prevent loss of default browser on Windows during upgrade/reinstall/etc
Fixes #5246
- Brave registers a handler called `BraveHTML`
- Using `Default Programs`, users can associate an extension or protocol with a handler (which in our case is `BraveHTML`.

Each upgrade was breaking default browser because the install or upgrade updates the path which is not allowed. For example, it would set:
`"C:\Users\brian\AppData\Local\brave\app-0.13.4\Brave.exe" -- "%1"`
to
`"C:\Users\brian\AppData\Local\brave\app-0.13.5\Brave.exe" -- "%1"`

Changing the value of keys associated with the `BraveHTML` handler would trigger the reset of the handler for http and https (but not extensions, email, or FTP). Specifically these keys:
- `HKEY_CURRENT_USER\SOFTWARE\Classes\BraveHTML\DefaultIcon`
- `HKEY_CURRENT_USER\SOFTWARE\Classes\BraveHTML\shell\open\command`

This PR fixes the issue by linking to the stub executable. Using the above example, this would look like:
`"C:\Users\brian\AppData\Local\brave\Brave.exe" -- "%1"`

This stub executable was something introduced (I believe) with Squirrel 1.5.0. We already use it for the shortcut which gets installed on the desktop (in fact, this change was something @aekeus 
 and I had to resolve because it broke the params being passed).

The stub executable has an absolute path which does not change, meaning:
- the path never gets updated in the registry
- default browser not modified (because registry wasn't updated)

### Update name shown in Windows to `Brave Software` (was `Brave Inc`)
Fixes #2061

**_BEFORE change_**
![screen shot 2017-04-04 at 1 08 12 am](https://cloud.githubusercontent.com/assets/4733304/24647733/f6608a2e-18d5-11e7-8ba8-769adf9ec5ca.png)
______
**_AFTER change_**
![screen shot 2017-04-04 at 1 44 31 am](https://cloud.githubusercontent.com/assets/4733304/24648380/4c7f11e4-18d8-11e7-8e9d-c22681f738e6.png)

______


- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

