### PR TITLE
Prevent webpack from generating source maps in production builds

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,6 +96,7 @@ function development () {  // eslint-disable-line
 
 function production () {  // eslint-disable-line
   var prod = config()
+  delete prod.devtool
   prod.plugins.push(new webpack.optimize.DedupePlugin())
   prod.plugins.push(new webpack.optimize.OccurrenceOrderPlugin(true))
   if (env !== 'test') {


### PR DESCRIPTION
## Test Plan:
?? - I need help verifying how to test this. I tried `npm run build-package` but didn't see file in either case.

## Description

Fixes https://github.com/brave/browser-laptop/issues/8255

Auditors: @jonathansampson, @bbondy, @bridiver 

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
