### PR TITLE
highlight favicon on dark colored background

### DIFF
--- a/app/renderer/components/styles/global.js
+++ b/app/renderer/components/styles/global.js
@@ -80,7 +80,8 @@ const globalStyles = {
     alphaWhite: 'rgba(255,255,255,0.8)'
   },
   filter: {
-    makeWhite: 'brightness(0) invert(1)'
+    makeWhite: 'brightness(0) invert(1)',
+    whiteShadow: 'drop-shadow(0px 0px 2px rgb(255, 255, 255))'
   },
   radius: {
     borderRadius: '4px',

--- a/app/renderer/components/tabs/content/favIcon.js
+++ b/app/renderer/components/tabs/content/favIcon.js
@@ -41,7 +41,8 @@ class Favicon extends ImmutableComponent {
   render () {
     const iconStyles = StyleSheet.create({
       favicon: {
-        backgroundImage: `url(${this.favicon})`
+        backgroundImage: `url(${this.favicon})`,
+        filter: getTabIconColor(this.props) === 'white' ? globalStyles.filter.whiteShadow : 'none'
       },
       loadingIconColor: {
         // Don't change icon color unless when it should be white


### PR DESCRIPTION
Auditors: @bradleyrichter
Fix #7635

Previews:

<img width="200" alt="screen shot 2017-04-18 at 12 41 28 am" src="https://cloud.githubusercontent.com/assets/4672033/25114549/b8ce38e0-23d5-11e7-9b16-896e8b48b151.png">
<img width="200" alt="screen shot 2017-04-18 at 12 41 43 am" src="https://cloud.githubusercontent.com/assets/4672033/25114550/b8d22842-23d5-11e7-82b9-d5c1118cfa81.png">
<img width="200" alt="screen shot 2017-04-18 at 12 44 41 am" src="https://cloud.githubusercontent.com/assets/4672033/25114551/b8d5c966-23d5-11e7-855f-b263f03525e5.png">
<img width="200" alt="screen shot 2017-04-18 at 12 44 36 am" src="https://cloud.githubusercontent.com/assets/4672033/25114552/b8d6f520-23d5-11e7-9189-5f50e26aa7bc.png">


Test Plan:
1. Go to any page that makes title's text white (i.e. Youtube, Github)
2. Favicon should have a white shadow around it