### PR TITLE
Remove merge into toolbar option from importer

### DIFF
--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -242,7 +242,6 @@ importDataCloseBrowserWarning=Please make sure the selected browser is closed be
 importSuccess=Your data has been imported to Brave successfully.
 closeFirefoxWarning=Firefox must be closed during data import. Please close and try again.
 favoritesOrBookmarks=Favorites/Bookmarks
-mergeIntoBookmarksToolbar=Merge Favorites into Bookmarks Toolbar
 cookies=Cookies
 licenseTextOk=Ok
 closeFirefoxWarningOk=Ok

--- a/app/renderer/components/importBrowserDataPanel.js
+++ b/app/renderer/components/importBrowserDataPanel.js
@@ -27,16 +27,11 @@ class ImportBrowserDataPanel extends ImmutableComponent {
     super()
     this.onToggleHistory = this.onToggleSetting.bind(this, 'history')
     this.onToggleFavorites = this.onToggleSetting.bind(this, 'favorites')
-    this.onToggleMergeFavorites = this.onToggleSetting.bind(this, 'mergeFavorites')
     this.onToggleCookies = this.onToggleSetting.bind(this, 'cookies')
     this.onImport = this.onImport.bind(this)
     this.onChange = this.onChange.bind(this)
   }
   onToggleSetting (setting, e) {
-    if (setting === 'favorites') {
-      this.props.importBrowserDataSelected =
-        this.props.importBrowserDataSelected.set('mergeFavorites', e.target.value)
-    }
     windowActions.setImportBrowserDataSelected(this.props.importBrowserDataSelected.set(setting, e.target.value))
   }
   get browserData () {
@@ -84,7 +79,6 @@ class ImportBrowserDataPanel extends ImmutableComponent {
     this.props.importBrowserDataSelected = this.props.importBrowserDataSelected.set('index', e.target.value)
     this.props.importBrowserDataSelected = this.props.importBrowserDataSelected.set('history', false)
     this.props.importBrowserDataSelected = this.props.importBrowserDataSelected.set('favorites', false)
-    this.props.importBrowserDataSelected = this.props.importBrowserDataSelected.set('mergeFavorites', false)
     this.props.importBrowserDataSelected = this.props.importBrowserDataSelected.set('cookies', false)
     let importBrowserDataSelected = this.props.importBrowserDataSelected
     if (this.supportHistory) {
@@ -92,7 +86,6 @@ class ImportBrowserDataPanel extends ImmutableComponent {
     }
     if (this.supportFavorites) {
       importBrowserDataSelected = importBrowserDataSelected.set('favorites', true)
-      importBrowserDataSelected = importBrowserDataSelected.set('mergeFavorites', true)
     }
     if (this.supportCookies) {
       importBrowserDataSelected = importBrowserDataSelected.set('cookies', true)
@@ -108,7 +101,6 @@ class ImportBrowserDataPanel extends ImmutableComponent {
       }
       if (this.supportFavorites) {
         this.props.importBrowserDataSelected = this.props.importBrowserDataSelected.set('favorites', true)
-        this.props.importBrowserDataSelected = this.props.importBrowserDataSelected.set('mergeFavorites', true)
       }
       if (this.supportCookies) {
         this.props.importBrowserDataSelected = this.props.importBrowserDataSelected.set('cookies', true)
@@ -149,14 +141,6 @@ class ImportBrowserDataPanel extends ImmutableComponent {
             onClick={this.onToggleFavorites}
             disabled={!this.supportFavorites}
           />
-          <div className={css(styles.subSectionMargin)} data-test-id='importBrowserSubDataOptions'>
-            <SwitchControl
-              rightl10nId='mergeIntoBookmarksToolbar'
-              checkedOn={this.props.importBrowserDataSelected.get('mergeFavorites')}
-              onClick={this.onToggleMergeFavorites}
-              disabled={!this.props.importBrowserDataSelected.get('favorites')}
-            />
-          </div>
           <SwitchControl
             rightl10nId='cookies'
             checkedOn={this.props.importBrowserDataSelected.get('cookies')}
@@ -182,9 +166,6 @@ class ImportBrowserDataPanel extends ImmutableComponent {
 const styles = StyleSheet.create({
   dropdownWrapper: {
     marginBottom: `calc(${globalStyles.spacing.dialogInsideMargin} / 2)`
-  },
-  subSectionMargin: {
-    marginLeft: globalStyles.spacing.dialogInsideMargin
   }
 })
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -505,7 +505,6 @@ WindowStore
     favorites: boolean,
     history: boolean,
     index: string,
-    mergeFavorites: boolean,
     type: number
   },
   lastAppVersion: string, // version of the last file that was saved

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -132,6 +132,26 @@ module.exports.getNextFolderId = (sites) => {
   return (maxIdItem ? (maxIdItem.get('folderId') || 0) : 0) + 1
 }
 
+module.exports.getNextFolderName = (sites, name) => {
+  if (!sites) {
+    return name
+  }
+  const site = sites.find((site) =>
+    isBookmarkFolder(site.get('tags')) &&
+    site.get('customTitle') === name
+  )
+  if (!site) {
+    return name
+  }
+  const filenameFormat = /(.*) \((\d+)\)/
+  let result = filenameFormat.exec(name)
+  if (!result) {
+    return module.exports.getNextFolderName(sites, name + ' (1)')
+  }
+  const nextNum = parseInt(result[2]) + 1
+  return module.exports.getNextFolderName(sites, result[1] + ' (' + nextNum + ')')
+}
+
 const mergeSiteLastAccessedTime = (oldSiteDetail, newSiteDetail, tag) => {
   const newTime = newSiteDetail && newSiteDetail.get('lastAccessedTime')
   const oldTime = oldSiteDetail && oldSiteDetail.get('lastAccessedTime')

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -169,6 +169,62 @@ describe('siteUtil', function () {
     })
   })
 
+  describe('getNextFolderName', function () {
+    it('returns original name when no duplicate', function () {
+      const sites = Immutable.fromJS({
+        'key1': {
+          folderId: 0,
+          customTitle: 'abc',
+          tags: [siteTags.BOOKMARK_FOLDER]
+        }
+      })
+      assert.equal(siteUtil.getNextFolderName(sites, 'def'), 'def')
+    })
+    it('returns original name if sites is falsey', function () {
+      assert.equal(siteUtil.getNextFolderName(null, 'abc'), 'abc')
+    })
+    it('returns first duplicate name', function () {
+      const sites = Immutable.fromJS({
+        'key1': {
+          folderId: 0,
+          customTitle: 'abc',
+          tags: [siteTags.BOOKMARK_FOLDER]
+        }
+      })
+      assert.equal(siteUtil.getNextFolderName(sites, 'abc'), 'abc (1)')
+    })
+    it('returns non first duplicate name', function () {
+      const sites = Immutable.fromJS({
+        'key1': {
+          folderId: 0,
+          customTitle: 'abc',
+          tags: [siteTags.BOOKMARK_FOLDER]
+        },
+        'key2': {
+          folderId: 1,
+          customTitle: 'abc (1)',
+          tags: [siteTags.BOOKMARK_FOLDER]
+        }
+      })
+      assert.equal(siteUtil.getNextFolderName(sites, 'abc'), 'abc (2)')
+    })
+    it('returns non first duplicate name from duplicate name', function () {
+      const sites = Immutable.fromJS({
+        'key1': {
+          folderId: 0,
+          customTitle: 'abc',
+          tags: [siteTags.BOOKMARK_FOLDER]
+        },
+        'key2': {
+          folderId: 1,
+          customTitle: 'abc (1)',
+          tags: [siteTags.BOOKMARK_FOLDER]
+        }
+      })
+      assert.equal(siteUtil.getNextFolderName(sites, 'abc (1)'), 'abc (2)')
+    })
+  })
+
   describe('addSite', function () {
     it('gets the tag from siteDetail if not provided', function () {
       const processedSites = siteUtil.addSite(emptySites, bookmarkAllFields)


### PR DESCRIPTION
## Test Plan:

a. getNextFolderName covered by unittest

b. Import bookmark:
1. Import bookmarks from other browser or html
2. There will always a folder contains the imported bookmarks
3. If the folder name already exist,
  it will be "Imported from XXX (1)", "Imported from XXX (2)" ... etc

## Description
fix #7194

Auditors: @bsclifton, @bbondy

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

