### PR TITLE
Fix bookmark hanger dialog alignment bug

### DIFF
--- a/app/renderer/components/bookmarks/addEditBookmarkHanger.js
+++ b/app/renderer/components/bookmarks/addEditBookmarkHanger.js
@@ -321,8 +321,9 @@ const styles = StyleSheet.create({
   },
 
   bookmarkHanger: {
-    justifyContent: 'flex-start',
-    background: 'none',
+    // See: #9040
+    justifyContent: 'flex-start !important',
+    background: 'none !important',
 
     // TODO: refactor navigationBar.less to remove !important
     animation: 'none !important',


### PR DESCRIPTION
Closes #9040 
Follow-up to https://github.com/brave/browser-laptop/pull/8985#issuecomment-303945565

Auditors:

Test Plan 1:
1. Click the star icon on the URL bar
2. Make sure the bookmark hanger appears under the star icon, not at the center of the browser window

Test Plan 2:
1. "Add bookmark" on the bookmark toolbar
2. Make sure the bookmark dialog appears at the center of the browser window

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


