### PR TITLE
fix various noscript issues

### DIFF
--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -58,7 +58,6 @@ class UrlBar extends React.Component {
         this.urlInput.setSelectionRange(len, len + suffixLen)
       }
     }, 10)
-    this.onNoScript = this.onNoScript.bind(this)
   }
 
   // restores the url bar to the current location
@@ -413,7 +412,7 @@ class UrlBar extends React.Component {
   }
 
   onNoScript () {
-    windowActions.setNoScriptVisible(!this.props.noScriptIsVisible)
+    windowActions.setNoScriptVisible()
   }
 
   onContextMenu (e) {
@@ -556,12 +555,12 @@ class UrlBar extends React.Component {
       {
         !this.showNoScriptInfo
         ? null
-        : <span className={css(styles.noScriptContainer)}>
-          <button
+        : <span className={css(styles.noScriptContainer)}
+          onClick={this.onNoScript}>
+          <span
             data-l10n-id='noScriptButton'
             data-test-id='noScriptButton'
-            className={css(styles.noScriptButton)}
-            onClick={this.onNoScript} />
+            className={css(styles.noScriptButton)} />
         </span>
       }
       {
@@ -580,8 +579,8 @@ class UrlBar extends React.Component {
 const styles = StyleSheet.create({
   noScriptContainer: {
     display: 'flex',
-    paddingLeft: '5px',
-    marginRight: '-3px',
+    padding: '5px',
+    marginRight: '-8px',
     WebkitAppRegion: 'drag'
   },
   noScriptButton: {

--- a/docs/state.md
+++ b/docs/state.md
@@ -474,7 +474,6 @@ WindowStore
     security: {
       blockedRunInsecureContent: Array<string>, // sources of blocked active mixed content
       isSecure: (boolean|number), // true = fully secure, false = fully insecure, 1 = partially secure
-      isExtendedValidation: boolean, // is using https ev. not currently used.
       loginRequiredDetail: {
         isProxy: boolean,
         host: string,

--- a/docs/windowActions.md
+++ b/docs/windowActions.md
@@ -683,25 +683,13 @@ Similar to setBlockedBy but for httpse redirects
 
 
 
-### setNoScript(frameProps, source) 
-
-Sets which scripts were blocked on a page.
-
-**Parameters**
-
-**frameProps**: `Object`, The frame to set blocked info on
-
-**source**: `string`, Source of blocked js
-
-
-
 ### setNoScriptVisible(isVisible) 
 
-Sets whether the noscript icon is visible.
+Sets/toggles whether the noscriptinfo dialog is visible.
 
 **Parameters**
 
-**isVisible**: `boolean`, Sets whether the noscript icon is visible.
+**isVisible**: `boolean`, if undefined, toggle the current state
 
 
 

--- a/js/actions/windowActions.js
+++ b/js/actions/windowActions.js
@@ -806,21 +806,8 @@ const windowActions = {
   },
 
   /**
-   * Sets which scripts were blocked on a page.
-   * @param {Object} frameProps - The frame to set blocked info on
-   * @param {string} source - Source of blocked js
-   */
-  setNoScript: function (frameProps, source) {
-    dispatch({
-      actionType: windowConstants.WINDOW_SET_NOSCRIPT,
-      frameProps,
-      source
-    })
-  },
-
-  /**
-   * Sets whether the noscript icon is visible.
-   * @param {boolean} isVisible
+   * Sets/toggles whether the noscriptinfo dialog is visible.
+   * @param {boolean=} isVisible - if undefined, toggle the current state
    */
   setNoScriptVisible: function (isVisible) {
     dispatch({

--- a/js/components/frame.js
+++ b/js/components/frame.js
@@ -667,13 +667,14 @@ class Frame extends ImmutableComponent {
         return
       }
       if (e.isMainFrame && !e.isErrorPage && !e.isFrameSrcDoc) {
+        if (e.url && e.url.startsWith(appConfig.noScript.twitterRedirectUrl) &&
+          this.getFrameBraverySettings(this.props).get('noScript') === true) {
+          // This result will be canceled immediately by sitehacks, so don't
+          // update the load state; otherwise it will not show the security
+          // icon.
+          return
+        }
         windowActions.onWebviewLoadStart(this.frame, e.url)
-        // Clear security state
-        windowActions.setBlockedRunInsecureContent(this.frame)
-        windowActions.setSecurityState(this.frame, {
-          secure: null,
-          runInsecureContent: false
-        })
       }
     }
 

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -39,7 +39,8 @@ module.exports = {
     enabled: false
   },
   noScript: {
-    enabled: false
+    enabled: false,
+    twitterRedirectUrl: 'https://mobile.twitter.com/i/nojs_router'
   },
   flash: {
     enabled: false,

--- a/js/data/siteHacks.js
+++ b/js/data/siteHacks.js
@@ -4,6 +4,7 @@
 
 const urlParse = require('../../app/common/urlParse')
 const base64Encode = require('../lib/base64').encode
+const appConfig = require('../constants/appConfig')
 
 // Polyfill similar to this: https://github.com/gorhill/uBlock/blob/de1ed89f62bf041416d2a721ec00741667bf3fa8/assets/ublock/resources.txt#L385
 const googleTagManagerRedirect = 'data:application/javascript;base64,' + base64Encode(`(function() { var noopfn = function() { ; }; window.ga = window.ga || noopfn; })();`)
@@ -119,7 +120,7 @@ module.exports.siteHacks = {
     onBeforeSendHeaders: function(details) {
       if (details.requestHeaders.Referer &&
         details.requestHeaders.Referer.startsWith('https://twitter.com/') &&
-        details.url.startsWith('https://mobile.twitter.com/')) {
+        details.url.startsWith(appConfig.noScript.twitterRedirectUrl)) {
         return {
           cancel: true
         }

--- a/js/state/frameStateUtil.js
+++ b/js/state/frameStateUtil.js
@@ -143,7 +143,7 @@ function getFrameByKey (windowState, key) {
 
 function isFrameSecure (frame) {
   frame = makeImmutable(frame)
-  if (frame && frame.getIn(['security', 'isSecure']) != null) {
+  if (frame && typeof frame.getIn(['security', 'isSecure']) === 'boolean') {
     return frame.getIn(['security', 'isSecure'])
   } else {
     return false
@@ -487,8 +487,7 @@ function addFrame (windowState, tabs, frameOpts, newKey, partitionNumber, active
       caseSensitivity: false
     },
     security: {
-      isSecure: urlParse(url).protocol === 'https:',
-      certDetails: null
+      isSecure: null
     },
     unloaded: frameOpts.unloaded,
     parentFrameKey,


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/8403

1. change noscript icon from button to span to fix CSP error
2. fix repeated toggling of noScriptInfo dialog
3. refactor to remove deprecated code and combine windowActions
4. increase noscript click area
5. fix security icon disappearing on twitter.com

test plan:
1. disable scripts on twitter.com. the lock icon should not disappear
2. click noscript icon
3. open browser console. you should not see any CSP errors.
4. now click the noscript icon repeatedly. you should see the popup come up and disappear repeatedly.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
