### PR TITLE
Replace all CSS/l10n selectors with data-test-id for unit tests

### DIFF
--- a/app/renderer/components/common/longPressButton.js
+++ b/app/renderer/components/common/longPressButton.js
@@ -79,6 +79,7 @@ class LongPressButton extends ImmutableComponent {
 
   render () {
     return <button data-l10n-id={this.props.l10nId}
+      data-test-id={this.props.testId}
       className={this.props.className}
       disabled={this.props.disabled}
       onClick={this.onClick}

--- a/app/renderer/components/common/messageBox.js
+++ b/app/renderer/components/common/messageBox.js
@@ -121,7 +121,7 @@ class MessageBox extends React.Component {
   }
 
   render () {
-    return <Dialog className={css(styles.dialog)}>
+    return <Dialog testId='messageBoxDialog' className={css(styles.dialog)}>
       <div data-test-id={'msgBoxTab_' + this.props.tabId}
         onKeyDown={this.onKeyDown}
         className={css(
@@ -138,6 +138,7 @@ class MessageBox extends React.Component {
           {
             this.props.showSuppress
               ? <SwitchControl
+                testId='showSuppressSwitch'
                 // TODO: refactor SwitchControl
                 className={css(
                   commonStyles.noPaddingLeft,

--- a/app/renderer/components/common/switchControl.js
+++ b/app/renderer/components/common/switchControl.js
@@ -46,7 +46,7 @@ class SwitchControl extends ImmutableComponent {
           ? <span className='switchControlTopText' data-l10n-id={this.props.topl10nId} />
           : null
         }
-        <div className={cx({
+        <div data-test-id='switchBackground' className={cx({
           switchBackground: true,
           switchedOn: this.props.checkedOn,
           [this.props.backgroundClassName]: !!this.props.backgroundClassName

--- a/app/renderer/components/download/downloadItem.js
+++ b/app/renderer/components/download/downloadItem.js
@@ -104,59 +104,59 @@ class DownloadItem extends ImmutableComponent {
       })}>
       {
         this.props.deleteConfirmationVisible
-        ? <div className='deleteConfirmation'><span data-l10n-id='downloadDeleteConfirmation' /><Button l10nId='ok' className='primaryButton confirmDeleteButton' onClick={this.onDeleteDownload} /></div>
+        ? <div className='deleteConfirmation'><span data-l10n-id='downloadDeleteConfirmation' /><Button testId='confirmDeleteButton' l10nId='ok' className='primaryButton confirmDeleteButton' onClick={this.onDeleteDownload} /></div>
         : null
       }
       <div className='downloadActions'>
         {
           downloadUtil.shouldAllowPause(this.props.download)
-          ? <Button className='pauseButton' l10nId='downloadPause' iconClass='fa-pause' onClick={this.onPauseDownload} />
+          ? <Button testId='pauseButton' className='pauseButton' l10nId='downloadPause' iconClass='fa-pause' onClick={this.onPauseDownload} />
           : null
         }
         {
           downloadUtil.shouldAllowResume(this.props.download)
-          ? <Button className='resumeButton' l10nId='downloadResume' iconClass='fa-play' onClick={this.onResumeDownload} />
+          ? <Button testId='resumeButton' className='resumeButton' l10nId='downloadResume' iconClass='fa-play' onClick={this.onResumeDownload} />
           : null
         }
         {
           downloadUtil.shouldAllowCancel(this.props.download)
-          ? <Button className='cancelButton' l10nId='downloadCancel' iconClass='fa-times' onClick={this.onCancelDownload} />
+          ? <Button testId='cancelButton' className='cancelButton' l10nId='downloadCancel' iconClass='fa-times' onClick={this.onCancelDownload} />
           : null
         }
         {
           downloadUtil.shouldAllowRedownload(this.props.download)
-          ? <Button className='redownloadButton' l10nId='downloadRedownload' iconClass='fa-repeat' onClick={this.onRedownload} />
+          ? <Button testId='redownloadButton' className='redownloadButton' l10nId='downloadRedownload' iconClass='fa-repeat' onClick={this.onRedownload} />
           : null
         }
         {
           downloadUtil.shouldAllowCopyLink(this.props.download)
-          ? <Button className='copyLinkButton' l10nId='downloadCopyLinkLocation' iconClass='fa-link' onClick={this.onCopyLinkToClipboard} />
+          ? <Button testId='copyLinkButton' className='copyLinkButton' l10nId='downloadCopyLinkLocation' iconClass='fa-link' onClick={this.onCopyLinkToClipboard} />
           : null
         }
         {
           downloadUtil.shouldAllowOpenDownloadLocation(this.props.download)
-          ? <Button className='revealButton' l10nId='downloadOpenPath' iconClass='fa-folder-open-o' onClick={this.onRevealDownload} />
+          ? <Button testId='revealButton' className='revealButton' l10nId='downloadOpenPath' iconClass='fa-folder-open-o' onClick={this.onRevealDownload} />
           : null
         }
         {
           downloadUtil.shouldAllowDelete(this.props.download)
-          ? <Button className='deleteButton' l10nId='downloadDelete' iconClass='fa-trash-o' onClick={this.onShowDeleteConfirmation} />
+          ? <Button testId='deleteButton' className='deleteButton' l10nId='downloadDelete' iconClass='fa-trash-o' onClick={this.onShowDeleteConfirmation} />
           : null
         }
         {
           downloadUtil.shouldAllowRemoveFromList(this.props.download)
-          ? <Button l10nId='downloadRemoveFromList' iconClass='fa-times' className='removeDownloadFromList' onClick={this.onClearDownload} />
+          ? <Button testId='downloadRemoveFromList' l10nId='downloadRemoveFromList' iconClass='fa-times' className='removeDownloadFromList' onClick={this.onClearDownload} />
           : null
         }
       </div>
       {
         (this.isInProgress || this.isPaused) && this.props.download.get('totalBytes')
-        ? <div className='downloadProgress' style={progressStyle} />
+        ? <div data-test-id='downloadProgress' className='downloadProgress' style={progressStyle} />
         : null
       }
       <div className='downloadInfo'>
         <span>
-          <div className='downloadFilename'
+          <div data-test-id='downloadFilename' className='downloadFilename'
             title={this.props.download.get('filename')}>
             {
               this.props.download.get('filename')
@@ -164,7 +164,7 @@ class DownloadItem extends ImmutableComponent {
           </div>
           {
             origin
-              ? <div className='downloadOrigin'>
+              ? <div data-test-id='downloadOrigin' className='downloadOrigin'>
                 {
                   isInsecure
                     ? <span className='fa fa-unlock isInsecure' />

--- a/app/renderer/components/download/downloadsBar.js
+++ b/app/renderer/components/download/downloadsBar.js
@@ -49,7 +49,7 @@ class DownloadsBar extends ImmutableComponent {
         }
       </div>
       <div className='downloadBarButtons'>
-        <Button className='downloadButton hideDownloadsToolbar'
+        <Button testId='hideDownloadsToolbar' className='downloadButton hideDownloadsToolbar'
           onClick={this.onHideDownloadsToolbar} />
       </div>
     </div>

--- a/app/renderer/components/navigation/navigator.js
+++ b/app/renderer/components/navigation/navigator.js
@@ -213,12 +213,18 @@ class Navigator extends React.Component {
             backforward: true,
             fullscreen: isFullScreen()
           })}>
-            <div className={cx({
-              navigationButtonContainer: true,
-              nav: true,
-              disabled: !this.props.canGoBack
-            })}>
+            <div data-test-id={
+              !this.props.canGoBack
+                ? 'navigationBackButtonDisabled'
+                : 'navigationBackButton'
+              }
+              className={cx({
+                navigationButtonContainer: true,
+                nav: true,
+                disabled: !this.props.canGoBack
+              })}>
               <LongPressButton
+                testId={!this.props.canGoBack ? 'backButtonDisabled' : 'backButton'}
                 l10nId='backButton'
                 className='normalizeButton navigationButton backButton'
                 disabled={!this.props.canGoBack}
@@ -226,12 +232,18 @@ class Navigator extends React.Component {
                 onLongPress={this.onBackLongPress}
               />
             </div>
-            <div className={cx({
-              navigationButtonContainer: true,
-              nav: true,
-              disabled: !this.props.canGoForward
-            })}>
+            <div data-test-id={
+              !this.props.canGoForward
+                ? 'navigationForwardButtonDisabled'
+                : 'navigationForwardButton'
+              }
+              className={cx({
+                navigationButtonContainer: true,
+                nav: true,
+                disabled: !this.props.canGoForward
+              })}>
               <LongPressButton
+                testId={!this.props.canGoForward ? 'forwardButtonDisabled' : 'forwardButton'}
                 l10nId='forwardButton'
                 className='normalizeButton navigationButton forwardButton'
                 disabled={!this.props.canGoForward}

--- a/app/renderer/components/navigation/urlBarIcon.js
+++ b/app/renderer/components/navigation/urlBarIcon.js
@@ -103,6 +103,7 @@ class UrlBarIcon extends ImmutableComponent {
       props.onDragStart = this.onDragStart
     }
     return <span
+      data-test-id='urlBarIcon'
       {...props}
       className={this.iconClasses}
       style={this.iconStyles} />

--- a/app/renderer/components/navigation/urlBarSuggestionItem.js
+++ b/app/renderer/components/navigation/urlBarSuggestionItem.js
@@ -17,7 +17,8 @@ class UrlBarSuggestionItem extends ImmutableComponent {
     }
   }
   render () {
-    return <li data-index={this.props.currentIndex}
+    return <li data-test-id='list-item'
+      data-index={this.props.currentIndex}
       onMouseOver={this.props.onMouseOver.bind(this)}
       onClick={this.props.onClick}
       key={`${this.props.suggestion.get('location')}|${this.props.currentIndex + this.props.i}`}
@@ -29,12 +30,12 @@ class UrlBarSuggestionItem extends ImmutableComponent {
       })}>
       {
         this.props.suggestion.get('type') !== suggestionTypes.TOP_SITE && this.props.suggestion.get('title')
-        ? <div className='suggestionTitle'>{this.props.suggestion.get('title')}</div>
+        ? <div data-test-id='suggestionTitle' className='suggestionTitle'>{this.props.suggestion.get('title')}</div>
         : null
       }
       {
         this.props.suggestion.get('type') !== suggestionTypes.SEARCH && this.props.suggestion.get('type') !== suggestionTypes.ABOUT_PAGES
-        ? <div className='suggestionLocation'>{this.props.suggestion.get('location')}</div>
+        ? <div data-test-id='suggestionLocation' className='suggestionLocation'>{this.props.suggestion.get('location')}</div>
         : null
       }
     </li>

--- a/app/renderer/components/preferences/payment/ledgerTable.js
+++ b/app/renderer/components/preferences/payment/ledgerTable.js
@@ -182,6 +182,7 @@ class LedgerTable extends ImmutableComponent {
             disabled
             checkedOn
             indicatorClassName={css(styles.pinnedToggle)}
+            testId='pinnedDisabled'
             onClick={() => {}}
           />
           : <SiteSettingCheckbox small
@@ -303,6 +304,7 @@ class LedgerTable extends ImmutableComponent {
         (totalUnPinnedRows !== unPinnedRows.size && hideLower)
         ? <div className={css(styles.ledgerTable__showAllWrap)}>
           <BrowserButton secondaryColor
+            testId={hideLower ? 'showAll' : 'hideLower'}
             l10nId={hideLower ? 'showAll' : 'hideLower'}
             onClick={this.showAll.bind(this, !hideLower)}
           />

--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -256,13 +256,13 @@ class NewTabPage extends React.Component {
       backgroundProps.style = this.state.backgroundImage.style
       gradientClassName = 'bgGradient'
     }
-    return <div className='dynamicBackground' {...backgroundProps}>
+    return <div data-test-id='dynamicBackground' className='dynamicBackground' {...backgroundProps}>
       {
         this.showImages
           ? <img src={this.state.backgroundImage.source} onError={this.onImageLoadFailed.bind(this)} data-test-id='backgroundImage' />
           : null
       }
-      <div className={gradientClassName} />
+      <div data-test-id={this.showImages ? 'bgGradient' : 'gradient'} className={gradientClassName} />
       <div className='content'>
         <main>
           <div className='statsBar'>

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -155,7 +155,7 @@ class GeneralTab extends ImmutableComponent {
 
     const defaultZoomSetting = getSetting(settings.DEFAULT_ZOOM_LEVEL, this.props.settings)
     return <SettingsList>
-      <DefaultSectionTitle data-l10n-id='generalSettings' />
+      <DefaultSectionTitle data-test-id='generalSettings' data-l10n-id='generalSettings' />
       <SettingsList>
         <SettingItem dataL10nId='startsWith'>
           <SettingDropdown value={getSetting(settings.STARTUP_MODE, this.props.settings)}
@@ -314,7 +314,7 @@ class SearchTab extends ImmutableComponent {
 
   render () {
     return <div>
-      <DefaultSectionTitle data-l10n-id='searchSettings' />
+      <DefaultSectionTitle data-test-id='searchSettings' data-l10n-id='searchSettings' />
       <SortableTable headings={['default', 'searchEngine', 'engineGoKey']} rows={this.searchProviders}
         defaultHeading='searchEngine'
         addHoverClass onClick={this.hoverCallback.bind(this)}

--- a/test/unit/about/newTabPageTest.js
+++ b/test/unit/about/newTabPageTest.js
@@ -193,13 +193,13 @@ describe('NewTab component unit tests', function () {
         })
 
         it('sets backgroundImage for root element to the URL of the image', function () {
-          const node = wrapper.find('.dynamicBackground').node
+          const node = wrapper.find('[data-test-id="dynamicBackground"]').node
           assert.notEqual(node, undefined)
           assert.deepEqual(node.props.style, backgroundImage.style)
         })
 
         it('includes div element with class bgGradient', function () {
-          assert.equal(wrapper.find('.bgGradient').length, 1)
+          assert.equal(wrapper.find('div[data-test-id="bgGradient"]').length, 1)
         })
 
         it('includes img element (used to detect onError)', function () {
@@ -218,7 +218,7 @@ describe('NewTab component unit tests', function () {
         })
 
         it('includes element with class gradient', function () {
-          assert.equal(wrapper.find('.gradient').length, 1)
+          assert.equal(wrapper.find('div[data-test-id="gradient"]').length, 1)
         })
 
         it('does NOT include img element (used to detect onError)', function () {

--- a/test/unit/about/preferencesTest.js
+++ b/test/unit/about/preferencesTest.js
@@ -78,23 +78,23 @@ describe('Preferences component', function () {
     })
 
     it('Changes pref pane on popstate event', function () {
-      assert.equal(this.result.find('[data-l10n-id="generalSettings"]').length, 1)
-      assert.equal(this.result.find('[data-l10n-id="searchSettings"]').length, 0)
+      assert.equal(this.result.find('[data-test-id="generalSettings"]').length, 1)
+      assert.equal(this.result.find('[data-test-id="searchSettings"]').length, 0)
       // emit a fake popstate event
       window.location.hash = 'search'
       this.eventMap.popstate()
-      assert.equal(this.result.find('[data-l10n-id="generalSettings"]').length, 0)
-      assert.equal(this.result.find('[data-l10n-id="searchSettings"]').length, 1)
+      assert.equal(this.result.find('[data-test-id="generalSettings"]').length, 0)
+      assert.equal(this.result.find('[data-test-id="searchSettings"]').length, 1)
     })
 
     it('Changes pref pane by hash on mount', function () {
       this.result = mount(Preferences)
-      assert.equal(this.result.find('[data-l10n-id="generalSettings"]').length, 1)
-      assert.equal(this.result.find('[data-l10n-id="searchSettings"]').length, 0)
+      assert.equal(this.result.find('[data-test-id="generalSettings"]').length, 1)
+      assert.equal(this.result.find('[data-test-id="searchSettings"]').length, 0)
       window.location.hash = 'search'
       this.result = mount(Preferences)
-      assert.equal(this.result.find('[data-l10n-id="generalSettings"]').length, 0)
-      assert.equal(this.result.find('[data-l10n-id="searchSettings"]').length, 1)
+      assert.equal(this.result.find('[data-test-id="generalSettings"]').length, 0)
+      assert.equal(this.result.find('[data-test-id="searchSettings"]').length, 1)
     })
   })
 

--- a/test/unit/app/renderer/components/common/messageBoxTest.js
+++ b/test/unit/app/renderer/components/common/messageBoxTest.js
@@ -68,7 +68,7 @@ describe('MessageBox component unit tests', function () {
           tabId={tabId}
         />
       )
-      assert.equal(wrapper.find('div.dialog').length, 1)
+      assert.equal(wrapper.find('[data-test-id="messageBoxDialog"]').length, 1)
     })
 
     it('renders the suppress checkbox if showSuppress is true', function () {
@@ -77,7 +77,7 @@ describe('MessageBox component unit tests', function () {
           tabId={tabId}
         />
       )
-      assert.equal(wrapper.find('div.switchControl').length, 1)
+      assert.equal(wrapper.find('[data-test-id="showSuppressSwitch"]').length, 1)
     })
 
     it('renders the button index 0 as primaryButton', function () {
@@ -106,7 +106,7 @@ describe('MessageBox component unit tests', function () {
           tabId={tabId}
         />
       )
-      assert.equal(wrapper.find('div.switchControl').length, 0)
+      assert.equal(wrapper.find('[data-test-id="showSuppressSwitch"]').length, 0)
     })
   })
 
@@ -122,7 +122,7 @@ describe('MessageBox component unit tests', function () {
           tabId={tabId}
         />
       )
-      wrapper.find('.switchBackground').simulate('click')
+      wrapper.find('[data-test-id="switchBackground"]').simulate('click')
       assert.equal(spy.calledOnce, true)
       appActions.tabMessageBoxUpdated.restore()
     })

--- a/test/unit/app/renderer/components/download/downloadBarTest.js
+++ b/test/unit/app/renderer/components/download/downloadBarTest.js
@@ -74,7 +74,7 @@ describe('downloadsBar component', function () {
     })
 
     it('hide downloads button is shown', function () {
-      assert.equal(this.result.find('.hideDownloadsToolbar').length, 1)
+      assert.equal(this.result.find('[data-test-id="hideDownloadsToolbar"]').length, 1)
     })
   })
 
@@ -88,7 +88,7 @@ describe('downloadsBar component', function () {
     })
 
     it('hide downloads button is shown', function () {
-      assert.equal(this.result.find('.hideDownloadsToolbar').length, 1)
+      assert.equal(this.result.find('[data-test-id="hideDownloadsToolbar"]').length, 1)
     })
   })
 
@@ -103,7 +103,7 @@ describe('downloadsBar component', function () {
     })
 
     it('but still shows hide downloads button', function () {
-      assert.equal(this.result.find('.hideDownloadsToolbar').length, 1)
+      assert.equal(this.result.find('[data-test-id="hideDownloadsToolbar"]').length, 1)
     })
   })
 })

--- a/test/unit/app/renderer/components/download/downloadItemTest.js
+++ b/test/unit/app/renderer/components/download/downloadItemTest.js
@@ -91,16 +91,16 @@ describe('downloadItem component', function () {
       })
 
       it('filename exists and matches download filename', function () {
-        assert.equal(this.result.find('.downloadFilename').text(), this.download.get('filename'))
+        assert.equal(this.result.find('[data-test-id="downloadFilename"]').text(), this.download.get('filename'))
       })
 
       it('origin exists and matches download origin', function () {
-        assert.equal(this.result.find('.downloadOrigin').text(), 'http://www.bradrichter.com')
+        assert.equal(this.result.find('[data-test-id="downloadOrigin"]').text(), 'http://www.bradrichter.com')
       })
 
       const shouldProgressBarExist = [downloadStates.IN_PROGRESS, downloadStates.PAUSED].includes(state)
       it(shouldProgressBarExist ? 'progress bar should exist' : 'progress bar should not exist', function () {
-        assert.equal(this.result.find('.downloadProgress').length, shouldProgressBarExist ? 1 : 0)
+        assert.equal(this.result.find('[data-test-id="downloadProgress"]').length, shouldProgressBarExist ? 1 : 0)
       })
 
       const testButton = function (buttonSelector, allowedStates, allowedFn) {
@@ -115,53 +115,53 @@ describe('downloadItem component', function () {
         })
       }
 
-      testButton('.pauseButton', [downloadStates.IN_PROGRESS], function (button) {
+      testButton('[data-test-id="pauseButton"]', [downloadStates.IN_PROGRESS], function (button) {
         const spy = sinon.spy(appActions, 'downloadActionPerformed')
         button.simulate('click')
         assert(spy.withArgs(this.downloadId, PAUSE).calledOnce)
         appActions.downloadActionPerformed.restore()
       })
 
-      testButton('.resumeButton', [downloadStates.PAUSED], function (button) {
+      testButton('[data-test-id="resumeButton"]', [downloadStates.PAUSED], function (button) {
         const spy = sinon.spy(appActions, 'downloadActionPerformed')
         button.simulate('click')
         assert(spy.withArgs(this.downloadId, RESUME).calledOnce)
         appActions.downloadActionPerformed.restore()
       })
 
-      testButton('.cancelButton', [downloadStates.IN_PROGRESS, downloadStates.PAUSED], function (button) {
+      testButton('[data-test-id="cancelButton"]', [downloadStates.IN_PROGRESS, downloadStates.PAUSED], function (button) {
         const spy = sinon.spy(appActions, 'downloadActionPerformed')
         button.simulate('click')
         assert(spy.withArgs(this.downloadId, CANCEL).calledOnce)
         appActions.downloadActionPerformed.restore()
       })
 
-      testButton('.redownloadButton', [downloadStates.CANCELLED, downloadStates.INTERRUPTED, downloadStates.COMPLETED], function (button) {
+      testButton('[data-test-id="redownloadButton"]', [downloadStates.CANCELLED, downloadStates.INTERRUPTED, downloadStates.COMPLETED], function (button) {
         const spy = sinon.spy(appActions, 'downloadRedownloaded')
         button.simulate('click')
         assert(spy.withArgs(this.downloadId).calledOnce)
         appActions.downloadRedownloaded.restore()
       })
 
-      testButton('.copyLinkButton', Object.values(downloadStates), function (button) {
+      testButton('[data-test-id="copyLinkButton"]', Object.values(downloadStates), function (button) {
         const spy = sinon.spy(appActions, 'downloadCopiedToClipboard')
         button.simulate('click')
         assert(spy.withArgs(this.downloadId).calledOnce)
         appActions.downloadCopiedToClipboard.restore()
       })
 
-      testButton('.revealButton', [downloadStates.IN_PROGRESS, downloadStates.PAUSED, downloadStates.COMPLETED], function (button) {
+      testButton('[data-test-id="revealButton"]', [downloadStates.IN_PROGRESS, downloadStates.PAUSED, downloadStates.COMPLETED], function (button) {
         const spy = sinon.spy(appActions, 'downloadRevealed')
         button.simulate('click')
         assert(spy.withArgs(this.downloadId).calledOnce)
         appActions.downloadRevealed.restore()
       })
 
-      testButton('.deleteButton', [downloadStates.CANCELLED, downloadStates.INTERRUPTED, downloadStates.COMPLETED], function (button) {
+      testButton('[data-test-id="deleteButton"]', [downloadStates.CANCELLED, downloadStates.INTERRUPTED, downloadStates.COMPLETED], function (button) {
         const spy = sinon.spy(appActions, 'showDownloadDeleteConfirmation')
         try {
           // Confirmation should NOT be visible by default
-          assert.equal(this.result.find('.confirmDeleteButton').length, 0)
+          assert.equal(this.result.find('[data-test-id="confirmDeleteButton"]').length, 0)
 
           // Clicking delete should show confirmation
           button.simulate('click')
@@ -179,7 +179,7 @@ describe('downloadItem component', function () {
             })
           })
 
-          testButton('.confirmDeleteButton', [downloadStates.CANCELLED, downloadStates.INTERRUPTED, downloadStates.COMPLETED], function (button) {
+          testButton('[data-test-id="confirmDeleteButton"]', [downloadStates.CANCELLED, downloadStates.INTERRUPTED, downloadStates.COMPLETED], function (button) {
             const spy = sinon.spy(appActions, 'downloadDeleted')
             try {
               // Accepting confirmation should delete the item

--- a/test/unit/app/renderer/components/navigation/navigatorTest.js
+++ b/test/unit/app/renderer/components/navigation/navigatorTest.js
@@ -108,16 +108,17 @@ describe('Navigator component unit tests', function () {
     })
 
     it('both back/forward navigationButtonContainers are enabled', function () {
-      assert.equal(wrapper.find('div.backforward > div.navigationButtonContainer.disabled').length, 0)
+      assert.equal(wrapper.find('[data-test-id="navigationBackButtonDisabled"]').length, 0)
+      assert.equal(wrapper.find('[data-test-id="navigationForwardButtonDisabled"]').length, 0)
     })
 
     it('back navigation button is enabled', function () {
-      const node = wrapper.find('div.backforward > div.navigationButtonContainer .backButton').getDOMNode()
+      const node = wrapper.find('[data-test-id="backButton"]').getDOMNode()
       assert.equal(node.disabled, false)
     })
 
     it('forward navigation button is enabled', function () {
-      const node = wrapper.find('div.backforward > div.navigationButtonContainer .forwardButton').getDOMNode()
+      const node = wrapper.find('[data-test-id="forwardButton"]').getDOMNode()
       assert.equal(node.disabled, false)
     })
   })
@@ -139,16 +140,17 @@ describe('Navigator component unit tests', function () {
     })
 
     it('disables both back/forward navigationButtonContainers', function () {
-      assert.equal(wrapper.find('div.backforward > div.navigationButtonContainer.disabled').length, 2)
+      assert.equal(wrapper.find('[data-test-id="navigationBackButtonDisabled"]').length, 1)
+      assert.equal(wrapper.find('[data-test-id="navigationForwardButtonDisabled"]').length, 1)
     })
 
     it('disables the back navigation button', function () {
-      const node = wrapper.find('div.backforward > div.navigationButtonContainer .backButton').getDOMNode()
+      const node = wrapper.find('[data-test-id="backButtonDisabled"]').getDOMNode()
       assert.equal(node.disabled, true)
     })
 
     it('disables the forward navigation button', function () {
-      const node = wrapper.find('div.backforward > div.navigationButtonContainer .forwardButton').getDOMNode()
+      const node = wrapper.find('[data-test-id="forwardButtonDisabled"]').getDOMNode()
       assert.equal(node.disabled, true)
     })
 

--- a/test/unit/app/renderer/components/navigation/urlBarIconTest.js
+++ b/test/unit/app/renderer/components/navigation/urlBarIconTest.js
@@ -52,7 +52,7 @@ describe('UrlBarIcon component unit tests', function () {
     const wrapper = mount(
       <UrlBarIcon {...props} />
     )
-    wrapper.find('span').simulate('click')
+    wrapper.find('[data-test-id="urlBarIcon"]').simulate('click')
     assert.equal(spy.calledOnce, true)
     windowActions.setSiteInfoVisible.restore()
   })
@@ -76,7 +76,7 @@ describe('UrlBarIcon component unit tests', function () {
       const wrapper = mount(
         <UrlBarIcon {...props2} />
       )
-      wrapper.find('span').simulate('click')
+      wrapper.find('[data-test-id="urlBarIcon"]').simulate('click')
       assert.equal(spy.notCalled, true)
       windowActions.setSiteInfoVisible.restore()
     })

--- a/test/unit/app/renderer/components/navigation/urlBarSuggestionItemTest.js
+++ b/test/unit/app/renderer/components/navigation/urlBarSuggestionItemTest.js
@@ -53,19 +53,19 @@ describe('UrlBarSuggestionItem component', function () {
 
       it('renders the suggestion title', function () {
         if (suggestionType !== suggestionTypes.TOP_SITE) {
-          assert.equal(this.result.find('.suggestionTitle').length, 1)
-          assert.equal(this.result.find('.suggestionTitle').text(), this.suggestion.get('title'))
+          assert.equal(this.result.find('[data-test-id="suggestionTitle"]').length, 1)
+          assert.equal(this.result.find('[data-test-id="suggestionTitle"]').text(), this.suggestion.get('title'))
         } else {
-          assert.equal(this.result.find('.suggestionTitle').length, 0)
+          assert.equal(this.result.find('[data-test-id="suggestionTitle"]').length, 0)
         }
       })
 
       it('renders a suggestion URL', function () {
         if (suggestionType !== suggestionTypes.SEARCH && suggestionType !== suggestionTypes.ABOUT_PAGES) {
-          assert.equal(this.result.find('.suggestionLocation').length, 1)
-          assert.equal(this.result.find('.suggestionLocation').text(), this.suggestion.get('location'))
+          assert.equal(this.result.find('[data-test-id="suggestionLocation"]').length, 1)
+          assert.equal(this.result.find('[data-test-id="suggestionLocation"]').text(), this.suggestion.get('location'))
         } else {
-          assert.equal(this.result.find('.suggestionLocation').length, 0)
+          assert.equal(this.result.find('[data-test-id="suggestionLocation"]').length, 0)
         }
       })
 

--- a/test/unit/app/renderer/components/preferences/payments/ledgerTableTest.js
+++ b/test/unit/app/renderer/components/preferences/payments/ledgerTableTest.js
@@ -274,7 +274,7 @@ describe('LedgerTable component', function () {
     )
     assert.equal(wrapper.find('[data-tbody-index="0"] [data-test-id="siteName"]').length, 2, '2 pinned')
     assert.equal(wrapper.find('[data-tbody-index="1"] [data-test-id="siteName"]').length, 1, '1 unpinned')
-    assert.equal(wrapper.find('[data-l10n-id="showAll"]').length, 0, 'show all button hidden')
+    assert.equal(wrapper.find('[data-test-id="showAll"]').length, 0, 'show all button hidden')
   })
 
   it('two pinned tabs, no un pinned (there shouldn\'t be any show all button', function () {
@@ -338,7 +338,7 @@ describe('LedgerTable component', function () {
     )
     assert.equal(wrapper.find('[data-tbody-index="0"] [data-test-id="siteName"]').length, 2, '2 pinned')
     assert.equal(wrapper.find('[data-tbody-index="1"] [data-test-id="siteName"]').length, 0, '0 unpinned')
-    assert.equal(wrapper.find('[data-l10n-id="showAll"]').length, 0, 'show all button hidden')
+    assert.equal(wrapper.find('[data-test-id="showAll"]').length, 0, 'show all button hidden')
   })
 
   it('pinned tabs should have exclude disabled', function () {
@@ -378,7 +378,7 @@ describe('LedgerTable component', function () {
         siteSettings={siteSettings}
       />
     )
-    assert.equal(wrapper.find('[data-tbody-index="0"] [data-td-index="2"] .disabled').length, 1, 'exclude disabled')
+    assert.equal(wrapper.find('[data-tbody-index="0"] [data-td-index="2"] [data-test-id="pinnedDisabled"]').length, 1, 'exclude disabled')
   })
 
   it('two pinned tabs (1 banned), 3 unpinned (1 banned)', function () {
@@ -533,6 +533,6 @@ describe('LedgerTable component', function () {
     )
     assert.equal(wrapper.find('[data-tbody-index="0"] [data-test-id="siteName"]').length, 8, '8 pinned')
     assert.equal(wrapper.find('[data-tbody-index="1"] [data-test-id="siteName"]').length, 10, '10 unpinned, 2 hidden')
-    assert.equal(wrapper.find('[data-l10n-id="showAll"]').length, 1, 'show all button visible')
+    assert.equal(wrapper.find('[data-test-id="showAll"]').length, 1, 'show all button visible')
   })
 })

--- a/test/unit/app/renderer/components/preferences/paymentsTabTest.js
+++ b/test/unit/app/renderer/components/preferences/paymentsTabTest.js
@@ -101,7 +101,7 @@ describe('PaymentsTab component', function () {
           ledgerData={Immutable.Map()}
           showOverlay={function () {}} />
       )
-      assert.equal(wrapper.find('.dialog').length, 0)
+      assert.equal(wrapper.find(advancedSettingsDialog).length, 0)
     })
 
     it('renders the create wallet button by default', function () {


### PR DESCRIPTION
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Close #8734
Auditors: @bsclifton, @nejczdovc
Test Plan: `npm run unittest` should pass