### PR TITLE
Incremently update the History/Recently closed menu

### DIFF
--- a/app/renderer/reducers/frameReducer.js
+++ b/app/renderer/reducers/frameReducer.js
@@ -118,7 +118,7 @@ const frameReducer = (state, action, immutableAction) => {
     case windowConstants.WINDOW_CLOSE_FRAMES:
       let closedFrames = new Immutable.List()
       action.framePropsList.forEach((frameProps) => {
-        if (!frameProps.get('isPrivate') && frameProps.get('location') !== 'about:newtab') {
+        if (frameStateUtil.isValidClosedFrame(frameProps)) {
           closedFrames = closedFrames.push(frameProps)
           if (closedFrames.size > config.maxClosedFrames) {
             closedFrames = closedFrames.shift()

--- a/js/constants/config.js
+++ b/js/constants/config.js
@@ -20,6 +20,10 @@ module.exports = {
   },
   fingerprintingInfoUrl: 'https://github.com/brave/browser-laptop/wiki/Fingerprinting-Protection-Mode',
   maxClosedFrames: 100,
+  menu: {
+    // History -> Recently closed frame list
+    maxClosedFrames: 10
+  },
   thumbnail: {
     width: 160,
     height: 100

--- a/js/state/frameStateUtil.js
+++ b/js/state/frameStateUtil.js
@@ -381,7 +381,7 @@ function removeFrame (state, frameProps, framePropsIndex) {
   let closedFrames = state.get('closedFrames')
   const newFrames = frames.splice(framePropsIndex, 1)
 
-  if (!frameProps.get('isPrivate') && frameProps.get('location') !== 'about:newtab') {
+  if (isValidClosedFrame(frameProps)) {
     frameProps = frameProps.set('isFullScreen', false)
     closedFrames = closedFrames.push(frameProps)
     if (frameProps.get('thumbnailBlob')) {
@@ -514,6 +514,14 @@ const updateFramesInternalIndex = (state, fromIndex) => {
   return state.set('framesInternal', framesInternal)
 }
 
+const isValidClosedFrame = (frame) => {
+  const location = frame.get('location')
+  if (location && (location.indexOf('about:newtab') !== -1 || location.indexOf('about:blank') !== -1)) {
+    return false
+  }
+  return !frame.get('isPrivate')
+}
+
 module.exports = {
   deleteTabInternalIndex,
   deleteFrameInternalIndex,
@@ -562,5 +570,6 @@ module.exports = {
   onFindBarHide,
   getTotalBlocks,
   isPinned,
-  updateTabPageIndex
+  updateTabPageIndex,
+  isValidClosedFrame
 }

--- a/test/unit/lib/fakeElectron.js
+++ b/test/unit/lib/fakeElectron.js
@@ -11,6 +11,11 @@ const fakeElectron = {
       }
     }
   },
+  MenuItem: class {
+    constructor (template) {
+      this.template = template
+    }
+  },
   ipcMain: {
     on: function () { },
     send: function () { }


### PR DESCRIPTION
Improves performance of tab close and undo tab close by avoiding recreating the system app menu.

With 10K bookmarks, tab close speed was previously 1400 ms and with this patch it's 100 ms.

Fix #4848
Fix #7395

Auditors: @bsclifton @bbondy

The patch was developed on MacOS but it should be tested also on Linux and Windows. 

Test plan:
1. Open the History menu and note Recently closed is not there.
2. Go to https://archive.org
3. Open a new tab and go to https://wikipedia.org
4. Close the tab
5. Examine the menu History > Recently closed; it should have Wikipedia
6. Close the archive.org tab
7. Examine the Recently closed menu; it should have the Internet archive
8. Use the menu item "Reopen last closed tab" or use the shortcut
9. Examine the Recently closed menu; it should be hidden now.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


