### PR TITLE
Polish groupedItem button & add groupedItem to the existing browserButtons

### DIFF
--- a/app/renderer/components/bookmarks/addEditBookmarkHanger.js
+++ b/app/renderer/components/bookmarks/addEditBookmarkHanger.js
@@ -275,18 +275,18 @@ class AddEditBookmarkHanger extends React.Component {
         <CommonFormButtonWrapper>
           {
             this.props.hasOriginalDetail
-            ? <BrowserButton secondaryColor
+            ? <BrowserButton groupedItem secondaryColor
               l10nId='remove'
               testId='bookmarkHangerRemoveButton'
               onClick={this.onRemoveBookmark}
             />
-            : <BrowserButton secondaryColor
+            : <BrowserButton groupedItem secondaryColor
               l10nId='cancel'
               testId='bookmarkHangerCancelButton'
               onClick={this.onClose}
             />
           }
-          <BrowserButton primaryColor
+          <BrowserButton groupedItem primaryColor
             l10nId='done'
             testId='bookmarkHangerDoneButton'
             disabled={!this.props.isBookmarkNameValid}

--- a/app/renderer/components/common/browserButton.js
+++ b/app/renderer/components/common/browserButton.js
@@ -84,7 +84,6 @@ const styles = StyleSheet.create({
   browserButton: {
     height: buttonSize,
     width: buttonSize,
-    margin: '0 3px',
     whiteSpace: 'nowrap',
     outline: 'none',
     cursor: 'default',
@@ -103,6 +102,11 @@ const styles = StyleSheet.create({
     // TODO: #9223
     fontSize: '13px',
     lineHeight: buttonSize,
+
+    // The buttons as such do not require margin.
+    // They are expected to have margin only if they are grouped.
+    // Also see note on browserButton_groupedItem below.
+    margin: 0,
 
     // cf: https://github.com/brave/browser-laptop/blob/548e11b1c889332fadb379237555625ad2a3c845/less/button.less#L49
     color: globalStyles.button.color,
@@ -188,8 +192,19 @@ const styles = StyleSheet.create({
     //
     // TODO: remove !important and check advancedSettings.js
     // once preferences is fully refactored
-    marginRight: '4px !important',
-    marginLeft: '4px !important'
+
+    // 'mm' assures theoretically the equal width of margin
+    // on every platform with any display monitor resolution.
+    // 7.5px = 1/12 inch
+    marginLeft: '7.5px !important',
+
+    // Issue #9252
+    // Because the grouped buttons are *by design* aligned to the right
+    // with flex/grid, margin-right of each one should be null.
+    // If you set margin-right to those buttons, it is expected to lead
+    // to the alignment inconsistency.
+    // Before making a change, please consult with Brad on your proposal.
+    marginRight: 0
   },
 
   browserButton_notificationItem: {

--- a/app/renderer/components/main/checkDefaultBrowserDialog.js
+++ b/app/renderer/components/main/checkDefaultBrowserDialog.js
@@ -67,12 +67,12 @@ class CheckDefaultBrowserDialog extends ImmutableComponent {
           </div>
         </CommonFormSection>
         <CommonFormButtonWrapper>
-          <BrowserButton secondaryColor
+          <BrowserButton groupedItem secondaryColor
             l10nId='notNow'
             testId='notNowButton'
             onClick={this.onNotNow}
           />
-          <BrowserButton primaryColor
+          <BrowserButton groupedItem primaryColor
             l10nId='useBrave'
             testId='useBraveButton'
             onClick={this.onUseBrave}

--- a/app/renderer/components/main/notificationBar.js
+++ b/app/renderer/components/main/notificationBar.js
@@ -42,7 +42,7 @@ class NotificationBar extends ImmutableComponent {
 class NotificationBarCaret extends ImmutableComponent {
   render () {
     return <div className={css(styles.caretWrapper)}>
-      <div className={css(styles.caret)} />
+      <div className={css(styles.caretWrapper__caret)} />
     </div>
   }
 }
@@ -56,10 +56,12 @@ const styles = StyleSheet.create({
     zIndex: globalStyles.zindex.zindexTabs,
     filter: 'drop-shadow(rgba(0,0,0,0.25) 0px 0px 1px)'
   },
-  caret: {
+
+  caretWrapper__caret: {
     position: 'relative',
     margin: 'auto',
     width: '16px',
+
     ':before': {
       content: '""',
       position: 'absolute',

--- a/app/renderer/components/main/notificationItem.js
+++ b/app/renderer/components/main/notificationItem.js
@@ -81,7 +81,7 @@ class NotificationItem extends ImmutableComponent {
           }
           {
             this.props.detail.get('buttons').map((button) =>
-              <BrowserButton secondaryColor notificationItem groupedItem
+              <BrowserButton groupedItem secondaryColor notificationItem
                 iconClass={button.get('className')}
                 testId='notificationButton'
                 label={button.get('text')}

--- a/app/renderer/components/main/updateBar.js
+++ b/app/renderer/components/main/updateBar.js
@@ -68,7 +68,7 @@ class UpdateHello extends ImmutableComponent {
 
 class UpdateHide extends ImmutableComponent {
   render () {
-    return <BrowserButton notificationItem secondaryColor
+    return <BrowserButton groupedItem notificationItem secondaryColor
       testId='updateHide'
       l10nId='updateHide'
       onClick={appActions.setUpdateStatus.bind(null, this.props.reset ? UpdateStatus.UPDATE_NONE : undefined, false, undefined)} />
@@ -80,7 +80,7 @@ class UpdateLog extends ImmutableComponent {
     appActions.updateLogOpened()
   }
   render () {
-    return <BrowserButton notificationItem secondaryColor
+    return <BrowserButton groupedItem notificationItem secondaryColor
       testId='updateViewLogButton'
       l10nId='updateViewLog'
       onClick={this.onViewLog.bind(this)} />
@@ -98,17 +98,17 @@ class UpdateAvailable extends ImmutableComponent {
       <span className={css(styles.flexAlignCenter)} data-test-id='notificationOptions'>
         {
           this.props.metadata && this.props.metadata.get('notes')
-          ? <BrowserButton notificationItem secondaryColor
+          ? <BrowserButton groupedItem notificationItem secondaryColor
             testId='updateDetails'
             l10nId='updateDetails'
             onClick={windowActions.setReleaseNotesVisible.bind(null, true)} />
           : null
         }
-        <BrowserButton notificationItem secondaryColor
+        <BrowserButton groupedItem notificationItem secondaryColor
           testId='updateLater'
           l10nId='updateLater'
           onClick={appActions.setUpdateStatus.bind(null, UpdateStatus.UPDATE_AVAILABLE_DEFERRED, false, undefined)} />
-        <BrowserButton notificationItem primaryColor
+        <BrowserButton groupedItem notificationItem primaryColor
           testId='updateNow'
           l10nId='updateNow'
           onClick={appActions.setUpdateStatus.bind(null, UpdateStatus.UPDATE_APPLYING_RESTART, false, undefined)} />

--- a/app/renderer/components/preferences/payment/ledgerBackup.js
+++ b/app/renderer/components/preferences/payment/ledgerBackup.js
@@ -73,17 +73,17 @@ class LedgerBackupFooter extends ImmutableComponent {
 
   render () {
     return <section>
-      <BrowserButton primaryColor groupedItem
+      <BrowserButton groupedItem primaryColor
         l10nId='printKeys'
         testId='printKeysButton'
         onClick={this.printKeys}
       />
-      <BrowserButton primaryColor groupedItem
+      <BrowserButton groupedItem primaryColor
         l10nId='saveRecoveryFile'
         testId='saveRecoveryFileButton'
         onClick={this.saveKeys}
       />
-      <BrowserButton secondaryColor groupedItem
+      <BrowserButton groupedItem secondaryColor
         l10nId='done'
         testId='doneButton'
         onClick={this.props.hideOverlay.bind(this, 'ledgerBackup')}

--- a/app/renderer/components/preferences/payment/ledgerRecovery.js
+++ b/app/renderer/components/preferences/payment/ledgerRecovery.js
@@ -126,17 +126,17 @@ class LedgerRecoveryFooter extends ImmutableComponent {
 
   render () {
     return <div>
-      <BrowserButton primaryColor groupedItem
+      <BrowserButton groupedItem primaryColor
         l10nId='recover'
         testId='recoverButton'
         onClick={this.recoverWallet}
       />
-      <BrowserButton primaryColor groupedItem
+      <BrowserButton groupedItem primaryColor
         l10nId='recoverFromFile'
         testId='recoverFromFileButton'
         onClick={this.recoverWalletFromFile}
       />
-      <BrowserButton secondaryColor groupedItem
+      <BrowserButton groupedItem secondaryColor
         l10nId='cancel'
         testId='cancelButton'
         onClick={this.props.hideOverlay.bind(this, 'ledgerRecovery')}

--- a/app/renderer/components/preferences/syncTab.js
+++ b/app/renderer/components/preferences/syncTab.js
@@ -93,12 +93,12 @@ class SyncTab extends ImmutableComponent {
     }
     // displayed before a sync userId has been created
     return <section className={css(styles.setupContent)}>
-      <BrowserButton primaryColor
+      <BrowserButton groupedItem primaryColor
         l10nId='syncStart'
         testId='syncStartButton'
         onClick={this.props.showOverlay.bind(this, 'syncStart')}
       />
-      <BrowserButton secondaryColor
+      <BrowserButton groupedItem secondaryColor
         l10nId='syncAdd'
         testId='syncAddButton'
         onClick={this.props.showOverlay.bind(this, 'syncAdd')}
@@ -365,12 +365,12 @@ class SyncTab extends ImmutableComponent {
 
   get resetOverlayFooter () {
     return <section>
-      <BrowserButton secondaryColor groupedItem
+      <BrowserButton groupedItem secondaryColor
         l10nId='cancel'
         testId='cancelButton'
         onClick={this.props.hideOverlay.bind(this, 'syncReset')}
       />
-      <BrowserButton primaryColor groupedItem
+      <BrowserButton groupedItem primaryColor
         l10nId='syncReset'
         testId='syncResetButton'
         onClick={this.onReset}

--- a/js/about/styles.js
+++ b/js/about/styles.js
@@ -282,13 +282,13 @@ class AboutStyle extends ImmutableComponent {
           &lt;BrowserButton subtleItem l10nId='cancel' onClick={'{this.onRemoveBookmark}'} />
         </Code></Pre>
 
-        <BrowserButton primaryColor groupedItem l10nId='primaryColor' onClick={this.onRemoveBookmark} />
-        <BrowserButton secondaryColor groupedItem l10nId='secondaryColor' onClick={this.onRemoveBookmark} />
-        <BrowserButton primaryColor groupedItem l10nId='primaryColor' onClick={this.onRemoveBookmark} />
+        <BrowserButton groupedItem primaryColor l10nId='primaryColor' onClick={this.onRemoveBookmark} />
+        <BrowserButton groupedItem secondaryColor l10nId='secondaryColor' onClick={this.onRemoveBookmark} />
+        <BrowserButton groupedItem primaryColor l10nId='primaryColor' onClick={this.onRemoveBookmark} />
         <Pre><Code>
-          &lt;BrowserButton primaryColor groupedItem l10nId='cancel' onClick={'{this.onRemoveBookmark}'} />{'\n'}
-          &lt;BrowserButton secondaryColor groupedItem l10nId='cancel' onClick={'{this.onRemoveBookmark}'} />{'\n'}
-          &lt;BrowserButton primaryColor groupedItem l10nId='cancel' onClick={'{this.onRemoveBookmark}'} />
+          &lt;BrowserButton groupedItem primaryColor l10nId='cancel' onClick={'{this.onRemoveBookmark}'} />{'\n'}
+          &lt;BrowserButton groupedItem secondaryColor l10nId='cancel' onClick={'{this.onRemoveBookmark}'} />{'\n'}
+          &lt;BrowserButton groupedItem primaryColor l10nId='cancel' onClick={'{this.onRemoveBookmark}'} />
         </Code></Pre>
 
         <BrowserButton extensionItem l10nId='extensionItem' onClick={this.onRemoveBookmark} />
@@ -296,11 +296,11 @@ class AboutStyle extends ImmutableComponent {
           &lt;BrowserButton extensionItem l10nId='cancel' onClick={'{this.onRemoveBookmark}'} />
         </Code></Pre>
 
-        <BrowserButton secondaryColor notificationItem groupedItem l10nId='notificationItem' onClick={this.onRemoveBookmark} />
-        <BrowserButton secondaryColor notificationItem groupedItem l10nId='notificationItem' onClick={this.onRemoveBookmark} />
+        <BrowserButton groupedItem secondaryColor notificationItem l10nId='notificationItem' onClick={this.onEnableAutoplay} />
+        <BrowserButton groupedItem secondaryColor notificationItem l10nId='notificationItem' onClick={this.onEnableAutoplay} />
         <Pre><Code>
-          &lt;BrowserButton secondaryColor notificationItem groupedItem l10nId='Yes' onClick={'{this.onRemoveBookmark}'} />{'\n'}
-          &lt;BrowserButton secondaryColor notificationItem groupedItem l10nId='No' onClick={'{this.onRemoveBookmark}'} />
+          &lt;BrowserButton groupedItem secondaryColor notificationItem l10nId='Yes' onClick={'{this.onEnableAutoplay}'} />{'\n'}
+          &lt;BrowserButton groupedItem secondaryColor notificationItem l10nId='No' onClick={'{this.onEnableAutoplay}'} />
         </Code></Pre>
 
         <BrowserButton iconOnly iconClass={globalStyles.appIcons.moreInfo} size='30px' color='rebeccapurple' />
@@ -350,8 +350,8 @@ class AboutStyle extends ImmutableComponent {
                 labore et dolore magna aliqua.
               </CommonFormSection>
               <CommonFormButtonWrapper>
-                <BrowserButton secondaryColor l10nId='Cancel' />
-                <BrowserButton primaryColor l10nId='Done' />
+                <BrowserButton groupedItem secondaryColor l10nId='Cancel' />
+                <BrowserButton groupedItem primaryColor l10nId='Done' />
               </CommonFormButtonWrapper>
               <CommonFormBottomWrapper>
                 <CommonFormClickable>CommonFormClickable</CommonFormClickable>
@@ -395,8 +395,8 @@ class AboutStyle extends ImmutableComponent {
             <Tab2>sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.{'\n'}</Tab2>
             <Tab>&lt;/CommonFormSection&gt;{'\n'}</Tab>
             <Tab>&lt;CommonFormButtonWrapper&gt;{'\n'}</Tab>
-            <Tab2>&lt;button data-l10n-id='Cancel' className='browserButton whiteButton' /&gt;{'\n'}</Tab2>
-            <Tab2>&lt;button data-l10n-id='Done' className='browserButton primaryButton' /&gt;{'\n'}</Tab2>
+            <Tab2>&lt;BrowserButton groupedItem secondaryColor l10nId='Cancel' /&gt;{'\n'}</Tab2>
+            <Tab2>&lt;BrowserButton groupedItem primaryColor l10nId='Done' /&gt;{'\n'}</Tab2>
             <Tab>&lt;/CommonFormButtonWrapper&gt;{'\n'}</Tab>
             <Tab>&lt;CommonFormBottomWrapper&gt;{'\n'}</Tab>
             <Tab2>&lt;CommonFormClickable&gt;CommonFormClickable&lt;/CommonFormClickable&gt;{'\n'}</Tab2>
@@ -541,8 +541,8 @@ class AboutStyle extends ImmutableComponent {
           }}>
             <CommonForm>
               <CommonFormButtonWrapper>
-                <BrowserButton secondaryColor l10nId='Cancel' />
-                <BrowserButton primaryColor l10nId='Done' />
+                <BrowserButton groupedItem secondaryColor l10nId='Cancel' />
+                <BrowserButton groupedItem primaryColor l10nId='Done' />
               </CommonFormButtonWrapper>
             </CommonForm>
           </div>
@@ -555,8 +555,8 @@ class AboutStyle extends ImmutableComponent {
             {'\n'}
             &lt;CommonForm&gt;{'\n'}
             <Tab>&lt;CommonFormButtonWrapper&gt;{'\n'}</Tab>
-            <Tab2>&lt;button data-l10n-id='Cancel' className='browserButton whiteButton' /&gt;{'\n'}</Tab2>
-            <Tab2>&lt;button data-l10n-id='Done' className='browserButton primaryButton' /&gt;{'\n'}</Tab2>
+            <Tab2>&lt;BrowserButton groupedItem secondaryColor l10nId='Cancel' /&gt;{'\n'}</Tab2>
+            <Tab2>&lt;BrowserButton groupedItem primaryColor l10nId='Done' /&gt;{'\n'}</Tab2>
             <Tab>&lt;/CommonFormButtonWrapper&gt;{'\n'}</Tab>
             &lt;/CommonForm&gt;{'\n'}
           </Code></Pre>

--- a/less/button.less
+++ b/less/button.less
@@ -152,13 +152,4 @@ span.buttonSeparator {
   .settingItem > span + button {
     margin-top: 5px;
   }
-
-  .paymentsContainer,
-  // TODO: refactor button.less to remove this and apply overlayButtonMargin in global.js
-  .syncContainer {
-    .browserButton + .browserButton {
-      margin-left: 8px;
-    }
-  }
-
 }


### PR DESCRIPTION
Fixes #9251
Fixes #9252

Test Plan:
1. Open about:styles
2. Click `buttons`
3. Make sure the buttons with 'groupedItem' have margin-left only

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


