### PR TITLE
"Select its parent tab" setting now works as expected

### DIFF
--- a/app/browser/reducers/tabsReducer.js
+++ b/app/browser/reducers/tabsReducer.js
@@ -51,15 +51,14 @@ const updateActiveTab = (state, closeTabId) => {
     case tabCloseAction.PARENT:
       {
         const openerTabId = tabState.getOpenerTabId(state, closeTabId)
-        const lastActiveTabId = tabState.getLastActiveTabId(state, windowId)
-        if (openerTabId === lastActiveTabId) {
+        if (openerTabId && openerTabId !== tabState.TAB_ID_NONE) {
           nextTabId = openerTabId
         }
         break
       }
   }
 
-  // always fall back to NEXT
+  // DEFAULT: always fall back to NEXT
   if (nextTabId === tabState.TAB_ID_NONE) {
     nextTabId = tabState.getNextTabIdByIndex(state, windowId, index)
     if (nextTabId === tabState.TAB_ID_NONE) {

--- a/app/browser/reducers/tabsReducer.js
+++ b/app/browser/reducers/tabsReducer.js
@@ -51,7 +51,7 @@ const updateActiveTab = (state, closeTabId) => {
     case tabCloseAction.PARENT:
       {
         const openerTabId = tabState.getOpenerTabId(state, closeTabId)
-        if (openerTabId && openerTabId !== tabState.TAB_ID_NONE) {
+        if (openerTabId !== tabState.TAB_ID_NONE) {
           nextTabId = openerTabId
         }
         break

--- a/app/common/state/tabState.js
+++ b/app/common/state/tabState.js
@@ -501,9 +501,9 @@ const tabState = {
   getOpenerTabId: (state, tabId) => {
     const openerTabId = tabState.getTabPropertyByTabId(state, tabId, 'openerTabId', tabState.TAB_ID_NONE)
     if (openerTabId !== tabState.TAB_ID_NONE) {
-      // Validate that tabId exists
-      const index = getTabInternalIndexByTabId(state, openerTabId)
-      if (index !== tabState.TAB_ID_NONE) {
+      // Validate that tab exists
+      const tab = tabState.getByTabId(state, openerTabId)
+      if (tab) {
         return openerTabId
       }
     }

--- a/app/common/state/tabState.js
+++ b/app/common/state/tabState.js
@@ -499,7 +499,15 @@ const tabState = {
   },
 
   getOpenerTabId: (state, tabId) => {
-    return tabState.getTabPropertyByTabId(state, tabId, 'openerTabId', tabState.TAB_ID_NONE)
+    const openerTabId = tabState.getTabPropertyByTabId(state, tabId, 'openerTabId', tabState.TAB_ID_NONE)
+    if (openerTabId !== tabState.TAB_ID_NONE) {
+      // Validate that tabId exists
+      const index = getTabInternalIndexByTabId(state, openerTabId)
+      if (index !== tabState.TAB_ID_NONE) {
+        return openerTabId
+      }
+    }
+    return tabState.TAB_ID_NONE
   },
 
   getIndex: (state, tabId) => {

--- a/test/unit/app/browser/reducers/tabsReducerTest.js
+++ b/test/unit/app/browser/reducers/tabsReducerTest.js
@@ -303,6 +303,7 @@ describe('tabsReducer unit tests', function () {
         after(function () {
           tabCloseSetting = tabCloseAction.PARENT
         })
+
         it('chooses the next tab', function () {
           const pickNextAction = {
             actionType: action.actionType,
@@ -316,25 +317,8 @@ describe('tabsReducer unit tests', function () {
           this.clock.tick(1510)
           assert(this.tabsAPI.setActive.withArgs(4).calledOnce)
         })
-      })
 
-      describe('when TAB_CLOSE_ACTION is set to PARENT', function () {
-        it('chooses parent tab id (if parent tab was last active)', function () {
-          tabsReducer(this.state, action)
-          this.clock.tick(1510)
-          assert(this.tabsAPI.setActive.withArgs(4).calledOnce)
-        })
-      })
-
-      describe('when last active tab is not set', function () {
-        beforeEach(function () {
-          this.getLastActiveTabIdStub = sinon.stub(this.tabStateAPI, 'getLastActiveTabId')
-        })
-        afterEach(function () {
-          this.getLastActiveTabIdStub.restore()
-        })
-
-        it('chooses next unpinned tab if nextTabId is TAB_ID_NONE', function () {
+        it('chooses next unpinned tab', function () {
           const pickNextAction = {
             actionType: action.actionType,
             tabId: 3
@@ -348,7 +332,7 @@ describe('tabsReducer unit tests', function () {
           assert(this.tabsAPI.setActive.withArgs(5).calledOnce)
         })
 
-        it('chooses previous unpinned tab if nextTabId is TAB_ID_NONE', function () {
+        it('chooses previous unpinned tab', function () {
           const testState = this.state
             .setIn(['tabs', 2, 'active'], true)
             .setIn(['tabs', 3, 'active'], false)
@@ -373,6 +357,23 @@ describe('tabsReducer unit tests', function () {
             this.clock.tick(1510)
             assert(this.tabsAPI.setActive.withArgs(4).calledOnce)
           })
+        })
+      })
+
+      describe('when TAB_CLOSE_ACTION is set to PARENT', function () {
+        it('chooses parent tab id (if parent tab was last active)', function () {
+          tabsReducer(this.state, action)
+          this.clock.tick(1510)
+          assert(this.tabsAPI.setActive.withArgs(4).calledOnce)
+        })
+
+        it('chooses parent tab id (even if parent tab was NOT last active)', function () {
+          const testState = this.state
+            .setIn(['tabs', 4, 'openerTabId'], 3)
+            .setIn(['tabsInternal', 'lastActive', '2'], Immutable.fromJS([]))
+          tabsReducer(testState, action)
+          this.clock.tick(1510)
+          assert(this.tabsAPI.setActive.withArgs(3).calledOnce)
         })
       })
     })

--- a/test/unit/app/common/state/tabStateTest.js
+++ b/test/unit/app/common/state/tabStateTest.js
@@ -13,8 +13,8 @@ const defaultAppState = Immutable.fromJS({
 
 const twoTabsAppState = defaultAppState
   .set('tabs', Immutable.fromJS([
-    { tabId: 1, index: 0, windowId: 1, frameKey: 2 },
-    { tabId: 2, index: 1, windowId: 1, frameKey: 1 }
+    { tabId: 1, index: 0, windowId: 1 },
+    { tabId: 2, index: 1, windowId: 1 }
   ]))
   .set('tabsInternal', Immutable.fromJS({
     index: {
@@ -204,7 +204,6 @@ describe('tabState unit tests', function () {
       let tab = tabState.getByTabId(this.appState, 2)
       assert(tab)
       assert.equal(1, tab.get('windowId'))
-      assert.equal(1, tab.get('frameKey'))
       assert.equal(2, tab.get('tabId'))
     })
 
@@ -333,7 +332,6 @@ describe('tabState unit tests', function () {
         .set('tabs', Immutable.fromJS([
           {
             windowId: 1,
-            frameKey: 1,
             tabId: 1,
             index: 0,
             myProp: 'test1',
@@ -341,7 +339,6 @@ describe('tabState unit tests', function () {
           },
           {
             windowId: 1,
-            frameKey: 1,
             tabId: 2,
             index: 1,
             myProp: 'test2',
@@ -364,13 +361,11 @@ describe('tabState unit tests', function () {
             index: 0,
             test: 'blue',
             windowId: 1,
-            frameKey: 1,
             myProp: 'test2',
             myProp2: 'blah'
           },
           {
             windowId: 1,
-            frameKey: 1,
             tabId: 2,
             index: 1,
             myProp: 'test2',
@@ -391,7 +386,6 @@ describe('tabState unit tests', function () {
           },
           {
             windowId: 1,
-            frameKey: 1,
             tabId: 2,
             index: 1,
             myProp: 'test2',
@@ -407,7 +401,6 @@ describe('tabState unit tests', function () {
       assert.equal('test1', tab.get('myProp'))
       assert.equal('blah', tab.get('myProp2'))
       assert.equal(1, tab.get('windowId'))
-      assert.equal(1, tab.get('frameKey'))
       assert.equal(1, tab.get('tabId'))
       assert.equal(true, state.get('otherProp'))
     })
@@ -429,7 +422,6 @@ describe('tabState unit tests', function () {
     it('removes the field specified', function () {
       const tab = Immutable.fromJS({
         windowId: 1,
-        frameKey: 1,
         tabId: 2,
         loginRequiredDetail: {
           request: { url: 'someurl' },
@@ -456,7 +448,6 @@ describe('tabState unit tests', function () {
     before(function () {
       const tabs = Immutable.fromJS([{
         windowId: 1,
-        frameKey: 1,
         tabId: 2,
         loginRequiredDetail: {
           request: { url: 'someurl' },
@@ -621,7 +612,7 @@ describe('tabState unit tests', function () {
       )
       assert.throws(
         () => {
-          tabState.setTabs(defaultAppState, [{ frameKey: 1 }])
+          tabState.setTabs(defaultAppState, [{ index: 0 }])
         },
         AssertionError
       )
@@ -691,6 +682,24 @@ describe('tabState unit tests', function () {
         },
         AssertionError
       )
+    })
+  })
+
+  describe('getOpenerTabId', function () {
+    it('returns tabId of the opener', function () {
+      const tempState = twoTabsAppState
+        .setIn(['tabs', 1, 'openerTabId'], 1)
+      assert.equal(tabState.getOpenerTabId(tempState, 2), 1)
+    })
+
+    it('defaults to TAB_ID_NONE if not found', function () {
+      assert.equal(tabState.getOpenerTabId(twoTabsAppState, 2), tabState.TAB_ID_NONE)
+    })
+
+    it('returns TAB_ID_NONE if tabId is invalid', function () {
+      const tempState = twoTabsAppState
+        .setIn(['tabs', 1, 'openerTabId'], 17)
+      assert.equal(tabState.getOpenerTabId(tempState, 2), tabState.TAB_ID_NONE)
     })
   })
 


### PR DESCRIPTION
"Select its parent tab" setting now works as expected
- Properly get openerTabId; it's located in the frame (not the tab)
- Don't consider if tab was active or not

Fixes https://github.com/brave/browser-laptop/issues/9395

Auditors: @bridiver, @BrendanEich

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


