### PR TITLE
Fix copy to clipboard tooltip

### DIFF
--- a/app/renderer/components/clipboardButton.js
+++ b/app/renderer/components/clipboardButton.js
@@ -37,9 +37,10 @@ class ClipboardButton extends React.Component {
       <span className={css(
         styles.doneLabel,
         this.state.visibleLabel && styles.visible
-      )} onAnimationEnd={this.onAnimationEnd} data-l10n-id='copied'>Copiesd!</span>
+      )} onAnimationEnd={this.onAnimationEnd} data-l10n-id='copied' />
       <span
         className={this.props.className}
+        data-l10n-id={this.props.dataL10nId}
         onClick={this.onClick}>
         {
           this.props.textContext

--- a/js/about/brave.js
+++ b/js/about/brave.js
@@ -60,7 +60,7 @@ class AboutBrave extends React.Component {
         <div className='title'>
           <span className='sectionTitle' data-l10n-id='versionInformation' />
           <ClipboardButton
-            data-l10n-id='copyToClipboard'
+            dataL10nId='copyToClipboard'
             className='fa fa-clipboard'
             copyAction={this.onCopy}
           />


### PR DESCRIPTION
## Test Plan:
1. Open about:brave with kabob > Help > About Brave.
2. Hover over the copy to clipboard button as shown in the screenshot below.
3. Make sure the tooltip `Copy to clipboard` tooltip is shown.

## Description
Fixes #8199

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).