### PR TITLE
Fix issue with not working select the last tab preference

### DIFF
--- a/js/state/frameStateUtil.js
+++ b/js/state/frameStateUtil.js
@@ -308,7 +308,7 @@ function getFramePropsIndex (frames, frameProps) {
 function getFrameByLastAccessedTime (frames) {
   const frameProps = frames.toJS()
     .reduce((pre, cur) => {
-      return (cur.pinnedLocation === undefined &&
+      return ([undefined, null].includes(cur.pinnedLocation) &&
         cur.lastAccessedTime &&
         cur.lastAccessedTime > pre.lastAccessedTime
       ) ? cur : pre
@@ -768,5 +768,6 @@ module.exports = {
   frameStatePathForFrame,
   tabStatePath,
   tabStatePathForFrame,
-  getLastCommittedURL
+  getLastCommittedURL,
+  getFrameByLastAccessedTime
 }

--- a/test/unit/state/frameStateUtilTest.js
+++ b/test/unit/state/frameStateUtilTest.js
@@ -354,4 +354,42 @@ describe('frameStateUtil', function () {
       })
     })
   })
+
+  describe('getFrameByLastAccessedTime', function () {
+    let framesWithLastAccessedTime, framesWithoutLastAccessedTime, framesWithNullifiedLastAccessedTime
+
+    beforeEach(function () {
+      framesWithLastAccessedTime = Immutable.fromJS([
+        { key: 2, lastAccessedTime: null },
+        { key: 3, lastAccessedTime: 1488184050731 },
+        { key: 4, lastAccessedTime: 1488184050711 },
+        { key: 5 }
+      ])
+      framesWithoutLastAccessedTime = Immutable.fromJS([
+        { key: 2 },
+        { key: 3 },
+        { key: 4 }
+      ])
+      framesWithNullifiedLastAccessedTime = Immutable.fromJS([
+        { key: 2, lastAccessedTime: null },
+        { key: 3, lastAccessedTime: null },
+        { key: 4, lastAccessedTime: null }
+      ])
+    })
+
+    it('gets correct frame by last accessed time', function () {
+      const result = frameStateUtil.getFrameByLastAccessedTime(framesWithLastAccessedTime)
+      assert.equal(1, result)
+    })
+
+    it('returns -1 for frames without last accessed time', function () {
+      const result = frameStateUtil.getFrameByLastAccessedTime(framesWithoutLastAccessedTime)
+      assert.equal(-1, result)
+    })
+
+    it('returns -1 for frames with nullified last accessed time', function () {
+      const result = frameStateUtil.getFrameByLastAccessedTime(framesWithNullifiedLastAccessedTime)
+      assert.equal(-1, result)
+    })
+  })
 })


### PR DESCRIPTION
## Test Plan:
1. Open https://github.com (tab 1)
2. Open about:preferences#tabs in a new tab (tab 2)
3. Set "Select the last viewed tab"
4. Open https://github.com/features in a new tab (tab 3)
5. Select tab 1
6. Select tab 3
7. Close tab 3

Expected result: tab 1 should be selected

## Description
Pinned locations for frames were nullified and due to that check by last accessed time didn't work. Added null case and tests for getFrameByLastAccessedTime function.

Fix brave/browser-laptop#8357

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

