### PR TITLE
show nothing for siteInfo on about: pages

### DIFF
--- a/js/components/siteInfo.js
+++ b/js/components/siteInfo.js
@@ -7,6 +7,7 @@ const PropTypes = require('prop-types')
 const ImmutableComponent = require('../../app/renderer/components/immutableComponent')
 const cx = require('../lib/classSet')
 const {isPotentialPhishingUrl} = require('../lib/urlutil')
+const {isSourceAboutUrl} = require('../lib/appUrlUtil')
 const Dialog = require('./dialog')
 const Button = require('./button')
 const appActions = require('../actions/appActions')
@@ -66,6 +67,10 @@ class SiteInfo extends ImmutableComponent {
     return isPotentialPhishingUrl(this.props.frameProps.getIn(['location']))
   }
   render () {
+    if (isSourceAboutUrl(this.location)) {
+      return null
+    }
+
     // Figure out the partition info display
     let l10nArgs = {
       partitionNumber: this.partitionNumber


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/8299

Test Plan:
1. open example.com
2. open a new tab
3. show siteInfo on example.com, then use Cmd+2 to switch to the second tab
4. no siteInfo should show on the second tab

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
