### PR TITLE
fix PDFJS loading PDFs in new tabs

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -5,7 +5,7 @@ const tabState = require('../common/state/tabState')
 const {app, BrowserWindow, extensions, session, ipcMain} = require('electron')
 const {makeImmutable} = require('../common/state/immutableUtil')
 const {getTargetAboutUrl, getSourceAboutUrl, isSourceAboutUrl, newFrameUrl} = require('../../js/lib/appUrlUtil')
-const {isURL, getUrlFromInput} = require('../../js/lib/urlutil')
+const {isURL, getUrlFromInput, toPDFJSLocation} = require('../../js/lib/urlutil')
 const {isSessionPartition} = require('../../js/state/frameStateUtil')
 const {getOrigin} = require('../../js/state/siteUtil')
 const {getSetting} = require('../../js/settings')
@@ -37,6 +37,9 @@ const normalizeUrl = function (url) {
   }
   if (isURL(url)) {
     url = getUrlFromInput(url)
+  }
+  if (getSetting(settings.PDFJS_ENABLED)) {
+    url = toPDFJSLocation(url)
   }
   return url
 }

--- a/app/extensions.js
+++ b/app/extensions.js
@@ -3,6 +3,7 @@ const contextMenus = require('./browser/extensions/contextMenus')
 const extensionActions = require('./common/actions/extensionActions')
 const config = require('../js/constants/config')
 const appConfig = require('../js/constants/appConfig')
+const messages = require('../js/constants/messages')
 const {fileUrl} = require('../js/lib/appUrlUtil')
 const {getExtensionsPath, getBraveExtUrl, getBraveExtIndexHTML} = require('../js/lib/appUrlUtil')
 const {getSetting} = require('../js/settings')
@@ -16,6 +17,7 @@ const fs = require('fs')
 const path = require('path')
 const l10n = require('../js/l10n')
 const {bravifyText} = require('./renderer/lib/extensionsUtil')
+const ipcMain = require('electron').ipcMain
 
 // Takes Content Security Policy flags, for example { 'default-src': '*' }
 // Returns a CSP string, for example 'default-src: *;'
@@ -338,6 +340,10 @@ module.exports.init = () => {
       extensionInfo.setState(extensionId, extensionStates.REGISTERED)
       loadExtension(extensionId, extensionPath)
     }
+  })
+
+  ipcMain.on(messages.LOAD_URL_REQUESTED, (e, tabId, url) => {
+    appActions.loadURLRequested(tabId, url)
   })
 
   process.on('reload-sync-extension', () => {

--- a/js/constants/messages.js
+++ b/js/constants/messages.js
@@ -147,6 +147,8 @@ const messages = {
   SAVE_INIT_DATA: _,
   RELOAD_SYNC_EXTENSION: _,
   RESET_SYNC: _,
+  // PDFJS
+  LOAD_URL_REQUESTED: _,
   // Torrent
   TORRENT_MESSAGE: _
 }

--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -315,6 +315,19 @@ const UrlUtil = {
   },
 
   /**
+   * Converts a potential PDF URL to the PDFJS URL.
+   * XXX: This only looks at the URL file extension, not MIME types.
+   * @param {string} url
+   * @return {string}
+   */
+  toPDFJSLocation: function (url) {
+    if (url && UrlUtil.isHttpOrHttps(url) && UrlUtil.isFileType(url, 'pdf')) {
+      return `chrome-extension://${pdfjsExtensionId}/${url}`
+    }
+    return url
+  },
+
+  /**
    * Gets location to display in the urlbar
    * @param {string} url
    * @param {boolean} pdfjsEnabled

--- a/test/unit/lib/urlutilTest.js
+++ b/test/unit/lib/urlutilTest.js
@@ -189,6 +189,22 @@ describe('urlutil', function () {
     })
   })
 
+  describe('toPDFJSLocation', function () {
+    const baseUrl = 'chrome-extension://jdbefljfgobbmcidnmpjamcbhnbphjnb/'
+    it('pdf', function () {
+      assert.equal(UrlUtil.toPDFJSLocation('http://abc.com/test.pdf'), baseUrl + 'http://abc.com/test.pdf')
+    })
+    it('non-pdf', function () {
+      assert.equal(UrlUtil.toPDFJSLocation('http://abc.com/test.pdf.txt'), 'http://abc.com/test.pdf.txt')
+    })
+    it('file url', function () {
+      assert.equal(UrlUtil.toPDFJSLocation('file://abc.com/test.pdf.txt'), 'file://abc.com/test.pdf.txt')
+    })
+    it('empty', function () {
+      assert.equal(UrlUtil.toPDFJSLocation(''), '')
+    })
+  })
+
   describe('getHostname', function () {
     it('returns undefined if the URL is invalid', function () {
       assert.equal(UrlUtil.getHostname(null), undefined)


### PR DESCRIPTION
fix #8364

also adds LOAD_URL_REQUESTED message handler, which is needed for https://github.com/brave/pdf.js/pull/2

test plan:
1. go to https://letsencrypt.org/repository/
2. right click on any of the links to open in a new tab. it should work.
3. right click on any of the links to open in a new private tab. it should work.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
