### PR TITLE
Fix alignment of showSuppress message and buttons on messageBox

### DIFF
--- a/app/renderer/components/common/messageBox.js
+++ b/app/renderer/components/common/messageBox.js
@@ -123,7 +123,10 @@ class MessageBox extends ImmutableComponent {
             this.showSuppress
               ? <SwitchControl
                 // TODO: refactor SwitchControl
-                className={css(commonStyles.noPaddingLeft)}
+                className={css(
+                  commonStyles.noPaddingLeft,
+                  styles.switchControl_marginBottom
+                )}
                 rightl10nId='preventMoreAlerts'
                 checkedOn={this.suppress}
                 onClick={this.onSuppressChanged} />
@@ -164,11 +167,16 @@ const styles = StyleSheet.create({
   },
   actions: {
     display: 'flex',
+    flexFlow: 'column nowrap',
     justifyContent: 'space-between'
   },
   buttons: {
     display: 'flex',
     justifyContent: 'flex-end'
+  },
+
+  switchControl_marginBottom: {
+    marginBottom: `calc(${globalStyles.spacing.dialogInsideMargin} - 5px)` // 5px = padding of SwitchControl
   }
 })
 


### PR DESCRIPTION
Closes #8598

Auditors:

Test Plan:
1. Open about:preferences#sync
2. Click "Reset Sync"
3. Click "Reset Sync" on the modal dialog
4. Click "Cancel"
5. Click "Reset Sync" again
6. Make sure there exists margin between the supress message and the buttons on the footer

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).