### PR TITLE
Restore guard to populateHistory, fixes #8767

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -96,7 +96,7 @@ const needsPartitionAssigned = (createProperties) => {
 // TODO(bridiver) - refactor this into an action
 ipcMain.on(messages.ABOUT_COMPONENT_INITIALIZED, (e) => {
   const tab = e.sender
-  const listener = () => {
+  const listener = (_diffs) => {
     if (!tab.isDestroyed()) {
       const tabValue = tabState.getByTabId(appStore.getState(), tab.getId())
       if (tabValue && tabValue.get('active') === true) {
@@ -167,7 +167,9 @@ const updateAboutDetails = (tab, tabValue) => {
       bookmarkFolders: bookmarkFolders.toJS()
     })
   } else if (location === 'about:history' && history) {
-    appActions.populateHistory()
+    if (!history) {
+      appActions.populateHistory()
+    }
     tab.send(messages.HISTORY_UPDATED, history.toJS())
     tab.send(messages.SETTINGS_UPDATED, appSettings.toJS())
   } else if (location === 'about:extensions' && extensions) {


### PR DESCRIPTION
Restores guard behavior from https://github.com/brave/browser-laptop/commit/4ddf839474588adb1822cf429c70472dd6ed943e#diff-303f0b6a297506f2cc18bf7b4cb370c5R844

Auditors:
@ayumi
@bsclifton

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
Run tests