### PR TITLE
make secure vs insecure download origins more accessible

### DIFF
--- a/app/renderer/components/downloadItem.js
+++ b/app/renderer/components/downloadItem.js
@@ -82,6 +82,7 @@ class DownloadItem extends ImmutableComponent {
     } else if (downloadUtil.isPendingState(this.props.download)) {
       l10nStateArgs.downloadPercent = downloadUtil.getPercentageComplete(this.props.download)
     }
+    const isInsecure = origin.startsWith('http://')
     return <span
       onContextMenu={contextMenus.onDownloadsToolbarContextMenu.bind(null, this.props.downloadId, this.props.download)}
       onDoubleClick={this.onOpenDownload}
@@ -153,11 +154,14 @@ class DownloadItem extends ImmutableComponent {
           </div>
           {
             origin
-              ? <div className={cx({
-                downloadOrigin: true,
-                isSecure: origin.startsWith('https://'),
-                isInsecure: origin.startsWith('http://')
-              })} title={origin}>{origin}</div>
+              ? <div className='downloadOrigin'>
+                {
+                  isInsecure
+                    ? <span className='fa fa-unlock isInsecure' />
+                    : null
+                }
+                <span title={origin}>{origin}</span>
+              </div>
               : null
           }
           {

--- a/less/downloadBar.less
+++ b/less/downloadBar.less
@@ -110,12 +110,9 @@
           margin: auto 0 auto auto;
         }
 
-        .isSecure {
-          color: #15b106;
-        }
-
         .isInsecure {
-          color: red;
+          color: @siteInsecureColor;
+          margin-right: 2px;
         }
 
         >span {


### PR DESCRIPTION
fix #8215 

Test Plan:
1. go to tavis-ci.org
2. download the 'build failing' image
3. it should show up in the downloads toolbar with an insecure icon

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

![screen shot 2017-04-10 at 11 57 49 pm](https://cloud.githubusercontent.com/assets/549654/24887266/06e265b0-1e4a-11e7-8a29-54ec7e232c12.png)

