### PR TITLE
Recursively add predefined messages

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -15,6 +15,7 @@ const appActions = require('../js/actions/appActions')
 const fs = require('fs')
 const path = require('path')
 const l10n = require('../js/l10n')
+const {bravifyText} = require('./renderer/lib/extensionsUtil')
 
 // Takes Content Security Policy flags, for example { 'default-src': '*' }
 // Returns a CSP string, for example 'default-src: *;'
@@ -370,27 +371,34 @@ module.exports.init = () => {
   })
 
   let insertLocaleStrings = (installInfo) => {
-    let pattern = /^__MSG_(.*)__$/
     let defaultLocale = installInfo.manifest.default_locale
     if (defaultLocale) {
       let msgPath = path.join(installInfo.base_path, '_locales', defaultLocale, 'messages.json')
       if (fs.existsSync(msgPath)) {
         let messages = JSON.parse(fs.readFileSync(msgPath).toString())
-        if (installInfo.name) {
-          let name = installInfo.name.match(pattern)
-          name && (installInfo.name = messages[name[1]].message)
-        }
-        if (installInfo.description) {
-          let description = installInfo.description.match(pattern)
-          description && (installInfo.description = messages[description[1]].message)
-        }
-        if (installInfo.manifest.browser_action.default_title) {
-          let defaultTitle = installInfo.manifest.browser_action.default_title.match(pattern)
-          defaultTitle && (installInfo.manifest.browser_action.default_title = messages[defaultTitle[1]].message)
-        }
+        installInfo = insertPredefinedMessages(installInfo, messages, /^__MSG_(.*)__$/)
       }
     }
     return installInfo
+  }
+
+  let insertPredefinedMessages = function (object, dictionary, pattern) {
+    Object.keys(object).forEach(key => {
+      let value = object[key]
+      let type = typeof value
+      if (type === 'object' && !Array.isArray(value)) {
+        object[key] = insertPredefinedMessages(value, dictionary, pattern)
+        return
+      }
+      if (type === 'string') {
+        let match = value.match(pattern)
+        if (match) {
+          let message = dictionary[match[1]]
+          object[key] = message ? bravifyText(message.message) : value
+        }
+      }
+    })
+    return object
   }
 
   let loadExtension = (extensionId, extensionPath, manifest = {}, manifestLocation = 'unpacked') => {

--- a/app/extensions.js
+++ b/app/extensions.js
@@ -390,7 +390,7 @@ module.exports.init = () => {
         object[key] = insertPredefinedMessages(value, dictionary, pattern)
         return
       }
-      if (type === 'string') {
+      if (typeof value === 'string') {
         let match = value.match(pattern)
         if (match) {
           let message = dictionary[match[1]]


### PR DESCRIPTION
# Test Plan:
Enable the _Save to Pocket_ extension
Ensure that the description does not contain *__MSG_*
Navigate to _about:extensions_
Ensure that _Save to Pocket_ does not contain references to *__MSG_* for _Google Chrome_

# PR Details
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes #8318 