### PR TITLE
handle empty objects in sync DELETEs, refactor DELETE code

### DIFF
--- a/js/actions/syncActions.js
+++ b/js/actions/syncActions.js
@@ -7,13 +7,6 @@ const AppDispatcher = require('../dispatcher/appDispatcher')
 const syncConstants = require('../constants/syncConstants')
 
 const syncActions = {
-  removeSite: function (item) {
-    AppDispatcher.dispatch({
-      actionType: syncConstants.SYNC_REMOVE_SITE,
-      item
-    })
-  },
-
   clearHistory: function () {
     AppDispatcher.dispatch({
       actionType: syncConstants.SYNC_CLEAR_HISTORY

--- a/js/constants/syncConstants.js
+++ b/js/constants/syncConstants.js
@@ -6,7 +6,6 @@ const mapValuesByKeys = require('../lib/functional').mapValuesByKeys
 
 const _ = null
 const syncConstants = {
-  SYNC_REMOVE_SITE: _,  /** @param {Immutable.Map} item */
   SYNC_CLEAR_HISTORY: _,
   SYNC_CLEAR_SITE_SETTINGS: _
 }


### PR DESCRIPTION
fix #9308
gets rid of syncActions.removeSite by DELETEing sites in the appStoreChange listener instead

test plan:
1. enable sync in pyramid 0.
2. bookmark some sites and folders and then delete some. 
2. sync pyramid 1 to pyramid 0. it should show the same bookmarks.
3. delete a bookmark and bookmark folder in pyramid 1. they should be deleted in pyramid 0.
4. syncing tests should pass.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


