### PR TITLE
Update min-threshold for closing a tab

### DIFF
--- a/app/renderer/components/tabs/content/tabTitle.js
+++ b/app/renderer/components/tabs/content/tabTitle.js
@@ -9,15 +9,16 @@ const {StyleSheet, css} = require('aphrodite/no-important')
 const ImmutableComponent = require('../../immutableComponent')
 
 // Utils
-const {hasBreakpoint, hasFixedCloseIcon, getTabIconColor} = require('../../../lib/tabUtil')
+const {hasBreakpoint, getTabIconColor} = require('../../../lib/tabUtil')
 const {isWindows, isDarwin} = require('../../../../common/lib/platformUtil')
 
 // Styles
 const globalStyles = require('../../styles/global')
 
 class TabTitle extends ImmutableComponent {
-  get locationHasSecondaryIcon () {
-    return !!this.props.tab.get('isPrivate') || !!this.props.tab.get('partitionNumber')
+  get isActiveOrHasSecondaryIcon () {
+    return this.props.isActive ||
+      (!!this.props.tab.get('isPrivate') || !!this.props.tab.get('partitionNumber'))
   }
 
   get isPinned () {
@@ -25,10 +26,8 @@ class TabTitle extends ImmutableComponent {
   }
 
   get shouldHideTitle () {
-    return (this.props.tab.get('breakpoint') === 'mediumSmall' && this.locationHasSecondaryIcon) ||
-      (hasBreakpoint(this.props, 'mediumSmall') && this.props.tab.get('hoverState')) ||
-      hasBreakpoint(this.props, ['extraSmall', 'smallest']) ||
-      hasFixedCloseIcon(this.props)
+    return (hasBreakpoint(this.props, 'small') && this.props.isActive) ||
+      hasBreakpoint(this.props, ['extraSmall', 'smallest'])
   }
 
   render () {

--- a/app/renderer/lib/tabUtil.js
+++ b/app/renderer/lib/tabUtil.js
@@ -48,7 +48,7 @@ module.exports.hasBreakpoint = (props, arr) => {
  */
 module.exports.hasRelativeCloseIcon = (props) => {
   return props.tab.get('hoverState') &&
-    !module.exports.hasBreakpoint(props, ['small', 'extraSmall', 'smallest'])
+    module.exports.hasBreakpoint(props, ['default', 'large'])
 }
 
 /**
@@ -57,8 +57,14 @@ module.exports.hasRelativeCloseIcon = (props) => {
  * @returns {Boolean} Whether or not private or newSession icon should be visible
  */
 module.exports.hasVisibleSecondaryIcon = (props) => {
-  return !props.tab.get('hoverState') &&
-    !module.exports.hasBreakpoint(props, ['small', 'extraSmall', 'smallest'])
+  return (
+    // Hide icon on hover
+    !module.exports.hasRelativeCloseIcon(props) &&
+    // If closeIcon is fixed then there's no room for another icon
+    !module.exports.hasFixedCloseIcon(props) &&
+    // completely hide it for small sizes
+    !module.exports.hasBreakpoint(props, ['mediumSmall', 'small', 'extraSmall', 'smallest'])
+    )
 }
 
 /**
@@ -67,7 +73,13 @@ module.exports.hasVisibleSecondaryIcon = (props) => {
  * @returns {Boolean} Whether or not the close icon is always visible (fixed)
  */
 module.exports.hasFixedCloseIcon = (props) => {
-  return props.isActive && module.exports.hasBreakpoint(props, ['small', 'extraSmall'])
+  return (
+    props.isActive &&
+    // larger sizes still have a relative closeIcon
+    !module.exports.hasBreakpoint(props, ['default', 'large']) &&
+    // We don't resize closeIcon as we do with favicon so don't show it
+    !module.exports.hasBreakpoint(props, 'smallest')
+  )
 }
 
 /**

--- a/test/unit/app/renderer/components/tabs/content/closeTabIconTest.js
+++ b/test/unit/app/renderer/components/tabs/content/closeTabIconTest.js
@@ -26,27 +26,29 @@ describe('Tabs content - CloseTabIcon', function () {
     mockery.disable()
   })
 
-  it('should show closeTab icon if mouse is over tab', function () {
+  it('should show closeTab icon if mouse is over tab and breakpoint is default', function () {
     const wrapper = shallow(
       <CloseTabIcon
         tab={
           Immutable.Map({
-            hoverState: true
+            hoverState: true,
+            breakpoint: 'default'
           })}
       />
     )
     assert.equal(wrapper.props()['data-test-id'], 'closeTabIcon')
   })
-  it('should not show closeTab icon if mouse is not over a tab', function () {
+  it('should show closeTab icon if mouse is over tab and breakpoint is large', function () {
     const wrapper = shallow(
       <CloseTabIcon
         tab={
           Immutable.Map({
-            hoverState: false
+            hoverState: true,
+            breakpoint: 'large'
           })}
       />
     )
-    assert.notEqual(wrapper.props()['data-test-id'], 'closeTabIcon')
+    assert.equal(wrapper.props()['data-test-id'], 'closeTabIcon')
   })
   it('should not show closeTab icon if tab is pinned', function () {
     const wrapper = shallow(
@@ -55,6 +57,80 @@ describe('Tabs content - CloseTabIcon', function () {
           Immutable.Map({
             hoverState: true,
             pinnedLocation: true
+          })}
+      />
+    )
+    assert.notEqual(wrapper.props()['data-test-id'], 'closeTabIcon')
+  })
+  it('should show closeTab icon if tab size is largeMedium and tab is active', function () {
+    const wrapper = shallow(
+      <CloseTabIcon isActive
+        tab={
+          Immutable.Map({
+            hoverState: false,
+            breakpoint: 'largeMedium'
+          })}
+      />
+    )
+    assert.equal(wrapper.props()['data-test-id'], 'closeTabIcon')
+  })
+  it('should not show closeTab icon if tab size is largeMedium and tab is not active', function () {
+    const wrapper = shallow(
+      <CloseTabIcon isActive={false}
+        tab={
+          Immutable.Map({
+            hoverState: true,
+            breakpoint: 'largeMedium'
+          })}
+      />
+    )
+    assert.notEqual(wrapper.props()['data-test-id'], 'closeTabIcon')
+  })
+
+  it('should show closeTab icon if tab size is medium and tab is active', function () {
+    const wrapper = shallow(
+      <CloseTabIcon isActive
+        tab={
+          Immutable.Map({
+            hoverState: false,
+            breakpoint: 'medium'
+          })}
+      />
+    )
+    assert.equal(wrapper.props()['data-test-id'], 'closeTabIcon')
+  })
+  it('should not show closeTab icon if tab size is medium and tab is not active', function () {
+    const wrapper = shallow(
+      <CloseTabIcon isActive={false}
+        tab={
+          Immutable.Map({
+            hoverState: true,
+            breakpoint: 'medium'
+          })}
+      />
+    )
+    assert.notEqual(wrapper.props()['data-test-id'], 'closeTabIcon')
+  })
+
+  it('should show closeTab icon if tab size is mediumSmall and tab is active', function () {
+    const wrapper = shallow(
+      <CloseTabIcon isActive
+        tab={
+          Immutable.Map({
+            hoverState: false,
+            breakpoint: 'mediumSmall'
+          })}
+      />
+    )
+    assert.equal(wrapper.props()['data-test-id'], 'closeTabIcon')
+  })
+  it('should not show closeTab icon if tab size is mediumSmall and tab is not active', function () {
+    const wrapper = shallow(
+      <CloseTabIcon isActive={false}
+        tab={
+          Immutable.Map({
+            hoverState: true,
+            breakpoint: 'mediumSmall'
           })}
       />
     )

--- a/test/unit/app/renderer/components/tabs/content/newSessionIconTest.js
+++ b/test/unit/app/renderer/components/tabs/content/newSessionIconTest.js
@@ -48,21 +48,126 @@ describe('Tabs content - NewSessionIcon', function () {
     )
     assert.notEqual(wrapper.props()['data-test-id'], 'newSessionIcon')
   })
-  it('should not show new session icon if mouse is over tab (avoid icon overflow)', function () {
+  it('should not show new session icon if mouse is over tab and breakpoint is default', function () {
     const wrapper = shallow(
       <NewSessionIcon
         tab={
           Immutable.Map({
             partitionNumber: 1,
-            hoverState: true
+            hoverState: true,
+            breakpoint: 'default'
           })}
       />
     )
     assert.notEqual(wrapper.props()['data-test-id'], 'newSessionIcon')
   })
-  it('should not show new session icon if tab size is small', function () {
+  it('should show new session icon if mouse is not over tab and breakpoint is default', function () {
     const wrapper = shallow(
       <NewSessionIcon
+        tab={
+          Immutable.Map({
+            partitionNumber: 1,
+            hoverState: false,
+            breakpoint: 'default'
+          })}
+      />
+    )
+    assert.equal(wrapper.props()['data-test-id'], 'newSessionIcon')
+  })
+  it('should not show new session icon if mouse is over tab and breakpoint is large', function () {
+    const wrapper = shallow(
+      <NewSessionIcon
+        tab={
+          Immutable.Map({
+            partitionNumber: 1,
+            hoverState: true,
+            breakpoint: 'large'
+          })}
+      />
+    )
+    assert.notEqual(wrapper.props()['data-test-id'], 'newSessionIcon')
+  })
+  it('should show new session icon if mouse is not over tab and breakpoint is large', function () {
+    const wrapper = shallow(
+      <NewSessionIcon
+        tab={
+          Immutable.Map({
+            partitionNumber: 1,
+            hoverState: false,
+            breakpoint: 'large'
+          })}
+      />
+    )
+    assert.equal(wrapper.props()['data-test-id'], 'newSessionIcon')
+  })
+  it('should not show new session icon if tab is active and breakpoint is largeMedium', function () {
+    const wrapper = shallow(
+      <NewSessionIcon isActive
+        tab={
+          Immutable.Map({
+            partitionNumber: 1,
+            hoverState: true,
+            breakpoint: 'largeMedium'
+          })}
+      />
+    )
+    assert.notEqual(wrapper.props()['data-test-id'], 'newSessionIcon')
+  })
+  it('should show new session icon if tab is not active and breakpoint is largeMedium', function () {
+    const wrapper = shallow(
+      <NewSessionIcon isActive={false}
+        tab={
+          Immutable.Map({
+            partitionNumber: 1,
+            hoverState: false,
+            breakpoint: 'largeMedium'
+          })}
+      />
+    )
+    assert.equal(wrapper.props()['data-test-id'], 'newSessionIcon')
+  })
+  it('should not show new session icon if tab is active and breakpoint is medium', function () {
+    const wrapper = shallow(
+      <NewSessionIcon isActive
+        tab={
+          Immutable.Map({
+            partitionNumber: 1,
+            hoverState: true,
+            breakpoint: 'medium'
+          })}
+      />
+    )
+    assert.notEqual(wrapper.props()['data-test-id'], 'newSessionIcon')
+  })
+  it('should show new session icon if tab is not active and breakpoint is medium', function () {
+    const wrapper = shallow(
+      <NewSessionIcon isActive={false}
+        tab={
+          Immutable.Map({
+            partitionNumber: 1,
+            hoverState: false,
+            breakpoint: 'medium'
+          })}
+      />
+    )
+    assert.equal(wrapper.props()['data-test-id'], 'newSessionIcon')
+  })
+  it('should not show new session icon if breakpoint is mediumSmall', function () {
+    const wrapper = shallow(
+      <NewSessionIcon isActive
+        tab={
+          Immutable.Map({
+            partitionNumber: 1,
+            hoverState: false,
+            breakpoint: 'mediumSmall'
+          })}
+      />
+    )
+    assert.notEqual(wrapper.props()['data-test-id'], 'newSessionIcon')
+  })
+  it('should not show new session icon if breakpoint is small', function () {
+    const wrapper = shallow(
+      <NewSessionIcon isActive
         tab={
           Immutable.Map({
             partitionNumber: 1,
@@ -73,9 +178,9 @@ describe('Tabs content - NewSessionIcon', function () {
     )
     assert.notEqual(wrapper.props()['data-test-id'], 'newSessionIcon')
   })
-  it('should not show new session icon if tab size is extraSmall', function () {
+  it('should not show new session icon if breakpoint is extraSmall', function () {
     const wrapper = shallow(
-      <NewSessionIcon
+      <NewSessionIcon isActive
         tab={
           Immutable.Map({
             partitionNumber: 1,
@@ -86,7 +191,7 @@ describe('Tabs content - NewSessionIcon', function () {
     )
     assert.notEqual(wrapper.props()['data-test-id'], 'newSessionIcon')
   })
-  it('should not show new session icon if tab size is the smallest', function () {
+  it('should not show new session icon if breakpoint is the smallest', function () {
     const wrapper = shallow(
       <NewSessionIcon
         tab={

--- a/test/unit/app/renderer/components/tabs/content/privateIconTest.js
+++ b/test/unit/app/renderer/components/tabs/content/privateIconTest.js
@@ -47,51 +47,156 @@ describe('Tabs content - PrivateIcon', function () {
     )
     assert.notEqual(wrapper.props()['data-test-id'], 'privateIcon')
   })
-  it('should not show private icon if mouse is over tab (avoid icon overflow)', function () {
+  it('should not show private icon if mouse is over tab and breakpoint is default', function () {
     const wrapper = shallow(
       <PrivateIcon
         tab={
           Immutable.Map({
             isPrivate: true,
-            hoverState: true
+            hoverState: true,
+            breakpoint: 'default'
           })}
       />
     )
     assert.notEqual(wrapper.props()['data-test-id'], 'privateIcon')
   })
-  it('should not show private icon if tab size is small', function () {
+  it('should show private icon if mouse is not over tab and breakpoint is default', function () {
     const wrapper = shallow(
       <PrivateIcon
         tab={
           Immutable.Map({
             isPrivate: true,
             hoverState: false,
+            breakpoint: 'default'
+          })}
+      />
+    )
+    assert.equal(wrapper.props()['data-test-id'], 'privateIcon')
+  })
+  it('should not show private icon if mouse is over tab and breakpoint is large', function () {
+    const wrapper = shallow(
+      <PrivateIcon
+        tab={
+          Immutable.Map({
+            isPrivate: 1,
+            hoverState: true,
+            breakpoint: 'large'
+          })}
+      />
+    )
+    assert.notEqual(wrapper.props()['data-test-id'], 'privateIcon')
+  })
+  it('should show private icon if mouse is not over tab and breakpoint is large', function () {
+    const wrapper = shallow(
+      <PrivateIcon
+        tab={
+          Immutable.Map({
+            isPrivate: 1,
+            hoverState: false,
+            breakpoint: 'large'
+          })}
+      />
+    )
+    assert.equal(wrapper.props()['data-test-id'], 'privateIcon')
+  })
+  it('should not show private icon if tab is active and breakpoint is largeMedium', function () {
+    const wrapper = shallow(
+      <PrivateIcon isActive
+        tab={
+          Immutable.Map({
+            isPrivate: 1,
+            hoverState: true,
+            breakpoint: 'largeMedium'
+          })}
+      />
+    )
+    assert.notEqual(wrapper.props()['data-test-id'], 'privateIcon')
+  })
+  it('should show private icon if tab is not active and breakpoint is largeMedium', function () {
+    const wrapper = shallow(
+      <PrivateIcon isActive={false}
+        tab={
+          Immutable.Map({
+            isPrivate: 1,
+            hoverState: false,
+            breakpoint: 'largeMedium'
+          })}
+      />
+    )
+    assert.equal(wrapper.props()['data-test-id'], 'privateIcon')
+  })
+  it('should not show private icon if tab is active and breakpoint is medium', function () {
+    const wrapper = shallow(
+      <PrivateIcon isActive
+        tab={
+          Immutable.Map({
+            isPrivate: 1,
+            hoverState: true,
+            breakpoint: 'medium'
+          })}
+      />
+    )
+    assert.notEqual(wrapper.props()['data-test-id'], 'privateIcon')
+  })
+  it('should show private icon if tab is not active and breakpoint is medium', function () {
+    const wrapper = shallow(
+      <PrivateIcon isActive={false}
+        tab={
+          Immutable.Map({
+            isPrivate: 1,
+            hoverState: false,
+            breakpoint: 'medium'
+          })}
+      />
+    )
+    assert.equal(wrapper.props()['data-test-id'], 'privateIcon')
+  })
+  it('should not show private icon if breakpoint is mediumSmall', function () {
+    const wrapper = shallow(
+      <PrivateIcon isActive
+        tab={
+          Immutable.Map({
+            isPrivate: 1,
+            hoverState: false,
+            breakpoint: 'mediumSmall'
+          })}
+      />
+    )
+    assert.notEqual(wrapper.props()['data-test-id'], 'privateIcon')
+  })
+  it('should not show private icon if breakpoint is small', function () {
+    const wrapper = shallow(
+      <PrivateIcon isActive
+        tab={
+          Immutable.Map({
+            isPrivate: 1,
+            hoverState: true,
             breakpoint: 'small'
           })}
       />
     )
     assert.notEqual(wrapper.props()['data-test-id'], 'privateIcon')
   })
-  it('should not show private icon if tab size is extraSmall', function () {
+  it('should not show private icon if breakpoint is extraSmall', function () {
     const wrapper = shallow(
-      <PrivateIcon
+      <PrivateIcon isActive
         tab={
           Immutable.Map({
-            isPrivate: true,
-            hoverState: false,
+            isPrivate: 1,
+            hoverState: true,
             breakpoint: 'extraSmall'
           })}
       />
     )
     assert.notEqual(wrapper.props()['data-test-id'], 'privateIcon')
   })
-  it('should not show private icon if tab size is the smallest', function () {
+  it('should not show private icon if breakpoint is the smallest', function () {
     const wrapper = shallow(
       <PrivateIcon
         tab={
           Immutable.Map({
-            isPrivate: true,
-            hoverState: false,
+            isPrivate: 1,
+            hoverState: true,
             breakpoint: 'smallest'
           })}
       />

--- a/test/unit/app/renderer/components/tabs/content/tabTitleTest.js
+++ b/test/unit/app/renderer/components/tabs/content/tabTitleTest.js
@@ -44,23 +44,91 @@ describe('Tabs content - Title', function () {
     )
     assert.notEqual(wrapper.text(), pageTitle1)
   })
-  it('should not show text if size is mediumSmall and location has a secondary icon', function () {
+  it('should show text if breakpoint is default', function () {
     const wrapper = shallow(
       <TabTitle
         tab={
           Immutable.Map({
             location: url1,
             title: pageTitle1,
-            breakpoint: 'mediumSmall',
-            audioPlaybackActive: false,
-            isPrivate: true
+            breakpoint: 'default'
+          })}
+        pageTitle={pageTitle1}
+      />
+    )
+    assert.equal(wrapper.text(), pageTitle1)
+  })
+  it('should show text if breakpoint is large', function () {
+    const wrapper = shallow(
+      <TabTitle
+        tab={
+          Immutable.Map({
+            location: url1,
+            title: pageTitle1,
+            breakpoint: 'large'
+          })}
+        pageTitle={pageTitle1}
+      />
+    )
+    assert.equal(wrapper.text(), pageTitle1)
+  })
+  it('should show text if breakpoint is medium', function () {
+    const wrapper = shallow(
+      <TabTitle
+        tab={
+          Immutable.Map({
+            location: url1,
+            title: pageTitle1,
+            breakpoint: 'medium'
+          })}
+        pageTitle={pageTitle1}
+      />
+    )
+    assert.equal(wrapper.text(), pageTitle1)
+  })
+  it('should show text if breakpoint is mediumSmall', function () {
+    const wrapper = shallow(
+      <TabTitle
+        tab={
+          Immutable.Map({
+            location: url1,
+            title: pageTitle1,
+            breakpoint: 'mediumSmall'
+          })}
+        pageTitle={pageTitle1}
+      />
+    )
+    assert.equal(wrapper.text(), pageTitle1)
+  })
+  it('should show text if breakpoint is small and tab is not active', function () {
+    const wrapper = shallow(
+      <TabTitle isActive={false}
+        tab={
+          Immutable.Map({
+            location: url1,
+            title: pageTitle1,
+            breakpoint: 'small'
+          })}
+        pageTitle={pageTitle1}
+      />
+    )
+    assert.equal(wrapper.text(), pageTitle1)
+  })
+  it('should not show text if breakpoint is small and tab is active', function () {
+    const wrapper = shallow(
+      <TabTitle isActive
+        tab={
+          Immutable.Map({
+            location: url1,
+            title: pageTitle1,
+            breakpoint: 'small'
           })}
         pageTitle={pageTitle1}
       />
     )
     assert.notEqual(wrapper.text(), pageTitle1)
   })
-  it('should not show text if size is too small', function () {
+  it('should not show text if breakpoint is extraSmall', function () {
     const wrapper = shallow(
       <TabTitle
         tab={
@@ -68,6 +136,20 @@ describe('Tabs content - Title', function () {
             location: url1,
             title: pageTitle1,
             breakpoint: 'extraSmall'
+          })}
+        pageTitle={pageTitle1}
+      />
+    )
+    assert.notEqual(wrapper.text(), pageTitle1)
+  })
+  it('should not show text if breakpoint is the smallest', function () {
+    const wrapper = shallow(
+      <TabTitle
+        tab={
+          Immutable.Map({
+            location: url1,
+            title: pageTitle1,
+            breakpoint: 'smallest'
           })}
         pageTitle={pageTitle1}
       />


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

### please don't squash, one commit is just for tests ✅ 

Test Plan:
1. Automated tests must pass for all tab content components:

```
# just to doublecheck -- not affected
npm run test -- --grep="Tabs content - AudioTabIcon"
npm run test -- --grep="Tabs content - Favicon"
```

```
# affected
npm run test -- --grep="Tabs content - PrivateIcon"
npm run test -- --grep="Tabs content - NewSessionIcon"
npm run test -- --grep="Tabs content - CloseTabIcon"
npm run test -- --grep="Tabs content - Title"
```

Manual Tests:

1. CloseTab icon must be visible for active tabs at 83px tab-size (largeMedium breakpoint)
2. CloseTab icon must not be visible (even on hover) for non-active tabs
3. Resizing a tab should be kept its content fluid without regressions nor bad UI

Test Plan:

1. Open tabs gradually
2. At some point, close tab icon should be fixed on active tab (83px tab-wide)
3. At that point, inactive tabs shouldn't have a close icon, unless you activate
4. Open some private/partitioned tab
5. Get around 30-40 tabs
6. Resize window
7. Tab content such as favicon, private/partitioned icons, and title should work as expected