### PR TITLE
Remove destroy from popup menus

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -1340,21 +1340,18 @@ function onMainContextMenu (nodeProps, frame, tab, contextMenuType) {
   } else {
     const mainMenu = Menu.buildFromTemplate(mainTemplateInit(nodeProps, frame, tab))
     mainMenu.popup(getCurrentWindow())
-    mainMenu.destroy()
   }
 }
 
 function onFlashContextMenu (nodeProps, frameProps) {
   const flashMenu = Menu.buildFromTemplate(flashTemplateInit(frameProps))
   flashMenu.popup(getCurrentWindow())
-  flashMenu.destroy()
 }
 
 function onTabContextMenu (frameProps, e) {
   e.stopPropagation()
   const tabMenu = Menu.buildFromTemplate(tabTemplateInit(frameProps))
   tabMenu.popup(getCurrentWindow())
-  tabMenu.destroy()
 }
 
 function onNewTabContextMenu (target) {
@@ -1366,14 +1363,12 @@ function onNewTabContextMenu (target) {
   ]
   const menu = Menu.buildFromTemplate(menuTemplate)
   menu.popup(getCurrentWindow())
-  menu.destroy()
 }
 
 function onTabsToolbarContextMenu (bookmarkTitle, bookmarkLink, closestDestinationDetail, isParent, e) {
   e.stopPropagation()
   const tabsToolbarMenu = Menu.buildFromTemplate(tabsToolbarTemplateInit(bookmarkTitle, bookmarkLink, closestDestinationDetail, isParent))
   tabsToolbarMenu.popup(getCurrentWindow())
-  tabsToolbarMenu.destroy()
 }
 
 function onDownloadsToolbarContextMenu (downloadId, downloadItem, e) {
@@ -1382,14 +1377,12 @@ function onDownloadsToolbarContextMenu (downloadId, downloadItem, e) {
   }
   const downloadsToolbarMenu = Menu.buildFromTemplate(downloadsToolbarTemplateInit(downloadId, downloadItem))
   downloadsToolbarMenu.popup(getCurrentWindow())
-  downloadsToolbarMenu.destroy()
 }
 
 function onTabPageContextMenu (framePropsList, e) {
   e.stopPropagation()
   const tabPageMenu = Menu.buildFromTemplate(tabPageTemplateInit(framePropsList))
   tabPageMenu.popup(getCurrentWindow())
-  tabPageMenu.destroy()
 }
 
 function onUrlBarContextMenu (e) {
@@ -1399,14 +1392,12 @@ function onUrlBarContextMenu (e) {
   const activeFrame = getActiveFrame(windowState)
   const inputMenu = Menu.buildFromTemplate(urlBarTemplateInit(searchDetail, activeFrame, e))
   inputMenu.popup(getCurrentWindow())
-  inputMenu.destroy()
 }
 
 function onFindBarContextMenu (e) {
   e.stopPropagation()
   const findBarMenu = Menu.buildFromTemplate(findBarTemplateInit(e))
   findBarMenu.popup(getCurrentWindow())
-  findBarMenu.destroy()
 }
 
 function onSiteDetailContextMenu (siteDetail, activeFrame, e) {
@@ -1415,7 +1406,6 @@ function onSiteDetailContextMenu (siteDetail, activeFrame, e) {
   }
   const menu = Menu.buildFromTemplate(siteDetailTemplateInit(siteDetail, activeFrame))
   menu.popup(getCurrentWindow())
-  menu.destroy()
 }
 
 function onLedgerContextMenu (location, hostPattern) {
@@ -1431,7 +1421,6 @@ function onLedgerContextMenu (location, hostPattern) {
   ]
   const menu = Menu.buildFromTemplate(template)
   menu.popup(getCurrentWindow())
-  menu.destroy()
 }
 
 function onShowBookmarkFolderMenu (bookmarks, bookmark, activeFrame, e) {


### PR DESCRIPTION
Remove destroy from popup menus; it now happens when menu is hidden in Muon with https://github.com/brave/muon/pull/161

Auditors: @bridiver, @bbondy

**DON'T MERGE UNTIL https://github.com/brave/muon/pull/161 IS MERGED**

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [X] Ran `git rebase -i` to squash commits (if needed).


Reviewer Checklist:

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


