### PR TITLE
Update tab bookmarked state

### DIFF
--- a/app/browser/reducers/sitesReducer.js
+++ b/app/browser/reducers/sitesReducer.js
@@ -21,13 +21,20 @@ const syncEnabled = () => {
   return getSetting(settings.SYNC_ENABLED) === true
 }
 
+const updateTabBookmarked = (state, tabValue) => {
+  if (!tabValue || !tabValue.get('tabId')) {
+    return state
+  }
+  const bookmarked = siteUtil.isLocationBookmarked(state, tabValue.get('url'))
+  return tabState.updateTabValue(state, tabValue.set('bookmarked', bookmarked))
+}
+
 const updateActiveTabBookmarked = (state) => {
   const tab = tabState.getActiveTab(state)
   if (!tab) {
     return state
   }
-  const bookmarked = siteUtil.isLocationBookmarked(state, tab.get('url'))
-  return tabState.updateTabValue(state, tab.set('bookmarked', bookmarked))
+  return updateTabBookmarked(state, tab)
 }
 
 const sitesReducer = (state, action, immutableAction) => {
@@ -135,6 +142,7 @@ const sitesReducer = (state, action, immutableAction) => {
           state = syncUtil.updateSiteCache(state, siteDetail)
         }
       }
+      state = updateTabBookmarked(state, action.tabValue)
       break
     case appConstants.APP_CREATE_TAB_REQUESTED: {
       const createProperties = immutableAction.get('createProperties')

--- a/test/bookmark-components/bookmarksTest.js
+++ b/test/bookmark-components/bookmarksTest.js
@@ -1,4 +1,4 @@
-/* global describe, it, before */
+/* global describe, it, before, beforeEach */
 
 const Brave = require('../lib/brave')
 const Immutable = require('immutable')
@@ -246,6 +246,41 @@ describe('bookmark tests', function () {
           .waitForVisible(doneButton)
           .waitForInputText(bookmarkLocationInput, page1Url)
       })
+    })
+  })
+
+  describe('bookmark star button is preserved', function () {
+    Brave.beforeEach(this)
+    beforeEach(function * () {
+      this.page1Url = Brave.server.url('page1.html')
+      this.page2Url = Brave.server.url('page2.html')
+      yield setup(this.app.client)
+      yield this.app.client
+        .addSite({
+          location: this.page1Url,
+          folderId: 1,
+          parentFolderId: 0,
+          tags: [siteTags.BOOKMARK]
+        }, siteTags.BOOKMARK)
+    })
+
+    it('on new active tabs', function * () {
+      yield this.app.client
+        .waitForVisible(navigatorNotBookmarked)
+        .newTab({ url: this.page1Url })
+        .waitForVisible(navigatorBookmarked)
+    })
+    it('on new active tabs', function * () {
+      yield this.app.client
+        .waitForVisible(navigatorNotBookmarked)
+        .newTab({ url: this.page1Url, active: false })
+        .waitForUrl(this.page1Url)
+        .tabByIndex(0)
+        .loadUrl(this.page2Url)
+        .waitForUrl(this.page2Url)
+        .windowByUrl(Brave.browserWindowUrl)
+        .ipcSend('shortcut-next-tab')
+        .waitForVisible(navigatorBookmarked)
     })
   })
 


### PR DESCRIPTION
Fix #8977

Auditors: @bsclifton @bbondy

Test Plan:
1. Open https://github.com
2. Bookmark the page
3. Click the middle mouse button to open it in a new tab and switch to the new tab quickly (before it finishes loading)
4. Tab should have bookmark star icon

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


