### PR TITLE
Add snap install instructions

### DIFF
--- a/docs/linuxInstall.md
+++ b/docs/linuxInstall.md
@@ -1,5 +1,14 @@
 # Linux install instructions
 
+## Snap
+
+Install <project> in seconds on [Ubuntu and other snap supported Linux distributions](https://snapcraft.io/docs/core/install) with:
+
+    snap install brave --beta
+
+Installing a snap is very quick. Snaps are secure. They are isolated with all of their dependencies. Snaps also auto update when a new version is released.
+
+
 **NOTE**: _If you experience a problem with dependencies while installing, you may
 want to try installing `git` using the package manager for your distro._
 

--- a/docs/linuxInstall.md
+++ b/docs/linuxInstall.md
@@ -1,24 +1,24 @@
 # Linux install instructions
 
-## Snap
-
-Install <project> in seconds on [Ubuntu and other snap supported Linux distributions](https://snapcraft.io/docs/core/install) with:
-
-    snap install brave --beta
-
-Installing a snap is very quick. Snaps are secure. They are isolated with all of their dependencies. Snaps also auto update when a new version is released.
-
-
 **NOTE**: _If you experience a problem with dependencies while installing, you may
 want to try installing `git` using the package manager for your distro._
 
 **NOTE**: _If Brave does not start and shows an error about sandboxing, you may need
 to [enable userns in your kernel](https://superuser.com/questions/1094597/enable-user-namespaces-in-debian-kernel#1122977). Running with the `--no-sandbox` flag is NOT recommended!_
 
+## Snapcraft
+
+According to [snapcraft.io](https://snapcraft.io/)
+> Snaps are quick to install, easy to create, safe to run, and they update automatically and transactionally so your app is always fresh and never broken.
+
+Installation instructions for `snapd` [can be found here](https://snapcraft.io/docs/core/install). Once `snapd` is installed, installing Brave looks like this:
+
+    snap install brave --beta
+
 ## Debian (jessie) and Ubuntu (Zesty, Yakkety, Xenial, and Trusty) AMD64:
 To install brave using apt and lsb\_release :
 
-``` 
+```
 curl https://s3-us-west-2.amazonaws.com/brave-apt/keys.asc | sudo apt-key add -
 echo "deb [arch=amd64] https://s3-us-west-2.amazonaws.com/brave-apt `lsb_release -sc` main" | sudo tee -a /etc/apt/sources.list.d/brave-`lsb_release -sc`.list
 ```
@@ -78,7 +78,7 @@ To install brave using dnf:
 
 ```
 sudo dnf config-manager --add-repo https://s3-us-west-2.amazonaws.com/brave-rpm-release/x86_64/
-sudo rpm --import https://s3-us-west-2.amazonaws.com/brave-rpm-release/keys.asc 
+sudo rpm --import https://s3-us-west-2.amazonaws.com/brave-rpm-release/keys.asc
 sudo dnf install brave
 ```
 


### PR DESCRIPTION
This pull request adds installation instructions for users of [snap enabled Linux distributions](https://snapcraft.io/docs/core/install). Snaps enable ISVs and projects to make their software available to millions of Linux users via the snap store and directly control delivery of software updates to their users. Snaps of stable desktop applications will also be available via the desktop Software Center, improving the discoverability of your software. Your software can be installed with a simple `snap install brave --beta` simplifying the installation instructions for your users.

Once the snap is released into the stable channel in the store, users no longer need to add the ```--beta``` and will appear in the desktop Software Center.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

#7140