### PR TITLE
Fix urlbar suggestions showing up when non-printable keys are pressed

### DIFF
--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -192,19 +192,16 @@ class UrlBar extends React.Component {
       case KeyCodes.TAB:
         this.hideAutoComplete()
         break
-      // Do not trigger rendering of suggestions if you are pressing alt or shift
-      case KeyCodes.ALT:
-      case KeyCodes.SHIFT:
-      case KeyCodes.CMD1:
-      case KeyCodes.CMD2:
-      case KeyCodes.CTRL:
-        break
       default:
         this.keyPressed = true
-        windowActions.setRenderUrlBarSuggestions(true)
-        // Any other keydown is fair game for autocomplete to be enabled.
-        if (!this.props.autocompleteEnabled) {
-          windowActions.urlBarAutocompleteEnabled(true)
+        // Only enable suggestions and autocomplete if we are typing in
+        // a printable character without cmd/ctrl
+        if (e.key && e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
+          windowActions.setRenderUrlBarSuggestions(true)
+          // Any other keydown is fair game for autocomplete to be enabled.
+          if (!this.props.autocompleteEnabled) {
+            windowActions.urlBarAutocompleteEnabled(true)
+          }
         }
     }
   }

--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -113,7 +113,8 @@ var exports = {
     DOWN: '\ue015',
     UP: '\ue013',
     PAGEDOWN: '\uE00F',
-    END: '\uE010'
+    END: '\uE010',
+    NULL: '\uE000'
   },
 
   defaultTimeout: 10000,

--- a/test/navbar-components/urlBarTest.js
+++ b/test/navbar-components/urlBarTest.js
@@ -1,5 +1,6 @@
 /* global describe, it, before, beforeEach */
 
+const assert = require('assert')
 const Brave = require('../lib/brave')
 const {urlInput, urlBarSuggestions, urlbarIcon, reloadButton} = require('../lib/selectors')
 const searchProviders = require('../../js/data/searchProviders')
@@ -180,6 +181,27 @@ describe('urlBar tests', function () {
           yield this.app.client
             .waitForInputText(urlInput, 'brave.coma')
         })
+      })
+    })
+
+    describe('press keyboard shortcut', function () {
+      beforeEach(function * () {
+        this.page = Brave.server.url('page1.html')
+        return yield this.app.client
+          .tabByIndex(0)
+          .loadUrl(this.page)
+          .windowByUrl(Brave.browserWindowUrl)
+      })
+
+      it('does not show autosuggest', function * () {
+        return yield this.app.client
+          .ipcSend('shortcut-focus-url')
+          .waitForElementFocus(urlInput)
+          .keys(Brave.keys.CONTROL)
+          .keys('c')
+          .keys(Brave.keys.NULL) // needed to release the modifier key
+          .pause(100) // wait for the suggestions
+          .isExisting(urlBarSuggestions).then((isExisting) => assert(!isExisting))
       })
     })
 


### PR DESCRIPTION
Fix https://github.com/brave/browser-laptop/issues/8896

Test Plan:
1. `npm run test -- --grep='press keyboard shortcut'` should pass
2. go to a site with autocomplete entries; ex: twitter.com. press cmd+L to focus the urlbar and the cmd+C to copy. the autosuggest dialog should not appear.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


