### PR TITLE
Re-allow dragging bookmarks inside folder in bookmarks manager

### DIFF
--- a/js/about/bookmarks.js
+++ b/js/about/bookmarks.js
@@ -59,9 +59,8 @@ class BookmarkFolderItem extends React.Component {
    */
   moveBookmark (e, bookmark) {
     if (siteUtil.isMoveAllowed(this.props.allBookmarkFolders, bookmark, this.props.bookmarkFolder)) {
-      const bookmarkSiteKey = siteUtil.getSiteKey(bookmark.toJS())
-      const bookmarkFolderSiteKey = siteUtil.getSiteKey(this.props.bookmarkFolder.toJS())
-
+      const bookmarkSiteKey = siteUtil.getSiteKey(bookmark)
+      const bookmarkFolderSiteKey = siteUtil.getSiteKey(this.props.bookmarkFolder)
       aboutActions.moveSite(bookmarkSiteKey,
         bookmarkFolderSiteKey,
         dndData.shouldPrependVerticalItem(e.target, e.clientY),


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Issue was unintentionally introduced in https://github.com/brave/browser-laptop/commit/21cfbf61c04fa2f49d6101070d56f3c2a5e34295#diff-157c36d119068b19baef9bde2ec07f22R62. `getSiteKey` method expects an Immutable object and converting to JS led method to get a null property.

Auditors: @bsclifton
Fix #9101
Fix #8946

Test Plan:
1. Have some bookmarks folders with bookmarks inside
2. Go to about:bookmarks
3. Right-hand side, drag a bookmark inside a folder
4. Go to folder, bookmark should be there

Reviewer Checklist:

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


