### PR TITLE
fix sync error when default newtab site is visited

### DIFF
--- a/app/renderer/reducers/urlBarSuggestionsReducer.js
+++ b/app/renderer/reducers/urlBarSuggestionsReducer.js
@@ -6,6 +6,7 @@
 
 const windowConstants = require('../../../js/constants/windowConstants')
 const getSetting = require('../../../js/settings').getSetting
+const {isDefaultEntry} = require('../../../js/state/siteUtil')
 const fetchSearchSuggestions = require('../fetchSearchSuggestions')
 const {activeFrameStatePath, frameStatePath, getFrameByKey, getFrameKeyByTabId, getActiveFrame} = require('../../../js/state/frameStateUtil')
 const searchProviders = require('../../../js/data/searchProviders')
@@ -128,11 +129,7 @@ const generateNewSuggestionsList = (state) => {
   let sites = appStoreRenderer.state.get('sites')
   if (sites) {
     // Filter out Brave default newtab sites and sites with falsey location
-    sites = sites.filterNot((site) =>
-      (Immutable.is(site.get('tags'), new Immutable.List(['default'])) &&
-      site.get('lastAccessedTime') === 1) ||
-      !site.get('location')
-    )
+    sites = sites.filter((site) => !isDefaultEntry(site) && site.get('location'))
   }
   const searchResults = state.getIn(activeFrameStatePath(state).concat(['navbar', 'urlbar', 'suggestions', 'searchResults']))
   const frameSearchDetail = state.getIn(activeFrameStatePath(state).concat(['navbar', 'urlbar', 'searchDetail']))

--- a/app/sync.js
+++ b/app/sync.js
@@ -53,7 +53,7 @@ const sendSyncRecords = (sender, action, data) => {
   if (!deviceId) {
     throw new Error('Cannot build a sync record because deviceId is not set')
   }
-  if (!data || !data.length) {
+  if (!data || !data.length || !data[0]) {
     return
   }
   const category = CATEGORY_MAP[data[0].name]

--- a/js/constants/siteTags.js
+++ b/js/constants/siteTags.js
@@ -6,6 +6,7 @@ const mapValuesByKeys = require('../lib/functional').mapValuesByKeys
 
 const _ = null
 const siteTags = {
+  DEFAULT: _,
   BOOKMARK: _,
   BOOKMARK_FOLDER: _,
   PINNED: _,

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -11,6 +11,8 @@ const UrlUtil = require('../lib/urlutil')
 const urlParse = require('../../app/common/urlParse')
 const {makeImmutable} = require('../../app/common/state/immutableUtil')
 
+const defaultTags = new Immutable.List([siteTags.DEFAULT])
+
 const isBookmark = (tags) => {
   if (!tags) {
     return false
@@ -604,14 +606,23 @@ module.exports.isHistoryEntry = function (siteDetail) {
     if (siteDetail.get('location').startsWith('about:')) {
       return false
     }
-    if (Immutable.is(siteDetail.get('tags'), new Immutable.List(['default'])) &&
-      siteDetail.get('lastAccessedTime') === 1) {
+    if (module.exports.isDefaultEntry(siteDetail)) {
       // This is a Brave default newtab site
       return false
     }
     return !!siteDetail.get('lastAccessedTime') && !isBookmarkFolder(siteDetail.get('tags'))
   }
   return false
+}
+
+/**
+ * Determines if the site detail is one of default sites in about:newtab.
+ * @param {Immutable.Map} siteDetail The site detail to check.
+ * @returns {boolean} if the site detail is a default newtab entry.
+ */
+module.exports.isDefaultEntry = function (siteDetail) {
+  return Immutable.is(siteDetail.get('tags'), defaultTags) &&
+    siteDetail.get('lastAccessedTime') === 1
 }
 
 /**

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -1259,6 +1259,14 @@ describe('siteUtil', function () {
       })
       assert.equal(siteUtil.isHistoryEntry(siteDetail), true)
     })
+    it('returns false for a default site', function () {
+      const siteDetail = Immutable.fromJS({
+        location: testUrl1,
+        tags: [siteTags.DEFAULT],
+        lastAccessedTime: 1
+      })
+      assert.equal(siteUtil.isHistoryEntry(siteDetail), false)
+    })
     it('returns false for a bookmark entry with falsey lastAccessedTime', function () {
       const siteDetail = Immutable.fromJS({
         location: testUrl1,
@@ -1277,7 +1285,7 @@ describe('siteUtil', function () {
     it('returns false for a brave default site', function () {
       const siteDetail = Immutable.fromJS({
         location: testUrl1,
-        tags: ['default'],
+        tags: [siteTags.DEFAULT],
         lastAccessedTime: 1
       })
       assert.equal(siteUtil.isHistoryEntry(siteDetail), false)
@@ -1292,6 +1300,41 @@ describe('siteUtil', function () {
         lastAccessedTime: 123
       })
       assert.equal(siteUtil.isHistoryEntry(siteDetail), false)
+    })
+  })
+
+  describe('isDefaultEntry', function () {
+    it('returns false for history entry which has lastAccessedTime', function () {
+      const siteDetail = Immutable.fromJS({
+        location: 'https://brave.com/',
+        tags: [siteTags.DEFAULT],
+        lastAccessedTime: 123
+      })
+      assert.equal(siteUtil.isDefaultEntry(siteDetail), false)
+    })
+    it('returns false for bookmark entry', function () {
+      const siteDetail = Immutable.fromJS({
+        location: 'https://brave.com/',
+        tags: [siteTags.BOOKMARK],
+        lastAccessedTime: 1
+      })
+      assert.equal(siteUtil.isDefaultEntry(siteDetail), false)
+    })
+    it('returns false for entry without lastAccessedTime', function () {
+      const siteDetail = Immutable.fromJS({
+        location: 'https://brave.com/',
+        tags: [siteTags.DEFAULT]
+      })
+      assert.equal(siteUtil.isDefaultEntry(siteDetail), false)
+    })
+    it('returns true for default entry', function () {
+      const siteDetail = Immutable.fromJS({
+        tags: [siteTags.DEFAULT],
+        lastAccessedTime: 1,
+        objectId: [210, 115, 31, 176, 57, 212, 167, 120, 104, 88, 88, 27, 141, 36, 235, 226],
+        location: testUrl1
+      })
+      assert.equal(siteUtil.isDefaultEntry(siteDetail), true)
     })
   })
 


### PR DESCRIPTION
fix #8217 and refactors syncUtil/urlBarSuggestions to use common siteUtil methods

Test Plan:
1. enable sync in a clean profile
2. go to https://brave.com
3. you should not see any console errors

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
