### PR TITLE
Fixes torrent download when torrent viewer is disabled

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -33,6 +33,7 @@ const {adBlockResourceName} = require('./adBlock')
 const {updateElectronDownloadItem} = require('./browser/electronDownloadItem')
 const {fullscreenOption} = require('./common/constants/settingsEnums')
 const isThirdPartyHost = require('./browser/isThirdPartyHost')
+var extensionState = require('./common/state/extensionState.js')
 
 let appStore = null
 
@@ -664,11 +665,17 @@ module.exports.isResourceEnabled = (resourceName, url, isPrivate) => {
   // TODO(bridiver) - need to clean up the rest of this so web can
   // remove this because it duplicates checks made in siteSettings
   // and not all resources  are controlled by shields up/down
-  if (resourceName === 'flash' || resourceName === 'webtorrent') {
+  if (resourceName === 'flash') {
     return true
   }
 
   const appState = appStore.getState()
+
+  if (resourceName === 'webtorrent') {
+    const extension = extensionState.getExtensionById(appState, config.torrentExtensionId)
+    return extension !== undefined ? extension.get('enabled') : false
+  }
+
   const settings = siteSettings.getSiteSettingsForURL(appState.get('siteSettings'), url)
   const tempSettings = siteSettings.getSiteSettingsForURL(appState.get('temporarySiteSettings'), url)
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #8452

Auditors: @bsclifton

Test Plan:
- disable Torrent Viewer in preferences
- go to https://webtorrent.io/free-torrents/
- download Big Buck Bunny torrent file
