### PR TITLE
Adds title attributes to extension buttons

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -371,18 +371,23 @@ module.exports.init = () => {
 
   let insertLocaleStrings = (installInfo) => {
     let pattern = /^__MSG_(.*)__$/
-    let properties = ['name', 'description']
     let defaultLocale = installInfo.manifest.default_locale
     if (defaultLocale) {
       let msgPath = path.join(installInfo.base_path, '_locales', defaultLocale, 'messages.json')
       if (fs.existsSync(msgPath)) {
         let messages = JSON.parse(fs.readFileSync(msgPath).toString())
-        properties.forEach((property) => {
-          let matches = installInfo[property].match(pattern)
-          if (matches) {
-            installInfo[property] = messages[matches[1]].message
-          }
-        })
+        if (installInfo.name) {
+          let name = installInfo.name.match(pattern)
+          name && (installInfo.name = messages[name[1]].message)
+        }
+        if (installInfo.description) {
+          let description = installInfo.name.match(pattern)
+          description && (installInfo.description = messages[description[1]].message)
+        }
+        if (installInfo.manifest.browser_action.default_title) {
+          let defaultTitle = installInfo.manifest.browser_action.default_title.match(pattern)
+          defaultTitle && (installInfo.manifest.browser_action.default_title = messages[defaultTitle[1]].message)
+        }
       }
     }
     return installInfo

--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -259,3 +259,4 @@ preventMoreAlerts=Prevent this page from creating additional dialogs
 copied=Copied!
 connectionError=Server connection failed. Please make sure you are connected to the Internet.
 unknownError=Oops, something went wrong.
+browserActionButton.title={{name}}

--- a/app/renderer/components/browserAction.js
+++ b/app/renderer/components/browserAction.js
@@ -48,6 +48,8 @@ class BrowserAction extends ImmutableComponent {
     // TODO(bridiver) should have some visual notification of hover/press
     return <div className={css(styles.browserActionButton)}>
       <Button iconClass='extensionBrowserAction'
+        l10nId='browserActionButton'
+        l10nArgs={{ name: this.props.browserAction.get('title') }}
         className={css(styles.extensionButton)}
         inlineStyles={{
           backgroundImage: extensionState.browserActionBackgroundImage(this.props.browserAction, this.props.tabId)

--- a/js/components/button.js
+++ b/js/components/button.js
@@ -13,6 +13,7 @@ class Button extends ImmutableComponent {
         data-l10n-id={this.props.l10nId}
         data-test-id={this.props.testId}
         data-test2-id={this.props.test2Id}
+        data-l10n-args={JSON.stringify(this.props.l10nArgs || {})}
         style={this.props.inlineStyles}
         data-button-value={this.props.dataButtonValue}
         className={cx({


### PR DESCRIPTION
# Test Plan:
With a screen reader enabled:
1. Place focus on address bar
2. Press <kbd>tab</kbd> until extension buttons are encountered
3. Listen for extension name to be mentioned

# PR Details:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #8269 
