### PR TITLE
fix flash always-deny setting

### DIFF
--- a/app/browser/reducers/flashReducer.js
+++ b/app/browser/reducers/flashReducer.js
@@ -6,6 +6,7 @@
 
 const appConstants = require('../../../js/constants/appConstants')
 const flash = require('../../../js/flash')
+const siteSettings = require('../../../js/state/siteSettings')
 const {makeImmutable} = require('../../common/state/immutableUtil')
 
 const flashReducer = (state, action, immutableAction) => {
@@ -15,8 +16,14 @@ const flashReducer = (state, action, immutableAction) => {
       flash.init()
       break
     case appConstants.APP_FLASH_PERMISSION_REQUESTED:
-      flash.showFlashMessageBox(action.get('location'), action.get('senderTabId'))
-      break
+      {
+        const location = action.get('location')
+        const settings = siteSettings.getSiteSettingsForURL(state.get('siteSettings'), location)
+        if (!(settings && ['boolean', 'number'].includes(typeof settings.get('flash')))) {
+          flash.showFlashMessageBox(location, action.get('senderTabId'))
+        }
+        break
+      }
   }
   return state
 }


### PR DESCRIPTION
fix #8826

Test Plan:
1. enable flash
2. go to http://homestarrunner.com/
3. you should see a Flash notification bar. click 'remember this decision' and 'deny'
4. close the tab and open http://homestarrunner.com/ in a new tab
5. you should not see a Flash notification bar this time

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run indivually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)


