### PR TITLE
Fix sync-after-import-bookmark hierarchy

### DIFF
--- a/app/sync.js
+++ b/app/sync.js
@@ -255,7 +255,7 @@ module.exports.onSyncReady = (isFirstRun, e) => {
       siteJS.parentFolderObjectId = folderToObjectId[parentFolderId]
     }
 
-    const record = syncUtil.createSiteData(siteJS)
+    const record = syncUtil.createSiteData(siteJS, appState)
     const folderId = site.get('folderId')
     if (typeof folderId === 'number') {
       folderToObjectId[folderId] = record.objectId


### PR DESCRIPTION
Fix #8892


Test plan:
1. Setup sync on pyramid 0 (desktop)
2. Sync pyramid 1 (desktop) to pyramid 0
3. Save the following as an HTML file and import it into pyramid 0 in about:bookmarks:
```
<!DOCTYPE NETSCAPE-Bookmark-file-1>
<!-- This is an automatically generated file. It will be read and overwritten. DO NOT EDIT! -->
<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">
<TITLE>Bookmarks</TITLE>
<H1>Bookmarks</H1>
<DL><p>
  <DT><H3 PERSONAL_TOOLBAR_FOLDER="true">Bookmarks Bar</H3>
  <DL><p>
    <DT><A HREF="https://twitter.com/">Twitter. It's what's happening.</A>
    <DT><H3>abc</H3>
    <DL><p>
      <DT><A HREF="https://www.facebook.com/">Facebook - Log In or Sign Up</A>
    </DL><p>
  </DL><p>

</DL><p>
```
4. You should see an 'Imported' folder appear in Pyramid 0 with some bookmarks in it.
5. Wait for the bookmarks to sync to Pyramid 1. It should have the same folder structure as Pyramid 0.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


