### PR TITLE
Bump electron-installer-redhat to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,7 +195,7 @@
   },
   "optionalDependencies": {
     "electron-installer-debian": "^0.3.0",
-    "electron-installer-redhat": "^0.3.0"
+    "electron-installer-redhat": "^0.5.0"
   },
   "standard": {
     "global": [


### PR DESCRIPTION
Versions prior to 0.5.0 don't run `update-desktop-database` on post-install and post-uninstall. This causes the Brave icon to not appear in GNOME/KDE/others after installation (user must install another package or reboot) and cause it not disappear when uninstalled for the same reason.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run indivually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)


