### PR TITLE
Shows notification caret on pinned tabs

### DIFF
--- a/app/renderer/components/tabs/pinnedTabs.js
+++ b/app/renderer/components/tabs/pinnedTabs.js
@@ -81,6 +81,7 @@ class PinnedTabs extends ImmutableComponent {
                paintTabs={this.props.paintTabs}
                previewTabs={this.props.previewTabs}
                isActive={this.props.activeFrameKey === frame.get('key')}
+               notificationBarActive={this.props.notificationBarActive}
                partOfFullPageSet={this.props.partOfFullPageSet} />)
       }
     </div>

--- a/app/renderer/components/tabs/tabsToolbar.js
+++ b/app/renderer/components/tabs/tabsToolbar.js
@@ -49,6 +49,7 @@ class TabsToolbar extends ImmutableComponent {
           dragData={this.props.dragData}
           tabPageIndex={this.props.tabPageIndex}
           pinnedTabs={pinnedTabs}
+          notificationBarActive={this.props.notificationBarActive}
           />
         : null
       }


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Resolves #8626 

Test Plan:
1. Open a new tab and navigate to google.com
2. Pin the tab
3. Confirm presence of caret when Google requests location
