### PR TITLE
Add "view all" option to download bar

### DIFF
--- a/app/extensions/brave/locales/en-US/downloads.properties
+++ b/app/extensions/brave/locales/en-US/downloads.properties
@@ -18,3 +18,5 @@ downloadCopyLinkLocation.title=Copy Link Location
 downloadDelete.title=Delete Download
 downloadOpenPath.title=Open Folder Path
 downloadRemoveFromList.title=Remove Download From List
+
+downloadViewAll=View All

--- a/app/renderer/components/download/downloadsBar.js
+++ b/app/renderer/components/download/downloadsBar.js
@@ -27,7 +27,6 @@ class DownloadsBar extends ImmutableComponent {
     super()
     this.onHideDownloadsToolbar = this.onHideDownloadsToolbar.bind(this)
     this.onShowDownloads = this.onShowDownloads.bind(this)
-    this.downloadBarButtonsNode = null
   }
   onHideDownloadsToolbar () {
     windowActions.setDownloadsToolbarVisible(false)
@@ -40,17 +39,12 @@ class DownloadsBar extends ImmutableComponent {
     })
     windowActions.setDownloadsToolbarVisible(false)
   }
-
   render () {
     const getComputedStyle = require('../../getComputedStyle')
     const downloadItemWidth = Number.parseInt(getComputedStyle('--download-item-width'), 10)
     const downloadItemMargin = Number.parseInt(getComputedStyle('--download-item-margin'), 10)
     const downloadBarPadding = Number.parseInt(getComputedStyle('--download-bar-padding'), 10)
-
-    const downloadBarButtons = this.downloadBarButtonsNode !== null
-                            ? this.downloadBarButtonsNode.getBoundingClientRect().width
-                            : 0
-
+    const downloadBarButtons = Number.parseInt(getComputedStyle('--download-bar-buttons'), 10)
     const numItems = Math.floor((this.props.windowWidth - (downloadBarPadding * 2) - downloadBarButtons) / (downloadItemWidth + downloadItemMargin))
     return <div className='downloadsBar'
       onContextMenu={contextMenus.onDownloadsToolbarContextMenu.bind(null, undefined, undefined)}>
@@ -68,13 +62,10 @@ class DownloadsBar extends ImmutableComponent {
                 downloadsSize={this.props.downloads.size} />)
         }
       </div>
-      <div
-        className={cx({
-          downloadBarButtons: true,
-          [css(styles.downloadsBar__downloadBarButtons)]: true
-        })}
-        ref={refNode => { this.downloadBarButtonsNode = refNode }}
-        >
+      <div className={cx({
+        downloadBarButtons: true,
+        [css(styles.downloadsBar__downloadBarButtons)]: true
+      })}>
         <BrowserButton secondaryColor
           l10nId='downloadViewAll'
           testId='downloadViewAll'

--- a/app/renderer/components/download/downloadsBar.js
+++ b/app/renderer/components/download/downloadsBar.js
@@ -10,7 +10,7 @@ const Button = require('../common/button')
 const BrowserButton = require('../common/browserButton')
 const DownloadItem = require('./downloadItem')
 
-const {StyleSheet} = require('aphrodite/no-important')
+const {StyleSheet, css} = require('aphrodite/no-important')
 
 // Actions
 const windowActions = require('../../../../js/actions/windowActions')
@@ -19,6 +19,8 @@ const appActions = require('../../../../js/actions/appActions')
 
 // Utils
 const contextMenus = require('../../../../js/contextMenus')
+
+const cx = require('../../../../js/lib/classSet')
 
 class DownloadsBar extends ImmutableComponent {
   constructor () {
@@ -61,11 +63,20 @@ class DownloadsBar extends ImmutableComponent {
                 downloadsSize={this.props.downloads.size} />)
         }
       </div>
-      <div className='downloadBarButtons'>
-        <BrowserButton secondaryColor label='View all' custom={styles.viewAllButton}
-          onClick={this.onShowDownloads} />
-        <Button testId='hideDownloadsToolbar' className='downloadButton hideDownloadsToolbar'
-          onClick={this.onHideDownloadsToolbar} />
+      <div className={cx({
+        downloadBarButtons: true,
+        [css(styles.downloadsBar__downloadBarButtons)]: true
+      })}>
+        <BrowserButton secondaryColor
+          l10nId='downloadViewAll'
+          testId='downloadViewAll'
+          custom={styles.downloadsBar__downloadBarButtons__viewAllButton}
+          onClick={this.onShowDownloads}
+        />
+        <Button className='downloadButton hideDownloadsToolbar'
+          testId='hideDownloadsToolbar'
+          onClick={this.onHideDownloadsToolbar}
+        />
       </div>
     </div>
   }
@@ -74,7 +85,13 @@ class DownloadsBar extends ImmutableComponent {
 module.exports = DownloadsBar
 
 const styles = StyleSheet.create({
-  viewAllButton: {
+  downloadsBar__downloadBarButtons: {
+    display: 'flex',
+    flexFlow: 'row nowrap',
+    alignItems: 'center'
+  },
+
+  downloadsBar__downloadBarButtons__viewAllButton: {
     marginRight: '20px'
   }
 })

--- a/app/renderer/components/download/downloadsBar.js
+++ b/app/renderer/components/download/downloadsBar.js
@@ -27,6 +27,7 @@ class DownloadsBar extends ImmutableComponent {
     super()
     this.onHideDownloadsToolbar = this.onHideDownloadsToolbar.bind(this)
     this.onShowDownloads = this.onShowDownloads.bind(this)
+    this.downloadBarButtonsNode = null
   }
   onHideDownloadsToolbar () {
     windowActions.setDownloadsToolbarVisible(false)
@@ -38,14 +39,13 @@ class DownloadsBar extends ImmutableComponent {
       url: 'about:downloads'
     })
     windowActions.setDownloadsToolbarVisible(false)
-    webviewActions.setWebviewFocused()
   }
   render () {
     const getComputedStyle = require('../../getComputedStyle')
     const downloadItemWidth = Number.parseInt(getComputedStyle('--download-item-width'), 10)
     const downloadItemMargin = Number.parseInt(getComputedStyle('--download-item-margin'), 10)
     const downloadBarPadding = Number.parseInt(getComputedStyle('--download-bar-padding'), 10)
-    const downloadBarButtons = Number.parseInt(getComputedStyle('--download-bar-buttons'), 10)
+    const { width: downloadBarButtons } = this.downloadBarButtonsNode.getBoundingClientRect()
     const numItems = Math.floor((this.props.windowWidth - (downloadBarPadding * 2) - downloadBarButtons) / (downloadItemWidth + downloadItemMargin))
     return <div className='downloadsBar'
       onContextMenu={contextMenus.onDownloadsToolbarContextMenu.bind(null, undefined, undefined)}>
@@ -63,10 +63,13 @@ class DownloadsBar extends ImmutableComponent {
                 downloadsSize={this.props.downloads.size} />)
         }
       </div>
-      <div className={cx({
-        downloadBarButtons: true,
-        [css(styles.downloadsBar__downloadBarButtons)]: true
-      })}>
+      <div
+        className={cx({
+          downloadBarButtons: true,
+          [css(styles.downloadsBar__downloadBarButtons)]: true
+        })}
+        ref={refNode => { this.downloadBarButtonsNode = refNode }}
+        >
         <BrowserButton secondaryColor
           l10nId='downloadViewAll'
           testId='downloadViewAll'

--- a/app/renderer/components/download/downloadsBar.js
+++ b/app/renderer/components/download/downloadsBar.js
@@ -40,12 +40,17 @@ class DownloadsBar extends ImmutableComponent {
     })
     windowActions.setDownloadsToolbarVisible(false)
   }
+
   render () {
     const getComputedStyle = require('../../getComputedStyle')
     const downloadItemWidth = Number.parseInt(getComputedStyle('--download-item-width'), 10)
     const downloadItemMargin = Number.parseInt(getComputedStyle('--download-item-margin'), 10)
     const downloadBarPadding = Number.parseInt(getComputedStyle('--download-bar-padding'), 10)
-    const { width: downloadBarButtons } = this.downloadBarButtonsNode.getBoundingClientRect()
+
+    const downloadBarButtons = this.downloadBarButtonsNode !== null
+                            ? this.downloadBarButtonsNode.getBoundingClientRect().width
+                            : 0
+
     const numItems = Math.floor((this.props.windowWidth - (downloadBarPadding * 2) - downloadBarButtons) / (downloadItemWidth + downloadItemMargin))
     return <div className='downloadsBar'
       onContextMenu={contextMenus.onDownloadsToolbarContextMenu.bind(null, undefined, undefined)}>

--- a/app/renderer/components/download/downloadsBar.js
+++ b/app/renderer/components/download/downloadsBar.js
@@ -7,11 +7,15 @@ const React = require('react')
 // Components
 const ImmutableComponent = require('../immutableComponent')
 const Button = require('../common/button')
+const BrowserButton = require('../common/browserButton')
 const DownloadItem = require('./downloadItem')
+
+const {StyleSheet} = require('aphrodite/no-important')
 
 // Actions
 const windowActions = require('../../../../js/actions/windowActions')
 const webviewActions = require('../../../../js/actions/webviewActions')
+const appActions = require('../../../../js/actions/appActions')
 
 // Utils
 const contextMenus = require('../../../../js/contextMenus')
@@ -20,8 +24,17 @@ class DownloadsBar extends ImmutableComponent {
   constructor () {
     super()
     this.onHideDownloadsToolbar = this.onHideDownloadsToolbar.bind(this)
+    this.onShowDownloads = this.onShowDownloads.bind(this)
   }
   onHideDownloadsToolbar () {
+    windowActions.setDownloadsToolbarVisible(false)
+    webviewActions.setWebviewFocused()
+  }
+  onShowDownloads () {
+    appActions.createTabRequested({
+      activateIfOpen: true,
+      url: 'about:downloads'
+    })
     windowActions.setDownloadsToolbarVisible(false)
     webviewActions.setWebviewFocused()
   }
@@ -49,6 +62,8 @@ class DownloadsBar extends ImmutableComponent {
         }
       </div>
       <div className='downloadBarButtons'>
+        <BrowserButton secondaryColor label='View all' custom={styles.viewAllButton}
+          onClick={this.onShowDownloads} />
         <Button testId='hideDownloadsToolbar' className='downloadButton hideDownloadsToolbar'
           onClick={this.onHideDownloadsToolbar} />
       </div>
@@ -57,3 +72,9 @@ class DownloadsBar extends ImmutableComponent {
 }
 
 module.exports = DownloadsBar
+
+const styles = StyleSheet.create({
+  viewAllButton: {
+    marginRight: '20px'
+  }
+})

--- a/less/downloadBar.less
+++ b/less/downloadBar.less
@@ -30,6 +30,7 @@
     display: flex;
     flex-grow: 1;
     position: relative;
+
     .downloadItem {
       background-color: white;
       border: 1px solid @chromeTertiary;
@@ -126,6 +127,7 @@
 
       .downloadActions {
         margin: 8px 0 0;
+
         .browserButton {
           font-size: 14px;
           height: auto;
@@ -168,8 +170,6 @@
     .downloadButton {
       background: url('../img/toolbar/close_download_btn.svg') center no-repeat;
       background-size: 14px 14px;
-      position: relative;
-      top: 5px;
       height: 18px;
       width: 18px;
 

--- a/less/downloadBar.less
+++ b/less/downloadBar.less
@@ -8,7 +8,7 @@
   --download-item-width: 200px;
   --download-item-margin: 10px;
   --download-bar-padding: 20px;
-  --download-bar-buttons: 127px;
+  --download-bar-buttons: 140px;
 }
 
 @downloadItemHeight: 50px;

--- a/less/downloadBar.less
+++ b/less/downloadBar.less
@@ -168,6 +168,8 @@
     .downloadButton {
       background: url('../img/toolbar/close_download_btn.svg') center no-repeat;
       background-size: 14px 14px;
+      position: relative;
+      top: 5px;
       height: 18px;
       width: 18px;
 

--- a/less/downloadBar.less
+++ b/less/downloadBar.less
@@ -8,7 +8,7 @@
   --download-item-width: 200px;
   --download-item-margin: 10px;
   --download-bar-padding: 20px;
-  --download-bar-buttons: 22px;
+  --download-bar-buttons: 127px;
 }
 
 @downloadItemHeight: 50px;


### PR DESCRIPTION
Resolve #9090

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues/9090) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:

Reviewer Checklist:

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

### Description
This tries to resolve issue #9090. The solution is still incomplete.
**Before:**
![2017-05-27-184118_1356x52_scrot](https://cloud.githubusercontent.com/assets/16974688/26521598/1e71bc30-430c-11e7-97fa-9e929eeb622c.png)

**After:**
![peek 2017-05-27 17-57](https://cloud.githubusercontent.com/assets/16974688/26521603/30523ab0-430c-11e7-8c14-5c8a3e60cab3.gif)

### Problem
However, a new problem arose with responsiveness.
![not-responsive](https://cloud.githubusercontent.com/assets/16974688/26521627/ab03def8-430c-11e7-8cee-fe5a86fac161.gif)

I do not have any idea where in the code and how this hiding of download items is being done. So, I hope I could use some help from here.


