### PR TITLE
Fix border-radius of commonFormBottomWrapper

### DIFF
--- a/app/renderer/components/common/commonForm.js
+++ b/app/renderer/components/common/commonForm.js
@@ -189,7 +189,8 @@ const styles = StyleSheet.create({
   commonFormBottomWrapper: {
     margin: 0,
     padding: `${globalStyles.spacing.dialogInsideMargin} 30px`,
-    background: globalStyles.color.commonFormBottomWrapperBackground
+    background: globalStyles.color.commonFormBottomWrapperBackground,
+    borderRadius: `0 0 ${globalStyles.radius.borderRadius} ${globalStyles.radius.borderRadius}`
   }
 })
 


### PR DESCRIPTION
Closes #8649

Auditors:

Test Plan:
1. Open about:styles
2. Click "commonForm"
3. Make sure the dialog has border-radius on bottom right and left

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).