### PR TITLE
Check description for __MSG_ values

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -381,7 +381,7 @@ module.exports.init = () => {
           name && (installInfo.name = messages[name[1]].message)
         }
         if (installInfo.description) {
-          let description = installInfo.name.match(pattern)
+          let description = installInfo.description.match(pattern)
           description && (installInfo.description = messages[description[1]].message)
         }
         if (installInfo.manifest.browser_action.default_title) {


### PR DESCRIPTION
# Test Plan:
From a fresh profile, navigate to about:preferences#extensions and turn on _Pocket_. Once enabled, you should see no presence of *__MSG_* in the extension's description.

# PR Details:
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #8307 