### PR TITLE
Add env var to disable webpack-notifier in build, fixes #8916

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ var env = process.env.NODE_ENV === 'production' ? 'production'
   : (process.env.NODE_ENV === 'test' ? 'test' : 'development')
 
 function config () {
-  return {
+  let c = {
     devtool: '#source-map',
     cache: true,
     module: {
@@ -55,7 +55,6 @@ function config () {
       'electron': 'chrome'
     },
     plugins: [
-      new WebpackNotifierPlugin({title: 'Brave-' + env}),
       new webpack.IgnorePlugin(/^\.\/stores\/appStore$/),
       new webpack.IgnorePlugin(/^spellchecker/),
       new webpack.DefinePlugin({
@@ -72,6 +71,10 @@ function config () {
       fs: 'empty'
     }
   }
+  if (!process.env.DISABLE_WEBPACK_NOTIFIER) {
+    c.plugins.push(new WebpackNotifierPlugin({title: 'Brave-' + env}))
+  }
+  return c
 }
 
 function watchOptions () {


### PR DESCRIPTION
Fix #8916

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


