### PR TITLE
Fix issue where tabs opened via context menu not opening in a private tab

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -85,6 +85,14 @@ const getPartition = (createProperties) => {
   return partition
 }
 
+const needsPartitionAssigned = (createProperties) => {
+  return !createProperties.openerTabId ||
+    createProperties.isPrivate ||
+    createProperties.isPartitioned ||
+    createProperties.partitionNumber ||
+    createProperties.partition
+}
+
 // TODO(bridiver) - refactor this into an action
 ipcMain.on(messages.ABOUT_COMPONENT_INITIALIZED, (e) => {
   const tab = e.sender
@@ -530,7 +538,7 @@ const api = {
       createProperties.url = newFrameUrl()
     }
     createProperties.url = normalizeUrl(createProperties.url)
-    if (!createProperties.openerTabId) {
+    if (needsPartitionAssigned(createProperties)) {
       createProperties.partition = getPartition(createProperties)
       if (isSessionPartition(createProperties.partition)) {
         createProperties.parent_partition = ''


### PR DESCRIPTION
## Test Plan
1. Go to https://slashdot.org/
2. Right click any link and pick (from the context menu) `Open Link in New Private Tab`
3. Confirm tab that opens is private
4. Close private tab, go back to slashdot.org
5. Right click a link and pick (from the context menu) `Open Link in New Session Tab`
6. Go back to slashdot.org and repeat step 5
7. You should now have two session tabs opened, each with a different ID

## Description
During app/browser/tab::create(), `isPrivate` is set to true. However, there is no partition set.
If this is missing, I believe the code is checking the opener (which is not correct in this case).

When handler `add-new-contents` fired, the `incognito` property was always set to false. Partition `default`
seems to match picking "New private tab" from file menu and hitting + button > New private tab in tabs bar

After review by @bbondy, this also makes sure to assign partition if isPartitioned/partitionNumber are set (same conditions as checked in getPartition)

Fixes https://github.com/brave/browser-laptop/issues/8271

Auditors: @bbondy, @bridiver

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
