### PR TITLE
Fixes #8540 - Added "Mute All", Fixed "Mute Other Tabs", made "(Un)Mu…

### DIFF
--- a/app/renderer/components/tabs/content/audioTabIcon.js
+++ b/app/renderer/components/tabs/content/audioTabIcon.js
@@ -14,7 +14,7 @@ const globalStyles = require('../../styles/global')
 const tabStyles = require('../../styles/tab')
 
 class AudioTabIcon extends ImmutableComponent {
-  get pageCanPlayAudio () {
+  get pageAudioActive () {
     return !!this.props.tab.get('audioPlaybackActive')
   }
 
@@ -24,7 +24,7 @@ class AudioTabIcon extends ImmutableComponent {
   }
 
   get mutedState () {
-    return this.pageCanPlayAudio && !!this.props.tab.get('audioMuted')
+    return !!this.props.tab.get('audioMuted')
   }
 
   get audioIcon () {
@@ -34,11 +34,11 @@ class AudioTabIcon extends ImmutableComponent {
   }
 
   render () {
-    return this.pageCanPlayAudio && this.shouldShowAudioIcon
-      ? <TabIcon
-        className={css(tabStyles.icon, styles.audioIcon)}
-        symbol={this.audioIcon} onClick={this.props.onClick} />
-      : null
+        return this.mutedState || (!this.mutedState && this.pageAudioActive)
+        ? <TabIcon
+          className={css(tabStyles.icon, styles.audioIcon)}
+          symbol={this.audioIcon} onClick={this.props.onClick} />
+        : null
   }
 }
 

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -102,14 +102,14 @@ function tabPageTemplateInit (framePropsList) {
 }
 
 function generateMuteFrameList (framePropsList, muted) {
-  return framePropsList.map((frameProp) => {
-    return {
-      frameKey: frameProp.get('key'),
-      tabId: frameProp.get('tabId'),
-      muted: muted && frameProp.get('audioPlaybackActive') && !frameProp.get('audioMuted')
-    }
-  })
-}
+   return framePropsList.map((frameProp) => {
+     return {
+       frameKey: frameProp.get('key'),
+       tabId: frameProp.get('tabId'),
+       muted: muted
+     }
+   })
+ }
 
 function urlBarTemplateInit (searchDetail, activeFrame, e) {
   const items = getEditableItems(window.getSelection().toString())
@@ -598,16 +598,15 @@ function tabTemplateInit (frameProps) {
       }
     })
 
-  if (frameProps.get('audioPlaybackActive')) {
-    const isMuted = frameProps.get('audioMuted')
+  const isMuted = frameProps.get('audioMuted')
 
-    template.push({
+  template.push({
       label: locale.translation(isMuted ? 'unmuteTab' : 'muteTab'),
       click: (item) => {
         windowActions.setAudioMuted(frameKey, tabId, !isMuted)
       }
     })
-  }
+  
 
   template.push(CommonMenu.separatorMenuItem)
 
@@ -665,6 +664,12 @@ function tabsBarTemplateInit (framePropsList) {
     CommonMenu.newWindowMenuItem(),
     CommonMenu.separatorMenuItem,
     CommonMenu.showTabPreviewsMenuItem(),
+    {
+       label: locale.translation('muteTabs'),
+       click: () => {
+         windowActions.muteAllAudio(generateMuteFrameList(framePropsList, true))
+       }
+     },
     CommonMenu.separatorMenuItem,
     CommonMenu.bookmarksManagerMenuItem(),
     CommonMenu.bookmarksToolbarMenuItem(),


### PR DESCRIPTION
Fixes #8540 - Added "Mute All", Fixed "Mute Other Tabs", made "(Un)Mute Tab" always present, changed Mute icon display behavior.

- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [X] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

This PR contains several things, many of which weren't discussed in #8540.  I probably shoved more stuff into this than I should have and I'm happy to have any and all ideas shot down -- I'm mainly doing this to familiarize myself with javascript and github.

1. I added a "Mute All" menu item to the tabsToolbar context menu and verified that it strictly mutes instead of toggling.  I did not implement a "master mute layer" proposed here https://github.com/brave/browser-laptop/pull/8320#issuecomment-297859212 for a few reasons.  One -- I didn't know how :).  Two - I really couldn't come up with a use case for it and it would have been hard to convey the effect of the button to the user succinctly.
2. The "Mute Other Tabs" tab menu item also suffered from the same issue of toggling, so I fixed that too.
3. The "Mute/Unmute Tab" menu item was only conditionally showing when the tab was actively playing audio.  This doesn't make sense to me since I want to be able to mute a tab _before_ I begin playing a video.  This behavior is identical to how Chrome works currently.
4. If a tab is muted, the icon should show regardless of whether or not it is currently playing audio.  I made this change.  Again, this mimics Chrome's behavior.

Lastly, I would suggest like to suggest that the mute icon be made less ambiguous.
![image](https://cloud.githubusercontent.com/assets/5502734/25624248/6eb806e2-2f1e-11e7-8510-f231c993817b.png) vs ![image](https://cloud.githubusercontent.com/assets/5502734/25624271/7e0e847c-2f1e-11e7-83b7-7d183e63f62d.png) seems obvious until you realize that if the first one isn't present as a comparison that the second one simply looks like a speaker.  The user doesn't know that it's missing the sound waves emanating from the speaker.  I would propose an icon with the speaker slashed out.