### PR TITLE
Make text inside siteInfo__wrapper unselectable

### DIFF
--- a/js/components/siteInfo.js
+++ b/js/components/siteInfo.js
@@ -284,7 +284,11 @@ const styles = StyleSheet.create({
   siteInfo__wrapper: {
     maxHeight: '300px',
     maxWidth: '400px',
-    width: 'auto'
+    width: 'auto',
+
+    // Issue #8650
+    userSelect: 'none',
+    cursor: 'default'
   },
   siteInfo__wrapper__large: {
     // temporary workaround


### PR DESCRIPTION
Closes #8650

Auditors:

Test Plan:
1. Open https://brave.com
2. Click the lock icon
3. Make sure you cannot select the text on the dialog

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
