### PR TITLE
remove isSwipeTrackingFromScrollEventsEnabled

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -7,7 +7,6 @@ const ImmutableComponent = require('../../app/renderer/components/immutableCompo
 const Immutable = require('immutable')
 const electron = require('electron')
 const ipc = electron.ipcRenderer
-const systemPreferences = electron.remote.systemPreferences
 
 // Actions
 const appActions = require('../actions/appActions')
@@ -234,7 +233,7 @@ class Main extends ImmutableComponent {
 
     // isSwipeTrackingFromScrollEventsEnabled is only true if "two finger scroll to swipe" is enabled
     ipc.on('scroll-touch-begin', () => {
-      if (swipeGesture && systemPreferences.isSwipeTrackingFromScrollEventsEnabled()) {
+      if (swipeGesture) {
         trackingFingers = true
         startTime = (new Date()).getTime()
       }


### PR DESCRIPTION
remote.systemPreferences is no longer available and muon now only fires scroll-touch-begin and scroll-touch-end if the system pref is enabled

Test Plan:
Turn on "swipe between pages"
Swipe back/forward should work
Turn off "swipe between pages"
Swipe back/forward should stop working

**** Requires muon 2.56.6 ****
https://github.com/brave/muon/commit/3ee6abd8bbc34f6b092d08bdbd9dcb916d53d616