### PR TITLE
Disables sorting on Extensions list

### DIFF
--- a/app/renderer/components/preferences/extensionsTab.js
+++ b/app/renderer/components/preferences/extensionsTab.js
@@ -105,6 +105,7 @@ class ExtensionsTab extends ImmutableComponent {
           <h1 className={css(styles.extensionsHeading)} data-l10n-id='extensions' />
         </header>
         <SortableTable
+          sortingDisabled
           tableClassNames={css(styles.extensionsTable)}
           headings={['icon', 'name', 'description', 'version', 'enabled', 'exclude']}
           columnClassNames={this.columnClassNames}


### PR DESCRIPTION
# Testing Plan
Navigate to _about:preferences#extensions_
Click the _Enabled_ column header
Note that sorting has been disabled

# Details
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #8197 
