### PR TITLE
Removes last check when component is unmounting

### DIFF
--- a/app/renderer/components/reduxComponent.js
+++ b/app/renderer/components/reduxComponent.js
@@ -19,10 +19,11 @@ class ReduxComponent extends ImmutableComponent {
     this.componentType = props.componentType
     this.state = buildPropsImpl(props, this.componentType)
     this.checkForUpdates = this.checkForUpdates.bind(this)
+    this.dontCheck = false
   }
 
   checkForUpdates () {
-    if (this.shouldComponentUpdate(this.props, this.buildProps())) {
+    if (!this.dontCheck && this.shouldComponentUpdate(this.props, this.buildProps())) {
       this.forceUpdate()
     }
   }
@@ -33,6 +34,7 @@ class ReduxComponent extends ImmutableComponent {
   }
 
   componentWillUnmount () {
+    this.dontCheck = true
     appStore.removeChangeListener(this.checkForUpdates)
     windowStore.removeChangeListener(this.checkForUpdates)
   }


### PR DESCRIPTION
- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bridiver

### Note
Because of checking params one last time when they weren't in the store any more I was getting error like this:
![image](https://cloud.githubusercontent.com/assets/9574457/25168136/a7949052-24e2-11e7-9329-bbdd41781a46.png)

This PR solves this problem

