### PR TITLE
Remove inlineButton

### DIFF
--- a/app/extensions/brave/locales/en-US/styles.properties
+++ b/app/extensions/brave/locales/en-US/styles.properties
@@ -16,7 +16,6 @@ offByDefault=Off by default
 buttons=Buttons
 browserButton=Browser Button
 secondaryColor=Secondary Button
-inlineButton=Inline Button
 wideButton=Wide Button
 smallButton=Small Button
 primaryColor=Primary Button

--- a/js/about/styles.js
+++ b/js/about/styles.js
@@ -261,16 +261,6 @@ class AboutStyle extends ImmutableComponent {
           &lt;BrowserButton secondaryColor l10nId='secondaryColor' onClick={'{this.onRemoveBookmark}'} />
         </Code></Pre>
 
-        {
-          /* TODO: I don't think we really need it. Once we confirm by removing
-            legacy button styles, remove this as well */
-        }
-        <button data-l10n-id='inlineButton' className='browserButton whiteButton inlineButton' onClick={this.onRemoveBookmark} />
-        <Pre><Code>
-          &lt;button data-l10n-id='inlineButton' className='browserButton whiteButton inlineButton'{'\n'}
-          onClick={'{this.onRemoveBookmark}'} />
-        </Code></Pre>
-
         {/* TODO: This button size doesn't match its name */}
         <button data-l10n-id='smallButton' className='browserButton whiteButton smallButton' onClick={this.onRemoveBookmark} />
         <Pre><Code>

--- a/less/button.less
+++ b/less/button.less
@@ -143,10 +143,6 @@ span.buttonSeparator {
     }
   }
 
-  &.inlineButton {
-    display: inline;
-  }
-
   &.subtleButton {
     background-color: #ccc;
     font-size: 14px;


### PR DESCRIPTION
Closes #9229

Auditors:

Test Plan:
1. Open `about:styles`
2. Click "button" on TOC
3. Make sure inlineButton is removed

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


