### PR TITLE
Fixes saving a .torrent file

### DIFF
--- a/app/browser/webtorrent.js
+++ b/app/browser/webtorrent.js
@@ -3,6 +3,7 @@ const ipc = electron.ipcMain
 const appUrlUtil = require('../../js/lib/appUrlUtil')
 const messages = require('../../js/constants/messages')
 const Filtering = require('../filtering')
+const url = require('url')
 
 // Set to see communication between WebTorrent and torrent viewer tabs
 const DEBUG_IPC = false
@@ -60,7 +61,13 @@ function setupFiltering () {
       return {}
     }
 
-    var viewerUrl = getViewerURL(details.url)
+    const parsedUrl = url.parse(details.url)
+    const directDownload = parsedUrl && parsedUrl.query && parsedUrl.query.includes('download=true')
+    if (directDownload) {
+      return {}
+    }
+
+    const viewerUrl = getViewerURL(details.url)
 
     return {
       responseHeaders: {

--- a/js/webtorrent/entry.js
+++ b/js/webtorrent/entry.js
@@ -176,6 +176,7 @@ function saveTorrentFile () {
   let a = document.createElement('a')
   a.target = '_blank'
   a.download = true
+  a.href = `${store.torrentId}?download=true`
   a.href = store.torrentId
   a.click()
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #8146

Auditors: @bsclifton

Test Plan:
- Visit https://webtorrent.io/free-torrents/
- Click "Big Buck Bunny (torrent file)"
- Click "Save Torrent File..."
- File is saved