### PR TITLE
Fix problems with file:/// URLs

### DIFF
--- a/app/common/lib/suggestion.js
+++ b/app/common/lib/suggestion.js
@@ -234,8 +234,8 @@ const getSortByDomain = (userInputLower, userInputHost) => {
     // any count or frequency calculation.
     // Note that for parsed URLs that are not complete, the pathname contains
     // what the user is entering as the host and the host is null.
-    const host1 = s1.parsedUrl.host || s1.parsedUrl.pathname
-    const host2 = s2.parsedUrl.host || s2.parsedUrl.pathname
+    const host1 = s1.parsedUrl.host || s1.parsedUrl.pathname || s1.location || ''
+    const host2 = s2.parsedUrl.host || s2.parsedUrl.pathname || s2.location || ''
 
     let pos1 = host1.indexOf(userInputHost)
     let pos2 = host2.indexOf(userInputHost)

--- a/test/bravery-components/noScriptTest.js
+++ b/test/bravery-components/noScriptTest.js
@@ -78,6 +78,26 @@ describe('noscript info', function () {
       .loadUrl(this.url)
       .waitForTextValue(result, '2')
   })
+
+  it('can allow scripts on a file:// URL without allowing all scripts', function * () {
+    const fileUrl = Brave.fixtureUrl('noscript2.html')
+    yield this.app.client
+      .tabByIndex(0)
+      .loadUrl(fileUrl)
+      .windowByUrl(Brave.browserWindowUrl)
+      .waitForVisible(noScriptNavButton)
+      .click(noScriptNavButton)
+      .waitForVisible(noScriptAllowTempButton)
+      .click(noScriptAllowTempButton)
+      .tabByIndex(0)
+      .loadUrl(fileUrl)
+      .waitForTextValue(result, 'scripts running')
+      .windowByUrl(Brave.browserWindowUrl)
+      .tabByIndex(0)
+      .loadUrl(this.url)
+      .windowByUrl(Brave.browserWindowUrl)
+      .waitForVisible(noScriptNavButton)
+  })
 })
 
 describe('noscript', function () {

--- a/test/fixtures/noscript2.html
+++ b/test/fixtures/noscript2.html
@@ -1,0 +1,8 @@
+<body>
+    <div id='result'></div>
+    <script>
+        var result = document.getElementById('result')
+        result.innerText = 'scripts running'
+    </script>
+    <script src='noscript2.js' />
+</body>

--- a/test/fixtures/noscript2.js
+++ b/test/fixtures/noscript2.js
@@ -1,0 +1,1 @@
+console.log(1)

--- a/test/unit/app/common/lib/suggestionTest.js
+++ b/test/unit/app/common/lib/suggestionTest.js
@@ -250,6 +250,9 @@ describe('suggestion unit tests', function () {
       it('simple domain gets matched higher', function () {
         assert(this.sort('https://www.google.com', 'https://www.google.com/extra') < 0)
       })
+      it('does not throw error for file:// URL', function () {
+        assert(this.sort('https://google.com', 'file://') < 0)
+      })
     })
     describe('getSortForSuggestions', function () {
       describe('with url entered as path', function () {


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/8967, fix https://github.com/brave/browser-laptop/issues/8947

test plan:
1. automated unittest and noscript test should pass
2. disable scripts globally. open test/fixtures/noscript2.html as a file:// URL in brave
3. open a new tab and type 'fi'. there should be no console errors.
4. in the file:// tab, click the noscript icon and 'allow until restart'
5. in a new tab, go to nytimes.com. you should see that scripts are blocked.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


