### PR TITLE
Add open bookmark in new window

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -285,6 +285,7 @@ function siteDetailTemplateInit (siteDetail, activeFrame) {
 
       template.push(openInNewTabMenuItem(location, undefined, siteDetail.get('partitionNumber')),
         openInNewPrivateTabMenuItem(location),
+        openInNewWindowMenuItem(location, undefined, siteDetail.get('partitionNumber')),
         openInNewSessionTabMenuItem(location),
         copyAddressMenuItem('copyLinkAddress', location),
         CommonMenu.separatorMenuItem)


### PR DESCRIPTION
Closes #8063

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. If there is not an item in the bookmarks toolbar, add one with Bookmark Page.
2. Right-click the bookmark and click `Open Link in New Window`.
3. Make sure the bookmarked page opens in a new window.

Screenshot:
![image](https://cloud.githubusercontent.com/assets/19424103/24889050/67782f80-1e2d-11e7-979f-1f0de6144e96.png)
