### PR TITLE
Fix bookmark hanger dialog overflow

### DIFF
--- a/app/renderer/components/common/commonForm.js
+++ b/app/renderer/components/common/commonForm.js
@@ -137,6 +137,9 @@ const styles = StyleSheet.create({
     cursor: 'default',
     width: '100%',
     maxWidth: globalStyles.spacing.dialogWidth,
+    minWidth: '310px',
+    height: 'auto',
+    maxHeight: '100vh', // #8634: commonStyles.flyoutDialog,
     userSelect: 'none'
 
     // Need a general solution
@@ -159,6 +162,7 @@ const styles = StyleSheet.create({
 
   commonFormBookmarkHanger: {
     maxWidth: globalStyles.spacing.bookmarkHangerMaxWidth,
+    height: 'initial', // #8634
 
     // Cancel the inherited value from .navbarMenubarFlexContainer, which is 'nowrap'.
     whiteSpace: 'normal'


### PR DESCRIPTION
Close #8634

Auditors:

Test Plan:
1. Change UI scale on about:preferences#advanced
2. Minimize the window size
3. Click the star icon
4. Make sure the hanger dialog is not broken

Test Plan 2:
1. Open about:autofill
2. Click "Add Address"
3. Make sure the autofill dialog is not broken

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
