### PR TITLE
Clicking on disabled Ad/Tracker count enables the <li> element under braveryPanelBody

### DIFF
--- a/app/renderer/components/main/braveryPanel.js
+++ b/app/renderer/components/main/braveryPanel.js
@@ -238,7 +238,7 @@ class BraveryPanel extends ImmutableComponent {
         <div className='braveryPanelBody'>
           <ul>
             {
-              this.isBlockedAdsShown
+              this.isBlockedAdsShown && (this.isBlockingAds || this.isBlockingTrackedContent)
               ? <li><ul>
                 {
                   this.isBlockingAds


### PR DESCRIPTION
Fix #7026
Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
Click on shield when Ads and trackers count is 0.
No space anymore because of empty `<li>` element
Reviewer Checklist:

Tests

<img width="514" alt="screen shot 2017-05-19 at 9 35 39 pm" src="https://cloud.githubusercontent.com/assets/4078325/26257187/4af7a9f2-3cdd-11e7-9683-891e703e262e.png">

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


