### PR TITLE
Fixes saving a .torrent file (follow up of #8246)

### DIFF
--- a/app/browser/webtorrent.js
+++ b/app/browser/webtorrent.js
@@ -62,7 +62,7 @@ function setupFiltering () {
     }
 
     const parsedUrl = url.parse(details.url)
-    const directDownload = parsedUrl && parsedUrl.query && parsedUrl.query.includes('download=true')
+    const directDownload = parsedUrl && parsedUrl.query && parsedUrl.query.includes('download=ok')
     if (directDownload) {
       return {}
     }

--- a/js/webtorrent/entry.js
+++ b/js/webtorrent/entry.js
@@ -176,8 +176,7 @@ function saveTorrentFile () {
   let a = document.createElement('a')
   a.target = '_blank'
   a.download = true
-  a.href = `${store.torrentId}?download=true`
-  a.href = store.torrentId
+  a.href = `${store.torrentId}?download=ok`
   a.click()
 }
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

**NOTE:**
There was some rebase conflict and `a.href` was duplicated. This PR removes it.

Resolves #8146

Auditors: @bsclifton @bbondy

Test Plan:
- Visit https://webtorrent.io/free-torrents/
- Click "Big Buck Bunny (torrent file)"
- Click "Save Torrent File..."
- File is saved