### PR TITLE
Add Widevine for Spotify

### DIFF
--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -590,6 +590,7 @@ class Frame extends ImmutableComponent {
     const widevineSites = ['https://www.netflix.com',
       'http://bitmovin.com',
       'https://www.primevideo.com',
+      'https://www.spotify.com',
       'https://shaka-player-demo.appspot.com']
     const isForWidevineTest = process.env.NODE_ENV === 'test' && location.endsWith('/drm.html')
     if (!isForWidevineTest && (!origin || !widevineSites.includes(origin))) {


### PR DESCRIPTION
Fixes #6881

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Open a new tab and go to spotify.com
2. Try using the player.
3. Make sure the Widevine popup is shown.