### PR TITLE
fix #8374 - Open image in new tab should recognize focus prefs

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -1027,6 +1027,7 @@ function mainTemplateInit (nodeProps, frame, tab) {
   }
 
   if (isImage) {
+    const active = getSetting(settings.SWITCH_TO_NEW_TABS) === true
     template.push(
       {
         label: locale.translation('openImageInNewTab'),
@@ -1035,7 +1036,8 @@ function mainTemplateInit (nodeProps, frame, tab) {
             appActions.createTabRequested({
               url: nodeProps.srcURL,
               openerTabId: frame.get('tabId'),
-              partition: getPartitionFromNumber(frame.get('partitionNumber'), isPrivate)
+              partition: getPartitionFromNumber(frame.get('partitionNumber'), isPrivate),
+              active: active
             })
           }
         }


### PR DESCRIPTION
## Test plan
1. In Preferences > Tabs, set "Switch to new tabs immediately" to false
2. Visit a site with images (ex: cnn.com)
3. Right click an image and pick "Open Image in New Tab"
4. Image should open in new tab- but focus is not sent
5. Toggle the setting (set in step 1)
6. Right click an image and pick "Open Image in New Tab"
7. Focus should be given immediately to the new tab

## Description
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fixes https://github.com/brave/browser-laptop/issues/8374