### PR TITLE
Add ability to update to a preview release

### DIFF
--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -350,6 +350,7 @@ importNow=Import now…
 clearAll=Clear all
 sendCrashReports=Send anonymous crash reports to Brave *
 sendUsageStatistics=Automatically send usage statistics to Brave
+updateToPreviewReleases=Update to preview releases *
 bookmarksBarTextOnly=Text only
 bookmarksBarTextAndFavicon=Text and Favicons
 bookmarksBarFaviconOnly=Favicons only

--- a/app/index.js
+++ b/app/index.js
@@ -469,6 +469,7 @@ app.on('ready', () => {
 
       // This is fired by a menu entry
       process.on(messages.CHECK_FOR_UPDATE, () => Updater.checkForUpdate(true))
+      ipcMain.on(messages.CHECK_FOR_UPDATE, () => Updater.checkForUpdate(true))
 
       // This is fired from a auto-update metadata call
       process.on(messages.UPDATE_META_DATA_RETRIEVED, (metadata) => {

--- a/app/renderer/components/preferences/advancedTab.js
+++ b/app/renderer/components/preferences/advancedTab.js
@@ -28,6 +28,7 @@ class AdvancedTab extends ImmutableComponent {
       <main className={css(styles.advancedTabMain)}>
         <DefaultSectionTitle data-l10n-id='contentSettings' />
         <SettingsList>
+          <SettingCheckbox dataL10nId='updateToPreviewReleases' prefKey={settings.UPDATE_TO_PREVIEW_RELEASES} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
           <SettingCheckbox dataL10nId='useHardwareAcceleration' prefKey={settings.HARDWARE_ACCELERATION_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
           <SettingCheckbox dataL10nId='useSmoothScroll' prefKey={settings.SMOOTH_SCROLL_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
           <SettingCheckbox dataL10nId='sendCrashReports' prefKey={settings.SEND_CRASH_REPORTS} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />

--- a/app/updater.js
+++ b/app/updater.js
@@ -44,6 +44,7 @@ var platforms = {
 // It is set in the init function
 var platformBaseUrl = null
 var version = null
+var updateToPreviewReleases = false
 
 // build the complete update url from the base, platform and version
 exports.updateUrl = function (updates, platform, arch) {
@@ -84,21 +85,26 @@ var scheduleUpdates = () => {
 }
 
 // set the feed url for the auto-update system
-exports.init = (platform, arch, ver) => {
+exports.init = (platform, arch, ver, updateToPreview) => {
   // When starting up we should not expect an update to be available
   appActions.setUpdateStatus(UpdateStatus.UPDATE_NONE)
 
   // Browser version X.X.X
   version = ver
 
+  // Flag controlling whether preview releases are accepted
+  updateToPreviewReleases = updateToPreview
+
   var baseUrl = exports.updateUrl(appConfig.updates, platform, arch)
+  var query = { accept_preview: updateToPreviewReleases ? 'true' : 'false' }
 
   if (baseUrl) {
     debug(`updateUrl = ${baseUrl}`)
     scheduleUpdates()
     // This will fail if we are in dev
     try {
-      autoUpdater.setFeedURL(baseUrl)
+      // add the preview flag to the base feed url
+      autoUpdater.setFeedURL(`${baseUrl}?${querystring.stringify(query)}`)
     } catch (err) {
       console.log(err)
     }
@@ -145,6 +151,7 @@ var requestVersionInfo = (done, pingOnly) => {
     lastCheckMonth,
     firstCheckMade
   )
+  query.accept_preview = updateToPreviewReleases ? 'true' : 'false'
   var queryString = `${platformBaseUrl}?${querystring.stringify(query)}`
   debug(queryString)
 

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -805,7 +805,7 @@ class AboutPreferences extends React.Component {
         key === settings.DO_NOT_TRACK ||
         key === settings.LANGUAGE ||
         key === settings.PDFJS_ENABLED || key === settings.TORRENT_VIEWER_ENABLED ||
-        key === settings.SMOOTH_SCROLL_ENABLED || key === settings.SEND_CRASH_REPORTS) {
+        key === settings.SMOOTH_SCROLL_ENABLED || key === settings.SEND_CRASH_REPORTS || key === settings.UPDATE_TO_PREVIEW_RELEASES) {
       ipc.send(messages.PREFS_RESTART, key, value)
     }
     if (key === settings.PAYMENTS_ENABLED) {

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -186,6 +186,7 @@ module.exports = {
     'advanced.smooth-scroll-enabled': false,
     'advanced.send-crash-reports': true,
     'advanced.send-usage-statistics': false,
+    'advanced.update-to-preview-releases': false,
     'advanced.hide-excluded-sites': false,
     'advanced.minimum-visit-time': 8000,
     'advanced.minimum-visits': 1,

--- a/js/constants/settings.js
+++ b/js/constants/settings.js
@@ -68,6 +68,7 @@ const settings = {
   SMOOTH_SCROLL_ENABLED: 'advanced.smooth-scroll-enabled',
   SEND_CRASH_REPORTS: 'advanced.send-crash-reports',
   SEND_USAGE_STATISTICS: 'advanced.send-usage-statistics',
+  UPDATE_TO_PREVIEW_RELEASES: 'advanced.update-to-preview-releases',
   ADBLOCK_CUSTOM_RULES: 'adblock.customRules',
   HIDE_EXCLUDED_SITES: 'advanced.hide-excluded-sites',
   HIDE_LOWER_SITES: 'advanced.hide-lower-sites',


### PR DESCRIPTION
  * Add advanced preference to update to preview releases
  * Add parameter sent to the updater service to allow preview releases
  * Re-factor method to retrieve version for the current browser

Auditors: @bbondy, @bsclifton

Test plan:

This pull request has been extensively tested with a manual
parallel update system. It has been tested on both windows and
mac with the following scenarios:

  a) preview off - confirmed update to subsequent release version
  b) preview off - confirmed no update to preview version
  c) preview on - confirmed update to subsequent preview version

This change set is dependent on having the most current version
of the updater, with preview support, installed.

Relates to #8769

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


