### PR TITLE
Make torrent file names on the table selectable

### DIFF
--- a/app/renderer/components/styles/commonStyles.js
+++ b/app/renderer/components/styles/commonStyles.js
@@ -157,6 +157,16 @@ const styles = StyleSheet.create({
     paddingRight: 0
   },
 
+  // User select
+  userSelect: {
+    userSelect: 'initial',
+    cursor: 'text'
+  },
+  userSelectNone: {
+    userSelect: 'none',
+    cursor: 'default'
+  },
+
   // notificationBar
   notificationBar: {
     display: 'inline-block',

--- a/js/webtorrent/components/torrentFileList.js
+++ b/js/webtorrent/components/torrentFileList.js
@@ -2,6 +2,9 @@ const prettierBytes = require('prettier-bytes')
 const React = require('react')
 const SortableTable = require('../../components/sortableTable')
 
+const {css} = require('aphrodite/no-important')
+const commonStyles = require('../../../app/renderer/components/styles/commonStyles')
+
 class TorrentFileList extends React.Component {
   render () {
     const { torrent, stateOwner } = this.props
@@ -9,9 +12,9 @@ class TorrentFileList extends React.Component {
 
     let content
     if (files == null) {
-      content = <div data-l10n-id='missingFilesList' />
+      content = <div className={css(commonStyles.userSelectNone)} data-l10n-id='missingFilesList' />
     } else if (files.length === 0) {
-      content = <div data-l10n-id='loadingFilesList' />
+      content = <div className={css(commonStyles.userSelectNone)} data-l10n-id='loadingFilesList' />
     } else {
       content = [
         <SortableTable
@@ -45,7 +48,7 @@ class TorrentFileList extends React.Component {
     if (isDownload) {
       if (serverUrl) {
         const httpURL = serverUrl + '/' + ix
-        return <a href={httpURL} download={file.name}>⇩</a>
+        return <a className={css(commonStyles.userSelect)} href={httpURL} download={file.name}>⇩</a>
       } else {
         return <div /> // No download links until the server is ready
       }
@@ -54,7 +57,7 @@ class TorrentFileList extends React.Component {
         ? '#ix=' + ix
         : '&ix=' + ix
       const href = torrentId + suffix
-      return <a href={href}>{file.name}</a>
+      return <a className={css(commonStyles.userSelect)} href={href}>{file.name}</a>
     }
   }
 }

--- a/js/webtorrent/components/torrentStatus.js
+++ b/js/webtorrent/components/torrentStatus.js
@@ -1,5 +1,9 @@
 const prettierBytes = require('prettier-bytes')
 const React = require('react')
+const cx = require('../../lib/classSet')
+
+const {css} = require('aphrodite/no-important')
+const commonStyles = require('../../../app/renderer/components/styles/commonStyles')
 
 class TorrentStats extends React.Component {
   render () {
@@ -16,7 +20,10 @@ class TorrentStats extends React.Component {
 
     return <div>
       <div data-l10n-id='torrentStatus' className='sectionTitle' />
-      <div className='torrentStats'>
+      <div className={cx({
+        torrentStats: true,
+        [css(commonStyles.userSelectNone)]: true
+      })}>
         {renderStatus()}
         {renderPercentage()}
         {renderSpeeds()}

--- a/js/webtorrent/components/torrentViewer.js
+++ b/js/webtorrent/components/torrentViewer.js
@@ -1,4 +1,8 @@
 const React = require('react')
+const cx = require('../../lib/classSet')
+
+const {css} = require('aphrodite/no-important')
+const commonStyles = require('../../../app/renderer/components/styles/commonStyles')
 
 // Components
 const Button = require('../../components/button')
@@ -31,22 +35,21 @@ class TorrentViewer extends React.Component {
       } else {
         // 'Loading torrent information...'
         titleElem = (
-          <div
-            className='sectionTitle'
-            data-l10n-id='torrentLoadingInfo'
-          />
+          <div className='sectionTitle' data-l10n-id='torrentLoadingInfo' />
         )
       }
       mainButton = (
-        <Button
+        <Button className='primaryButton mainButton'
           l10nId='stopDownload'
-          className='primaryButton mainButton'
+          testId='stopDownload'
           onClick={() => dispatch('stop')}
         />
       )
       legalNotice = (
-        <a
-          className='legalNotice'
+        <a className={cx({
+          legalNotice: true,
+          [css(commonStyles.userSelectNone)]: true
+        })}
           data-l10n-id='poweredByWebTorrent'
           href='https://webtorrent.io'
           target='_blank'
@@ -56,34 +59,37 @@ class TorrentViewer extends React.Component {
       const l10nStart = name ? 'startPrompt' : 'startPromptUntitled'
       const l10nArgs = {name}
       titleElem = (
-        <div
+        <div className='sectionTitle'
           data-l10n-id={l10nStart}
           data-l10n-args={JSON.stringify(l10nArgs)}
-          className='sectionTitle' />
+        />
       )
       mainButton = (
-        <Button
+        <Button className='primaryButton mainButton'
           l10nId='startDownload'
-          className='primaryButton mainButton'
+          testId='startDownload'
           onClick={() => dispatch('start')}
         />
       )
-      legalNotice = <div className='legalNotice' data-l10n-id='legalNotice' />
+      legalNotice = <div className={cx({
+        legalNotice: true,
+        [css(commonStyles.userSelectNone)]: true
+      })} data-l10n-id='legalNotice' />
     }
 
     if (torrentIdProtocol === 'magnet:') {
       saveButton = (
-        <Button
+        <Button className='whiteButton copyMagnetLink'
           l10nId='copyMagnetLink'
-          className='whiteButton copyMagnetLink'
+          testId='copyMagnetLink'
           onClick={() => dispatch('copyMagnetLink')}
         />
       )
     } else {
       saveButton = (
-        <Button
+        <Button className='whiteButton saveTorrentFile'
           l10nId='saveTorrentFile'
-          className='whiteButton saveTorrentFile'
+          testId='saveTorrentFile'
           onClick={() => dispatch('saveTorrentFile')}
         />
       )


### PR DESCRIPTION
Closes #8148

Also:
- Added testIds to the buttons for future work
- Made missingFilesList, loadingFilesList, torrentStats, and legalNotice unselectable

Auditors:

Test Plan:
1. Open https://webtorrent.io/free-torrents
2. Click "Big Buck Bunny (magnet link)"
3. Make sure nothing is selectable
4. Click "Start download"
5. Make sure only the file names on the table are selectable

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).