### PR TITLE
Add autofocus on sync input fields

### DIFF
--- a/app/renderer/components/preferences/syncTab.js
+++ b/app/renderer/components/preferences/syncTab.js
@@ -432,6 +432,15 @@ class SyncTab extends ImmutableComponent {
     window.alert('Invalid input code; please try again or create a new profile.')
   }
 
+  componentDidUpdate () {
+    if (!this.isSetup && this.props.syncStartOverlayVisible) {
+      this.deviceNameInput.focus()
+    }
+    if (!this.isSetup && this.props.syncAddOverlayVisible) {
+      this.passphraseInput.focus()
+    }
+  }
+
   render () {
     return <section className='syncContainer'>
       {


### PR DESCRIPTION
When the Sync setup buttons are selected, the first input element have focus

Fix #9175

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
1. Open about:preferences#sync
2. Click on I am new to Sync or I have an existing Sync code
3. Focus is now on the input field

I have attempted to add testing to the feature, but I have been unable to run the testing suite with consistency

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

