### PR TITLE
noscript exceptions from private tabs should not apply to regular tabs

### DIFF
--- a/docs/appActions.md
+++ b/docs/appActions.md
@@ -766,7 +766,7 @@ Dispatches a message when a tab is being cloned
 
 
 
-### noScriptExceptionsAdded(hostPattern, origins) 
+### noScriptExceptionsAdded(hostPattern, origins, temporary) 
 
 Dispatches a message when noscript exceptions are added for an origin
 
@@ -775,6 +775,8 @@ Dispatches a message when noscript exceptions are added for an origin
 **hostPattern**: `string`, Dispatches a message when noscript exceptions are added for an origin
 
 **origins**: `Object.&lt;string, (boolean|number)&gt;`, Dispatches a message when noscript exceptions are added for an origin
+
+**temporary**: `boolean`, Dispatches a message when noscript exceptions are added for an origin
 
 
 

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -943,12 +943,14 @@ const appActions = {
    * Dispatches a message when noscript exceptions are added for an origin
    * @param {string} hostPattern
    * @param {Object.<string, (boolean|number)>} origins
+   * @param {boolean} temporary
    */
-  noScriptExceptionsAdded: function (hostPattern, origins) {
+  noScriptExceptionsAdded: function (hostPattern, origins, temporary) {
     AppDispatcher.dispatch({
       actionType: appConstants.APP_ADD_NOSCRIPT_EXCEPTIONS,
       hostPattern,
-      origins
+      origins,
+      temporary
     })
   },
 

--- a/js/components/noScriptInfo.js
+++ b/js/components/noScriptInfo.js
@@ -84,7 +84,7 @@ class NoScriptInfo extends ImmutableComponent {
       }
     })
     if (checkedOrigins.filter((value) => value !== false).size) {
-      appActions.noScriptExceptionsAdded(this.origin, checkedOrigins)
+      appActions.noScriptExceptionsAdded(this.origin, checkedOrigins, this.isPrivate)
       this.reload()
       this.props.onHide()
     }

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -562,15 +562,18 @@ const handleAppAction = (action) => {
         break
       }
     case appConstants.APP_ADD_NOSCRIPT_EXCEPTIONS:
-      // Note that this is always cleared on restart or reload, so should not
-      // be synced or persisted.
-      let key = 'noScriptExceptions'
-      if (!action.origins || !action.origins.size) {
-        // Clear the exceptions
-        appState = appState.setIn(['siteSettings', action.hostPattern, key], new Immutable.Map())
-      } else {
-        const currentExceptions = appState.getIn(['siteSettings', action.hostPattern, key]) || new Immutable.Map()
-        appState = appState.setIn(['siteSettings', action.hostPattern, key], currentExceptions.merge(action.origins))
+      {
+        const propertyName = action.temporary ? 'temporarySiteSettings' : 'siteSettings'
+        // Note that this is always cleared on restart or reload, so should not
+        // be synced or persisted.
+        const key = 'noScriptExceptions'
+        if (!action.origins || !action.origins.size) {
+          // Clear the exceptions
+          appState = appState.setIn([propertyName, action.hostPattern, key], new Immutable.Map())
+        } else {
+          const currentExceptions = appState.getIn([propertyName, action.hostPattern, key]) || new Immutable.Map()
+          appState = appState.setIn([propertyName, action.hostPattern, key], currentExceptions.merge(action.origins))
+        }
       }
       break
     case appConstants.APP_UPDATE_LEDGER_INFO:


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/8779

Test Plan:
1. disable scripts on twitter.com
2. open twitter.com in a private tab. scripts should be disabled.
3. click the noscript icon to allow scripts in the private tab.
4. load twitter again in a regular tab. scripts should still be disabled.

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
