### PR TITLE
only set the activeFrameKey if the tab is already active

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -332,7 +332,7 @@ const api = {
       const frameOpts = {
         location,
         partition: newTab.session.partition,
-        openInForeground: !!newTabValue.get('active'),
+        active: !!newTabValue.get('active'),
         guestInstanceId: newTab.guestInstanceId,
         isPinned: !!newTabValue.get('pinned'),
         openerTabId,

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -169,6 +169,10 @@ module.exports.cleanPerWindowData = (perWindowData, isShutdown) => {
     delete frame.adblock
     delete frame.noScript
 
+    // clean up any legacy frame opening props
+    delete frame.openInForeground
+    delete frame.disposition
+
     // Guest instance ID's are not valid after restarting.
     // Electron won't know about them.
     delete frame.guestInstanceId

--- a/js/state/frameStateUtil.js
+++ b/js/state/frameStateUtil.js
@@ -367,15 +367,9 @@ function addFrame (state, frameOpts, newKey, partitionNumber, openInForeground, 
     history: []
   }, frameOpts))
 
-  const result = {
+  return {
     frames: frames.splice(insertionIndex, 0, frame)
   }
-
-  if (openInForeground) {
-    result.activeFrameKey = newKey
-  }
-
-  return result
 }
 
 /**

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -95,7 +95,7 @@ const addToHistory = (frameProps) => {
   return history.slice(-10)
 }
 
-const newFrame = (state, frameOpts, openInForeground) => {
+const newFrame = (state, frameOpts) => {
   if (frameOpts === undefined) {
     frameOpts = {}
   }
@@ -114,12 +114,17 @@ const newFrame = (state, frameOpts, openInForeground) => {
   }
   frameOpts.partitionNumber = frameOpts.partitionNumber || 0
 
-  if (frameOpts.disposition) {
+  const active = frameOpts.active
+  delete frameOpts.active
+  delete frameOpts.openInForeground // clean up any legacy openInForeground props
+  let openInForeground = active
+
+  if (openInForeground == null && frameOpts.disposition) {
     openInForeground = frameOpts.disposition !== 'background-tab'
+    delete frameOpts.disposition
   }
 
-  const activeFrame = frameStateUtil.getActiveFrame(state)
-  if (openInForeground === undefined || !activeFrame) {
+  if (openInForeground == null || state.get('activeFrameKey') == null) {
     openInForeground = true
   }
 
@@ -180,10 +185,13 @@ const newFrame = (state, frameOpts, openInForeground) => {
   state = frameStateUtil.updateFramesInternalIndex(state, insertionIndex)
 
   if (openInForeground) {
-    const activeFrame = frameStateUtil.getActiveFrame(state)
-    const tabId = activeFrame.get('tabId')
-    state = frameStateUtil.updateTabPageIndex(state, activeFrame)
-    if (tabId) {
+    const tabId = frameOpts.tabId
+    const frame = frameStateUtil.getFrameByTabId(state, tabId)
+    state = frameStateUtil.updateTabPageIndex(state, frame)
+    if (active) {
+      // only set the activeFrameKey if the tab is already active
+      state = state.set('activeFrameKey', frame.get('key'))
+    } else {
       appActions.tabActivateRequested(tabId)
     }
   }
@@ -695,7 +703,7 @@ const doAction = (action) => {
         action.frameOpts.tabId = tabValue.get('tabId')
         action.frameOpts.icon = action.frameOpts.icon || tabValue.get('favIconUrl')
       }
-      windowState = newFrame(windowState, action.frameOpts, action.frameOpts.openInForeground)
+      windowState = newFrame(windowState, action.frameOpts)
       break
     case windowConstants.WINDOW_FRAME_MOUSE_ENTER:
       windowState = windowState.setIn(['ui', 'mouseInFrame'], true)

--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -649,6 +649,15 @@ var exports = {
         }, createProperties)
     })
 
+    this.app.client.addCommand('activateTabByIndex', function (index) {
+      return this.waitForTab({index}).getAppState().then((val) => {
+        const tab = val.value.tabs.find((tab) => tab.index === index)
+        return this.execute(function (tabId) {
+          devTools('appActions').tabActivateRequested(tabId)
+        }, tab.tabId)
+      })
+    })
+
     /**
      * Adds a site to the sites list, such as a bookmarks.
      *


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

probable fix for https://github.com/brave/browser-laptop/issues/9134

Test Plan:
also fixes issue an mac where the first regular tab is restored instead of the pinned tab. Same QA steps as #9134 (minus the waiting)

Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header

