### PR TITLE
do not show phishing warning for javascript URLs

### DIFF
--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -214,7 +214,7 @@ const UrlUtil = {
   isPotentialPhishingUrl: function (url) {
     if (typeof url !== 'string') { return false }
     const protocol = urlParse(url.trim().toLowerCase()).protocol
-    return ['data:', 'blob:', 'javascript:'].includes(protocol)
+    return ['data:', 'blob:'].includes(protocol)
   },
 
   /**

--- a/test/unit/lib/urlutilTest.js
+++ b/test/unit/lib/urlutilTest.js
@@ -281,11 +281,8 @@ describe('urlutil', function () {
     it('returns true if input is a data URL', function () {
       assert.equal(UrlUtil.isPotentialPhishingUrl('data:text/html,<script>alert("no crash")</script>'), true)
     })
-    it('returns true if input is a js URL', function () {
-      assert.equal(UrlUtil.isPotentialPhishingUrl('   JAVASCRIPT:alert(1)'), true)
-    })
     it('returns true if input is a blob URL', function () {
-      assert.equal(UrlUtil.isPotentialPhishingUrl('   blob:foo '), true)
+      assert.equal(UrlUtil.isPotentialPhishingUrl('   BLOB:foo '), true)
     })
   })
 })


### PR DESCRIPTION
fix #8087 

Test Plan:
1. go to any site and bookmark it
2. click 'edit bookmark' in the bookmark toolbar
3. change the bookmark's location to 'javascript:alert(1)'
4. click the bookmark. you should see an alert appear without a phishing warning.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).