### PR TITLE
Standardizes on Lion badge design

### DIFF
--- a/app/renderer/components/browserActionBadge.js
+++ b/app/renderer/components/browserActionBadge.js
@@ -39,17 +39,19 @@ class BrowserActionBadge extends ImmutableComponent {
 
 const styles = StyleSheet.create({
   browserActionBadge: {
+    left: 'calc(50% - 1px)',
+    top: '14px',
+    position: 'absolute',
     color: '#FFF',
-    borderRadius: '2px',
+    borderRadius: '2.5px',
     padding: '1px 2px',
     pointerEvents: 'none',
-    font: '7pt "Arial Narrow"',
+    font: '6pt "Arial Narrow"',
     textAlign: 'center',
-    position: 'absolute',
-    top: '50%',
-    left: '40%',
-    border: '.5px solid #FFF',
-    minWidth: '8px'
+    border: '0px solid #FFF',
+    background: '#555555',
+    minWidth: '10px',
+    userSelect: 'none'
   },
   centered: {
     left: '50%',


### PR DESCRIPTION
## Test plan
1. Set LastPass as your active password manager in Preferences > Security
2. Add a login/password for GitHub
3. Go to https://github.com/login and the LastPass icon with badge should show in the top right corner
4. Confirm it matches spec (below)

## Description
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes #8185 

Before:

![image](https://cloud.githubusercontent.com/assets/815158/24871466/49aa289e-1ddf-11e7-9bcc-56eaa1fa86ca.png)

After:

![image](https://cloud.githubusercontent.com/assets/815158/24871528/79c05904-1ddf-11e7-827a-15e97e2313d6.png)
