### PR TITLE
the-atlantic-allow-1p-ab-checks

### DIFF
--- a/js/data/siteHacks.js
+++ b/js/data/siteHacks.js
@@ -139,5 +139,9 @@ module.exports.siteHacks = {
   },
   'www.youtube.com': {
     allowFirstPartyAdblockChecks: true
-  }
+  },
+   'www.theatlantic.com': {
+    allowFirstPartyAdblockChecks: true
+  } 
 }
+


### PR DESCRIPTION
Allows for 1p checks for theatlantic.com. Fixes #6291
- Will allow for additional filters to be applied in `brave/adblock-lists` to prevent content blocking. 
- WIll provide flexibility for additional filters, should the URL change to another 1p URL.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

- Open `about:adblock`
- Add the following custom filters: 
```
||theatlantic.blueconic.net$domain=theatlantic.com
||theatlantic.com/please-support-us^
```
- Begin with a clean profile.
- Refresh the `about:adblock` page
- Go to https://www.theatlantic.com
- Navigate to any article, and scroll below the fold. 
- The "please support us" blocker should no longer render. 

Once the PR has been confirmed, I will update adblock-lists with the custom filters from above, and have dat files pushed. Custom filters will serve the same purpose for testing, and limit potential risk.

The `please-support-us` url redirects the user to the blocker page. 
The blueconic.com URL is used to track users. 