### PR TITLE
Apply font-weight to browserButton_primaryColor

### DIFF
--- a/app/renderer/components/common/browserButton.js
+++ b/app/renderer/components/common/browserButton.js
@@ -80,16 +80,18 @@ const styles = StyleSheet.create({
 
   // applies for primary and white buttons
   browserButton_default: {
+    // TODO: #9223
+    fontSize: globalStyles.spacing.defaultFontSize,
+    lineHeight: 1.25,
+
     // cf: https://github.com/brave/browser-laptop/blob/548e11b1c889332fadb379237555625ad2a3c845/less/button.less#L92
     color: globalStyles.button.default.color,
 
     position: 'relative',
     boxShadow: globalStyles.button.default.boxShadow,
     cursor: 'pointer',
-    lineHeight: 1.25,
     width: 'auto',
     height: 'auto',
-    fontSize: globalStyles.spacing.defaultFontSize,
 
     // cf: https://github.com/brave/browser-laptop/blob/548e11b1c889332fadb379237555625ad2a3c845/less/button.less#L94-L95
     paddingTop: '5px',
@@ -115,6 +117,9 @@ const styles = StyleSheet.create({
     borderTop: `2px solid ${globalStyles.button.primary.gradientColor1}`,
     borderBottom: `2px solid ${globalStyles.button.primary.gradientColor2}`,
     cursor: 'pointer',
+
+    // https://github.com/brave/browser-laptop/blob/548e11b1c889332fadb379237555625ad2a3c845/less/button.less#L115
+    fontWeight: 500,
 
     ':hover': {
       border: `2px solid ${globalStyles.button.primary.borderHoverColor}`,

--- a/app/renderer/components/common/browserButton.js
+++ b/app/renderer/components/common/browserButton.js
@@ -50,15 +50,13 @@ const buttonSize = '25px'
 
 const styles = StyleSheet.create({
   browserButton: {
+    height: buttonSize,
+    width: buttonSize,
     margin: '0 3px',
     whiteSpace: 'nowrap',
     outline: 'none',
     cursor: 'default',
     display: 'inline-block',
-    lineHeight: buttonSize,
-    height: buttonSize,
-    width: buttonSize,
-    fontSize: '13px',
     borderRadius: '2px',
     textAlign: 'center',
     transition: '.1s opacity, .1s background',
@@ -70,6 +68,10 @@ const styles = StyleSheet.create({
     backgroundColor: globalStyles.button.default.backgroundColor,
     border: 'none',
 
+    // TODO: #9223
+    fontSize: '13px',
+    lineHeight: buttonSize,
+
     // cf: https://github.com/brave/browser-laptop/blob/548e11b1c889332fadb379237555625ad2a3c845/less/button.less#L49
     color: globalStyles.button.color,
 
@@ -80,18 +82,18 @@ const styles = StyleSheet.create({
 
   // applies for primary and white buttons
   browserButton_default: {
+    position: 'relative',
+    boxShadow: globalStyles.button.default.boxShadow,
+    cursor: 'pointer',
+    width: 'auto',
+    height: 'auto',
+
     // TODO: #9223
     fontSize: globalStyles.spacing.defaultFontSize,
     lineHeight: 1.25,
 
     // cf: https://github.com/brave/browser-laptop/blob/548e11b1c889332fadb379237555625ad2a3c845/less/button.less#L92
     color: globalStyles.button.default.color,
-
-    position: 'relative',
-    boxShadow: globalStyles.button.default.boxShadow,
-    cursor: 'pointer',
-    width: 'auto',
-    height: 'auto',
 
     // cf: https://github.com/brave/browser-laptop/blob/548e11b1c889332fadb379237555625ad2a3c845/less/button.less#L94-L95
     paddingTop: '5px',


### PR DESCRIPTION
Addresses #9223

Auditors:

Test Plan:
1. Open about:preferences#security
2. Open about:preferences#sync
3. Make sure the font-weight of the buttons is equal

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


