### PR TITLE
move the nav controls to left in full screen mode - in macOS Fix #7872

### DIFF
--- a/app/renderer/components/navigation/navigator.js
+++ b/app/renderer/components/navigation/navigator.js
@@ -27,7 +27,7 @@ const extensionState = require('../../../common/state/extensionState')
 const siteSettingsState = require('../../../common/state/siteSettingsState')
 
 // Util
-const {getCurrentWindowId, isMaximized} = require('../../currentWindow')
+const {getCurrentWindowId, isMaximized, isFullScreen} = require('../../currentWindow')
 const {makeImmutable} = require('../../../common/state/immutableUtil')
 const platformUtil = require('../../../common/lib/platformUtil')
 const {braveShieldsEnabled} = require('../../../common/state/shieldState')
@@ -225,7 +225,10 @@ class Navigator extends ImmutableComponent {
           onDragOver={this.onDragOver}
           onDrop={this.onDrop}
         >
-          <div className='backforward'>
+          <div className={cx({
+            backforward: true,
+            fullscreen: isFullScreen()
+          })}>
             <div className={cx({
               navigationButtonContainer: true,
               nav: true,

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -19,6 +19,10 @@
 .platform--darwin .navigatorWrapper .backforward {
   margin-left: @navbarLeftMarginDarwin;
 
+  &.fullscreen {
+    margin-left: 0;
+  }
+
   // Since we want to keep the navigator centered, we need to calculate the
   // difference between the width of the left box and the width of the right box.
   @centerOffset: @navbarLeftMarginDarwin + 2 * (@navbarButtonWidth + @navbarButtonSpacing) // width area on the left


### PR DESCRIPTION
- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #7872

Test Plan:
<img width="1440" alt="screen shot 2017-04-27 at 12 12 15 am" src="https://cloud.githubusercontent.com/assets/4078325/25450970/42351464-2ade-11e7-9a65-69c5799f60bc.png">
