### PR TITLE
Fix issue with lost tabs ordering on relaunch

### DIFF
--- a/app/browser/windows.js
+++ b/app/browser/windows.js
@@ -9,6 +9,7 @@ const debounce = require('../../js/lib/debounce')
 const {getSetting} = require('../../js/settings')
 const locale = require('../locale')
 const LocalShortcuts = require('../localShortcuts')
+const {getSiteProps} = require('../common/lib/windowsUtil')
 const {makeImmutable} = require('../common/state/immutableUtil')
 const {getPinnedTabsByWindowId} = require('../common/state/tabState')
 const {siteSort} = require('../../js/state/siteUtil')
@@ -61,13 +62,6 @@ const updateWindow = (windowId) => {
   }
 }
 
-const siteProps = (site) => {
-  return Immutable.fromJS({
-    location: site.get('location'),
-    partitionNumber: site.get('partitionNumber') || 0
-  })
-}
-
 const updatePinnedTabs = (win) => {
   if (win.webContents.browserWindowOptions.disposition === 'new-popup') {
     return
@@ -77,7 +71,7 @@ const updatePinnedTabs = (win) => {
   const state = appStore.getState()
   const windowId = win.id
   const pinnedSites = state.get('sites').toList().filter((site) =>
-    site.get('tags').includes(siteTags.PINNED)).map((site) => siteProps(site))
+    site.get('tags').includes(siteTags.PINNED)).map(site => getSiteProps(site))
   const pinnedTabs = getPinnedTabsByWindowId(state, windowId)
 
   pinnedSites.filter((site) =>

--- a/app/common/lib/windowsUtil.js
+++ b/app/common/lib/windowsUtil.js
@@ -1,0 +1,13 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const Immutable = require('immutable')
+
+module.exports.getSiteProps = site => {
+  return Immutable.fromJS({
+    location: site.get('location'),
+    order: site.get('order'),
+    partitionNumber: site.get('partitionNumber') || 0
+  })
+}

--- a/test/unit/app/common/lib/windowsUtilTest.js
+++ b/test/unit/app/common/lib/windowsUtilTest.js
@@ -1,0 +1,40 @@
+/* global describe, beforeEach, it */
+const windowsUtil = require('../../../../../app/common/lib/windowsUtil')
+const assert = require('assert')
+const Immutable = require('immutable')
+
+require('../../../braveUnit')
+
+describe('windowsUtil', () => {
+  const location = 'https://css-tricks.com/'
+  const order = 9
+  const partitionNumber = 5
+  const expectedSiteProps = Immutable.fromJS({
+    location,
+    order,
+    partitionNumber
+  })
+  let site
+
+  describe('getSiteProps', () => {
+    beforeEach(() => {
+      site = Immutable.fromJS({
+        favicon: 'https://css-tricks.com/favicon.ico',
+        lastAccessedTime: 1493560182224,
+        location: location,
+        order: order,
+        partitionNumber: partitionNumber,
+        title: 'CSS-Tricks'
+      })
+    })
+    it('returns object with necessary fields', () => {
+      const result = windowsUtil.getSiteProps(site)
+      assert.deepEqual(expectedSiteProps, result)
+    })
+    it('set partitionNumber field to 0 in case of missing this field', () => {
+      site = site.delete('partitionNumber')
+      const result = windowsUtil.getSiteProps(site)
+      assert.equal(0, result.get('partitionNumber'))
+    })
+  })
+})


### PR DESCRIPTION
## Test plan
1. Pin some tabs,
2. Change pin order,
3. quit, re-open
4. tabs should be in the same order

## Description
siteProps function returns an object without order field, but this field needs to apply correct custom sorting for tabs.

Fix brave/browser-laptop#8543

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
