### PR TITLE
Fix "Save Torrent File" feature

### DIFF
--- a/js/webtorrent/entry.js
+++ b/js/webtorrent/entry.js
@@ -178,10 +178,15 @@ function stop () {
 }
 
 function saveTorrentFile () {
-  let a = document.createElement('a')
+  const parsedUrl = url.parse(store.torrentId, true)
+  parsedUrl.query.download = true
+  const name = path.basename(parsedUrl.pathname) || 'untitled.torrent'
+  const href = url.format(parsedUrl)
+
+  const a = document.createElement('a')
   a.target = '_blank'
-  a.download = true
-  a.href = `${store.torrentId}?download=ok`
+  a.download = name
+  a.href = href
   a.click()
 }
 


### PR DESCRIPTION
Fixes #8146

This feature broke again after PR #8325. My fault for not catching it
during review. This PR fixes the code that is now on `master`.

Addresses these comments:

- https://github.com/brave/browser-laptop/pull/8446#issuecomment-298138573
- https://github.com/brave/browser-laptop/issues/8146#issuecomment-298138452

It is better to add the '?download=true' querystring param with
`url.parse` and `url.format` since blindly tacking on a
'?download=true' can lead to invalid URLs.

A couple examples:

- `magnet:?a=b&c=d?download=true` is invalid and should use `&download=true` instead
- `https://example.com/file.torrent#ix=1?download=true` is invalid as there should not be a query param after a hash

Also, this names the downloaded file correctly, which didn't seem to be working either after PR #8325.

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Didn't submit an issue since this isn't broken in a released version of Brave, just on `master` as of a few minutes ago. Lmk if I still should make an issue.

Test Plan:

- Visit https://webtorrent.io/free-torrents/
- Click "Big Buck Bunny (torrent file)"
- Click "Save Torrent File..."
- File is saved