### PR TITLE
Remove darkening for all non-modal dialogs

### DIFF
--- a/app/renderer/components/common/dialog.js
+++ b/app/renderer/components/common/dialog.js
@@ -43,6 +43,7 @@ class Dialog extends ImmutableComponent {
   render () {
     return <div className={cx({
       [css(styles.dialog)]: true,
+      [css(styles.dialog_isNotClickDismiss)]: !this.props.isClickDismiss,
       [this.props.className]: !!this.props.className
     })}
       data-test-id={this.props.testId}
@@ -77,7 +78,9 @@ const styles = StyleSheet.create({
     zIndex: globalStyles.zindex.zindexDialogs,
     display: 'flex',
     justifyContent: 'center',
-    alignItems: 'center',
+    alignItems: 'center'
+  },
+  dialog_isNotClickDismiss: {
     background: 'rgba(0, 0, 0, 0.15)'
   }
 })

--- a/app/renderer/components/common/dialog.js
+++ b/app/renderer/components/common/dialog.js
@@ -43,7 +43,7 @@ class Dialog extends ImmutableComponent {
   render () {
     return <div className={cx({
       [css(styles.dialog)]: true,
-      [css(styles.dialog_isNotClickDismiss)]: !this.props.isClickDismiss,
+      [css(styles.dialog_isNotClickDismiss)]: !this.props.isClickDismiss || this.props.isBraveryPanel,
       [this.props.className]: !!this.props.className
     })}
       data-test-id={this.props.testId}
@@ -65,6 +65,7 @@ Dialog.propTypes = {
   ]),
   className: PropTypes.string,
   isClickDismiss: PropTypes.bool,
+  isBraveryPanel: PropTypes.bool,
   onHide: PropTypes.func
 }
 

--- a/app/renderer/components/main/braveryPanel.js
+++ b/app/renderer/components/main/braveryPanel.js
@@ -242,7 +242,7 @@ class BraveryPanel extends ImmutableComponent {
     })
     const compactBraveryPanel = getSetting(settings.COMPACT_BRAVERY_PANEL)
 
-    return <Dialog onHide={this.props.onHide} testId='braveryPanelContainer' isClickDismiss>
+    return <Dialog onHide={this.props.onHide} testId='braveryPanelContainer' isClickDismiss isBraveryPanel>
       <div className={css(
         commonStyles.flyoutDialog,
         styles.braveryPanel,


### PR DESCRIPTION
If 'isClickDismiss' is specified to a Dialog, its background color will be transparent. Otherwise it will be gray.

Fix #3653

Auditors:

Test Plan 1:
1. Open http://browserspy.dk/password.php
2. Click "password-ok.php"
3. Make sure darkening effect does not occur
4. Click the outside of the dialog
5. Make sure the dialog is closed

Test Plan 2:
1. Disable widevine
2. Open netflix.com
3. Make sure widevine dialog with the dark background appears
4. Click the outside of the dialog
5. Make sure the dialog is not closed

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


