### PR TITLE
Use fast-url-parser

### DIFF
--- a/app/common/urlParse.js
+++ b/app/common/urlParse.js
@@ -3,7 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const LRUCache = require('lru-cache')
-const urlParse = require('url').parse
+const urlParse = require('fast-url-parser').parse
 const config = require('../../js/constants/config')
 let cachedUrlParse = new LRUCache(config.cache.urlParse)
 
@@ -14,7 +14,23 @@ module.exports = (url, ...args) => {
     return Object.assign({}, parsedUrl)
   }
 
-  parsedUrl = urlParse(url, ...args)
+  // In fast-url-parser href, port, prependSlash, protocol, and query
+  // are lazy so access them.
+  const raw = urlParse(url, ...args)
+  parsedUrl = {
+    auth: raw.auth,
+    hash: raw.hash,
+    host: raw.host,
+    hostname: raw.hostname,
+    href: raw.href,
+    path: raw.path,
+    pathname: raw.pathname,
+    port: raw.port,
+    protocol: raw.protocol,
+    query: raw.query,
+    search: raw.search,
+    slashes: raw.slashes
+  }
   cachedUrlParse.set(url, parsedUrl)
   return parsedUrl
 }

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "clipboard-copy": "^1.0.0",
     "electron-localshortcut": "^0.6.0",
     "electron-squirrel-startup": "brave/electron-squirrel-startup",
+    "fast-url-parser": "^1.1.3",
     "file-loader": "^0.8.5",
     "font-awesome": "^4.5.0",
     "font-awesome-webpack": "0.0.4",


### PR DESCRIPTION
Use faster implementation of `url.parse()`.

Related to #7453. With 10K bookmarks, the URL bar first letter latency reduces from 2600 ms to 1700 ms.

Fix #8707

Auditors: @bsclifton @bbondy

Test Plan:
- Make sure automated tests pass.
- Examine https://github.com/petkaantonov/urlparser/blob/master/test/node.js for legitness (I locally successfully ran the tests)

Related benchmark:
```sh
~/repos/github.com/petkaantonov/urlparser(master*) % node -v                                                                                          23:39:48
v7.9.0
~/repos/github.com/petkaantonov/urlparser(master*) % node ./benchmark/nodecore.js                                                                     23:39:53
misc/url.js parse(): 67219.592
misc/url.js format(): 50081.595
misc/url.js resolve("../foo/bar?baz=boom"): 49206.484
misc/url.js resolve("foo/bar"): 54228.107
misc/url.js resolve("http://nodejs.org"): 49014.074
misc/url.js resolve("./foo/bar?baz"): 54074.062
~/repos/github.com/petkaantonov/urlparser(master*) % node ./benchmark/urlparser.js                                                                    23:39:58
misc/url.js parse(): 246442.84
misc/url.js format(): 139617.20
misc/url.js resolve("../foo/bar?baz=boom"): 208489.18
misc/url.js resolve("foo/bar"): 216373.50
misc/url.js resolve("http://nodejs.org"): 144010.28
misc/url.js resolve("./foo/bar?baz"): 215226.83
```