### PR TITLE
Remove deprecated wideButton from button.less

### DIFF
--- a/app/extensions/brave/locales/en-US/styles.properties
+++ b/app/extensions/brave/locales/en-US/styles.properties
@@ -16,7 +16,6 @@ offByDefault=Off by default
 buttons=Buttons
 browserButton=Browser Button
 secondaryColor=Secondary Button
-wideButton=Wide Button
 smallButton=Small Button
 primaryColor=Primary Button
 actionButton=Action Button

--- a/less/button.less
+++ b/less/button.less
@@ -85,7 +85,6 @@ span.buttonSeparator {
   }
 
   &.primaryButton,
-  &.wideButton,
   &.subtleButton,
   &.whiteButton {
     color: #fff;
@@ -117,12 +116,6 @@ span.buttonSeparator {
       color: white;
       cursor: pointer;
     }
-  }
-
-  &.wideButton {
-    width: auto;
-    padding-right: 35px;
-    padding-left: 35px;
   }
 
   &.whiteButton {


### PR DESCRIPTION
Closes #9227

Auditors:

Test Plan: n/a

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


