### PR TITLE
Change tab loading icon

### DIFF
--- a/app/extensions/brave/img/tabs/loading.svg
+++ b/app/extensions/brave/img/tabs/loading.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 20.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1_copy" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px"
+	 y="0px" viewBox="0 0 48 48" style="enable-background:new 0 0 48 48;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FF5500;}
+</style>
+<path class="st0" d="M42.4,38c0.3-0.3,0.5-0.7,0.8-1c6.5-9,5.8-21.7-2.4-29.8c7.5,9.1,6.9,21.6-1.7,30.1c-2.6,2.6-5.6,4.4-8.8,5.6
+	c-2,0.5-4.1,0.8-6.2,0.8c-12.1,0-22.1-8.1-23.2-19.8C0.8,36.7,11.2,47,24,47c7.4,0,13.9-3.4,18.2-8.8C42.2,38.2,42.3,38.1,42.4,38z"
+	/>
+</svg>

--- a/app/renderer/components/styles/animations.js
+++ b/app/renderer/components/styles/animations.js
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const spinKeyframes = {
+  'from': {
+    transform: 'rotate(0deg)'
+  },
+  'to': {
+    transform: 'rotate(360deg)'
+  }
+}
+
+module.exports = {
+  spinKeyframes
+}

--- a/app/renderer/components/styles/global.js
+++ b/app/renderer/components/styles/global.js
@@ -78,6 +78,9 @@ const globalStyles = {
     urlBarOutline: '#bbb',
     alphaWhite: 'rgba(255,255,255,0.8)'
   },
+  filter: {
+    makeWhite: 'brightness(0) invert(1)'
+  },
   radius: {
     borderRadius: '4px',
     borderRadiusTabs: '4px',

--- a/app/renderer/components/tabContent.js
+++ b/app/renderer/components/tabContent.js
@@ -7,10 +7,12 @@ const ImmutableComponent = require('../../../js/components/immutableComponent')
 const {StyleSheet, css} = require('aphrodite/no-important')
 const globalStyles = require('./styles/global')
 const {isWindows} = require('../../common/lib/platformUtil')
-const {getTextColorForBackground} = require('../../../js/lib/color')
 const {tabs} = require('../../../js/constants/config')
 const {hasBreakpoint, hasRelativeCloseIcon,
-      hasFixedCloseIcon, hasVisibleSecondaryIcon} = require('../lib/tabUtil')
+      hasFixedCloseIcon, hasVisibleSecondaryIcon, getTabIconColor} = require('../lib/tabUtil')
+const {spinKeyframes} = require('./styles/animations')
+
+const loadingIconSvg = require('../../extensions/brave/img/tabs/loading.svg')
 const newSessionSvg = require('../../extensions/brave/img/tabs/new_session.svg')
 const privateSvg = require('../../extensions/brave/img/tabs/private.svg')
 const closeTabSvg = require('../../extensions/brave/img/tabs/close_btn_normal.svg')
@@ -57,12 +59,6 @@ class Favicon extends ImmutableComponent {
     return !this.props.isLoading && this.props.tab.get('icon')
   }
 
-  get loadingIcon () {
-    return this.props.isLoading
-      ? globalStyles.appIcons.loading
-      : null
-  }
-
   get defaultIcon () {
     return (!this.props.isLoading && !this.favicon)
       ? globalStyles.appIcons.defaultIcon
@@ -80,18 +76,25 @@ class Favicon extends ImmutableComponent {
 
   render () {
     const iconStyles = StyleSheet.create({
-      favicon: {backgroundImage: `url(${this.favicon})`}
+      favicon: {backgroundImage: `url(${this.favicon})`},
+      loadingIconColor: {
+        // Don't change icon color unless when it should be white
+        filter: getTabIconColor(this.props) === 'white' ? globalStyles.filter.makeWhite : 'none'
+      }
     })
     return !this.shouldHideFavicon
       ? <TabIcon
         data-test-favicon={this.favicon}
-        data-test-id={this.loadingIcon ? 'loading' : 'defaultIcon'}
+        data-test-id={this.props.isLoading ? 'loading' : 'defaultIcon'}
         className={css(
           styles.icon,
           this.favicon && iconStyles.favicon,
           !this.props.tab.get('pinnedLocation') && this.narrowView && styles.faviconNarrowView
         )}
-        symbol={this.loadingIcon || this.defaultIcon} />
+        symbol={
+          (this.props.isLoading && css(styles.loadingIcon, iconStyles.loadingIconColor)) ||
+          this.defaultIcon
+        } />
       : null
   }
 }
@@ -166,10 +169,7 @@ class NewSessionIcon extends ImmutableComponent {
   }
 
   get iconColor () {
-    const themeColor = this.props.tab.get('themeColor') || this.props.tab.get('computedThemeColor')
-    return this.props.paintTabs && themeColor
-      ? getTextColorForBackground(themeColor)
-      : globalStyles.color.black100
+    return getTabIconColor(this.props)
   }
 
   render () {
@@ -206,22 +206,11 @@ class TabTitle extends ImmutableComponent {
       hasFixedCloseIcon(this.props)
   }
 
-  get themeColor () {
-    const themeColor = this.props.tab.get('themeColor') || this.props.tab.get('computedThemeColor')
-    const activeNonPrivateTab = !this.props.tab.get('isPrivate') && this.props.isActive
-    const isPrivateTab = this.props.tab.get('isPrivate') && (this.props.isActive || this.props.tab.get('hoverState'))
-    const defaultColor = isPrivateTab ? globalStyles.color.white100 : globalStyles.color.black100
-
-    return activeNonPrivateTab && this.props.paintTabs && !!themeColor
-      ? getTextColorForBackground(themeColor)
-      : defaultColor
-  }
-
   render () {
     const titleStyles = StyleSheet.create({
       gradientText: {
         backgroundImage: `-webkit-linear-gradient(left,
-        ${this.themeColor} 90%, ${globalStyles.color.almostInvisible} 100%)`
+        ${getTabIconColor(this.props)} 90%, ${globalStyles.color.almostInvisible} 100%)`
       }
     })
 
@@ -284,6 +273,14 @@ const styles = StyleSheet.create({
     padding: '0',
     fontSize: '10px',
     backgroundPosition: 'center center'
+  },
+
+  loadingIcon: {
+    backgroundImage: `url(${loadingIconSvg})`,
+    animationName: spinKeyframes,
+    animationTimingFunction: 'linear',
+    animationDuration: '1200ms',
+    animationIterationCount: 'infinite'
   },
 
   audioIcon: {

--- a/app/renderer/lib/tabUtil.js
+++ b/app/renderer/lib/tabUtil.js
@@ -6,6 +6,7 @@ const styles = require('../components/styles/global')
 const frameStateUtil = require('../../../js/state/frameStateUtil')
 const settings = require('../../../js/constants/settings')
 const getSetting = require('../../../js/settings').getSetting
+const {getTextColorForBackground} = require('../../../js/lib/color')
 
 /**
  * Get tab's breakpoint name for current tab size.
@@ -67,6 +68,22 @@ module.exports.hasVisibleSecondaryIcon = (props) => {
  */
 module.exports.hasFixedCloseIcon = (props) => {
   return props.isActive && module.exports.hasBreakpoint(props, ['small', 'extraSmall'])
+}
+
+/**
+ * Gets the icon color based on tab's background
+ * @param {Object} props - Object that hosts the tab props
+ * @returns {String} Contrasting color to use based on tab's color
+ */
+module.exports.getTabIconColor = (props) => {
+  const themeColor = props.tab.get('themeColor') || props.tab.get('computedThemeColor')
+  const activeNonPrivateTab = !props.tab.get('isPrivate') && props.isActive
+  const isPrivateTab = props.tab.get('isPrivate') && (props.isActive || props.tab.get('hoverState'))
+  const defaultColor = isPrivateTab ? styles.color.white100 : styles.color.black100
+
+  return activeNonPrivateTab && props.paintTabs && !!themeColor
+    ? getTextColorForBackground(themeColor)
+    : defaultColor
 }
 
 /**

--- a/js/components/tab.js
+++ b/js/components/tab.js
@@ -290,6 +290,7 @@ class Tab extends ImmutableComponent {
           )}>
           <Favicon
             isActive={this.props.isActive}
+            paintTabs={this.props.paintTabs}
             tab={this.props.tab}
             isLoading={this.loading}
             isPinned={this.isPinned}

--- a/test/unit/app/renderer/tabContentTest.js
+++ b/test/unit/app/renderer/tabContentTest.js
@@ -15,6 +15,7 @@ require('../../braveUnit')
 
 describe('tabContent components', function () {
   before(function () {
+    mockery.registerMock('../../extensions/brave/img/tabs/loading.svg')
     mockery.registerMock('../../extensions/brave/img/tabs/new_session.svg')
     mockery.registerMock('../../extensions/brave/img/tabs/close_btn_normal.svg')
     mockery.registerMock('../../extensions/brave/img/tabs/close_btn_hover.svg')
@@ -77,7 +78,7 @@ describe('tabContent components', function () {
           isLoading
         />
       )
-      assert.equal(wrapper.props().symbol, globalStyles.appIcons.loading)
+      assert.equal(wrapper.props()['data-test-id'], 'loading')
     })
     it('should not show favicon for new tab page', function () {
       const wrapper = shallow(


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Change tab loading icon

Close #7265
Close #7779

```
npm run test -- --grep="should show a loading icon if page is still loading"
```

QA Steps:

Interface should match GIF:
(orange on non-themed tabs - same color as title for other cases)

![black_bg_loading](https://cloud.githubusercontent.com/assets/4672033/24832284/f5816b54-1c82-11e7-96c9-004ac8074ed4.gif)

