### PR TITLE
Looking up site using tab details now considers provisionalLocation

### DIFF
--- a/app/browser/reducers/sitesReducer.js
+++ b/app/browser/reducers/sitesReducer.js
@@ -97,11 +97,12 @@ const sitesReducer = (state, action, emitChanges) => {
         console.warn('Trying to pin a tabId which does not exist:', action.tabId, 'tabs: ', state.get('tabs').toJS())
         break
       }
-      const siteDetail = siteUtil.getDetailFromTab(tab, siteTags.PINNED)
+      const sites = state.get('sites')
+      const siteDetail = siteUtil.getDetailFromTab(tab, siteTags.PINNED, sites)
       if (action.pinned) {
-        state = state.set('sites', siteUtil.addSite(state.get('sites'), siteDetail, siteTags.PINNED))
+        state = state.set('sites', siteUtil.addSite(sites, siteDetail, siteTags.PINNED))
       } else {
-        state = state.set('sites', siteUtil.removeSite(state.get('sites'), siteDetail, siteTags.PINNED))
+        state = state.set('sites', siteUtil.removeSite(sites, siteDetail, siteTags.PINNED))
       }
       if (syncEnabled()) {
         state = syncUtil.updateSiteCache(state, siteDetail)


### PR DESCRIPTION
## Test Plan
### folder case
1. Visit https://brave.com?abc
2. Add a bookmark and then put this bookmark inside a folder
3. While you are still at this URL, pin the site
4. Quit Brave and relaunch
5. Confirm pinned tab is there
6. Unpin the tab pinned in step 3
7. Quit Brave and relaunch
8. Confirm pinned tab is NOT there

### redirect case
1. Visit a site that you own the hosting for
2. Pin the site
3. Quit Brave and relaunch
4. Confirm pinned tab is there
5. Quit Brave
6. Create/update the .htaccess file (or similar for nginx, etc) and put a redirect in to a different URL than step 1
7. Relaunch Brave
8. Unpin the tab pinned in step 2
9. Quit Brave and relaunch
10. Confirm pinned tab is NOT there

## Description
This PR fixes two bugs with pinned tabs
- if you pin a tab which is bookmarked and inside a folder, you can't unpin it
- if you pin a tab which later redirects the original URL, you can't unpin it

Looking up site using tab details now considers provisionalLocation
Result returned now includes parentFolderId

Fixes https://github.com/brave/browser-laptop/issues/8477

Auditors: @bbondy, @NejcZdovc

cc: @darkdh

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
