### PR TITLE
include and locale-ready webtorrent description

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -14,6 +14,7 @@ const extensionState = require('./common/state/extensionState')
 const appActions = require('../js/actions/appActions')
 const fs = require('fs')
 const path = require('path')
+const l10n = require('../js/l10n')
 
 // Takes Content Security Policy flags, for example { 'default-src': '*' }
 // Returns a CSP string, for example 'default-src: *;'
@@ -193,6 +194,7 @@ let generateTorrentManifest = () => {
 
   return {
     name: 'Torrent Viewer',
+    description: l10n.translation('l10nWebtorrentDesc'),
     manifest_version: 2,
     version: '1.0',
     content_security_policy: concatCSP(cspDirectives),

--- a/app/extensions/brave/locales/en-US/extensions.properties
+++ b/app/extensions/brave/locales/en-US/extensions.properties
@@ -26,6 +26,6 @@ l10nPocketDesc=Pocket Extension for Brave - The best way to save articles, video
 l10nSync= Brave Sync
 l10nSyncDesc=
 l10nWebtorrent= Torrent Viewer
-l10nWebtorrentDesc=
+l10nWebtorrentDesc=Uses WebTorrent to display torrents directly in the browser. Supports torrent files and magnet links.
 l10nVimium= Vimium
 l10nVimiumDesc=

--- a/app/locale.js
+++ b/app/locale.js
@@ -230,6 +230,7 @@ var rendererIdentifiers = function () {
     'downloadItemClear',
     'downloadToolbarHide',
     'downloadItemClearCompleted',
+    'l10nWebtorrentDesc',
     // Caption buttons in titlebar (min/max/close - Windows only)
     'windowCaptionButtonMinimize',
     'windowCaptionButtonMaximize',

--- a/js/about/extensions.js
+++ b/js/about/extensions.js
@@ -59,7 +59,7 @@ class ExtensionItem extends ImmutableComponent {
         <span className={css(styles.extensionVersion)}>{this.props.extension.get('version')}</span>
         {
           !['__MSG_extDescriptionGoogleChrome__', '__MSG_appDesc__'].includes(this.props.extension.get('description'))
-          ? <div data-test-id='extensionDescription'>{bravifyText(this.props.extension.get('description'))}</div>
+          ? <div data-test-id='extensionDescription' data-l10n-id={this.props.extension.get('description')} />
           : null
         }
         <div className='extensionPath'><span data-l10n-id='extensionPathLabel' /> <span>{this.props.extension.get('base_path')}</span></div>


### PR DESCRIPTION
- Auditors: @jonathansampson
- Fix #8208

Test Plan:
* Go to about:extensions
  * Webtorrent description should be _Uses WebTorrent to display torrents directly in the browser. Supports torrent files and magnet links._
* Go to preferences -> extensions
  * Webtorrent description should be _Uses WebTorrent to display torrents directly in the browser. Supports torrent files and magnet links._
* Other extensions descriptions on both places shouldn't be affected