### PR TITLE
Deprioritize search suggestions that start with 'http'

### DIFF
--- a/test/unit/app/common/lib/suggestionTest.js
+++ b/test/unit/app/common/lib/suggestionTest.js
@@ -320,6 +320,28 @@ describe('suggestion unit tests', function () {
         assert(this.sort('www.google.com', 'mygoogle.com') < 0)
       })
     })
+    describe('getSortForSearchSuggestions', function () {
+      it('0 if suggestions are not URLs', function () {
+        const sort = suggestion.getSortForSearchSuggestions('bug')
+        assert.equal(sort('foo', 'bar'), 0)
+      })
+      it('0 if suggestions are the same', function () {
+        const sort = suggestion.getSortForSearchSuggestions('bug')
+        assert.equal(sort('http://foo.com', 'http://foo.com'), 0)
+      })
+      it('0 if user input starts with HTTP', function () {
+        const sort = suggestion.getSortForSearchSuggestions('http://')
+        assert.equal(sort('http://foo.com', 'foo'), 0)
+      })
+      it('negative if second suggestion is HTTP', function () {
+        const sort = suggestion.getSortForSearchSuggestions('bug')
+        assert.equal(sort('bugs', 'http://bug'), -1)
+      })
+      it('positive if first suggestion is HTTP', function () {
+        const sort = suggestion.getSortForSearchSuggestions('bug')
+        assert.equal(sort('https://bug', 'bugs'), 1)
+      })
+    })
     describe('getSortForSuggestions', function () {
       describe('with url entered as path', function () {
         before(function () {


### PR DESCRIPTION
unless the user is actually typing 'http' into the URL bar

Fix #9141

Test Plan:
1. automated tests related to search suggestions should pass
2. Disable all options except 'Autocomplete search term' under search in preferences
3. type 'bug' in the URL bar. you should not see any results that start with 'http'
4. type 'http' in the URL bar. you should see some results that start with 'http'.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


