### PR TITLE
Implement app.dock.downloadFinished

### DIFF
--- a/app/browser/electronDownloadItem.js
+++ b/app/browser/electronDownloadItem.js
@@ -3,6 +3,8 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const downloadStates = require('../../js/constants/downloadStates')
+const electron = require('electron')
+const app = electron.app
 
 /**
  * Maps downloadId to an electron download-item
@@ -11,6 +13,9 @@ const downloadMap = {}
 
 module.exports.updateElectronDownloadItem = (downloadId, item, state) => {
   if (state === downloadStates.INTERRUPTED || state === downloadStates.CANCELLED || state === downloadStates.COMPLETED) {
+    if (state === downloadStates.COMPLETED) {
+      app.dock.downloadFinished(item.getSavePath())
+    }
     delete downloadMap[downloadId]
   } else {
     downloadMap[downloadId] = item


### PR DESCRIPTION
Make the Downloads folder dock icon "bounce" when a download is complete (macOS-only).

Resolves #1667

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Navigate to https://brave.com/ .
2. Click `Get Brave` and then click `Save`.
3. As the download progress bar approaches 100%, look at the Downloads folder dock icon.
4. Make sure the dock icon "bounces" when the download finishes.