### PR TITLE
Fixes url bar shape when payment is disabled

### DIFF
--- a/app/renderer/components/navigation/navigationBar.js
+++ b/app/renderer/components/navigation/navigationBar.js
@@ -129,16 +129,18 @@ class NavigationBar extends ImmutableComponent {
   }
 
   get visiblePublisher () {
-    // No publisher is visible if ledger is disabled
-    if (!getSetting(settings.PAYMENTS_ENABLED) || !this.publisherId) {
-      return false
-    }
     const hostPattern = UrlUtil.getHostPattern(this.publisherId)
     const hostSettings = this.props.siteSettings.get(hostPattern)
     const ledgerPaymentsShown = hostSettings && hostSettings.get('ledgerPaymentsShown')
     return typeof ledgerPaymentsShown === 'boolean'
       ? ledgerPaymentsShown
       : true
+  }
+
+  get isPublisherButtonEnabled () {
+    return getSetting(settings.PAYMENTS_ENABLED) &&
+      UrlUtil.isHttpOrHttps(this.props.location) &&
+      this.visiblePublisher
   }
 
   componentDidMount () {
@@ -242,7 +244,7 @@ class NavigationBar extends ImmutableComponent {
         urlbar={this.props.navbar.get('urlbar')}
         onStop={this.onStop}
         menubarVisible={this.props.menubarVisible}
-        noBorderRadius={!isSourceAboutUrl(this.props.location)}
+        noBorderRadius={this.isPublisherButtonEnabled}
         activeTabShowingMessageBox={this.props.activeTabShowingMessageBox}
         />
       {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #8170

### Auditors
@srirambv @bsclifton

### Test Plan
- with payments disabled visit a site
- url border should be shaped