### PR TITLE
Fix broken torrent file view (fix for PR #8325)

### DIFF
--- a/js/webtorrent/entry.js
+++ b/js/webtorrent/entry.js
@@ -20,7 +20,7 @@ require('../../node_modules/font-awesome/css/font-awesome.css')
 const store = {
   name: null, // Torrent name
   ix: null, // Selected file index
-  torrentId: window.decodeURIComponent(window.location.hash.substring(1)),
+  torrentId: null,
   torrentIdProtocol: null,
   torrent: null,
   serverUrl: null,
@@ -31,7 +31,12 @@ let client, server
 
 init()
 
+// Fix for issue: https://github.com/brave/browser-laptop/pull/8325#issuecomment-298134616
+window.addEventListener('hashchange', init)
+
 function init () {
+  store.torrentId = window.decodeURIComponent(window.location.hash.substring(1))
+
   const parsedUrl = url.parse(store.torrentId)
   store.torrentIdProtocol = parsedUrl.protocol
 


### PR DESCRIPTION
**This is a PR to a PR!** Merge this **BEFORE** merging PR #8325.

Once a torrent is started, clicking on a video file within the torrent
should play it. Instead, the starting page is shown again and the user
has to restart the torrent. Once doing so, the file doesn't play. The
file list is still shown.

This is due to the ix= parameter not getting processed correctly on
hashchange after this change. Before, the redirect-based implementation
meant we didn't need to listen to hashchange since a redirect always
happened. Now, a file click actually just adds a hash to the URL and
triggers the hashchange event.
