### PR TITLE
Add padding around showAllWrap button

### DIFF
--- a/app/renderer/components/preferences/payment/ledgerTable.js
+++ b/app/renderer/components/preferences/payment/ledgerTable.js
@@ -301,7 +301,7 @@ class LedgerTable extends ImmutableComponent {
       />
       {
         (totalUnPinnedRows !== unPinnedRows.size && hideLower)
-        ? <div className={css(styles.showAllWrap)}>
+        ? <div className={css(styles.ledgerTable__showAllWrap)}>
           <BrowserButton secondaryColor
             l10nId={hideLower ? 'showAll' : 'hideLower'}
             onClick={this.showAll.bind(this, !hideLower)}
@@ -464,10 +464,9 @@ const styles = StyleSheet.create({
     right: '2px'
   },
 
-  showAllWrap: {
+  ledgerTable__showAllWrap: {
     textAlign: 'center',
-    paddingBottom: '10px',
-    marginTop: '-20px'
+    marginTop: globalStyles.spacing.panelMargin
   }
 })
 

--- a/app/renderer/components/preferences/paymentsTab.js
+++ b/app/renderer/components/preferences/paymentsTab.js
@@ -288,7 +288,8 @@ const styles = StyleSheet.create({
   paymentsContainer: {
     position: 'relative',
     overflowX: 'hidden',
-    width: '805px'
+    width: '805px',
+    paddingBottom: '40px' // cf: padding of .prefTabContainer
   },
   paymentsSwitches: {
     display: 'flex',


### PR DESCRIPTION
Fix #8869

Auditors:

Test Plan:
1. Run `npm run add-simulated-synopsis-visits` until "Show All" button appears
2. Open about:preferences#payments
3. Disable payments
4. Make sure there is 40 px padding under the panel
5. Enable payments
6. Make sure there is 40 px padding under "Show All" button

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Reviewer Checklist:

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


