### PR TITLE
workaround to fix about:safebrowsing redirect

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -144,7 +144,9 @@ function registerForBeforeRequest (session, partition) {
           }))
 
         if (parentResourceName === appConfig.resourceNames.SAFE_BROWSING) {
-          cb({ redirectURL: appUrlUtil.getTargetAboutUrl('about:safebrowsing#' + details.url) })
+          cb({ cancel: true })
+          appActions.loadURLRequested(details.tabId,
+            appUrlUtil.getTargetAboutUrl('about:safebrowsing#' + details.url))
         } else if (details.resourceType === 'image') {
           cb({ redirectURL: transparent1pxGif })
         } else {

--- a/js/about/entry.js
+++ b/js/about/entry.js
@@ -37,8 +37,12 @@ const ipc = window.chrome.ipcRenderer
 let element
 
 ipc.on('language', (e, detail) => {
-  document.l10n.requestLanguages([detail.langCode])
-  document.getElementsByName('availableLanguages')[0].content = detail.languageCodes.join(', ')
+  if (document.l10n) {
+    document.l10n.requestLanguages([detail.langCode])
+    document.getElementsByName('availableLanguages')[0].content = detail.languageCodes.join(', ')
+  } else {
+    console.error('Missing document.l10n object.')
+  }
 })
 ipc.send('request-language')
 

--- a/test/bravery-components/safebrowsingTest.js
+++ b/test/bravery-components/safebrowsingTest.js
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* global describe, it, before */
+
+const Brave = require('../lib/brave')
+const {urlInput} = require('../lib/selectors')
+
+describe('safebrowsing interception', function () {
+  function * setup (client) {
+    yield client
+      .waitForBrowserWindow()
+      .waitForVisible(urlInput)
+  }
+
+  Brave.beforeAll(this)
+  before(function * () {
+    this.badUrl = 'http://downloadme.org'
+    this.safebrowsingUrl = `about:safebrowsing#${this.badUrl}`
+    yield setup(this.app.client)
+  })
+
+  it('redirects to safebrowsing URL', function * () {
+    yield this.app.client
+      .tabByIndex(0)
+      .url(this.badUrl)
+      .waitUntil(function () {
+        return this.getText('body').then((val) => {
+          return val.includes('For your safety, Brave has blocked this site')
+        })
+      })
+      .windowByUrl(Brave.browserWindowUrl)
+      .getAttribute(urlInput, 'value').then((value) => {
+        return value === this.safebrowsingUrl
+      })
+  })
+})


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/8905. this is a workaround for the underlying issue, which is that the l20n.min.js resource is blocked when `about:safebrowsing` is redirected to from a remote page instead of loaded directly. 

Test Plan:
1. safebrowsing test should pass
2. go to downloadme.org. it should redirect to the safebrowsing page and the page should not be blank or have missing text.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


