### PR TITLE
fix 'Error: ENOTEMPTY: directory not empty' test errors

### DIFF
--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -7,7 +7,7 @@ require('./coMocha')
 const series = require('async/series')
 
 const path = require('path')
-const fs = require('fs')
+const fs = require('fs-extra')
 const os = require('os')
 const {getTargetAboutUrl, isSourceAboutUrl, getBraveExtIndexHTML} = require('../../js/lib/appUrlUtil')
 
@@ -51,7 +51,7 @@ const rmDir = (dirPath) => {
     }
   }
   try {
-    fs.rmdirSync(dirPath)
+    fs.removeSync(dirPath)
   } catch (e) {
     console.error(e)
   }


### PR DESCRIPTION
Test Plan:
1. Run a test such as `npm run test -- --grep='Syncing then'`. You should not see any ENOTEMPTY errors.
2. Travis logs should not contain a lot of ENOTEMPTY errors.