### PR TITLE
Escape path passed into spawn so `npm start` works if there are space…

### DIFF
--- a/tools/start.js
+++ b/tools/start.js
@@ -7,7 +7,7 @@ const options = {
   stdio: 'inherit',
   shell: true
 }
-const muon = spawn('electron', [path.join(__dirname, '..')].concat(process.argv.slice(2)), options)
+const muon = spawn('electron', [`"${path.join(__dirname, '..')}"`].concat(process.argv.slice(2)), options)
 
 muon.on('error', (err) => {
   console.error(`could not start muon ${err}`)


### PR DESCRIPTION
…s in the path. See: https://github.com/nodejs/node/issues/6803

Fixes: brave/browser-laptop#8516

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

Built and tested on macOS, Windows 10, and Ubuntu. (That was fun!)
