### PR TITLE
Fix regression: privateTabPaddingHorizontal

### DIFF
--- a/js/about/newprivatetab.js
+++ b/js/about/newprivatetab.js
@@ -88,11 +88,11 @@ const styles = StyleSheet.create({
   title: {
     color: globalStyles.color.white100,
     fontSize: '30px',
-    marginBottom: '20px'
+    marginBottom: globalStyles.spacing.privateTabPaddingHorizontal
   },
 
   text: {
-    paddingBottom: '20px',
+    paddingBottom: globalStyles.spacing.privateTabPaddingHorizontal,
     lineHeight: '1.5',
     fontSize: '17px',
     color: globalStyles.color.alphaWhite


### PR DESCRIPTION
Addresses #8895

Auditors: @cezaraugusto

Test Plan:
1. new private tab paragraphs should be properly spaced

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


