### PR TITLE
block webgl2 fingerprinting and webgl readPixels

### DIFF
--- a/app/extensions/brave/content/scripts/blockCanvasFingerprinting.js
+++ b/app/extensions/brave/content/scripts/blockCanvasFingerprinting.js
@@ -113,13 +113,15 @@ if (chrome.contentSettings.canvasFingerprinting == 'block') {
   })
 
   var webglMethods = ['getSupportedExtensions', 'getParameter', 'getContextAttributes',
-    'getShaderPrecisionFormat', 'getExtension']
+    'getShaderPrecisionFormat', 'getExtension', 'readPixels']
   webglMethods.forEach(function (method) {
     var item = {
       type: 'WebGL',
       objName: 'WebGLRenderingContext',
       propName: method
     }
+    methods.push(item)
+    item.objName = 'WebGL2RenderingContext',
     methods.push(item)
   })
 


### PR DESCRIPTION
fix #8448

Test Plan:
1. go to https://browserleaks.com/webgl and turn on fingerprinting protection
2. the report hash should be '0C21A6FA2A9BD79DFF6E128FE55094B4'
3. the image hash should be empty
4. all the fields under the triangle image should be empty

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

