### PR TITLE
disable extension context menus in private tabs

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -997,6 +997,7 @@ function mainTemplateInit (nodeProps, frame, tab) {
   const isInputField = nodeProps.isEditable || nodeProps.inputFieldType !== 'none'
   const isTextSelected = nodeProps.selectionText && nodeProps.selectionText.length > 0
   const isAboutPage = aboutUrls.has(frame.get('location'))
+  const isPrivate = frame.get('isPrivate')
 
   if (isLink) {
     template = addLinkMenu(nodeProps.linkURL, frame)
@@ -1013,7 +1014,7 @@ function mainTemplateInit (nodeProps, frame, tab) {
             appActions.createTabRequested({
               url: nodeProps.srcURL,
               openerTabId: frame.get('tabId'),
-              partition: getPartitionFromNumber(frame.get('partitionNumber'), frame.get('isPrivate'))
+              partition: getPartitionFromNumber(frame.get('partitionNumber'), isPrivate)
             })
           }
         }
@@ -1047,7 +1048,7 @@ function mainTemplateInit (nodeProps, frame, tab) {
               .replace('?q', 'byimage?image_url')
             appActions.createTabRequested({
               url: searchUrl,
-              isPrivate: frame.get('isPrivate'),
+              isPrivate,
               partitionNumber: frame.get('partitionNumber')
             })
           }
@@ -1199,8 +1200,9 @@ function mainTemplateInit (nodeProps, frame, tab) {
     })
   }
 
-  const extensionContextMenus =
-    extensionState.getContextMenusProperties(appStore.state)
+  const extensionContextMenus = isPrivate
+    ? undefined
+    : extensionState.getContextMenusProperties(appStore.state)
   if (extensionContextMenus !== undefined &&
     extensionContextMenus.length) {
     template.push(CommonMenu.separatorMenuItem)


### PR DESCRIPTION
fix #8180

Test Plan:
1. enable lastpass
2. right-click on a page in a regular tab. you should see the lastpass context menu.
3. right-click on a page in a private tab. you should not see the lastpass context menu.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
