### PR TITLE
fix webgl antifingerprint regression

### DIFF
--- a/app/extensions/brave/content/scripts/blockCanvasFingerprinting.js
+++ b/app/extensions/brave/content/scripts/blockCanvasFingerprinting.js
@@ -121,8 +121,7 @@ if (chrome.contentSettings.canvasFingerprinting == 'block') {
       propName: method
     }
     methods.push(item)
-    item.objName = 'WebGL2RenderingContext',
-    methods.push(item)
+    methods.push(Object.assign({}, item, {objName: 'WebGL2RenderingContext'}))
   })
 
   var audioBufferMethods = ['copyFromChannel', 'getChannelData']


### PR DESCRIPTION
fix #8961

Test Plan:
1. https://jsfiddle.net/bkf50r8v/13/ should show no webgl fingerprint results with 'Fingerprinting Protection' enabled
2.  https://browserleaks.com/webgl with fingerprint protection on:  report hash should be '0C21A6FA2A9BD79DFF6E128FE55094B4', the image hash should be empty, all the fields under the triangle image should be empty

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


