### PR TITLE
remove CSP referrer directive from extensions

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -152,7 +152,6 @@ let generateBraveManifest = () => {
   let cspDirectives = {
     'default-src': '\'self\'',
     'form-action': '\'none\'',
-    'referrer': 'no-referrer',
     'style-src': '\'self\' \'unsafe-inline\'',
     'img-src': '* data: file://*',
     'frame-src': '\'self\' https://buy.coinbase.com'
@@ -184,7 +183,6 @@ let generateTorrentManifest = () => {
     'connect-src': '\'self\' https://example.com',
     'media-src': '\'self\' http://localhost:*',
     'form-action': '\'none\'',
-    'referrer': 'no-referrer',
     'style-src': '\'self\' \'unsafe-inline\'',
     'frame-src': '\'self\' http://localhost:*'
   }

--- a/app/extensions/brave/about-about.html
+++ b/app/extensions/brave/about-about.html
@@ -7,6 +7,7 @@
     <meta charset="utf-8">
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
+    <meta name="referrer" content="no-referrer">
     <link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,">
     <title data-l10n-id="aboutPages"></title>
     <script src="ext/l20n.min.js"></script>

--- a/app/extensions/brave/about-adblock.html
+++ b/app/extensions/brave/about-adblock.html
@@ -8,6 +8,7 @@
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
     <meta name='theme-color' content='#4B0082'>
+    <meta name="referrer" content="no-referrer">
     <link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,">
     <title data-l10n-id="adblockTitle"></title>
     <script src="ext/l20n.min.js"></script>

--- a/app/extensions/brave/about-autofill.html
+++ b/app/extensions/brave/about-autofill.html
@@ -8,6 +8,7 @@
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
     <meta name='theme-color' content='#ff5000'>
+    <meta name="referrer" content="no-referrer">
     <link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,">
     <title data-l10n-id="autofillTitle"></title>
     <script src="ext/l20n.min.js"></script>

--- a/app/extensions/brave/about-blank.html
+++ b/app/extensions/brave/about-blank.html
@@ -7,6 +7,7 @@
     <meta charset="utf-8">
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
+    <meta name="referrer" content="no-referrer">
     <title data-l10n-id="aboutBlankTitle"></title>
     <script src="ext/l20n.min.js"></script>
     <script src="gen/aboutPages.entry.js" async></script>

--- a/app/extensions/brave/about-bookmarks.html
+++ b/app/extensions/brave/about-bookmarks.html
@@ -8,6 +8,7 @@
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
     <meta name='theme-color' content='#ff5000'>
+    <meta name="referrer" content="no-referrer">
     <link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,">
     <title data-l10n-id="bookmarkManager"></title>
     <script src="ext/l20n.min.js"></script>

--- a/app/extensions/brave/about-brave.html
+++ b/app/extensions/brave/about-brave.html
@@ -7,6 +7,7 @@
     <meta charset="utf-8">
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
+    <meta name="referrer" content="no-referrer">
     <link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,">
     <title data-l10n-id="aboutBrave"></title>
     <script src="ext/l20n.min.js"></script>

--- a/app/extensions/brave/about-certerror.html
+++ b/app/extensions/brave/about-certerror.html
@@ -8,6 +8,7 @@
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
     <meta name='theme-color' content='#ff5000'>
+    <meta name="referrer" content="no-referrer">
     <title data-l10n-id="certError"></title>
     <script src="ext/l20n.min.js"></script>
     <script src="gen/aboutPages.entry.js" async></script>

--- a/app/extensions/brave/about-contributions.html
+++ b/app/extensions/brave/about-contributions.html
@@ -8,6 +8,7 @@
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
     <meta name='theme-color' content='#ff5000'>
+    <meta name="referrer" content="no-referrer">
     <link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,">
     <title data-l10n-id="contributionStatement"></title>
     <script src="ext/l20n.min.js"></script>

--- a/app/extensions/brave/about-downloads.html
+++ b/app/extensions/brave/about-downloads.html
@@ -8,6 +8,7 @@
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
     <meta name='theme-color' content='#000080'>
+    <meta name="referrer" content="no-referrer">
     <link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,">
     <title data-l10n-id="downloads"></title>
     <script src="ext/l20n.min.js"></script>

--- a/app/extensions/brave/about-error.html
+++ b/app/extensions/brave/about-error.html
@@ -8,6 +8,7 @@
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
     <meta name='theme-color' content='#ff5000'>
+    <meta name="referrer" content="no-referrer">
     <link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,">
     <title data-l10n-id="error"></title>
     <script src="ext/l20n.min.js"></script>

--- a/app/extensions/brave/about-extensions.html
+++ b/app/extensions/brave/about-extensions.html
@@ -8,6 +8,7 @@
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
     <meta name='theme-color' content='#565656'>
+    <meta name="referrer" content="no-referrer">
     <link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,">
     <title data-l10n-id="extensionsTitle"></title>
     <script src="ext/l20n.min.js"></script>

--- a/app/extensions/brave/about-history.html
+++ b/app/extensions/brave/about-history.html
@@ -8,6 +8,7 @@
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
     <meta name='theme-color' content='#565656'>
+    <meta name="referrer" content="no-referrer">
     <link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,">
     <title data-l10n-id="historyTitle"></title>
     <script src="ext/l20n.min.js"></script>

--- a/app/extensions/brave/about-newtab.html
+++ b/app/extensions/brave/about-newtab.html
@@ -7,6 +7,7 @@
     <meta charset="utf-8">
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
+    <meta name="referrer" content="no-referrer">
     <title data-l10n-id="newTab"></title>
     <script src="ext/l20n.min.js"></script>
     <script src="gen/aboutPages.entry.js" async></script>

--- a/app/extensions/brave/about-passwords.html
+++ b/app/extensions/brave/about-passwords.html
@@ -8,6 +8,7 @@
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
     <meta name='theme-color' content='#ff5000'>
+    <meta name="referrer" content="no-referrer">
     <link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,">
     <title data-l10n-id="passwordsTitle"></title>
     <script src="ext/l20n.min.js"></script>

--- a/app/extensions/brave/about-preferences.html
+++ b/app/extensions/brave/about-preferences.html
@@ -8,6 +8,7 @@
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
     <meta name='theme-color' content='#ff5000'>
+    <meta name="referrer" content="no-referrer">
     <link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,">
     <title data-l10n-id="preferences"></title>
     <script src="ext/l20n.min.js"></script>

--- a/app/extensions/brave/about-safebrowsing.html
+++ b/app/extensions/brave/about-safebrowsing.html
@@ -7,6 +7,7 @@
     <meta charset="utf-8">
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
+    <meta name="referrer" content="no-referrer">
     <meta name='theme-color' content='#ff5000'>
     <title data-l10n-id="safebrowsingError"></title>
     <script src="ext/l20n.min.js"></script>

--- a/app/extensions/brave/about-styles.html
+++ b/app/extensions/brave/about-styles.html
@@ -8,6 +8,7 @@
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
     <meta name='theme-color' content='#4B0082'>
+    <meta name="referrer" content="no-referrer">
     <link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,">
     <title data-l10n-id="styleGuide"></title>
     <script src="ext/l20n.min.js"></script>

--- a/app/extensions/torrent/webtorrent.html
+++ b/app/extensions/torrent/webtorrent.html
@@ -7,6 +7,7 @@
     <meta charset="utf-8">
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
+    <meta name="referrer" content="no-referrer">
     <link rel="shortcut icon" type="image/x-icon" href="img/webtorrent-128.png">
     <title data-l10n-id="webtorrentPage"></title>
     <script src="ext/l20n.min.js"></script>


### PR DESCRIPTION
Test Plan:
1. go to downloadme.org. it should redirect to about:safebrowsing
2. open console. you should not see any referrer errors.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


