### PR TITLE
Removes whole frame from onTabsToolbarContextMenu

### DIFF
--- a/app/renderer/components/bookmarks/bookmarksToolbar.js
+++ b/app/renderer/components/bookmarks/bookmarksToolbar.js
@@ -192,7 +192,7 @@ class BookmarksToolbar extends ImmutableComponent {
   }
   onContextMenu (e) {
     const closest = dnd.closestFromXOffset(this.bookmarkRefs.filter((x) => !!x), e.clientX).selectedRef
-    contextMenus.onTabsToolbarContextMenu(this.activeFrame, (closest && closest.props.bookmark) || undefined, closest && closest.isDroppedOn, e)
+    contextMenus.onTabsToolbarContextMenu(this.activeFrame.get('title'), this.activeFrame.get('location'), (closest && closest.props.bookmark) || undefined, closest && closest.isDroppedOn, e)
   }
   render () {
     let showFavicon = this.props.showFavicon

--- a/app/renderer/components/tabs/tabsToolbar.js
+++ b/app/renderer/components/tabs/tabsToolbar.js
@@ -26,7 +26,8 @@ class TabsToolbar extends ImmutableComponent {
       // Don't show the tabs menu if the new tab "+"" was clicked
       return
     }
-    contextMenus.onTabsToolbarContextMenu(windowStore.getFrame(this.props.activeFrameKey), undefined, undefined, e)
+    const activeFrame = windowStore.getFrame(this.props.activeFrameKey)
+    contextMenus.onTabsToolbarContextMenu(activeFrame.get('title'), activeFrame.get('location'), undefined, undefined, e)
   }
 
   render () {

--- a/js/components/main.js
+++ b/js/components/main.js
@@ -644,7 +644,7 @@ class Main extends ImmutableComponent {
 
   onTabContextMenu (e) {
     const activeFrame = frameStateUtil.getActiveFrame(this.props.windowState)
-    contextMenus.onTabsToolbarContextMenu(activeFrame, undefined, undefined, e)
+    contextMenus.onTabsToolbarContextMenu(activeFrame.get('title'), activeFrame.get('location'), undefined, undefined, e)
   }
 
   get allSiteSettings () {

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -144,7 +144,7 @@ function findBarTemplateInit () {
   return getEditableItems(window.getSelection().toString())
 }
 
-function tabsToolbarTemplateInit (activeFrame, closestDestinationDetail, isParent) {
+function tabsToolbarTemplateInit (bookmarkTitle, bookmarkLink, closestDestinationDetail, isParent) {
   const template = [
     CommonMenu.bookmarksManagerMenuItem(),
     CommonMenu.bookmarksToolbarMenuItem(),
@@ -156,8 +156,12 @@ function tabsToolbarTemplateInit (activeFrame, closestDestinationDetail, isParen
       CommonMenu.separatorMenuItem)
   }
 
-  template.push(addBookmarkMenuItem('addBookmark', siteUtil.getDetailFromFrame(activeFrame, siteTags.BOOKMARK), closestDestinationDetail, isParent),
-    addFolderMenuItem(closestDestinationDetail, isParent))
+  template.push(addBookmarkMenuItem('addBookmark', {
+    title: bookmarkTitle,
+    location: bookmarkLink,
+    tags: [siteTags.BOOKMARK]
+  }, closestDestinationDetail, isParent))
+  template.push(addFolderMenuItem(closestDestinationDetail, isParent))
 
   return menuUtil.sanitizeTemplateItems(template)
 }
@@ -1406,9 +1410,9 @@ function onNewTabContextMenu (target) {
   menu.destroy()
 }
 
-function onTabsToolbarContextMenu (activeFrame, closestDestinationDetail, isParent, e) {
+function onTabsToolbarContextMenu (bookmarkTitle, bookmarkLink, closestDestinationDetail, isParent, e) {
   e.stopPropagation()
-  const tabsToolbarMenu = Menu.buildFromTemplate(tabsToolbarTemplateInit(activeFrame, closestDestinationDetail, isParent))
+  const tabsToolbarMenu = Menu.buildFromTemplate(tabsToolbarTemplateInit(bookmarkTitle, bookmarkLink, closestDestinationDetail, isParent))
   tabsToolbarMenu.popup(getCurrentWindow())
   tabsToolbarMenu.destroy()
 }


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #8562

**Note**: This change is needed for converting `tabsToolbar.js` to redux

Auditors: @bsclifton

Test Plan:
- open https://clifton.io
- right click on bookmarks toolbar
- click add bookmarks
- populated bookmark dialog is shown
