### PR TITLE
Replace menu_btn

### DIFF
--- a/img/toolbar/menu_btn.svg
+++ b/img/toolbar/menu_btn.svg
@@ -1,1 +1,16 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 2.63 11.58"><defs><style>.cls-1{fill:none;stroke:#6d6e70;stroke-linecap:round;stroke-linejoin:round;stroke-width:2.33px;}</style></defs><title>menu_btn</title><g id="Layer_2" data-name="Layer 2"><g id="Layer_1-2" data-name="Layer 1"><line class="cls-1" x1="1.46" y1="5.79" x2="1.16" y2="5.79"/><line class="cls-1" x1="1.46" y1="1.16" x2="1.16" y2="1.16"/><line class="cls-1" x1="1.46" y1="10.41" x2="1.16" y2="10.41"/></g></g></svg>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 21.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 4.3 11.6" style="enable-background:new 0 0 4.3 11.6;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:none;stroke:#6D6E70;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;}
+</style>
+<title>menu_btn</title>
+<g id="Layer_2">
+	<g id="Layer_1-2">
+		<line class="st0" x1="4.7" y1="5.7" x2="-0.4" y2="5.7"/>
+		<line class="st0" x1="4.7" y1="1.6" x2="-0.4" y2="1.6"/>
+		<line class="st0" x1="4.7" y1="9.9" x2="-0.4" y2="9.9"/>
+	</g>
+</g>
+</svg>

--- a/less/tabs.less
+++ b/less/tabs.less
@@ -130,7 +130,7 @@
 .tabsToolbarButtons {
   box-sizing: border-box;
   height: @tabHeight;
-  padding-right: 2px;
+  padding-right: 5px;
 
   .browserButton {
     display: inline-block;


### PR DESCRIPTION
Closes #9305

Auditors:

Test Plan:
1. Make sure the menu button on the tabs bar is replaced

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


