### PR TITLE
Make up/down arrow keys wrap to other end in urlbar suggestions

### DIFF
--- a/app/renderer/reducers/urlBarSuggestionsReducer.js
+++ b/app/renderer/reducers/urlBarSuggestionsReducer.js
@@ -328,6 +328,8 @@ const urlBarSuggestionsReducer = (state, action) => {
         state = state.setIn(selectedIndexPath, 0)
       } else if (selectedIndex > 0) {
         state = state.setIn(selectedIndexPath, selectedIndex - 1)
+      } else {
+        state = state.setIn(selectedIndexPath, suggestionList.size - 1)
       }
       state = updateUrlSuffix(state, state.getIn(activeFrameStatePath(state).concat(['navbar', 'urlbar', 'suggestions', 'suggestionList']), suggestionList))
       break
@@ -341,6 +343,8 @@ const urlBarSuggestionsReducer = (state, action) => {
         state = state.setIn(selectedIndexPath, 0)
       } else if (selectedIndex < suggestionList.size - 1) {
         state = state.setIn(selectedIndexPath, selectedIndex + 1)
+      } else if (selectedIndex === suggestionList.size - 1) {
+        state = state.setIn(selectedIndexPath, 0)
       }
       state = updateUrlSuffix(state, state.getIn(activeFrameStatePath(state).concat(['navbar', 'urlbar', 'suggestions', 'suggestionList']), suggestionList))
       break


### PR DESCRIPTION
## Test plan
1. Ensure all suggestions switch is enabled in the search setting page
2. Have sufficient history so that suggestion are shown based on all the options
3. Try using UP arrow key to select the bottom most suggestion list, it works now

## Description
Fix #7682

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).