### PR TITLE
Add webdriver test to noScript exceptions on compact bravery panel and apply .changeSetting

### DIFF
--- a/test/bravery-components/braveryPanelTest.js
+++ b/test/bravery-components/braveryPanelTest.js
@@ -648,6 +648,57 @@ describe('Bravery Panel', function () {
         .keys(Brave.keys.ESCAPE)
         .waitForVisible(noScriptNavButton)
     })
+    it('does not apply exceptions from private tabs to regular tabs on compact panel', function * () {
+      const url = Brave.server.url('scriptBlock.html')
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(prefsShieldsUrl)
+        .waitForVisible(compactBraveryPanelSwitch)
+        .click(compactBraveryPanelSwitch)
+        .windowByUrl(Brave.browserWindowUrl)
+        .keys(Brave.keys.ESCAPE)
+
+        .tabByIndex(0)
+        .loadUrl(url)
+        .waitForTextValue('body', 'test1 test2')
+        .openBraveMenu(braveMenu, braveryPanelCompact)
+        .click(noScriptSwitch)
+        .waitForTextValue(noScriptStat, '2')
+        .keys(Brave.keys.ESCAPE)
+        .waitForVisible(noScriptNavButton)
+
+        .newTab({ url, isPrivate: true })
+        .waitForTabCount(2)
+        .waitForUrl(url)
+        .waitUntil(function () {
+          // getText returns empty in this case
+          return this.getElementSize('noscript')
+            .then((size) => size.height > 0)
+        })
+        .openBraveMenu(braveMenu, braveryPanelCompact)
+        .waitForTextValue(noScriptStat, '2')
+        .keys(Brave.keys.ESCAPE)
+        .waitForVisible(noScriptNavButton)
+
+        .openBraveMenu(braveMenu, braveryPanelCompact)
+        .click(noScriptSwitch)
+        .waitForTextValue(noScriptStat, '0')
+        .keys(Brave.keys.ESCAPE)
+
+        .newTab({ url })
+        .waitForTabCount(3)
+        .waitForUrl(url)
+        .waitUntil(function () {
+          // getText returns empty in this case
+          return this.getElementSize('noscript')
+            .then((size) => size.height > 0)
+        })
+        .openBraveMenu(braveMenu, braveryPanelCompact)
+        .waitForTextValue(noScriptStat, '2')
+        .keys(Brave.keys.ESCAPE)
+        .waitForVisible(noScriptNavButton)
+    })
+
     it('shows noscript tag content', function * () {
       const url = Brave.server.url('scriptBlock.html')
       yield this.app.client

--- a/test/bravery-components/braveryPanelTest.js
+++ b/test/bravery-components/braveryPanelTest.js
@@ -23,6 +23,7 @@ const {
 } = require('../lib/selectors')
 const {getTargetAboutUrl} = require('../../js/lib/appUrlUtil')
 const prefsShieldsUrl = 'about:preferences#shields'
+const settings = require('../../js/constants/settings')
 
 describe('Bravery Panel', function () {
   function * setup (client) {
@@ -79,11 +80,9 @@ describe('Bravery Panel', function () {
         .click(showAdsOption)
         .waitForTextValue(adsBlockedStat, '0')
 
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
         .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
+
         .windowByUrl(Brave.browserWindowUrl)
         .newTab({ url, isPrivate: true })
         .waitForTabCount(3)
@@ -108,11 +107,9 @@ describe('Bravery Panel', function () {
         .click(showAdsOption)
         .waitForTextValue(adsBlockedStat, '0')
 
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
         .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
+
         .windowByUrl(Brave.browserWindowUrl)
         .tabByIndex(0)
         .loadUrl(url)
@@ -168,11 +165,9 @@ describe('Bravery Panel', function () {
         .click(blockAdsOption)
         .waitForTextValue(adsBlockedStat, '2')
 
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
         .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
+
         .windowByUrl(Brave.browserWindowUrl)
         .newTab({ url, isPrivate: true })
         .waitForTabCount(3)
@@ -218,11 +213,9 @@ describe('Bravery Panel', function () {
         .click(blockAdsOption)
         .waitForTextValue(adsBlockedStat, '2')
 
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
         .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
+
         .windowByUrl(Brave.browserWindowUrl)
         .newTab({ url })
         .waitForTabCount(2)
@@ -256,13 +249,10 @@ describe('Bravery Panel', function () {
         .click(blockAdsOption)
         .waitForTextValue(adsBlockedStat, '1')
 
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
         .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
-        .windowByUrl(Brave.browserWindowUrl)
 
+        .windowByUrl(Brave.browserWindowUrl)
         .newTab({ url, isPrivate: true })
         .waitForTabCount(3)
         .waitForUrl(url)
@@ -296,13 +286,10 @@ describe('Bravery Panel', function () {
         .click(blockAdsOption)
         .waitForTextValue(adsBlockedStat, '1')
 
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
         .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
-        .windowByUrl(Brave.browserWindowUrl)
 
+        .windowByUrl(Brave.browserWindowUrl)
         .newTab({ url })
         .waitForTabCount(3)
         .waitForUrl(url)
@@ -349,13 +336,10 @@ describe('Bravery Panel', function () {
         .click(blockAdsOption)
         .waitForTextValue(adsBlockedStat, '2')
 
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
         .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
-        .windowByUrl(Brave.browserWindowUrl)
 
+        .windowByUrl(Brave.browserWindowUrl)
         .newTab({ url, isPrivate: true })
         .waitForTabCount(3)
         .waitForUrl(url)
@@ -403,13 +387,10 @@ describe('Bravery Panel', function () {
         .click(blockAdsOption)
         .waitForTextValue(adsBlockedStat, '2')
 
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
         .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
-        .windowByUrl(Brave.browserWindowUrl)
 
+        .windowByUrl(Brave.browserWindowUrl)
         .newTab({ url })
         .waitForTabCount(3)
         .waitForUrl(url)
@@ -440,13 +421,10 @@ describe('Bravery Panel', function () {
             })
         })
 
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
         .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
-        .windowByUrl(Brave.browserWindowUrl)
 
+        .windowByUrl(Brave.browserWindowUrl)
         .newTab({ url })
         .waitForTabCount(2)
         .waitForUrl(url)
@@ -477,13 +455,10 @@ describe('Bravery Panel', function () {
         .openBraveMenu(braveMenu, braveryPanel)
         .waitForTextValue(httpsEverywhereStat, '1')
 
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
         .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
-        .windowByUrl(Brave.browserWindowUrl)
 
+        .windowByUrl(Brave.browserWindowUrl)
         .newTab({ url, isPrivate: true })
         .waitForTabCount(3)
         .waitForUrl(url)
@@ -500,13 +475,10 @@ describe('Bravery Panel', function () {
         .openBraveMenu(braveMenu, braveryPanel)
         .waitForTextValue(httpsEverywhereStat, '1')
 
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
         .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
-        .windowByUrl(Brave.browserWindowUrl)
 
+        .windowByUrl(Brave.browserWindowUrl)
         .newTab({ url })
         .waitForTabCount(2)
         .waitForUrl(url)
@@ -541,13 +513,10 @@ describe('Bravery Panel', function () {
         .keys(Brave.keys.ESCAPE)
         .waitForElementCount(noScriptNavButton, 0)
 
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
         .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
-        .windowByUrl(Brave.browserWindowUrl)
 
+        .windowByUrl(Brave.browserWindowUrl)
         .newTab({ url })
         .openBraveMenu(braveMenu, braveryPanelCompact)
         .click(noScriptSwitch)
@@ -583,13 +552,10 @@ describe('Bravery Panel', function () {
         .keys(Brave.keys.ESCAPE)
         .waitForElementCount(noScriptNavButton, 0)
 
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
         .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
-        .windowByUrl(Brave.browserWindowUrl)
 
+        .windowByUrl(Brave.browserWindowUrl)
         .newTab({ url, isPrivate: true })
         .openBraveMenu(braveMenu, braveryPanelCompact)
         .click(noScriptSwitch)
@@ -651,11 +617,7 @@ describe('Bravery Panel', function () {
     it('does not apply exceptions from private tabs to regular tabs on compact panel', function * () {
       const url = Brave.server.url('scriptBlock.html')
       yield this.app.client
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
-        .windowByUrl(Brave.browserWindowUrl)
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
         .keys(Brave.keys.ESCAPE)
 
         .tabByIndex(0)
@@ -718,14 +680,10 @@ describe('Bravery Panel', function () {
             .then((size) => size.height > 0)
         })
 
-        .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
         .windowByUrl(Brave.browserWindowUrl)
-
         .keys(Brave.keys.ESCAPE)
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
+
         .tabByIndex(0)
         .loadUrl(url)
         .waitUntil(function () {
@@ -765,14 +723,10 @@ describe('Bravery Panel', function () {
         .loadUrl(url)
         .waitForTextValue('body', expectedBlocked)
 
-        .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
         .windowByUrl(Brave.browserWindowUrl)
-
         .keys(Brave.keys.ESCAPE)
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
+
         .tabByIndex(0)
         .loadUrl(url)
         .openBraveMenu(braveMenu, braveryPanelCompact)
@@ -804,20 +758,17 @@ describe('Bravery Panel', function () {
           })
         })
 
-        .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
         .windowByUrl(Brave.browserWindowUrl)
-
         .keys(Brave.keys.ESCAPE)
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
+
         .tabByIndex(0)
         .loadUrl(url)
         .openBraveMenu(braveMenu, braveryPanelCompact)
         .click(cookieControl)
         .waitForVisible(blockAllCookiesOption)
         .click(allowAllCookiesOption)
+
         .tabByIndex(0)
         .loadUrl(url)
         .waitUntil(function () {
@@ -867,12 +818,7 @@ describe('Bravery Panel', function () {
     it('blocks fingerprinting on compact panel', function * () {
       const url = Brave.server.url('fingerprinting.html')
       yield this.app.client
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
-        .windowByUrl(Brave.browserWindowUrl)
-        .keys(Brave.keys.ESCAPE)
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
 
         .tabByIndex(0)
         .loadUrl(url)
@@ -967,12 +913,8 @@ describe('Bravery Panel', function () {
         .openBraveMenu(braveMenu, braveryPanel)
         .waitForTextValue(fpStat, '0')
 
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
         .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
-        .windowByUrl(Brave.browserWindowUrl)
 
         .newTab({ url, isPrivate: true })
         .waitForTabCount(3)
@@ -990,12 +932,8 @@ describe('Bravery Panel', function () {
         .openBraveMenu(braveMenu, braveryPanel)
         .waitForTextValue(fpStat, '0')
 
+        .changeSetting(settings.COMPACT_BRAVERY_PANEL, true)
         .keys(Brave.keys.ESCAPE)
-        .tabByIndex(0)
-        .loadUrl(prefsShieldsUrl)
-        .waitForVisible(compactBraveryPanelSwitch)
-        .click(compactBraveryPanelSwitch)
-        .windowByUrl(Brave.browserWindowUrl)
 
         .tabByIndex(0)
         .loadUrl(url)


### PR DESCRIPTION
Follow-up to #8837

Because `does not apply exceptions from private tabs to regular tabs` is already complex somewhat, I'm adding another test to cover #8837 on compact bravery panel.

Also I applied `this.app.client.changeSetting` to the other tests with https://github.com/brave/browser-laptop/pull/9075/commits/17c2f041571750816ab4fc92fa9de68885b009b6

Test Plan:

    npm run test -- --grep='does not apply exceptions from private tabs to regular tabs on compact panel'
    npm run test -- --grep='Bravery Panel'

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


