### PR TITLE
Removes store logic from windowActions

### DIFF
--- a/app/browser/reducers/tabsReducer.js
+++ b/app/browser/reducers/tabsReducer.js
@@ -54,6 +54,11 @@ const tabsReducer = (state, action) => {
     case windowConstants.WINDOW_SET_AUDIO_MUTED:
       state = tabs.setAudioMuted(state, action)
       break
+    case windowConstants.WINDOW_SET_ALL_AUDIO_MUTED:
+      action.get('frameList').forEach((frameProp) => {
+        state = tabs.setAudioMuted(state, frameProp)
+      })
+      break
     case windowConstants.WINDOW_SET_ACTIVE_FRAME:
       state = tabs.setActive(state, action)
       break

--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -457,9 +457,8 @@ const api = {
 
   setAudioMuted: (state, action) => {
     action = makeImmutable(action)
-    const frameProps = action.get('frameProps')
     const muted = action.get('muted')
-    const tabId = frameProps.get('tabId')
+    const tabId = action.get('tabId')
     const tab = api.getWebContents(tabId)
     if (tab && !tab.isDestroyed()) {
       tab.setAudioMuted(muted)

--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -183,7 +183,8 @@ class Tab extends ImmutableComponent {
 
   onMuteFrame (muted, event) {
     event.stopPropagation()
-    windowActions.setAudioMuted(this.frame, muted)
+    const frame = this.frame
+    windowActions.setAudioMuted(frame.get('key'), frame.get('tabId'), muted)
   }
 
   get loading () {

--- a/docs/windowActions.md
+++ b/docs/windowActions.md
@@ -505,38 +505,27 @@ If set, also indicates that the popup window is shown.
 
 
 
-### setAudioMuted(frameProps, muted) 
+### setAudioMuted(frameKey, tabId, muted) 
 
 Dispatches a message to indicate that the frame should be muted
 
 **Parameters**
 
-**frameProps**: `Object`, Properties of the frame in question
+**frameKey**: `number`, Key of the frame in question
+
+**tabId**: `number`, Id of the tab in question
 
 **muted**: `boolean`, true if the frame is muted
 
 
 
-### muteAllAudio(framePropsList, muted) 
+### muteAllAudio(frameList) 
 
-Dispatches a mute/unmute call to all frames in a provided list (used by TabList).
-
-**Parameters**
-
-**framePropsList**: `Object`, List of frame properties to consider
-
-**muted**: `boolean`, true if the frames should be muted
-
-
-
-### muteAllAudioExcept(frameToSkip) 
-
-Dispatches a mute call to all frames except the one provided.
-The provided frame will have its audio unmuted.
+Dispatches a mute/unmute call to all frames in a provided list.
 
 **Parameters**
 
-**frameToSkip**: `Object`, Properties of the frame to keep audio
+**frameList**: `Object`, List of frames to consider (frameKey and tabId)
 
 
 

--- a/js/actions/windowActions.js
+++ b/js/actions/windowActions.js
@@ -6,7 +6,6 @@
 
 const AppDispatcher = require('../dispatcher/appDispatcher')
 const windowConstants = require('../constants/windowConstants')
-const windowStore = require('../stores/windowStore')
 
 function dispatch (action) {
   AppDispatcher.dispatch(action)
@@ -604,48 +603,28 @@ const windowActions = {
   /**
    * Dispatches a message to indicate that the frame should be muted
    *
-   * @param {Object} frameProps - Properties of the frame in question
+   * @param {number} frameKey - Key of the frame in question
+   * @param {number} tabId - Id of the tab in question
    * @param {boolean} muted - true if the frame is muted
    */
-  setAudioMuted: function (frameProps, muted) {
+  setAudioMuted: function (frameKey, tabId, muted) {
     dispatch({
       actionType: windowConstants.WINDOW_SET_AUDIO_MUTED,
-      frameProps,
+      frameKey,
+      tabId,
       muted
     })
   },
 
   /**
-   * Dispatches a mute/unmute call to all frames in a provided list (used by TabList).
+   * Dispatches a mute/unmute call to all frames in a provided list.
    *
-   * @param {Object} framePropsList - List of frame properties to consider
-   * @param {boolean} muted - true if the frames should be muted
+   * @param {Object} frameList - List of frames to consider (frameKey and tabId)
    */
-  muteAllAudio: function (framePropsList, mute) {
-    framePropsList.forEach((frameProps) => {
-      if (mute && frameProps.get('audioPlaybackActive') && !frameProps.get('audioMuted')) {
-        this.setAudioMuted(frameProps, true)
-      } else if (!mute && frameProps.get('audioMuted')) {
-        this.setAudioMuted(frameProps, false)
-      }
-    })
-  },
-
-  /**
-   * Dispatches a mute call to all frames except the one provided.
-   * The provided frame will have its audio unmuted.
-   *
-   * @param {Object} frameToSkip - Properties of the frame to keep audio
-   */
-  muteAllAudioExcept: function (frameToSkip) {
-    let framePropsList = windowStore.getState().get('frames')
-
-    framePropsList.forEach((frameProps) => {
-      if (frameProps.get('key') !== frameToSkip.get('key') && frameProps.get('audioPlaybackActive') && !frameProps.get('audioMuted')) {
-        this.setAudioMuted(frameProps, true)
-      } else {
-        this.setAudioMuted(frameProps, false)
-      }
+  muteAllAudio: function (frameList) {
+    dispatch({
+      actionType: windowConstants.WINDOW_SET_ALL_AUDIO_MUTED,
+      frameList
     })
   },
 

--- a/js/constants/windowConstants.js
+++ b/js/constants/windowConstants.js
@@ -100,7 +100,8 @@ const windowConstants = {
   WINDOW_SHOULD_MAXIMIZE: _,
   WINDOW_SHOULD_UNMAXIMIZE: _,
   WINDOW_SHOULD_EXIT_FULL_SCREEN: _,
-  WINDOW_SHOULD_OPEN_DEV_TOOLS: _
+  WINDOW_SHOULD_OPEN_DEV_TOOLS: _,
+  WINDOW_SET_ALL_AUDIO_MUTED: _
 }
 
 module.exports = mapValuesByKeys(windowConstants)

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -494,8 +494,18 @@ const doAction = (action) => {
       }
       break
     case windowConstants.WINDOW_SET_AUDIO_MUTED:
-      windowState = windowState.setIn(['frames', frameStateUtil.getFramePropsIndex(frameStateUtil.getFrames(windowState), action.frameProps), 'audioMuted'], action.muted)
-      windowState = windowState.setIn(['tabs', frameStateUtil.getFramePropsIndex(frameStateUtil.getFrames(windowState), action.frameProps), 'audioMuted'], action.muted)
+      {
+        const index = frameStateUtil.getFrameIndex(windowState, action.frameKey)
+        windowState = windowState.setIn(['frames', index, 'audioMuted'], action.muted)
+        windowState = windowState.setIn(['tabs', index, 'audioMuted'], action.muted)
+      }
+      break
+    case windowConstants.WINDOW_SET_ALL_AUDIO_MUTED:
+      action.frameList.forEach((frameProp) => {
+        let index = frameStateUtil.getFrameIndex(windowState, frameProp.frameKey)
+        windowState = windowState.setIn(['frames', index, 'audioMuted'], frameProp.muted)
+        windowState = windowState.setIn(['tabs', index, 'audioMuted'], frameProp.muted)
+      })
       break
     case windowConstants.WINDOW_SET_AUDIO_PLAYBACK_ACTIVE:
       windowState = windowState.setIn(['frames', frameStateUtil.getFramePropsIndex(frameStateUtil.getFrames(windowState), action.frameProps), 'audioPlaybackActive'], action.audioPlaybackActive)


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #8380

Auditors: @bsclifton

Test Plan:
1) tests should be green
2) mute a tab (click on a volume icon in a tab that is playing some music)
3) mute a tab (right click on a tab and select it from the context menu)
4) mute other tabs  (right click on a tab and select it from the context menu)
5) mute/un-mute whole tab page  (right click on a tab page and select it from the context menu) 