### PR TITLE
Add disabled state for bookmark modal button

### DIFF
--- a/app/renderer/components/common/browserButton.js
+++ b/app/renderer/components/common/browserButton.js
@@ -19,13 +19,16 @@ class BrowserButton extends ImmutableComponent {
         [styles.browserButton_default, styles.browserButton_subtleItem, styles.browserButton_actionItem],
       this.props.extensionItem && styles.browserButton_extensionItem,
       this.props.groupedItem && styles.browserButton_groupedItem,
-      this.props.notificationItem && styles.browserButton_notificationItem
+      this.props.notificationItem && styles.browserButton_notificationItem,
       // TODO: These are other button styles app-wise
       // that needs to be refactored and included in this file
       // .............................................
       // this.props.smallItem && styles.browserButton_smallItem,
       // this.props.navItem && styles.browserButton_navItem,
       // this.props.panelItem && styles.browserButton_panelItem,
+
+      // note: this should be the last item so it can override other styles
+      this.props.disabled && styles.browserButton_disabled
     ]
   }
   render () {
@@ -191,6 +194,12 @@ const styles = StyleSheet.create({
 
   browserButton_actionItem: {
     background: globalStyles.button.action.backgroundColor
+  },
+
+  browserButton_disabled: {
+    pointerEvents: 'none',
+    animation: 'none',
+    opacity: 0.25
   }
 })
 


### PR DESCRIPTION
Auditors: @luixxiul
Close #9019

I needed to split this out of https://github.com/brave/browser-laptop/pull/9236/commits/9d89df8e926ee1b267dc3810610ff06cebf506c8 as it will be included in 0.17.x

STR: 
1. Create a folder under bookmarks toolbar
2. Modal should show with disabled button state

<img width="380" alt="screen shot 2017-06-07 at 6 01 54 pm" src="https://user-images.githubusercontent.com/4672033/26901317-c4432854-4bab-11e7-81d3-5f87d42a4f92.png">
