### PR TITLE
Saving a document doesn't show correct origin

### DIFF
--- a/app/extensions/brave/locales/en-US/downloads.properties
+++ b/app/extensions/brave/locales/en-US/downloads.properties
@@ -8,6 +8,7 @@ downloadInProgress=Downloading: {{downloadPercent}}
 downloadInProgressUnknownTotal=Downloading…
 downloadPaused=Paused: {{downloadPercent}}
 downloadDeleteConfirmation=Delete?
+downloadLocalFile=Local file
 
 downloadPause.title=Pause Download
 downloadResume.title=Resume Download

--- a/app/renderer/components/downloadItem.js
+++ b/app/renderer/components/downloadItem.js
@@ -73,6 +73,8 @@ class DownloadItem extends ImmutableComponent {
   }
   render () {
     const origin = getOrigin(this.props.download.get('url'))
+    const localFileOrigins = ['file:', 'blob:', 'data:', 'chrome-extension:', 'chrome:']
+    const localFile = origin && localFileOrigins.some((localFileOrigin) => origin.startsWith(localFileOrigin))
     const progressStyle = {
       width: downloadUtil.getPercentageComplete(this.props.download)
     }
@@ -160,7 +162,7 @@ class DownloadItem extends ImmutableComponent {
                     ? <span className='fa fa-unlock isInsecure' />
                     : null
                 }
-                <span title={origin}>{origin}</span>
+                <span data-l10n-id={localFile ? 'downloadLocalFile' : null} title={origin}>{localFile ? null : origin}</span>
               </div>
               : null
           }

--- a/test/unit/app/renderer/downloadItemTest.js
+++ b/test/unit/app/renderer/downloadItemTest.js
@@ -18,11 +18,22 @@ require('../../braveUnit')
 
 const savePath = path.join(require('os').tmpdir(), 'mostHatedPrimes.txt')
 const downloadUrl = 'http://www.bradrichter.com/mostHatedPrimes.txt'
+const localFileDownloadUrl = 'file:///Users/foobar/Library/abc.txt'
 const newDownload = (state) => Immutable.fromJS({
   startTime: new Date().getTime(),
   filename: 'mostHatedPrimes.txt',
   savePath,
   url: downloadUrl,
+  totalBytes: 104729,
+  receivedBytes: 96931,
+  deleteConfirmationVisible: false,
+  state
+})
+const newDownloadLocalFile = (state) => Immutable.fromJS({
+  startTime: new Date().getTime(),
+  filename: 'abc.txt',
+  savePath,
+  url: localFileDownloadUrl,
   totalBytes: 104729,
   receivedBytes: 96931,
   deleteConfirmationVisible: false,
@@ -46,6 +57,27 @@ describe('downloadItem component', function () {
   })
 
   Object.values(downloadStates).forEach(function (state) {
+    describe(`${state} download local item`, function () {
+      before(function () {
+        this.downloadId = uuid.v4()
+        this.download = newDownloadLocalFile(state)
+        this.result = mount(
+          <DownloadItem
+            downloadId={this.downloadId}
+            download={this.download}
+            deleteConfirmationVisible={this.download.get('deleteConfirmationVisible')} />
+        )
+      })
+
+      it('filename exists and matches download filename', function () {
+        assert.equal(this.result.find('.downloadFilename').text(), this.download.get('filename'))
+      })
+
+      it('has local origin i.e file: and matches to "Local file" origin', function () {
+        assert.equal(this.result.find('.downloadOrigin').text(), '')
+      })
+    })
+
     describe(`${state} download item`, function () {
       before(function () {
         this.downloadId = uuid.v4()


### PR DESCRIPTION
- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Fix #8698

Test Plan:
Open browser
Download file having orgin file:/// or chrome-extension: or other local origin.
It should show text 'Local file' for local origin file/
<img width="283" alt="screen shot 2017-05-10 at 5 48 05 pm" src="https://cloud.githubusercontent.com/assets/4078325/25899229/a4eafb18-35ac-11e7-99e5-a7d675c69258.png">
