### PR TITLE
allow PDFJS to load local files

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -400,6 +400,9 @@ module.exports.init = () => {
   }
 
   let loadExtension = (extensionId, extensionPath, manifest = {}, manifestLocation = 'unpacked') => {
+    if (extensionId === config.PDFJSExtensionId) {
+      manifestLocation = 'component'
+    }
     if (!extensionInfo.isLoaded(extensionId) && !extensionInfo.isLoading(extensionId)) {
       extensionInfo.setState(extensionId, extensionStates.LOADING)
       if (extensionId === config.braveExtensionId || extensionId === config.torrentExtensionId || extensionId === config.syncExtensionId) {

--- a/app/filtering.js
+++ b/app/filtering.js
@@ -592,7 +592,7 @@ const initPartition = (partition) => {
 }
 module.exports.initPartition = initPartition
 
-const filterableProtocols = ['http:', 'https:', 'ws:', 'wss:', 'magnet:']
+const filterableProtocols = ['http:', 'https:', 'ws:', 'wss:', 'magnet:', 'file:']
 
 function shouldIgnoreUrl (details) {
   // internal requests
@@ -676,6 +676,9 @@ module.exports.isResourceEnabled = (resourceName, url, isPrivate) => {
     return true
   }
 
+  if (resourceName === 'pdfjs') {
+    return getSetting(settings.PDFJS_ENABLED)
+  }
   if (resourceName === 'webtorrent') {
     return getSetting(settings.TORRENT_VIEWER_ENABLED)
   }

--- a/app/index.js
+++ b/app/index.js
@@ -65,6 +65,7 @@ const TrackingProtection = require('./trackingProtection')
 const AdBlock = require('./adBlock')
 const AdInsertion = require('./browser/ads/adInsertion')
 const HttpsEverywhere = require('./httpsEverywhere')
+const PDFJS = require('./pdfJS')
 const SiteHacks = require('./siteHacks')
 const CmdLine = require('./cmdLine')
 const UpdateStatus = require('../js/constants/updateStatus')
@@ -333,6 +334,7 @@ app.on('ready', () => {
     TrackingProtection.init()
     AdBlock.init()
     AdInsertion.init()
+    PDFJS.init()
 
     if (!loadedPerWindowState || loadedPerWindowState.length === 0) {
       if (!CmdLine.newWindowURL()) {

--- a/app/pdfJS.js
+++ b/app/pdfJS.js
@@ -1,0 +1,35 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+'use strict'
+
+const UrlUtil = require('../js/lib/urlutil')
+const Filtering = require('./filtering')
+const config = require('../js/constants/config')
+const appActions = require('../js/actions/appActions')
+const getSetting = require('../js/settings').getSetting
+const settings = require('../js/constants/settings')
+
+const pdfjsBaseUrl = `chrome-extension://${config.PDFJSExtensionId}/`
+const viewerBaseUrl = `${pdfjsBaseUrl}content/web/viewer.html`
+
+const onBeforeRequest = (details) => {
+  const result = { resourceName: 'pdfjs' }
+  if (!(details.resourceType === 'mainFrame' &&
+    UrlUtil.isFileScheme(details.url) &&
+    UrlUtil.isFileType(details.url, 'pdf'))) {
+    return result
+  }
+  appActions.loadURLRequested(details.tabId, `${viewerBaseUrl}?file=${encodeURIComponent(details.url)}`)
+  result.cancel = true
+  return result
+}
+
+/**
+ * Load PDF.JS
+ */
+module.exports.init = () => {
+  if (getSetting(settings.PDFJS_ENABLED)) {
+    Filtering.registerBeforeRequestFilteringCB(onBeforeRequest)
+  }
+}

--- a/test/unit/lib/urlutilTest.js
+++ b/test/unit/lib/urlutilTest.js
@@ -254,6 +254,10 @@ describe('urlutil', function () {
       assert.equal(UrlUtil.getLocationIfPDF('chrome-extension://blank'), 'chrome-extension://blank')
       assert.equal(UrlUtil.getLocationIfPDF(null), null)
     })
+    it('gets location for file: PDF URL', function () {
+      let url = 'chrome-extension://jdbefljfgobbmcidnmpjamcbhnbphjnb/file:///Users/yan/Downloads/test.pdf'
+      assert.equal(UrlUtil.getLocationIfPDF(url), 'file:///Users/yan/Downloads/test.pdf')
+    })
   })
 
   describe('getDisplayLocation', function () {


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/2714

test plan:
1. start Brave with PDFJS enabled and browse to a local PDF file. it should display correctly. the urlbar should show the 'file:' location.
2. turn off PDFJS and go to the file. it should prompt to download.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
