### PR TITLE
Fix various suggestion sort issues

### DIFF
--- a/app/common/lib/siteSuggestions.js
+++ b/app/common/lib/siteSuggestions.js
@@ -25,8 +25,13 @@ const getSiteIdentity = (data) => {
 }
 
 const init = (sites) => {
+  sites = sites.toJS ? sites.toJS() : sites
+  // Sort sites with smaller count first because later ones will overwrite with correct counts based on the site identity.
+  // This can happen when a user bookmarks the same site multiple times, but only one of the items are getting counts
+  // incremented by normal operations.
+  sites = sites.sort((s1, s2) => (s1.count || 0) - (s2.count || 0))
   engine = new Bloodhound({
-    local: sites.toJS ? sites.toJS() : sites,
+    local: sites,
     sorter: sortForSuggestions,
     queryTokenizer: tokenizeInput,
     datumTokenizer: tokenizeInput,

--- a/test/navbar-components/urlBarTest.js
+++ b/test/navbar-components/urlBarTest.js
@@ -332,7 +332,7 @@ describe('urlBar tests', function () {
         .waitForVisible(urlBarSuggestions)
         // highlight for autocomplete brianbondy.com
         .moveToObject(urlBarSuggestions, 0, 100)
-      yield selectsText(this.app.client, 'rave.com/test3')
+      yield selectsText(this.app.client, 'rave.com/test2')
         .keys('rian')
         .execute(function (urlBarSuggestions) {
           document.querySelector(urlBarSuggestions).scrollTop = 200


### PR DESCRIPTION
- Handle bookmarks that appear twice in folders with different counts.
- Handle comparing items with no counts.
- Handle comparing items with no lastAccessedTime
- Handle sorting 2 sites when one is a substring of the other, match the
  shorter one first.
- Fixed an issue with Immutable data sometimes being used in the
    sorting functions, and adds an assert to make sure it's correctly
    used.
- Support `javascript:` bookmarklets
- Avoid re-sorting suggestions that are generated
- Adds lots of tests

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


