### PR TITLE
Fixes ledger calculation when you don't have any unpinned sites

### DIFF
--- a/app/ledger.js
+++ b/app/ledger.js
@@ -1131,7 +1131,7 @@ var synopsisNormalizer = (changedPublisher) => {
   underscore.keys(synopsis.publishers).forEach((publisher) => {
     if (!visibleP(publisher)) return
 
-    results.push(underscore.extend({ publisher: publisher }, underscore.omit(synopsis.publishers[publisher], 'window')))
+    results.push(underscore.extend({publisher: publisher}, underscore.omit(synopsis.publishers[publisher], 'window')))
   }, synopsis)
   results = underscore.sortBy(results, (entry) => { return -entry.scores[scorekeeper] })
 
@@ -1177,6 +1177,13 @@ var synopsisNormalizer = (changedPublisher) => {
     })
 
     dataPinned.push(changedObject)
+
+    // sync app store
+    appActions.changeLedgerPinnedPercentages(dataPinned)
+  } else if (dataUnPinned.length === 0 && pinnedTotal < 100) {
+    // when you don't have any unpinned sites and pinned total is less then 100 %
+    dataPinned = normalizePinned(dataPinned, pinnedTotal, 100, false)
+    dataPinned = roundToTarget(dataPinned, 100, 'pinPercentage')
 
     // sync app store
     appActions.changeLedgerPinnedPercentages(dataPinned)

--- a/test/about/ledgerTableTest.js
+++ b/test/about/ledgerTableTest.js
@@ -148,6 +148,19 @@ describe('Ledger table', function () {
         }, 5000)
         .waitForVisible(`${firstTableFirstRow} [data-switch-status="true"]`)
     })
+
+    it('check pinned sites amount, when you have 0 eligible unpinned sites', function * () {
+      yield this.app.client
+        .tabByIndex(0)
+        .click(`${secondTableFirstRow} [data-test-pinned="false"]`)
+        .waitForVisible(`${firstTableFirstRow} [data-test-pinned="true"]`)
+        .click(`${firstTableFirstRow} [data-test-id="pinnedInput"]`)
+        .keys([Brave.keys.DELETE, Brave.keys.DELETE, '60', Brave.keys.ENTER])
+        .waitForInputText(`${firstTableFirstRow} [data-test-id="pinnedInput"]`, '60')
+        .waitForTextValue(`${secondTableSecondRow} [data-test-id="percentageValue"]`, '40')
+        .click(`${secondTableSecondRow} .switchBackground`)
+        .waitForInputText(`${firstTableFirstRow} [data-test-id="pinnedInput"]`, '100')
+    })
   })
 
   describe('4 publishers', function () {


### PR DESCRIPTION
## Test Plan
- Go to payments and add two publishers
- Pin one and exclude the second one
- Set 60 % for a pinned publisher
- Value should be adjusted to 100%

## Automated test plan
`npm run test -- --grep="check pinned sites amount, when you have 0 eligible unpinned sites"`

## Description
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #8102

### Auditors
@mrose17 @bradleyrichter 
