### PR TITLE
Adjusts layout of download items

### DIFF
--- a/less/downloadBar.less
+++ b/less/downloadBar.less
@@ -11,7 +11,7 @@
   --download-bar-buttons: 22px;
 }
 
-@downloadItemHeight: 46px;
+@downloadItemHeight: 50px;
 
 .downloadsBar {
   user-select: none;
@@ -46,7 +46,7 @@
       min-width: var(--download-item-width);
 
       &:hover {
-        height: 72px;
+        height: 73px;
         top: -23px;
 
         .downloadInfo .downloadArrow {
@@ -55,6 +55,7 @@
 
         .downloadProgress {
           bottom: 0;
+          height: 47px;
         }
       }
 
@@ -82,7 +83,7 @@
       }
 
       &.deleteConfirmationVisible:hover {
-        height: 97px;
+        height: 108px;
         top: -58px;
       }
 
@@ -92,8 +93,8 @@
         left: 0;
         opacity: 0.5;
         position: absolute;
-        height: @downloadItemHeight;
         width: 100%;
+        height: 100%;
       }
 
       .downloadInfo {
@@ -124,7 +125,7 @@
       }
 
       .downloadActions {
-        margin: auto 0;
+        margin: 8px 0 0;
         .browserButton {
           font-size: 14px;
           height: auto;


### PR DESCRIPTION
# Test Plan:
Click the trash bin on a download item
Note that the bottom alignment with other items isn't broken

# PR Details:
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #8143 

![download-items](https://cloud.githubusercontent.com/assets/815158/24996422/6cf2bdaa-1ff8-11e7-87e0-5960bfa36628.gif)

