### PR TITLE
Fix syncing bookmarks in 'Other bookmarks' folder

### DIFF
--- a/js/constants/sync/messages.js
+++ b/js/constants/sync/messages.js
@@ -51,7 +51,7 @@ const messages = {
    * with new records, do
    * GET_EXISTING_OBJECTS -> RESOLVE_SYNC_RECORDS -> RESOLVED_SYNC_RECORDS
    */
-  FETCH_SYNC_RECORDS: _, /* @param Array.<string> categoryNames, @param {number} startAt (in seconds or milliseconds), @param {boolean=} limitResponse true to limit response to 1000 records */
+  FETCH_SYNC_RECORDS: _, /* @param Array.<string> categoryNames, @param {number} startAt (in seconds or milliseconds), @param {number=} maxRecords limit response to a given max number of records. set to 0 or falsey to not limit the response. */
   /**
    * browser -> webview
    * sent to fetch all sync devices. webview responds with RESOLVED_SYNC_RECORDS.
@@ -61,8 +61,8 @@ const messages = {
    * webview -> browser
    * after sync gets records, it requests the browser's existing objects so sync
    * can perform conflict resolution.
-   * isTruncated is true if limitResponse was used and the total number of
-   * records exceeds the limit (1000).
+   * isTruncated is true if maxRecords was used and the total number of
+   * records exceeds the limit.
    */
   GET_EXISTING_OBJECTS: _, /* @param {string} categoryName, @param {Array.<Object>} records, @param {lastRecordTimeStamp} number, @param {boolean} isTruncated */
   /**

--- a/js/state/syncUtil.js
+++ b/js/state/syncUtil.js
@@ -108,6 +108,8 @@ module.exports.getSiteDataFromRecord = (record, appState, records) => {
     if (parentFolderObjectId && parentFolderObjectId.length > 0) {
       siteProps.parentFolderId =
         getFolderIdByObjectId(new Immutable.List(parentFolderObjectId), appState, records)
+    } else if (siteProps.hideInToolbar === true) {
+      siteProps.parentFolderId = -1
     }
   }
   const siteDetail = new Immutable.Map(pickFields(siteProps, SITE_FIELDS))
@@ -422,7 +424,7 @@ module.exports.newObjectId = (objectPath) => {
  * @returns {Array.<number>}
  */
 const findOrCreateFolderObjectId = (folderId, appState) => {
-  if (typeof folderId !== 'number') { return undefined }
+  if (typeof folderId !== 'number' || folderId < 0) { return undefined }
   if (!appState) {
     const AppStore = require('../stores/appStore')
     appState = AppStore.getState()
@@ -472,6 +474,7 @@ module.exports.createSiteData = (site, appState) => {
       value: {
         site: siteData,
         isFolder: siteUtil.isFolder(immutableSite),
+        hideInToolbar: site.parentFolderId === -1,
         parentFolderObjectId
       }
     }

--- a/test/unit/state/syncUtilTest.js
+++ b/test/unit/state/syncUtilTest.js
@@ -47,6 +47,7 @@ describe('syncUtil', () => {
         value: {
           site: expectedSite.value,
           isFolder: false,
+          hideInToolbar: false,
           parentFolderObjectId: undefined
         }
       }
@@ -62,6 +63,7 @@ describe('syncUtil', () => {
         value: {
           site: newValue,
           isFolder: false,
+          hideInToolbar: false,
           parentFolderObjectId: undefined
         }
       }
@@ -77,6 +79,22 @@ describe('syncUtil', () => {
         value: {
           site: newValue,
           isFolder: false,
+          hideInToolbar: false,
+          parentFolderObjectId: undefined
+        }
+      }
+      assert.deepEqual(syncUtil.createSiteData(bookmark), expectedBookmark)
+    })
+
+    it('bookmark in Other Bookmarks folder', () => {
+      const bookmark = Object.assign({}, site, {tags: ['bookmark'], parentFolderId: -1})
+      const expectedBookmark = {
+        name: 'bookmark',
+        objectId,
+        value: {
+          site: expectedSite.value,
+          isFolder: false,
+          hideInToolbar: true,
           parentFolderObjectId: undefined
         }
       }


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/8024

Test Plan:
1. in about:bookmarks, right-click on 'Other bookmarks' and add a folder.
2. enable sync
3. open pyramid 1 and sync to pyramid 0
4. the bookmark folder from pyramid 0 should appear in 'Other bookmarks' in pyramid 1

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


