### PR TITLE
Add tests for tab reducer => APP_TAB_CLOSED

### DIFF
--- a/app/browser/reducers/tabsReducer.js
+++ b/app/browser/reducers/tabsReducer.js
@@ -47,7 +47,7 @@ const updateActiveTab = (state, closeTabId) => {
     case tabCloseAction.LAST_ACTIVE:
       nextTabId = tabState.getLastActiveTabId(state, windowId)
       break
-    default:
+    case tabCloseAction.PARENT:
       {
         const openerTabId = tabState.getOpenerTabId(state, closeTabId)
         const lastActiveTabId = tabState.getLastActiveTabId(state, windowId)
@@ -65,11 +65,6 @@ const updateActiveTab = (state, closeTabId) => {
       // no unpinned tabs so find the next pinned tab
       nextTabId = tabState.getNextTabIdByIndex(state, windowId, index, true)
     }
-  }
-
-  // if we can't find anything else just pick the first tab
-  if (nextTabId === tabState.TAB_ID_NONE) {
-    nextTabId = tabState.getTabIdByIndex(state, windowId, 0, true)
   }
 
   if (nextTabId !== tabState.TAB_ID_NONE) {

--- a/app/browser/windows.js
+++ b/app/browser/windows.js
@@ -328,7 +328,7 @@ const api = {
     let win = api.getWindow(windowId)
     try {
       setImmediate(() => {
-        if (!win.isDestroyed()) {
+        if (win && !win.isDestroyed()) {
           win.close()
         }
       })


### PR DESCRIPTION
Test all branches for tabsReducer => APP_TAB_CLOSED
Fixes https://github.com/brave/browser-laptop/issues/9178

During this process, three issues were found/fixed:
- window was not being checked if truthy when closed
- tab close action NEXT was not being respected
- because getNextTabIdByIndex searches forward and backwards, the setting to first block was dead code (and was removed)

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


