### PR TITLE
refactor sync to use appStore change listener

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -233,6 +233,7 @@ AppStore
       originalSeed: Array.<number>, // only set for bookmarks that have been synced before a sync profile reset
       parentFolderId: number, // set for bookmarks and bookmark folders only
       partitionNumber: number, // optionally specifies a specific session
+      skipSync: boolean, // Set for objects FETCHed by sync
       tags: [string], // empty, 'bookmark', 'bookmark-folder', 'default', or 'reader'
       themeColor: string, // CSS compatible color string
       title: string
@@ -259,6 +260,7 @@ AppStore
       openExternalPermission: boolean,
       pointerLockPermission: boolean,
       protocolRegistrationPermission: boolean,
+      skipSync: boolean, // Set for objects FETCHed by sync
       runInsecureContent: boolean, // allow active mixed content
       safeBrowsing: boolean,
       savePasswords: boolean, // only false or undefined/null

--- a/js/actions/syncActions.js
+++ b/js/actions/syncActions.js
@@ -7,20 +7,6 @@ const AppDispatcher = require('../dispatcher/appDispatcher')
 const syncConstants = require('../constants/syncConstants')
 
 const syncActions = {
-  addSite: function (item) {
-    AppDispatcher.dispatch({
-      actionType: syncConstants.SYNC_ADD_SITE,
-      item
-    })
-  },
-
-  updateSite: function (item) {
-    AppDispatcher.dispatch({
-      actionType: syncConstants.SYNC_UPDATE_SITE,
-      item
-    })
-  },
-
   removeSite: function (item) {
     AppDispatcher.dispatch({
       actionType: syncConstants.SYNC_REMOVE_SITE,
@@ -37,30 +23,6 @@ const syncActions = {
   clearSiteSettings: function () {
     AppDispatcher.dispatch({
       actionType: syncConstants.SYNC_CLEAR_SITE_SETTINGS
-    })
-  },
-
-  addSiteSetting: function (hostPattern, item) {
-    AppDispatcher.dispatch({
-      actionType: syncConstants.SYNC_ADD_SITE_SETTING,
-      item,
-      hostPattern
-    })
-  },
-
-  updateSiteSetting: function (hostPattern, item) {
-    AppDispatcher.dispatch({
-      actionType: syncConstants.SYNC_UPDATE_SITE_SETTING,
-      item,
-      hostPattern
-    })
-  },
-
-  removeSiteSetting: function (hostPattern, item) {
-    AppDispatcher.dispatch({
-      actionType: syncConstants.SYNC_REMOVE_SITE_SETTING,
-      item,
-      hostPattern
     })
   }
 }

--- a/js/constants/syncConstants.js
+++ b/js/constants/syncConstants.js
@@ -6,15 +6,9 @@ const mapValuesByKeys = require('../lib/functional').mapValuesByKeys
 
 const _ = null
 const syncConstants = {
-  SYNC_ADD_SITE: _, /** @param {Immutable.Map} item */
-  SYNC_UPDATE_SITE: _, /** @param {Immutable.Map} item */
   SYNC_REMOVE_SITE: _,  /** @param {Immutable.Map} item */
   SYNC_CLEAR_HISTORY: _,
-  SYNC_CLEAR_SITE_SETTINGS: _,
-  SYNC_DELETE_USER: _,
-  SYNC_ADD_SITE_SETTING: _, /** @param {string} hostPattern, @param {Immutable.Map} item */
-  SYNC_UPDATE_SITE_SETTING: _, /** @param {string} hostPattern, @param {Immutable.Map} item */
-  SYNC_REMOVE_SITE_SETTING: _  /** @param {string} hostPattern, @param {Immutable.Map} item */
+  SYNC_CLEAR_SITE_SETTINGS: _
 }
 
 module.exports = mapValuesByKeys(syncConstants)

--- a/js/state/syncUtil.js
+++ b/js/state/syncUtil.js
@@ -28,7 +28,7 @@ const CATEGORY_MAP = {
 }
 module.exports.CATEGORY_MAP = CATEGORY_MAP
 
-const siteSettingDefaults = {
+module.exports.siteSettingDefaults = {
   hostPattern: '',
   zoomLevel: 0,
   shieldsUp: true,
@@ -391,7 +391,7 @@ module.exports.isSyncable = (type, item) => {
   if (type === 'bookmark') {
     return siteUtil.isBookmark(item) || siteUtil.isFolder(item)
   } else if (type === 'siteSetting') {
-    for (let field in siteSettingDefaults) {
+    for (let field in module.exports.siteSettingDefaults) {
       if (item.has(field)) {
         return true
       }
@@ -510,7 +510,7 @@ module.exports.createSiteSettingsData = (hostPattern, setting) => {
       objectData[key] = adControlEnum[value]
     } else if (key === 'cookieControl' && typeof cookieControlEnum[value] !== 'undefined') {
       objectData[key] = cookieControlEnum[value]
-    } else if (key in siteSettingDefaults) {
+    } else if (key in module.exports.siteSettingDefaults) {
       objectData[key] = value
     }
   }

--- a/test/unit/app/sessionStoreTest.js
+++ b/test/unit/app/sessionStoreTest.js
@@ -50,8 +50,8 @@ describe('sessionStore unit tests', function () {
     }
   }
   const mockSiteUtil = {
-    clearHistory: (sites, syncCallback) => {
-      return siteUtil.clearHistory(sites, syncCallback)
+    clearHistory: (sites) => {
+      return siteUtil.clearHistory(sites)
     },
     getSiteKey: (siteDetail) => {
       return siteUtil.getSiteKey(siteDetail)

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -436,7 +436,7 @@ describe('siteUtil', function () {
         expectedSites[expectedSiteKey] = expectedSiteDetail.set('objectId', undefined).toJS()
         assert.deepEqual(processedSites.toJS(), expectedSites)
       })
-      it('sets an objectId when syncCallback is provided', function () {
+      it('sets skipSync when skipSync is provided', function () {
         mockery.enable({
           warnOnReplace: false,
           warnOnUnregistered: false,
@@ -469,10 +469,10 @@ describe('siteUtil', function () {
         const sites = Immutable.fromJS({
           [siteKey]: oldSiteDetail
         })
-        const processedSites = siteUtil.addSite(sites, newSiteDetail, siteTags.BOOKMARK, oldSiteDetail, () => {})
+        const processedSites = siteUtil.addSite(sites, newSiteDetail, siteTags.BOOKMARK, oldSiteDetail, true)
         mockery.deregisterMock('./stores/appStoreRenderer')
         mockery.disable()
-        assert.equal(processedSites.getIn([siteKey, 'objectId']).size, 16)
+        assert.equal(processedSites.getIn([siteKey, 'skipSync']), true)
       })
     })
   })


### PR DESCRIPTION
and only trigger sync when important site fields are modified.
fix #8415
may also fix https://github.com/brave/sync/issues/31

test plan:
0. automated sync tests should pass
1. enable sync and go to https://example.com
2. bookmark it. you should see a message in the console indicating a record was sent.
3. close the page and visit it again. you should not see a message in the console.
4. unbookmark it. you should see a message in the console indicating a record was sent.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
