### PR TITLE
Increase urlbarForm input height to the equal value as 'urlbarFormHeight'

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -642,7 +642,6 @@
   justify-content: center;
   height: @urlbarFormHeight;
   padding: 0 10px 0 3px;
-  background: @navigationBarBackgroundActive;
   display: flex;
   flex-grow: 1;
   min-width: 0%; // allow the navigator to shrink
@@ -654,7 +653,6 @@
   legend:before {
     content: ' ';
     position: absolute;
-    background: @navigationBarBackgroundActive;
     border-radius: 0 4px 4px 0;
     color: #333;
     box-shadow: inset 0 0 0 1px @urlBarOutline, inset 0 0 0 3px @focusUrlbarOutline;
@@ -672,13 +670,17 @@
   }
 
   #navigator:not(.titleMode) & {
-    background: @navigationBarBackgroundActive;
     border-radius: @borderRadiusURL;
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
     box-shadow: inset 0 0 0 1px rgba(187, 187, 187, 1.0);
     color: @chromeText;
+
+    // #4922
+    // TODO: replace this value with a CSS variable to add a dark UI.
+    background: #fff;
   }
+
   @media (max-width: @breakpointNarrowViewport) {
     max-width: 80%;
   }
@@ -718,7 +720,7 @@
     }
 
     .urlbarForm {
-        &.noBorderRadius {
+      &.noBorderRadius {
         border-radius: 0;
 
         legend:before {
@@ -825,13 +827,11 @@
   .urlbarForm {
     .loadTime {
       color: @loadTimeColor;
-      // background: @navigationBarBackground;
       font-size: 12px;
       text-align: right;
       cursor: default;
 
       &.onFocus {
-        background: @navigationBarBackgroundActive;
         display: none;
       }
     }
@@ -842,7 +842,6 @@
     }
 
     .inputbar-wrapper {
-      //background: white;
       display: flex;
       flex: 1 1 0;
       border-radius: 4px;
@@ -851,7 +850,6 @@
     }
 
     input {
-      background: @navigationBarBackgroundActive;
       border: none;
       box-sizing: border-box;
       color: #333;
@@ -864,9 +862,9 @@
       text-overflow: ellipsis;
       min-width: 0%; // allow the navigator to shrink
 
-      &:hover {
-        background: @navigationBarBackgroundActive;
-      }
+      // #4922: make the whole .urlbarForm clickable
+      height: @urlbarFormHeight;
+      background: transparent;
 
       &.private {
         background: @privateTabBackground;
@@ -874,7 +872,6 @@
       }
 
       &:focus {
-        background: @navigationBarBackgroundActive;
         margin-right: 3px;
       }
     }

--- a/less/variables.less
+++ b/less/variables.less
@@ -25,9 +25,6 @@
 @tabsBackground: #ddd;
 @tabsBackgroundInactive: #ddd;
 @tabsToolbarBorderColor: #bbb;
-@navigationBarBackground: @chromeSecondary;
-@navigationBarBackground: #f7f7f7;
-@navigationBarBackgroundActive: #fff;
 @chromeBorderColor: @chromePrimary;
 @chromeControlsBackground: #bbb;
 @chromeControlsWarningBackground: @chromePrimary;


### PR DESCRIPTION
Also:
- Set white background to .urlbarForm inside navigator
- Remove redundant specifications (the specified background is inherited to all of the elements inside .urlbarForm)
- Remove duplicate variables

Fixes #4922
Addresses #9283

Auditors:

Test Plan:
1. Make sure that clicking the area between the top and bottom edge of the URL bar selects the URL address

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

Assigning @cezaraugusto & @bsclifton for review - it would be appreciated if one of you could check if the fix should work as expected on Windows.