### PR TITLE
Increase urlbar fontsize

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -40,6 +40,7 @@
     .urlbarForm {
       input {
         font-weight: 500;
+        line-height: 1.5;
         margin: 0; // #5624
         top: 0; // #5624
       }
@@ -848,10 +849,11 @@
       background: @navigationBarBackgroundActive;
       border: none;
       box-sizing: border-box;
-      color: @chromeText;
+      color: #333;
+      letter-spacing: -0.125px;
       cursor: text;
       flex-grow: 1;
-      font-size: @defaultFontSize;
+      font-size: 13.5px;
       font-weight: normal;
       outline: none;
       text-overflow: ellipsis;
@@ -884,20 +886,23 @@
 
       .urlbarIcon {
         color: @siteSecureColor;
-        font-size: 13px;
+        font-size: 12px;
         background-repeat: no-repeat;
         background-position: center;
+        position: relative;
+        bottom: -1px;
 
         // about:newtab
         &.fa-search {
           position: relative;
-          bottom: 1px;
+          bottom: 0;
         }
 
         &.fa-lock,
         &.fa-unlock,
         &.fa-exclamation-triangle {
           font-size: 16px;
+          bottom: 0;
         }
 
         &.insecure-color {

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -40,7 +40,7 @@
     .urlbarForm {
       input {
         font-weight: 500;
-        line-height: 1.5;
+        line-height: 1.4;
         margin: 0; // #5624
         top: 0; // #5624
       }


### PR DESCRIPTION
- Auditors: @bradleyrichter
- Close #7848

Test Plan:
* While this font size is pre-approved by @bradleyrichter, it's worth checking urlbar icons (list, lock, unlock and search) that must be aligned with new font size.

Tagging @bsclifton for review on Windows

Screenshots (macOS):

<img width="318" alt="screen shot 2017-04-19 at 12 41 01 am" src="https://cloud.githubusercontent.com/assets/4672033/25194003/5e3e1c84-250f-11e7-9133-a43ed564b07a.png">
<img width="317" alt="screen shot 2017-04-19 at 12 41 17 am" src="https://cloud.githubusercontent.com/assets/4672033/25194004/5e417974-250f-11e7-8ac6-113e90ceea9f.png">
<img width="318" alt="screen shot 2017-04-19 at 12 40 36 am" src="https://cloud.githubusercontent.com/assets/4672033/25194006/5e45f8dc-250f-11e7-8e0f-206c6b7074ef.png">
<img width="316" alt="screen shot 2017-04-19 at 12 40 52 am" src="https://cloud.githubusercontent.com/assets/4672033/25194005/5e420c04-250f-11e7-9353-2b6c501952e6.png">
