### PR TITLE
Avoid iterating all sites on every about page

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -131,6 +131,23 @@ ipcMain.on(messages.ABOUT_COMPONENT_INITIALIZED, (e) => {
   })
 })
 
+const getBookmarksData = function (state) {
+  let bookmarkSites = new Immutable.Map()
+  let bookmarkFolderSites = new Immutable.Map()
+  state.get('sites').forEach((site, siteKey) => {
+    const tags = site.get('tags')
+    if (tags.includes(siteTags.BOOKMARK)) {
+      bookmarkSites = bookmarkSites.set(siteKey, site)
+    }
+    if (tags.includes(siteTags.BOOKMARK_FOLDER)) {
+      bookmarkFolderSites = bookmarkFolderSites.set(siteKey, site)
+    }
+  })
+  const bookmarks = bookmarkSites.toList().sort(siteUtil.siteSort).toJS()
+  const bookmarkFolders = bookmarkFolderSites.toList().sort(siteUtil.siteSort).toJS()
+  return {bookmarks, bookmarkFolders}
+}
+
 const updateAboutDetails = (tab, tabValue) => {
   const appState = appStore.getState()
   const url = getSourceAboutUrl(tab.getURL())
@@ -146,8 +163,6 @@ const updateAboutDetails = (tab, tabValue) => {
     allSiteSettings = allSiteSettings.mergeDeep(appState.get('temporarySiteSettings'))
   }
   const extensionsValue = appState.get('extensions')
-  const bookmarks = appState.get('sites').filter((site) => site.get('tags').includes(siteTags.BOOKMARK)).toList().sort(siteUtil.siteSort)
-  const bookmarkFolders = appState.get('sites').filter((site) => site.get('tags').includes(siteTags.BOOKMARK_FOLDER)).toList().sort(siteUtil.siteSort)
   const sync = appState.get('sync')
   const braveryDefaults = siteSettings.braveryDefaults(appState, appConfig)
   const history = aboutHistoryState.getHistory(appState)
@@ -170,11 +185,11 @@ const updateAboutDetails = (tab, tabValue) => {
     tab.send(messages.SYNC_UPDATED, sync.toJS())
     tab.send(messages.BRAVERY_DEFAULTS_UPDATED, braveryDefaults)
     tab.send(messages.EXTENSIONS_UPDATED, extensionsValue.toJS())
-  } else if (location === 'about:bookmarks' && bookmarks) {
-    tab.send(messages.BOOKMARKS_UPDATED, {
-      bookmarks: bookmarks.toJS(),
-      bookmarkFolders: bookmarkFolders.toJS()
-    })
+  } else if (location === 'about:bookmarks') {
+    const bookmarksData = getBookmarksData(appState)
+    if (bookmarksData.bookmarks) {
+      tab.send(messages.BOOKMARKS_UPDATED, bookmarksData)
+    }
   } else if (location === 'about:history') {
     if (!history) {
       appActions.populateHistory()


### PR DESCRIPTION
Fix #9004

With 10K bookmarks, saves 350 ms every new tab!

Auditors: @bsclifton

Test Plan:

0. Check that tests pass.
1. Bookmark a page
2. Make a bookmark folder
3. Open Bookmarks manager and confirm bookmark page and folder.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


