### PR TITLE
Don't allow view certificate option for urlbar searches

### DIFF
--- a/app/renderer/components/main/siteInfo.js
+++ b/app/renderer/components/main/siteInfo.js
@@ -231,7 +231,7 @@ class SiteInfo extends ImmutableComponent {
         </div>
     }
 
-    return <Dialog onHide={this.props.onHide} className='siteInfo' isClickDismiss>
+    return <Dialog testId='siteInfoDialog' onHide={this.props.onHide} className='siteInfo' isClickDismiss>
       <div onClick={(e) => e.stopPropagation()}
         className={cx({
           [css(commonStyles.flyoutDialog)]: true,

--- a/app/renderer/components/navigation/urlBarIcon.js
+++ b/app/renderer/components/navigation/urlBarIcon.js
@@ -84,7 +84,7 @@ class UrlBarIcon extends ImmutableComponent {
     }
   }
   onClick () {
-    if (isSourceAboutUrl(this.props.location)) {
+    if (isSourceAboutUrl(this.props.location) || this.isSearch) {
       return
     }
     windowActions.setSiteInfoVisible(true)

--- a/test/lib/selectors.js
+++ b/test/lib/selectors.js
@@ -16,7 +16,7 @@ module.exports = {
   tabPage1: '[data-tab-page="0"]',
   tabPage2: '[data-tab-page="1"]',
   closeTab: '[data-test-id="closeTabIcon"]',
-  urlbarIcon: '.urlbarIcon',
+  urlbarIcon: '[data-test-id="urlBarIcon"]',
   urlBarSuggestions: '.urlBarSuggestions',
   titleBar: '#titleBar',
   navigatorBookmarked: '#navigator .removeBookmarkButton',
@@ -125,5 +125,7 @@ module.exports = {
   downloadReDownload: '[data-test-id="redownloadButton"]',
   downloadDelete: '[data-test-id="deleteButton"]',
   downloadDeleteConfirm: '[data-test-id="confirmDeleteButton"]',
-  downloadRemoveFromList: '[data-test-id="downloadRemoveFromList"]'
+  downloadRemoveFromList: '[data-test-id="downloadRemoveFromList"]',
+
+  siteInfoDialog: '[data-test-id="siteInfoDialog"]'
 }

--- a/test/unit/app/renderer/components/navigation/urlBarIconTest.js
+++ b/test/unit/app/renderer/components/navigation/urlBarIconTest.js
@@ -57,6 +57,25 @@ describe('UrlBarIcon component unit tests', function () {
     windowActions.setSiteInfoVisible.restore()
   })
 
+  describe('when user is searching', function () {
+    const props2 = Object.assign({}, props)
+
+    before(function () {
+      props2.isSearching = true
+      props2.titleMode = false
+    })
+
+    it('does not show site information when clicked', function () {
+      const spy = sinon.spy(windowActions, 'setSiteInfoVisible')
+      const wrapper = mount(
+        <UrlBarIcon {...props2} />
+      )
+      wrapper.find('[data-test-id="urlBarIcon"]').simulate('click')
+      assert.equal(spy.notCalled, true)
+      windowActions.setSiteInfoVisible.restore()
+    })
+  })
+
   describe('when active tab is showing a message box', function () {
     const props2 = Object.assign({}, props)
 


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Auditors: @diracdeltas
Close #9172 

Test Plan:

```
npm run test -- --grep="UrlBarIcon component unit tests when user is searching does not show site information when clicked"
```

Manual Tests:

1. Go to https://brave.com
2. Cut or remove all url text
3. Search icon show up indicating search mode
4. Click search icon
4. siteInfo modal shouldn't be show

Reviewer Checklist:

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header