### PR TITLE
Show search indicator when urlBar is empty

### DIFF
--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -258,6 +258,11 @@ class UrlBar extends React.Component {
     if (this.suggestionLocation) {
       windowActions.setUrlBarSuggestions(undefined, null)
     }
+    // onChange is fired if text is cut from contextMenu
+    // for such cases we have to trigger render again to update urlIcon
+    if (e.target.value === '') {
+      windowActions.setNavBarUserInput('')
+    }
   }
 
   // Keeps track of which part was set for the url suffix and which

--- a/test/navbar-components/navigationBarTest.js
+++ b/test/navbar-components/navigationBarTest.js
@@ -904,6 +904,36 @@ describe('navigationBar tests', function () {
 
     })
 
+    describe('with no url input value', function () {
+      Brave.beforeAll(this)
+
+      before(function * () {
+        this.page1 = Brave.server.url('page1.html')
+        yield setup(this.app.client)
+        yield this.app.client
+          .waitForExist(urlInput)
+        yield this.app.client
+          .keys(this.page1)
+        yield this.app.client
+          .keys(Brave.keys.ENTER)
+      })
+
+      it('shows search icon when input is empty', function * () {
+        // test that url is shown with proper icon
+        // before getting cleared
+        yield this.app.client
+          .waitForExist(urlbarIcon)
+          .getAttribute(urlbarIcon, 'class').then(classes => classes.includes('fa-unlock'))
+
+        // ensure that once cleaned, search icon
+        // is shown instead of protocol icon
+        yield this.app.client
+          .setValue(urlInput, '')
+          .waitForExist(urlbarIcon)
+          .getAttribute(urlbarIcon, 'class').then(classes => classes.includes('fa-search'))
+      })
+    })
+
     describe('with javascript url input value', function () {
       Brave.beforeAll(this)
 


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Close #8468 

Test Plan:
covered by automated test

QA Steps:
empty url bar should have search icon instead of current one