### PR TITLE
Remove downloadsBarOffset for new coordinate calculation

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -77,11 +77,6 @@ const addFolderMenuItem = (closestDestinationDetail, isParent) => {
   }
 }
 
-const getDownloadsBarHeight = () => {
-  const root = window.getComputedStyle(document.querySelector(':root'))
-  return Number.parseInt(root.getPropertyValue('--downloads-bar-height'), 10)
-}
-
 function tabPageTemplateInit (framePropsList) {
   return [{
     label: locale.translation('unmuteTabs'),
@@ -1455,8 +1450,6 @@ function onShowBookmarkFolderMenu (bookmarks, bookmark, activeFrame, e) {
 
 function onShowAutofillMenu (suggestions, targetRect, frame, boundingClientRect) {
   const menuTemplate = autofillTemplateInit(suggestions, frame)
-  const downloadsBarOffset = windowStore.getState().getIn(['ui', 'downloadsToolbar', 'isVisible']) &&
-    appStore.state.get('downloads') && appStore.state.get('downloads').size ? getDownloadsBarHeight() : 0
   // toolbar UI scale ratio
   const xRatio = window.innerWidth / window.outerWidth
   const yRatio = window.innerHeight / window.outerHeight
@@ -1465,7 +1458,7 @@ function onShowAutofillMenu (suggestions, targetRect, frame, boundingClientRect)
     type: 'autofill',
     tabId,
     left: boundingClientRect.left + (targetRect.x * xRatio),
-    top: boundingClientRect.top + ((targetRect.y + targetRect.height) * yRatio) - downloadsBarOffset,
+    top: boundingClientRect.top + ((targetRect.y + targetRect.height) * yRatio),
     template: menuTemplate
   }))
 }


### PR DESCRIPTION
fix #9020

Auditors: @bsclifton, @bbondy

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:
1. Open about:autofill
2. Create an entry
3. Open www.roboform.com/filling-test-all-fields
4. Download that page
5. Trigger the autofill pulldown with different UI scale

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


