### PR TITLE
saveAppState needs to be called to perform the quit

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -181,6 +181,7 @@ const initiateSessionStateSave = () => {
     // quit triggered by window-all-closed should save last window state
     if (lastWindowClosed && lastWindowState) {
       perWindowState.push(lastWindowState)
+      saveAppState(true)
     } else if (BrowserWindow.getAllWindows().length > 0) {
       ++requestId
       BrowserWindow.getAllWindows().forEach((win) => win.webContents.send(messages.REQUEST_WINDOW_STATE, requestId))


### PR DESCRIPTION
saveAppState needs to be called to perform the quit 
(was only missing from the lastWindowClosed case)

Unintentionally introduced with https://github.com/brave/browser-laptop/commit/40abc0c780050eb0b8dd42c15065d1c784268b47#diff-2018087f584c4398b5c3a23fc0e5f9dbR172
True needs to be passed, because the last known window state is saved, so receivedAllWindows is always false

Fixes https://github.com/brave/browser-laptop/issues/8629

Auditors: @bridiver
cc: @jonathansampson, @NejcZdovc 

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run indivually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)


