### PR TITLE
Add new context menu to entire tab bar (including Reopen last closed tab)

### DIFF
--- a/app/common/commonMenu.js
+++ b/app/common/commonMenu.js
@@ -134,15 +134,6 @@ module.exports.reopenLastClosedTabItem = () => {
   }
 }
 
-module.exports.muteAllTabsMenuItem = () => {
-  return {
-    label: locale.translation('muteTabs'),
-    click: (item) => {
-      windowActions.muteAllAudio(framePropsList, true)
-    }
-  }
-}
-
 module.exports.separatorMenuItem = {
   type: 'separator'
 }

--- a/app/common/commonMenu.js
+++ b/app/common/commonMenu.js
@@ -134,6 +134,15 @@ module.exports.reopenLastClosedTabItem = () => {
   }
 }
 
+module.exports.muteAllTabsMenuItem = () => {
+  return {
+    label: locale.translation('muteTabs'),
+    click: (item) => {
+      windowActions.muteAllAudio(framePropsList, true)
+    }
+  }
+}
+
 module.exports.separatorMenuItem = {
   type: 'separator'
 }
@@ -340,6 +349,17 @@ module.exports.bookmarksToolbarMenuItem = () => {
     checked: getSetting(settings.SHOW_BOOKMARKS_TOOLBAR),
     click: (item, focusedWindow) => {
       appActions.changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, !getSetting(settings.SHOW_BOOKMARKS_TOOLBAR))
+    }
+  }
+}
+
+module.exports.showTabPreviewsMenuItem = () => {
+  return {
+    label: locale.translation('showTabPreviews'),
+    type: 'checkbox',
+    checked: getSetting(settings.SHOW_TAB_PREVIEWS),
+    click: (item, focusedWindow) => {
+      appActions.changeSetting(settings.SHOW_TAB_PREVIEWS, !getSetting(settings.SHOW_TAB_PREVIEWS))
     }
   }
 }

--- a/app/extensions/brave/locales/en-US/menu.properties
+++ b/app/extensions/brave/locales/en-US/menu.properties
@@ -173,3 +173,4 @@ downloadItemDelete=Delete Download
 downloadItemClear=Clear Download
 downloadToolbarHide=Hide downloads bar
 downloadItemClearCompleted=Clear completed downloads
+showTabPreviews=Show Tab Previews

--- a/app/locale.js
+++ b/app/locale.js
@@ -180,6 +180,7 @@ var rendererIdentifiers = function () {
     'learnSpelling',
     'ignoreSpelling',
     'lookupSelection',
+    'showTabPreviews',
     // Other identifiers
     'aboutBlankTitle',
     'urlCopied',

--- a/app/renderer/components/tabs/tabs.js
+++ b/app/renderer/components/tabs/tabs.js
@@ -132,7 +132,8 @@ class Tabs extends ImmutableComponent {
     const index = this.props.previewTabPageIndex !== undefined
       ? this.props.previewTabPageIndex : this.props.tabPageIndex
     return <div className='tabs'
-      onMouseLeave={this.props.fixTabWidth ? this.onMouseLeave : null}>
+      onMouseLeave={this.props.fixTabWidth ? this.onMouseLeave : null}
+      onContextMenu={contextMenus.onTabsContextMenu.bind(this, this.frame)}>
       <span className={cx({
         tabStripContainer: true,
         isPreview: this.props.previewTabPageIndex !== undefined,

--- a/app/renderer/components/tabs/tabs.js
+++ b/app/renderer/components/tabs/tabs.js
@@ -133,7 +133,7 @@ class Tabs extends ImmutableComponent {
       ? this.props.previewTabPageIndex : this.props.tabPageIndex
     return <div className='tabs'
       onMouseLeave={this.props.fixTabWidth ? this.onMouseLeave : null}
-      onContextMenu={contextMenus.onTabsContextMenu.bind(this, this.frame)}>
+      onContextMenu={contextMenus.onTabsBarContextMenu.bind(this, windowStore.getFrames())}>
       <span className={cx({
         tabStripContainer: true,
         isPreview: this.props.previewTabPageIndex !== undefined,

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -654,6 +654,32 @@ function tabTemplateInit (frameProps) {
   return menuUtil.sanitizeTemplateItems(template)
 }
 
+function tabsTemplateInit () {
+
+  const template = []
+
+  template.push( CommonMenu.newTabMenuItem(),
+    CommonMenu.separatorMenuItem,
+    CommonMenu.newPrivateTabMenuItem(),
+    CommonMenu.newPartitionedTabMenuItem(),
+    CommonMenu.newWindowMenuItem(),
+    CommonMenu.separatorMenuItem,
+    CommonMenu.muteAllTabsMenuItem(),
+    CommonMenu.showTabPreviewsMenuItem(),
+    CommonMenu.separatorMenuItem,
+    CommonMenu.bookmarksManagerMenuItem(),
+    CommonMenu.bookmarksToolbarMenuItem(),
+    CommonMenu.separatorMenuItem
+  )
+
+  template.push(Object.assign({},
+     CommonMenu.reopenLastClosedTabItem(),
+    { enabled: windowStore.getState().get('closedFrames').size > 0 }
+  ))
+
+  return menuUtil.sanitizeTemplateItems(template)
+}
+
 function getMisspelledSuggestions (selection, isMisspelled, suggestions) {
   const hasSelection = selection.length > 0
   const template = []
@@ -1362,6 +1388,13 @@ function onTabContextMenu (frameProps, e) {
   tabMenu.destroy()
 }
 
+function onTabsContextMenu (frameProps, e) {
+  e.stopPropagation()
+  const tabsMenu = Menu.buildFromTemplate(tabsTemplateInit(frameProps))
+  tabsMenu.popup(getCurrentWindow())
+  tabsMenu.destroy()
+}
+
 function onNewTabContextMenu (target) {
   const menuTemplate = [
     CommonMenu.newTabMenuItem(),
@@ -1518,6 +1551,7 @@ module.exports = {
   onFlashContextMenu,
   onMainContextMenu,
   onTabContextMenu,
+  onTabsContextMenu,
   onNewTabContextMenu,
   onTabsToolbarContextMenu,
   onDownloadsToolbarContextMenu,

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -654,17 +654,16 @@ function tabTemplateInit (frameProps) {
   return menuUtil.sanitizeTemplateItems(template)
 }
 
-function tabsTemplateInit () {
-
+function tabsBarTemplateInit (framePropsList) {
   const template = []
 
-  template.push( CommonMenu.newTabMenuItem(),
+  template.push(
+    CommonMenu.newTabMenuItem(),
     CommonMenu.separatorMenuItem,
     CommonMenu.newPrivateTabMenuItem(),
     CommonMenu.newPartitionedTabMenuItem(),
     CommonMenu.newWindowMenuItem(),
     CommonMenu.separatorMenuItem,
-    CommonMenu.muteAllTabsMenuItem(),
     CommonMenu.showTabPreviewsMenuItem(),
     CommonMenu.separatorMenuItem,
     CommonMenu.bookmarksManagerMenuItem(),
@@ -1388,9 +1387,9 @@ function onTabContextMenu (frameProps, e) {
   tabMenu.destroy()
 }
 
-function onTabsContextMenu (frameProps, e) {
+function onTabsBarContextMenu (framePropsList, e) {
   e.stopPropagation()
-  const tabsMenu = Menu.buildFromTemplate(tabsTemplateInit(frameProps))
+  const tabsMenu = Menu.buildFromTemplate(tabsBarTemplateInit(framePropsList))
   tabsMenu.popup(getCurrentWindow())
   tabsMenu.destroy()
 }
@@ -1551,7 +1550,7 @@ module.exports = {
   onFlashContextMenu,
   onMainContextMenu,
   onTabContextMenu,
-  onTabsContextMenu,
+  onTabsBarContextMenu,
   onNewTabContextMenu,
   onTabsToolbarContextMenu,
   onDownloadsToolbarContextMenu,


### PR DESCRIPTION
- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

This is my attempt to resolve https://github.com/brave/browser-laptop/issues/8303.
Note -- this is really my first pull request beyond a README grammar change, so it's quite possible I overlooked something.

Test Plan:
Open a new tab, visit a site (i.e. https://google.com), close the tab and then right-click in the space to the right of any open tabs.  You should be presented with a new context menu with an option to reopen the last closed tab.