### PR TITLE
Remove CommonFormSection from widevineInfo.js

### DIFF
--- a/app/renderer/components/widevineInfo.js
+++ b/app/renderer/components/widevineInfo.js
@@ -14,8 +14,7 @@ const appConfig = require('../../../js/constants/appConfig')
 const cx = require('../../../js/lib/classSet')
 
 const {StyleSheet, css} = require('aphrodite/no-important')
-
-const {CommonFormSection} = require('./common/commonForm')
+const globalStyles = require('./styles/global')
 
 class WidevineInfo extends ImmutableComponent {
   constructor () {
@@ -34,8 +33,8 @@ class WidevineInfo extends ImmutableComponent {
     })
   }
   render () {
-    return <div data-test-id='widevineInfo'>
-      <CommonFormSection>
+    return <section data-test-id='widevineInfo'>
+      <div className={css(styles.widevineInfo__div)}>
         <span data-l10n-id='enableWidevineSubtext' />
         <span className={cx({
           fa: true,
@@ -46,8 +45,8 @@ class WidevineInfo extends ImmutableComponent {
           onClick={this.onMoreInfo}
           title={appConfig.widevine.moreInfoUrl}
         />
-      </CommonFormSection>
-      <CommonFormSection>
+      </div>
+      <div className={css(styles.widevineInfo__div)}>
         <span data-l10n-id='enableWidevineSubtext2' />
         <span className={cx({
           fa: true,
@@ -58,12 +57,15 @@ class WidevineInfo extends ImmutableComponent {
           onClick={this.onViewLicense}
           title={appConfig.widevine.licenseUrl}
         />
-      </CommonFormSection>
-    </div>
+      </div>
+    </section>
   }
 }
 
 const styles = StyleSheet.create({
+  widevineInfo__div: {
+    marginBottom: globalStyles.spacing.dialogInsideMargin
+  },
   cursor: {
     cursor: 'pointer'
   }

--- a/app/renderer/components/widevinePanel.js
+++ b/app/renderer/components/widevinePanel.js
@@ -16,6 +16,7 @@ const siteUtil = require('../../../js/state/siteUtil')
 const {
   CommonFormLarge,
   CommonFormTitle,
+  CommonFormSection,
   CommonFormButtonWrapper,
   CommonFormBottomWrapper
 } = require('./common/commonForm')
@@ -58,7 +59,9 @@ class ImportBrowserDataPanel extends ImmutableComponent {
     return <Dialog onHide={this.props.onHide} testId='widevinePanelDialog'>
       <CommonFormLarge onClick={(e) => e.stopPropagation()}>
         <CommonFormTitle data-l10n-id='widevinePanelTitle' />
-        <WidevineInfo createTabRequestedAction={appActions.createTabRequested} />
+        <CommonFormSection>
+          <WidevineInfo createTabRequestedAction={appActions.createTabRequested} />
+        </CommonFormSection>
         <CommonFormButtonWrapper>
           <Button className='whiteButton'
             l10nId='cancel'


### PR DESCRIPTION
as widevineInfo is also used outside of widevinePanel.js

Fixes #8907

Auditors:

Test Plan 1:
1. Open about:preferences#plugins
2. Make sure there is margin between the divs, the div and the switch

Test Plan 2:
1. Open netflix.com
2. Make sure the dialog design is not affected by this change

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


