### PR TITLE
Bravify about:extensions descriptions

### DIFF
--- a/js/about/extensions.js
+++ b/js/about/extensions.js
@@ -58,8 +58,9 @@ class ExtensionItem extends ImmutableComponent {
         <h3 className={css(styles.extensionTitle)}>{bravifyText(this.props.extension.get('name'))}</h3>
         <span className={css(styles.extensionVersion)}>{this.props.extension.get('version')}</span>
         {
+          // SAMPSON: Revisit to see if we can remove this Array.prototype.includes call
           !['__MSG_extDescriptionGoogleChrome__', '__MSG_appDesc__'].includes(this.props.extension.get('description'))
-          ? <div data-test-id='extensionDescription' data-l10n-id={this.props.extension.get('description')} />
+          ? <div data-test-id='extensionDescription' data-l10n-id={bravifyText(this.props.extension.get('description'))} />
           : null
         }
         <div className='extensionPath'><span data-l10n-id='extensionPathLabel' /> <span>{this.props.extension.get('base_path')}</span></div>


### PR DESCRIPTION
# Test Plan:
1. Clean install 0.15.0 RC3
2. Enable 1Password extension
3. Go to about:extensions, 1Password description says `1Password extension for Google Chrome.`

# PR Details:
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #8465 
