### PR TITLE
Temporary fix for #9056

### DIFF
--- a/app/adBlock.js
+++ b/app/adBlock.js
@@ -32,6 +32,10 @@ module.exports.safeBrowsingResourceName = 'safeBrowsing'
  *   for example safe browsing checks main frame URLs but ad block checks do not.
  */
 const startAdBlocking = (adblock, resourceName, shouldCheckMainFrame) => {
+  if (resourceName === module.exports.safeBrowsingResourceName) {
+    // Needed for #9056
+    module.exports.safeBrowsingInstance = adblock
+  }
   Filtering.registerBeforeRequestFilteringCB((details) => {
     const mainFrameUrl = Filtering.getMainFrameUrl(details)
     // this can happen if the tab is closed and the webContents is no longer available

--- a/app/filtering.js
+++ b/app/filtering.js
@@ -144,9 +144,10 @@ function registerForBeforeRequest (session, partition) {
           }))
 
         if (parentResourceName === appConfig.resourceNames.SAFE_BROWSING) {
-          cb({ cancel: true })
-          appActions.loadURLRequested(details.tabId,
-            appUrlUtil.getTargetAboutUrl('about:safebrowsing#' + details.url))
+          let redirectURL = appUrlUtil.getTargetAboutUrl('about:safebrowsing#' + details.url)
+          cb({ redirectURL })
+          // Workaround #8905
+          appActions.loadURLRequested(details.tabId, redirectURL)
         } else if (details.resourceType === 'image') {
           cb({ redirectURL: transparent1pxGif })
         } else {

--- a/test/fixtures/safebrowsing.html
+++ b/test/fixtures/safebrowsing.html
@@ -1,0 +1,1 @@
+<a id='clickme' href='http://downloadme.org'>clickme</a>


### PR DESCRIPTION

Test Plan:
1. go to http://alexwykoff.com/tests/testlinks.html
2. open downloadme.org directly in the urlbar, via a link, via right-click to open in new tab, and via cmd+click. all should eventually redirect to the safebrowsing page, and the safebrowsing text should be visible.
3. safebrowsing travis test should still pass
4. go to about:preferences#shields and disable safebrowsing
5. go back to  http://alexwykoff.com/tests/testlinks.html and cmd+click on downloadme.org. the site should now load.

this is a temporary workaround. it causes the safebrowsing page to flicker while loading in some cases.
