### PR TITLE
Handle `show-warning-dialog` event on app

### DIFF
--- a/app/importer.js
+++ b/app/importer.js
@@ -5,6 +5,7 @@
 'strict mode'
 
 const electron = require('electron')
+const app = electron.app
 const importer = electron.importer
 const dialog = electron.dialog
 const BrowserWindow = electron.BrowserWindow
@@ -235,7 +236,7 @@ const showImportSuccess = function () {
   }
 }
 
-importer.on('show-warning-dialog', (e) => {
+app.on('show-warning-dialog', (e) => {
   showImportWarning()
 })
 


### PR DESCRIPTION
requires https://github.com/brave/muon/pull/196

fix #8846

Auditors: @bridiver, @bbondy

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Open Firefox
2. Open Brave and import from Firefox
3. There will be a warning window

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run indivually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)


