### PR TITLE
fix 'beta' logo alignment, add it to sync tab

### DIFF
--- a/app/renderer/components/preferences/syncTab.js
+++ b/app/renderer/components/preferences/syncTab.js
@@ -284,11 +284,14 @@ class SyncTab extends ImmutableComponent {
         ? <ModalOverlay title={'syncReset'} content={this.resetOverlayContent} footer={this.resetOverlayFooter} onHide={this.props.hideOverlay.bind(this, 'syncReset')} />
         : null
       }
-      <div className='sectionTitle' data-l10n-id='syncTitle' />
+      <div className='sectionTitleWrapper'>
+        <span className='sectionTitle' data-l10n-id='syncTitle' />
+        <span className='sectionSubTitle'>beta</span>
+      </div>
       <div className='settingsListContainer'>
         <span className='settingsListTitle syncTitleMessage' data-l10n-id='syncTitleMessage' />
         <a href='https://github.com/brave/sync/wiki/Design' target='_blank'>
-          <span className='fa fa-question-circle fundsFAQ' />
+          <span className='fa fa-question-circle' />
         </a>
         <div className='settingsListTitle syncBetaMessage' data-l10n-id='syncBetaMessage' />
         {

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -31,18 +31,13 @@ body {
     .sectionTitle {
       color: @braveOrange;
       font-size: 28px;
-      margin-bottom: 0;
-      position: absolute;
-      bottom: 0;
-      left: 0;
+      margin-bottom: 8px;
     }
 
     .sectionSubTitle {
       color: #999;
       font-size: 15px;
-      position: absolute;
-      bottom: 25px;
-      right: 19px;
+      vertical-align: top;
     }
   }
 


### PR DESCRIPTION
address https://github.com/brave/browser-laptop/issues/8121#issuecomment-293023244 and makes the logo look the same on sync and payments tabs

fix #8121 

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
go to about:preferences, check that the 'beta' logo is on the sync and payments tabs and looks the same.