### PR TITLE
Cleanup the multi-type context menu item

### DIFF
--- a/js/components/contextMenu.js
+++ b/js/components/contextMenu.js
@@ -21,9 +21,16 @@ class ContextMenuItem extends ImmutableComponent {
   get submenu () {
     return this.props.contextMenuItem.get('submenu')
   }
+  get items () {
+    return this.props.contextMenuItem.get('items')
+  }
   get hasSubmenu () {
     return this.submenu && this.submenu.size > 0
   }
+  get isMulti () {
+    return this.items && this.items.size > 0
+  }
+
   get accelerator () {
     const accelerator = this.props.contextMenuItem.get('accelerator')
     return accelerator && typeof accelerator === 'string'
@@ -138,17 +145,6 @@ class ContextMenuItem extends ImmutableComponent {
       return <div className='contextMenuItem contextMenuSeparator' role='listitem'>
         <hr />
       </div>
-    } else if (this.props.contextMenuItem.get('type') === 'multi') {
-      return <div className='contextMenuItem multiContextMenuItem'>
-        <span className='multiItemTitle' data-l10n-id={this.props.contextMenuItem.get('l10nLabelId')} />
-        {
-          this.props.contextMenuItem.get('submenu').map((subItem) =>
-            <div className='contextMenuSubItem'
-              onClick={this.onClick.bind(this, subItem.get('click'), false)}>
-              <span data-l10n-id={subItem.get('l10nLabelId')}>{this.getLabelForItem(subItem)}</span>
-            </div>)
-        }
-      </div>
     }
     const props = {
       className: cx({
@@ -156,7 +152,8 @@ class ContextMenuItem extends ImmutableComponent {
         hasFaIcon: faIcon,
         checkedMenuItem: this.props.contextMenuItem.get('checked'),
         hasIcon: icon || faIcon,
-        selectedByKeyboard: this.props.selected
+        selectedByKeyboard: this.props.selected,
+        multiContextMenuItem: this.isMulti
       }),
       role: 'listitem'
     }
@@ -194,6 +191,13 @@ class ContextMenuItem extends ImmutableComponent {
       }
       <span className='contextMenuItemText'
         data-l10n-id={this.props.contextMenuItem.get('l10nLabelId')}>{this.props.contextMenuItem.get('label')}</span>
+      {
+        this.isMulti && this.props.contextMenuItem.get('items').map((subItem) =>
+          <div className='contextMenuSubItem'
+            onClick={this.onClick.bind(this, subItem.get('click'), false)}>
+            <span data-l10n-id={subItem.get('l10nLabelId')}>{this.getLabelForItem(subItem)}</span>
+          </div>)
+      }
       {
         this.hasSubmenu
         ? <span className='submenuIndicatorContainer'>

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -755,8 +755,7 @@ function hamburgerTemplateInit (location, e) {
     CommonMenu.separatorMenuItem,
     {
       l10nLabelId: 'zoom',
-      type: 'multi',
-      submenu: [{
+      items: [{
         label: '-',
         click: () => {
           ipc.emit(messages.SHORTCUT_ACTIVE_FRAME_ZOOM_OUT)

--- a/less/contextMenu.less
+++ b/less/contextMenu.less
@@ -107,7 +107,7 @@
       text-align: center;
     }
 
-    .multiItemTitle {
+    .contextMenuItemText {
       margin-top: auto;
       margin-bottom: auto;
       padding-right: 10px;


### PR DESCRIPTION
This fixes #7816 and simplifies the logic of context menu item by making a distinction between the `submenu` collection and the structure of a multi-type item.

By creating a new collection (`items`), we're able to treat the `multi`-item as a normal item (sharing all it's behaviours -- lack of them was the precise cause of #7816 ). This also solves some other, probably unfilled issues (i.e, it wasn't possible to focus the `multi`-type item using keyboard[1]), and makes it possible to define `multi`-type items with submenus, if needed.

[1] - While this PR makes it possible to select the `multi`-item, keyboard navigation still won't work *inside* it. I believe this should be discussed in another issue.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

## Test Plan:
See https://github.com/brave/browser-laptop/issues/7816