### PR TITLE
Fix URLbar typing fast after newtab getting cleared

### DIFF
--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -389,11 +389,15 @@ class UrlBar extends React.Component {
         // Each tab has a focused state stored separately
         if (this.props.isFocused) {
           this.focus()
+          this.select()
         }
         windowActions.setRenderUrlBarSuggestions(false)
       } else if (this.props.location !== prevProps.location) {
         // This is a url nav change
-        this.setValue(UrlUtil.getDisplayLocation(this.props.location, pdfjsEnabled))
+        // This covers the case of user typing fast on newtab when they have lag from lots of bookmarks.
+        if (!(prevProps.location === 'about:blank' && this.props.location === 'about:newtab' && this.props.locationValue !== 'about:blank')) {
+          this.setValue(UrlUtil.getDisplayLocation(this.props.location, pdfjsEnabled))
+        }
       } else if (this.props.hasSuggestionMatch &&
                 this.props.isActive &&
                 this.props.locationValueSuffix !== this.lastSuffix) {

--- a/test/navbar-components/urlBarTest.js
+++ b/test/navbar-components/urlBarTest.js
@@ -618,6 +618,28 @@ describe('urlBar tests', function () {
     })
   })
 
+  describe('Typing fast with newtab does not clear user input', function () {
+    Brave.beforeAll(this)
+
+    before(function * () {
+      const input = 'brianbondy.com/projects'
+      yield setup(this.app.client)
+      yield this.app.client.waitForExist(urlInput)
+      yield this.app.client.waitForElementFocus(urlInput)
+      yield this.app.client
+        .waitForInputText(urlInput, '')
+        .windowByUrl(Brave.browserWindowUrl)
+        .newTab()
+        .waitForElementFocus(urlInput)
+        .keys(input)
+        .waitForInputText(urlInput, input)
+    })
+
+    it('Retains user input on tab switches', function () {
+      tabLoadingTest('')
+    })
+  })
+
   describe('loading same URL as current page with changed input', function () {
     Brave.beforeAll(this)
 


### PR DESCRIPTION
Submitter Checklist:

Fix #8959

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


