### PR TITLE
Fixed Ecosia Favicon

### DIFF
--- a/js/data/searchProviders.js
+++ b/js/data/searchProviders.js
@@ -135,7 +135,7 @@ module.exports = { "providers" :
     {
       "name" : "Ecosia",
       "base" : "https://www.ecosia.org/",
-      "image" : "https://www.ecosia.org/favicon.ico",
+      "image" : "https://cdn.ecosia.org/assets/images/ico/favicon.ico",
       "search" : "https://www.ecosia.org/search?q={searchTerms}",
       "autocomplete": "https://ac.ecosia.org/autocomplete?q={searchTerms}&type=list",
       "shortcut" : ":e"


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:

Reviewer Checklist:

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite ref
- [ ] New files have MPL2 license header



Favicon does not display correctly when pulling the favicon information from Brave source. Such as when searching using engine go key or in preferences page. Already worked when navigating on ecosia domain.

fixed by updating the favicon URL from Ecosia. For some reason `www.domain.com/favicon.ico` did not work originally.