### PR TITLE
Add support for welcome page

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -155,7 +155,7 @@ let generateBraveManifest = () => {
     'referrer': 'no-referrer',
     'style-src': '\'self\' \'unsafe-inline\'',
     'img-src': '* data: file://*',
-    'frame-src': '\'self\' https://buy.coinbase.com'
+    'frame-src': '\'self\' https://buy.coinbase.com https://brave.com'
   }
 
   if (process.env.NODE_ENV === 'development') {

--- a/app/extensions/brave/about-welcome.html
+++ b/app/extensions/brave/about-welcome.html
@@ -1,0 +1,21 @@
+
+<!DOCTYPE html>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="availableLanguages" content="">
+    <meta name="defaultLanguage" content="en-US">
+    <link rel="shortcut icon" type="image/x-icon" href="data:image/x-icon;,">
+    <title data-l10n-id="aboutWelcome"></title>
+    <script src="ext/l20n.min.js"></script>
+    <script src="gen/aboutPages.entry.js" async></script>
+    <link rel="localization" href="locales/{locale}/app.properties">
+    <link rel="stylesheet" href="content/styles/defaultStyles.css">
+  </head>
+  <body>
+    <div id="appContainer" class="welcomePage" />
+  </body>
+</html>

--- a/app/extensions/brave/content/styles/defaultStyles.css
+++ b/app/extensions/brave/content/styles/defaultStyles.css
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Use this file as a normalizer
+ * to edit webview for about:pages.
+*/
+
+html, body {
+  font-family: "Helvetica Neue", Arial, sans-serif;
+  font-weight: 400;
+  margin: 0;
+  padding: 0;
+}
+
+html, body, #appContainer, #appContainer > div {
+  height: 100%;
+}
+
+body {
+  font-size: 100%;
+}
+
+.welcomePage {
+  overflow: hidden;
+}

--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -16,6 +16,7 @@ submit=Submit
 settings=Settings
 aboutPages=About pages
 aboutBrave=About Brave
+aboutWelcome=Welcome to Brave
 braveInfo=Browse faster and safer with Brave.
 releaseNotes=Release Notes
 relNotesInfo1=Click

--- a/app/renderer/about/welcome.js
+++ b/app/renderer/about/welcome.js
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const React = require('react')
+const {StyleSheet, css} = require('aphrodite/no-important')
+
+class AboutWelcome extends React.Component {
+  render () {
+    return <iframe data-test-id='welcomeIframe'
+      className={css(styles.welcomeIframe)} src='https://brave.com/welcome.html' />
+  }
+}
+
+const styles = StyleSheet.create({
+  welcomeIframe: {
+    width: '100%',
+    height: '100%',
+    border: 0
+  }
+})
+
+module.exports = <AboutWelcome />

--- a/js/about/entry.js
+++ b/js/about/entry.js
@@ -95,6 +95,9 @@ switch (getBaseUrl(getSourceAboutUrl(window.location.href))) {
   case 'about:contributions':
     element = require('./contributionStatement')
     break
+  case 'about:welcome':
+    element = require('../../app/renderer/about/welcome')
+    break
 }
 
 if (element) {

--- a/js/lib/appUrlUtil.js
+++ b/js/lib/appUrlUtil.js
@@ -107,7 +107,8 @@ module.exports.aboutUrls = new Immutable.Map({
   'about:preferences': module.exports.getBraveExtUrl('about-preferences.html'),
   'about:safebrowsing': module.exports.getBraveExtUrl('about-safebrowsing.html'),
   'about:styles': module.exports.getBraveExtUrl('about-styles.html'),
-  'about:contributions': module.exports.getBraveExtUrl('about-contributions.html')
+  'about:contributions': module.exports.getBraveExtUrl('about-contributions.html'),
+  'about:welcome': module.exports.getBraveExtUrl('about-welcome.html')
 })
 
 module.exports.isIntermediateAboutPage = (location) =>

--- a/test/unit/about/welcomePageTest.js
+++ b/test/unit/about/welcomePageTest.js
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* global describe, before, after, it */
+
+const mockery = require('mockery')
+const {shallow} = require('enzyme')
+const assert = require('assert')
+let AboutWelcome
+require('../braveUnit')
+
+describe('AboutWelcome component', function () {
+  before(function () {
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    })
+    AboutWelcome = require('../../../app/renderer/about/welcome')
+    mockery.registerMock('../../../less/about/common.less', {})
+  })
+
+  after(function () {
+    mockery.disable()
+  })
+
+  describe('Rendering', function () {
+    it('renders an iframe', function () {
+      const wrapper = shallow(
+        AboutWelcome
+      )
+      assert.equal(wrapper.find('[data-test-id="welcomeIframe"]').length, 1)
+    })
+  })
+})


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bsclifton
Closes #7821

Test Plan:
```
npm run test -- --grep="AboutWelcome component"
```

QA steps:
* Navigate to about:welcome
* should load content from https://brave.com/welcome.html