### PR TITLE
prevent Dialog from being uncloseable with long text

### DIFF
--- a/app/renderer/components/common/messageBox.js
+++ b/app/renderer/components/common/messageBox.js
@@ -118,18 +118,20 @@ class MessageBox extends ImmutableComponent {
         <div className={css(styles.body)} data-test-id='msgBoxMessage'>
           {this.message}
         </div>
-        {
-          this.showSuppress
-            ? <SwitchControl
-              // TODO: refactor SwitchControl
-              className={css(commonStyles.noPaddingLeft)}
-              rightl10nId='preventMoreAlerts'
-              checkedOn={this.suppress}
-              onClick={this.onSuppressChanged} />
-            : null
-        }
-        <div className={css(styles.buttons)} data-test-id='msgBoxButtons'>
-          {this.messageBoxButtons}
+        <div className={css(this.showSuppress && styles.actions)}>
+          {
+            this.showSuppress
+              ? <SwitchControl
+                // TODO: refactor SwitchControl
+                className={css(commonStyles.noPaddingLeft)}
+                rightl10nId='preventMoreAlerts'
+                checkedOn={this.suppress}
+                onClick={this.onSuppressChanged} />
+              : null
+          }
+          <div className={css(styles.buttons)} data-test-id='msgBoxButtons'>
+            {this.messageBoxButtons}
+          </div>
         </div>
       </div>
     </Dialog>
@@ -142,24 +144,31 @@ const styles = StyleSheet.create({
   },
   container: {
     outline: 'none',
-    display: 'block'
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between'
   },
   title: {
     fontWeight: 'bold',
     fontSize: '12pt',
-    marginBottom: globalStyles.spacing.dialogInsideMargin,
     userSelect: 'text'
   },
   body: {
     marginTop: globalStyles.spacing.dialogInsideMargin,
     minWidth: '425px',
     marginBottom: globalStyles.spacing.dialogInsideMargin,
-    userSelect: 'text'
+    userSelect: 'text',
+    maxHeight: 'calc(80vh - 220px)',
+    overflowY: 'auto',
+    overflowX: 'hidden'
+  },
+  actions: {
+    display: 'flex',
+    justifyContent: 'space-between'
   },
   buttons: {
     display: 'flex',
-    justifyContent: 'flex-end',
-    marginTop: globalStyles.spacing.dialogInsideMargin
+    justifyContent: 'flex-end'
   }
 })
 

--- a/app/renderer/components/styles/commonStyles.js
+++ b/app/renderer/components/styles/commonStyles.js
@@ -45,7 +45,11 @@ const styles = StyleSheet.create({
     // Issue #7949
     padding: `${globalStyles.spacing.dialogInsideMargin} 30px`,
     position: 'absolute',
-    top: globalStyles.spacing.dialogTopOffset
+    top: globalStyles.spacing.dialogTopOffset,
+    // Issue #7930
+    boxSizing: 'border-box',
+    maxWidth: '600px',
+    maxHeight: `calc(80vh - ${globalStyles.spacing.downloadsBarHeight})`
   },
 
   // itemList.less

--- a/app/renderer/components/styles/global.js
+++ b/app/renderer/components/styles/global.js
@@ -110,7 +110,7 @@ const globalStyles = {
     buttonHeight: '25px',
     buttonWidth: '25px',
     navbarHeight: '36px',
-    downloadsBarHeight: '50px',
+    downloadsBarHeight: '60px',
     tabsToolbarHeight: '26px',
     tabPagesHeight: '7px',
     bookmarkHangerMaxWidth: '350px',


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

- Fix #7930
- Auditors: @luixxiul

Screenshot: 
<img width="697" alt="screen shot 2017-04-28 at 1 59 30 am" src="https://cloud.githubusercontent.com/assets/4672033/25514949/4a48944e-2bb7-11e7-8ea6-eae1797d53a2.png">
<img width="705" alt="screen shot 2017-04-28 at 2 00 12 am" src="https://cloud.githubusercontent.com/assets/4672033/25514950/4a519ab2-2bb7-11e7-9053-6cc023a17717.png">

> **Note:** no scrollbar is shown because I have it hidden by default in macOS. It's set as default so each OS will render native scrollbars (per Brad https://github.com/brave/browser-laptop/pull/8475#pullrequestreview-35229895)

/cc @bradleyrichter for design review

Test Plan:

1. Open https://jsfiddle.net/c5o7arqu/
2. Make the browser window small
3. Click "OK"
4. Scrollbar should show, text should be scrollable
5. Remove some text with devTools or open a smaller dialog
6. Scrollbar shouldn't show
7. everything should be properly aligned
8. Resizing screen should resize dialog as well (responsive)