### PR TITLE
In siteUtil.updateSiteFavicon use location cache

### DIFF
--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -805,7 +805,7 @@ const handleAppAction = (action) => {
       appState = appState.set('defaultBrowserCheckComplete', {})
       break
     case windowConstants.WINDOW_SET_FAVICON:
-      appState = appState.set('sites', siteUtil.updateSiteFavicon(appState.get('sites'), action.frameProps.get('location'), action.favicon))
+      appState = siteUtil.updateSiteFavicon(appState, action.frameProps.get('location'), action.favicon)
       appState = aboutNewTabState.setSites(appState, action)
       break
     case appConstants.APP_RENDER_URL_TO_PDF:

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -1051,37 +1051,44 @@ describe('siteUtil', function () {
 
   describe('updateSiteFavicon', function () {
     it('updates the favicon for all matching entries (normalizing the URL)', function () {
+      const folderDetail = Immutable.fromJS({
+        folderId: 1,
+        tags: [siteTags.BOOKMARK_FOLDER]
+      })
       const siteDetail1 = Immutable.fromJS({
         tags: [siteTags.BOOKMARK],
         location: testUrl1,
         title: 'bookmarked site',
-        lastAccessedTime: 123
+        lastAccessedTime: 123,
+        parentFolderId: 1
       })
       const siteDetail2 = Immutable.fromJS({
         tags: [],
-        location: 'https://www.brave.com',
+        location: testUrl1,
         title: 'history entry',
         lastAccessedTime: 456
       })
-      let state = siteUtil.addSite(emptyState, siteDetail1, siteTags.BOOKMARK)
+      let state = siteUtil.addSite(emptyState, folderDetail, siteTags.BOOKMARK_FOLDER)
+      state = siteUtil.addSite(state, siteDetail1, siteTags.BOOKMARK)
       state = siteUtil.addSite(state, siteDetail2)
-      const processedSites = siteUtil.updateSiteFavicon(state.get('sites'), testUrl1, testFavicon1)
+      const processedState = siteUtil.updateSiteFavicon(state, testUrl1, testFavicon1)
       const updatedSiteDetail1 = siteDetail1.set('favicon', testFavicon1)
       const updatedSiteDetail2 = siteDetail2.set('favicon', testFavicon1)
-      let expectedState = siteUtil.addSite(emptyState, updatedSiteDetail1, siteTags.BOOKMARK)
+      let expectedState = siteUtil.addSite(emptyState, folderDetail, siteTags.BOOKMARK_FOLDER)
+      expectedState = siteUtil.addSite(expectedState, updatedSiteDetail1, siteTags.BOOKMARK)
       expectedState = siteUtil.addSite(expectedState, updatedSiteDetail2)
 
-      assert.deepEqual(processedSites.toJS(), expectedState.get('sites').toJS())
+      assert.deepEqual(processedState.get('sites').toJS(), expectedState.get('sites').toJS())
     })
     it('returns the object unchanged if location is not a URL', function () {
-      const sites = siteUtil.addSite(emptyState, bookmarkMinFields, siteTags.BOOKMARK)
-      const processedSites = siteUtil.updateSiteFavicon(sites, 'not-a-url', 'https://brave.com/favicon.ico')
-      assert.deepEqual(processedSites, sites)
+      const state = siteUtil.addSite(emptyState, bookmarkMinFields, siteTags.BOOKMARK)
+      const processedState = siteUtil.updateSiteFavicon(state, 'not-a-url', 'https://brave.com/favicon.ico')
+      assert.deepEqual(processedState.get('sites'), state.get('sites'))
     })
     it('returns the object unchanged if it is not an Immutable.Map', function () {
       const emptyLegacySites = Immutable.fromJS([])
-      const processedSites = siteUtil.updateSiteFavicon(emptyLegacySites, testUrl1, 'https://brave.com/favicon.ico')
-      assert.deepEqual(processedSites, emptyLegacySites)
+      const processedState = siteUtil.updateSiteFavicon(emptyLegacySites, testUrl1, 'https://brave.com/favicon.ico')
+      assert.deepEqual(processedState.get('sites'), emptyLegacySites.get('sites'))
     })
     it('works even if null/undefined entries are present', function () {
       const stateWithInvalidEntries = Immutable.fromJS({
@@ -1091,10 +1098,10 @@ describe('siteUtil', function () {
         }
       })
       const state = siteUtil.addSite(stateWithInvalidEntries, bookmarkMinFields, siteTags.BOOKMARK)
-      const processedSites = siteUtil.updateSiteFavicon(state.get('sites'), testUrl1, 'https://brave.com/favicon.ico')
+      const processedState = siteUtil.updateSiteFavicon(state, testUrl1, 'https://brave.com/favicon.ico')
       const updatedSiteDetail = bookmarkMinFields.set('favicon', 'https://brave.com/favicon.ico')
       const expectedState = siteUtil.addSite(stateWithInvalidEntries, updatedSiteDetail, siteTags.BOOKMARK)
-      assert.deepEqual(processedSites.toJS(), expectedState.get('sites').toJS())
+      assert.deepEqual(processedState.get('sites').toJS(), expectedState.get('sites').toJS())
     })
   })
 


### PR DESCRIPTION
Fix #9276

Note: This slightly changes the function behavior because it removes use of [normalizeUrl](https://github.com/sindresorhus/normalize-url) when comparing locations. By default the library removes `www` from URLs:
```
'https://www.example.com/about.html#test'
=> 'https://example.com/about.html#test'
```

We had been testing this case, assuming that we had both `https://www.brave.com/` and `https://brave.com`, calling updateSiteFavicon with `https://brave.com` and expected both sites to be updated.

I don't think this case actually happens (please correct me if I'm wrong), and the siteKey cache does normalize location when [setting](https://github.com/brave/browser-laptop/blob/master/app/common/state/siteCache.js#L52) and [getting](https://github.com/brave/browser-laptop/blob/master/app/common/state/siteCache.js#L37) so it seems safe.

Auditors: @bsclifton @bbondy

Test Plan:
1. load 10K bookmarks
1. Enable bookmarks bar favicons via Preferences > General > "Bookmarks Bar" => "Text and Favicons".
2. Create a bookmark folder.
3. Navigate to https://archive.org
4. Bookmark page.
5. Navigate to https://wikipedia.org
6. Bookmark page into the folder.
7. Examine bookmarks toolbar; there should be favicons for archive and wikipedia.
8. Open the Bookmarks Manager and confirm there are favicons.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


Related: #8541