### PR TITLE
fix 'about:blank' being displayed permanently on new tabs

### DIFF
--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -357,10 +357,13 @@ class UrlBar extends React.Component {
   componentDidUpdate (prevProps) {
     // this.urlInput is not initialized in titleMode
     if (this.urlInput) {
+      const pdfjsEnabled = getSetting(settings.PDFJS_ENABLED)
       if (this.props.activeFrameKey !== prevProps.activeFrameKey) {
         this.keyPressed = false
         // The user just changed tabs
-        this.setValue(this.props.locationValue)
+        this.setValue(this.props.locationValue !== 'about:blank'
+          ? this.props.locationValue
+          : UrlUtil.getDisplayLocation(this.props.location, pdfjsEnabled))
         // Each tab has a focused state stored separately
         if (this.props.isFocused) {
           this.focus()
@@ -369,7 +372,7 @@ class UrlBar extends React.Component {
         windowActions.setRenderUrlBarSuggestions(false)
       } else if (this.props.location !== prevProps.location) {
         // This is a url nav change
-        this.setValue(UrlUtil.getDisplayLocation(this.props.location, getSetting(settings.PDFJS_ENABLED)))
+        this.setValue(UrlUtil.getDisplayLocation(this.props.location, pdfjsEnabled))
       } else if (this.props.hasLocationValueSuffix &&
                 this.props.isActive &&
                 this.props.locationValueSuffix !== this.lastSuffix) {

--- a/test/tab-components/tabTest.js
+++ b/test/tab-components/tabTest.js
@@ -5,6 +5,8 @@ const messages = require('../../js/constants/messages')
 const settings = require('../../js/constants/settings')
 const {urlInput, backButton, forwardButton, activeTab, activeTabTitle, activeTabFavicon, newFrameButton, notificationBar, contextMenu, pinnedTabsTabs, tabsTabs} = require('../lib/selectors')
 
+const newTabUrl = 'chrome-extension://mnojpmjdmbbfmejpflffifhffcmidifd/about-newtab.html'
+
 describe('tab tests', function () {
   function * setup (client) {
     yield client
@@ -89,6 +91,18 @@ describe('tab tests', function () {
         .waitForExist('[data-test-id="tab"][data-frame-key="2"]')
         .waitForTextValue('[data-test-id="tab"][data-frame-key="2"]', 'New Tab')
     })
+
+    it('shows empty urlbar', function * () {
+      yield this.app.client
+        .newTab()
+        .waitForExist('webview[data-frame-key="4"]')
+        .waitUntil(function () {
+          return this.getAttribute('webview[data-frame-key="4"]', 'src').then((value) => value === newTabUrl)
+        })
+        .waitUntil(function () {
+          return this.getAttribute(urlInput, 'value').then((value) => value === '')
+        })
+    })
   })
 
   describe('new tab button', function () {
@@ -101,6 +115,17 @@ describe('tab tests', function () {
       yield this.app.client
         .click(newFrameButton)
         .waitForExist('[data-test-id="tab"][data-frame-key="2"]')
+    })
+    it('shows empty urlbar', function * () {
+      yield this.app.client
+        .click(newFrameButton)
+        .waitForExist('webview[data-frame-key="2"]')
+        .waitUntil(function () {
+          return this.getAttribute('webview[data-frame-key="2"]', 'src').then((value) => value === newTabUrl)
+        })
+        .waitUntil(function () {
+          return this.getAttribute(urlInput, 'value').then((value) => value === '')
+        })
     })
     it.skip('shows a context menu when long pressed (click and hold)', function * () {
       yield this.app.client


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/8850

Test Plan:
1. open several new tabs. they should all show blank in the urlbar instead of about:blank after a short lag.
2. 'new tab button' and 'new tab signal' tests should pass.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


