### PR TITLE
Don't activate tab on right click

### DIFF
--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -170,11 +170,17 @@ class Tab extends React.Component {
   }
 
   onClickTab (e) {
-    if (e.button === 1) {
-      this.onTabClosedWithMouse(e)
-    } else {
-      e.stopPropagation()
-      appActions.tabActivateRequested(this.props.tabId)
+    switch (e.button) {
+      case 2:
+        // Ignore right click
+        return
+      case 1:
+        // Close tab with middle click
+        this.onTabClosedWithMouse(e)
+        break
+      default:
+        e.stopPropagation()
+        appActions.tabActivateRequested(this.props.tabId)
     }
   }
 


### PR DESCRIPTION
## Test plan
1. Open two tabs. Set focus to tab 2
2. Right click tab 1 and verify context menu appears
3. Press ESC (if your keyboard has it 🤣  )
4. verify menu closes and focus did NOT change
5. Right click tab 1 so that context menu appears
6. Right click another place in tab 1 so that the context menu closes then reopens
7. Verify focus did NOT change
8. Push ESC and verify menu closes / focus did not change

## Description
Fixes https://github.com/brave/browser-laptop/issues/7327

Auditors: @NejcZdovc, @cezaraugusto

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


