### PR TITLE
Apply two fingers swiper changes to 901d5dba082a5e5d5213d726337a532b95b269d6

### DIFF
--- a/js/components/main.js
+++ b/js/components/main.js
@@ -214,7 +214,7 @@ class Main extends ImmutableComponent {
 
   registerSwipeListener () {
     // Navigates back/forward on macOS two- and or three-finger swipe
-    let swipeGesture = false
+    let mouseInFrame = false
     let trackingFingers = false
     let startTime = 0
     let isSwipeOnLeftEdge = false
@@ -223,17 +223,10 @@ class Main extends ImmutableComponent {
     let deltaY = 0
     let time
 
-    ipc.on(messages.ENABLE_SWIPE_GESTURE, (e) => {
-      swipeGesture = true
-    })
-
-    ipc.on(messages.DISABLE_SWIPE_GESTURE, (e) => {
-      swipeGesture = false
-    })
-
     // isSwipeTrackingFromScrollEventsEnabled is only true if "two finger scroll to swipe" is enabled
     ipc.on('scroll-touch-begin', () => {
-      if (swipeGesture) {
+      mouseInFrame = this.props.windowState.getIn(['ui', 'mouseInFrame'])
+      if (mouseInFrame) {
         trackingFingers = true
         startTime = (new Date()).getTime()
       }
@@ -278,7 +271,7 @@ class Main extends ImmutableComponent {
     })
 
     const throttledSwipe = _.throttle(direction => {
-      if (swipeGesture) {
+      if (mouseInFrame) {
         if (direction === 'left') {
           ipc.emit(messages.SHORTCUT_ACTIVE_FRAME_BACK)
         } else if (direction === 'right') {


### PR DESCRIPTION
fix #8627

Auditors: @bbondy, @bridiver

Test Plan:
1. Search something on google.com
2. Click one of the search result
3. Try to navigate back to previous results page by two fingers swiping

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

