### PR TITLE
linuxInstall.md: import key for openSUSE

### DIFF
--- a/docs/linuxInstall.md
+++ b/docs/linuxInstall.md
@@ -75,6 +75,7 @@ sudo dnf install ./brave.rpm
 To install brave using zypper:
 
 ```
+sudo rpmkeys --import https://s3-us-west-2.amazonaws.com/brave-rpm-release/keys.asc
 sudo zypper install lsb
 sudo zypper addrepo https://s3-us-west-2.amazonaws.com/brave-rpm-release/x86_64/ brave-rpm-release
 sudo zypper ref


### PR DESCRIPTION
Signed-off-by: Mateusz Mikula <mati865@gmail.com>

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Without the key Brave installation fails with (you have to ignore missing dependency):
```
brave-0.14.1.x86_64.rpm:
    Header V4 RSA/SHA256 Signature, key ID 448eee6c: NOKEY
    V4 RSA/SHA256 Signature, key ID 448eee6c: NOKEY

brave-0.14.1-1.x86_64 (brave-rpm-release): Signature verification failed [4-Signatures public key is not available]
```
2. After adding the key it installs but you still have to ignore missing dependency.