### PR TITLE
Fix 'blocks fingerprinting' test

### DIFF
--- a/test/bravery-components/braveryPanelTest.js
+++ b/test/bravery-components/braveryPanelTest.js
@@ -447,7 +447,6 @@ describe('Bravery Panel', function () {
         .waitForTabCount(3)
         .waitForUrl(url)
         .openBraveMenu(braveMenu, braveryPanel)
-        .click(fpSwitch)
         .waitUntil(function () {
           // TOOD: This should be 3, but see:
           // https://github.com/brave/browser-laptop/issues/3227


### PR DESCRIPTION
Auditors:

Test Plan: `npm run test -- --grep='blocks fingerprinting'`

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

related: #8760
