### PR TITLE
Replace slashdot with local iframe with adblock

### DIFF
--- a/test/bravery-components/braveryPanelTest.js
+++ b/test/bravery-components/braveryPanelTest.js
@@ -920,26 +920,23 @@ describe('Bravery Panel', function () {
     })
   })
 
-  // TODO: Fix iframe tests (See: #8760)
   describe('Adblock stats iframe tests', function () {
     Brave.beforeEach(this)
     beforeEach(function * () {
       yield setup(this.app.client)
-      yield this.app.client
-        .waitForDataFile('adblock')
     })
-    // TODO(bridiver) using slashdot won't provide reliable results so we should
-    // create our own iframe page with urls we expect to be blocked
     it('detects blocked elements in iframe in private tab', function * () {
-      const url = Brave.server.url('slashdot.html')
+      const url = Brave.server.url('iframe_with_adblock.html')
       yield this.app.client
         .newTab({ url, isPrivate: true })
         .waitForTabCount(2)
         .windowByUrl(Brave.browserWindowUrl)
         .openBraveMenu(braveMenu, braveryPanel)
+        .waitForVisible(adsBlockedStat)
+        .moveToObject(adsBlockedStat)
         .waitUntil(function () {
           return this.getText(adsBlockedStat)
-            .then((blocked) => Number(blocked) > 1)
+            .then((blocked) => Number(blocked) === 1)
         })
         .click(adsBlockedControl)
         .waitForVisible(showAdsOption)
@@ -949,20 +946,25 @@ describe('Bravery Panel', function () {
         .newTab({ url })
         .waitForTabCount(3)
         .openBraveMenu(braveMenu, braveryPanel)
+        .waitForVisible(adsBlockedStat)
+        .moveToObject(adsBlockedStat)
         .waitUntil(function () {
           return this.getText(adsBlockedStat)
-            .then((blocked) => Number(blocked) > 1)
+            .then((blocked) => Number(blocked) === 1)
         })
     })
     it('detects blocked elements in iframe', function * () {
-      const url = Brave.server.url('slashdot.html')
+      const url = Brave.server.url('iframe_with_adblock.html')
       yield this.app.client
-        .tabByIndex(0)
-        .loadUrl(url)
+        .newTab({ url })
+        .waitForTabCount(2)
+        .windowByUrl(Brave.browserWindowUrl)
         .openBraveMenu(braveMenu, braveryPanel)
+        .waitForVisible(adsBlockedStat)
+        .moveToObject(adsBlockedStat)
         .waitUntil(function () {
           return this.getText(adsBlockedStat)
-            .then((blocked) => Number(blocked) > 1)
+            .then((blocked) => Number(blocked) === 1)
         })
         .click(adsBlockedControl)
         .waitForVisible(showAdsOption)
@@ -970,16 +972,19 @@ describe('Bravery Panel', function () {
         .waitForTextValue(adsBlockedStat, '0')
         .keys(Brave.keys.ESCAPE)
         .newTab({ url, isPrivate: true })
-        .waitForTabCount(1)
         .waitForUrl(url)
+        .waitForTabCount(3)
         .openBraveMenu(braveMenu, braveryPanel)
+        .waitForVisible(adsBlockedStat)
+        .moveToObject(adsBlockedStat)
         .waitForTextValue(adsBlockedStat, '0')
         .click(adsBlockedControl)
         .waitForVisible(blockAdsOption)
         .click(blockAdsOption)
+        .moveToObject(adsBlockedStat)
         .waitUntil(function () {
           return this.getText(adsBlockedStat)
-            .then((blocked) => Number(blocked) > 1)
+            .then((blocked) => Number(blocked) === 1)
         })
     })
   })

--- a/test/fixtures/adblock2.html
+++ b/test/fixtures/adblock2.html
@@ -1,0 +1,2 @@
+<h1>serg don't know pokemons</h1>
+<script src="https://c.amazon-adsystem.com/aax2/amzn_ads.js"></script></body></html>

--- a/test/fixtures/iframe_with_adblock.html
+++ b/test/fixtures/iframe_with_adblock.html
@@ -1,0 +1,1 @@
+<iframe src='adblock2.html' />

--- a/test/fixtures/slashdot.html
+++ b/test/fixtures/slashdot.html
@@ -1,1 +1,0 @@
-<iframe src='https://slashdot.org' />


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Auditors: @bbondy
Close #8760

Test plan:
npm run test -- --grep="Adblock stats iframe tests"

Reviewer Checklist:

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


