### PR TITLE
Trigger tab preview based on frame key

### DIFF
--- a/app/renderer/reducers/frameReducer.js
+++ b/app/renderer/reducers/frameReducer.js
@@ -42,11 +42,18 @@ const closeFrame = (state, action) => {
   if (state.get('frames', Immutable.List()).size === 0) {
     appActions.closeWindow(getCurrentWindowId())
   }
-  // Copy the hover state if tab closed with mouse as long as we have a next frame
-  // This allow us to have closeTab button visible  for sequential frames closing, until onMouseLeave event happens.
+
   const nextFrame = frameStateUtil.getFrameByIndex(state, index)
-  if (hoverState && nextFrame) {
-    windowActions.setTabHoverState(nextFrame.get('key'), hoverState)
+
+  if (nextFrame) {
+    // After closing a tab, preview the next frame as long as there is one
+    windowActions.setPreviewFrame(nextFrame.get('key'))
+    // Copy the hover state if tab closed with mouse as long as we have a next frame
+    // This allow us to have closeTab button visible for sequential frames closing,
+    // until onMouseLeave event happens.
+    if (hoverState) {
+      windowActions.setTabHoverState(nextFrame.get('key'), hoverState)
+    }
   }
 
   return state


### PR DESCRIPTION
- Auditors: @bsclifton, @luixxiul
- Close: #7606

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
## When next tab exists
### Static ordering
1. Open 3 tabs with different websites
2. Make first active
3. Hover over second
4. Close it
5. Third tab (now second) should show as a preview 

### dynamic ordering
1. Open 3 tabs with different websites
2. Ensure you reorder tabs by drag-n-drop
3. Make first active
4. Hover over second
5. Close it
6. Third tab (now second) should show as a preview 

### when previous frame is not active
1. Open 5 tabs
2. Make third active
3. Hover over fourth
4. Close it
5. Fifth tab (now fourth) should show as a preview 


## when next tab is null
1. Open 3 tabs with different websites
2. Close the 3rd tab
3. no preview is triggered

## when frame is closed by close tab shortcut
1. Open 3 tabs with different websites
2. Make first active
3. Close it by shortcut (<kbd>cmd/ctrl</kbd>+<kbd>w</kbd>)
4. No preview is triggered

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


