### PR TITLE
Move the FAQ link next to the payment on/off toggle 

### DIFF
--- a/app/renderer/components/preferences/paymentsTab.js
+++ b/app/renderer/components/preferences/paymentsTab.js
@@ -180,6 +180,16 @@ class PaymentsTab extends ImmutableComponent {
               switchClassName={css(styles.switchWrap__switchControl)}
               labelClassName={css(styles.switchWrap__label)}
             />
+            <a className={cx({
+              fa: true,
+              'fa-question-circle': true,
+              [css(styles.autoSuggestSwitch__moreInfo)]: true,
+              [css(styles.autoSuggestSwitch__moreInfoBtnSuggest)]: true
+            })}
+              href='https://brave.com/Payments_FAQ.html'
+              target='_blank'
+              data-l10n-id='paymentsFAQLink'
+            />
           </div>
           {
             this.enabled
@@ -196,16 +206,6 @@ class PaymentsTab extends ImmutableComponent {
                     disabled={!enabled}
                     onChangeSetting={this.props.onChangeSetting}
                     switchClassName={css(styles.switchWrap__switchControl)}
-                  />
-                  <a className={cx({
-                    fa: true,
-                    'fa-question-circle': true,
-                    [css(styles.autoSuggestSwitch__moreInfo)]: true,
-                    [css(styles.autoSuggestSwitch__moreInfoBtnSuggest)]: true
-                  })}
-                    href='https://brave.com/Payments_FAQ.html'
-                    target='_blank'
-                    data-l10n-id='paymentsFAQLink'
                   />
                 </div>
               </div>
@@ -308,7 +308,8 @@ const styles = StyleSheet.create({
   },
   autoSuggestSwitch__moreInfoBtnSuggest: {
     position: 'relative',
-    left: '5px',
+    top: '-1px',
+    left: '8px',
     cursor: 'pointer',
 
     // TODO: refactor preferences.less to remove !important


### PR DESCRIPTION
(instead of next to auto-include)

![screen shot 2017-04-15 at 12 22 01 am](https://cloud.githubusercontent.com/assets/4733304/25061725/9711d862-2171-11e7-87e5-f866197ca50e.png)

This is a suggestion, but I think it makes more sense here. See issue details for more info:
https://github.com/brave/browser-laptop/issues/7796

Fixes https://github.com/brave/browser-laptop/issues/7796

Auditors: @bradleyrichter, @luixxiul

Test Plan:
1. Launch Brave and open Preferences > Payments
2. You should see the "?" icon next to the on/off switch
3. Toggle the on/off switch; it should still show after changing
4. Click link and confirm it goes to Payment FAQ

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
