### PR TITLE
fix PDF loading local files

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -592,7 +592,7 @@ const initPartition = (partition) => {
 }
 module.exports.initPartition = initPartition
 
-const filterableProtocols = ['http:', 'https:', 'ws:', 'wss:', 'magnet:']
+const filterableProtocols = ['http:', 'https:', 'ws:', 'wss:', 'magnet:', 'file:']
 
 function shouldIgnoreUrl (details) {
   // internal requests
@@ -676,6 +676,9 @@ module.exports.isResourceEnabled = (resourceName, url, isPrivate) => {
     return true
   }
 
+  if (resourceName === 'pdfjs') {
+    return getSetting(settings.PDFJS_ENABLED)
+  }
   if (resourceName === 'webtorrent') {
     return getSetting(settings.TORRENT_VIEWER_ENABLED)
   }

--- a/app/index.js
+++ b/app/index.js
@@ -65,6 +65,7 @@ const TrackingProtection = require('./trackingProtection')
 const AdBlock = require('./adBlock')
 const AdInsertion = require('./browser/ads/adInsertion')
 const HttpsEverywhere = require('./httpsEverywhere')
+const PDFJS = require('./pdfJS')
 const SiteHacks = require('./siteHacks')
 const CmdLine = require('./cmdLine')
 const UpdateStatus = require('../js/constants/updateStatus')
@@ -333,6 +334,7 @@ app.on('ready', () => {
     TrackingProtection.init()
     AdBlock.init()
     AdInsertion.init()
+    PDFJS.init()
 
     if (!loadedPerWindowState || loadedPerWindowState.length === 0) {
       if (!CmdLine.newWindowURL()) {

--- a/app/pdfJS.js
+++ b/app/pdfJS.js
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict'
+
+const UrlUtil = require('../js/lib/urlutil')
+const Filtering = require('./filtering')
+const config = require('../js/constants/config')
+const appActions = require('../js/actions/appActions')
+const {getPathFromFileURI} = require('./common/lib/platformUtil')
+const extensionState = require('./common/state/extensionState')
+const appStore = require('../js/stores/appStore')
+const fs = require('fs')
+const path = require('path')
+const getSetting = require('../js/settings').getSetting
+const settings = require('../js/constants/settings')
+
+const pdfjsBaseUrl = `chrome-extension://${config.PDFJSExtensionId}/`
+const viewerBaseUrl = `${pdfjsBaseUrl}content/web/viewer.html`
+
+const onBeforeRequest = (details) => {
+  const result = { resourceName: 'pdfjs' }
+  if (!(details.resourceType === 'mainFrame' &&
+    UrlUtil.isFileScheme(details.url) &&
+    UrlUtil.isFileType(details.url, 'pdf'))) {
+    return result
+  }
+  // Cancel and redirect to the PDF viewer URL
+  const extensions = extensionState.getExtensions(appStore.getState())
+  const extensionPath = extensions.getIn([config.PDFJSExtensionId, 'filePath'])
+  const pdfPath = getPathFromFileURI(details.url)
+  const pdfName = pdfPath.split('/').pop()
+  try {
+    const writeStream = fs.createWriteStream(path.join(extensionPath, 'tmp', pdfName))
+    writeStream.on('close', () => {
+      const pdfChromeUrl = `${pdfjsBaseUrl}tmp/${pdfName}`
+      const viewerUrl = `${viewerBaseUrl}?file=${encodeURIComponent(pdfChromeUrl)}#${pdfPath}`
+      appActions.loadURLRequested(details.tabId, viewerUrl)
+    })
+    fs.createReadStream(pdfPath).pipe(writeStream)
+  } catch (e) {
+    return result
+  }
+
+  result.cancel = true
+  return result
+}
+
+/**
+ * Load PDF.JS
+ */
+module.exports.init = () => {
+  if (getSetting(settings.PDFJS_ENABLED)) {
+    Filtering.registerBeforeRequestFilteringCB(onBeforeRequest)
+  }
+}

--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -306,8 +306,16 @@ const UrlUtil = {
    * @return {string}
    */
   getLocationIfPDF: function (url) {
-    if (url && url.startsWith(`chrome-extension://${pdfjsExtensionId}/`)) {
-      return url.replace(`chrome-extension://${pdfjsExtensionId}/`, '')
+    const fileUrl = require('./appUrlUtil').fileUrl
+    const pdfjsBaseUrl = `chrome-extension://${pdfjsExtensionId}/`
+    if (url && url.startsWith(pdfjsBaseUrl)) {
+      url = url.replace(pdfjsBaseUrl, '')
+      if (url.startsWith(`${pdfjsBaseUrl}tmp/`)) {
+        // This is a file: URL loaded by PDFJS. The url hash is the actual
+        // file path on disk.
+        let hash = urlParse(url).hash
+        url = hash ? fileUrl(hash.replace('#', '')) : url
+      }
     }
     return url
   },

--- a/test/unit/lib/urlutilTest.js
+++ b/test/unit/lib/urlutilTest.js
@@ -254,6 +254,10 @@ describe('urlutil', function () {
       assert.equal(UrlUtil.getLocationIfPDF('chrome-extension://blank'), 'chrome-extension://blank')
       assert.equal(UrlUtil.getLocationIfPDF(null), null)
     })
+    it('gets location for file: PDF URL', function () {
+      let url = 'chrome-extension://jdbefljfgobbmcidnmpjamcbhnbphjnb/chrome-extension://jdbefljfgobbmcidnmpjamcbhnbphjnb/tmp/test.pdf#/Users/yan/Downloads/test.pdf'
+      assert.equal(UrlUtil.getLocationIfPDF(url), 'file:///Users/yan/Downloads/test.pdf')
+    })
   })
 
   describe('getDisplayLocation', function () {


### PR DESCRIPTION
muon changes are needed in order to allow extensions to access local files. in the meantime, we can workaround this for pdfjs by copying local pdf files to a disk location to `chrome-extension://`.

fix https://github.com/brave/browser-laptop/issues/2714
requires https://github.com/brave/pdf.js/commit/6b3081e7b4a11a4450161974ac6bc1e6996e330d

test plan:
1. git clone https://github.com/brave/pdf.js and run 'gulp chromium'
2. copy 'build/chromium' to '~/Library/Application\ Support/brave-development/Extensions/jdbefljfgobbmcidnmpjamcbhnbphjnb/1.8.251' or whatever your corrresponding userData directory is
3. start Brave with PDFJS enabled and browse to a local PDF file. it should display correctly and the url in the urlbar should be the file: url.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
