### PR TITLE
Add margin between buttons on backup brave wallet dialog

### DIFF
--- a/app/renderer/components/preferences/payment/ledgerBackup.js
+++ b/app/renderer/components/preferences/payment/ledgerBackup.js
@@ -73,17 +73,17 @@ class LedgerBackupFooter extends ImmutableComponent {
 
   render () {
     return <section>
-      <BrowserButton primaryColor
+      <BrowserButton primaryColor groupedItem
         l10nId='printKeys'
         testId='printKeysButton'
         onClick={this.printKeys}
       />
-      <BrowserButton primaryColor
+      <BrowserButton primaryColor groupedItem
         l10nId='saveRecoveryFile'
         testId='saveRecoveryFileButton'
         onClick={this.saveKeys}
       />
-      <BrowserButton secondaryColor
+      <BrowserButton secondaryColor groupedItem
         l10nId='done'
         testId='doneButton'
         onClick={this.props.hideOverlay.bind(this, 'ledgerBackup')}


### PR DESCRIPTION
Fix #8736

Auditors:

Test Plan:
1. Open about:preferences#payments
2. Open advanced settings
3. Click "Back up your wallet"

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).