### PR TITLE
reliably activate titleMode based on mouse state

### DIFF
--- a/app/renderer/components/frame/frame.js
+++ b/app/renderer/components/frame/frame.js
@@ -739,8 +739,6 @@ class Frame extends React.Component {
       if (!this.frame.isEmpty()) {
         windowActions.setNavigated(e.url, this.props.frameKey, false, this.props.tabId)
       }
-      // force temporary url display for tabnapping protection
-      windowActions.setMouseInTitlebar(true)
     }, { passive: true })
     this.webview.addEventListener('crashed', (e) => {
       if (this.frame.isEmpty()) {


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Auditors: @bbondy, @bsclifton 
fix #9410

Test Plan:

General manual test plan is to:

Check when mouse is over navigation content, titleMode should be active. Otherwise it should not.

Also shortcuts such as <kbd>cmd/ctrl</kbd>+<kbd>L</kbd> and <kbd>f6</kbd> should activate urlbar even when mouse is not over navigation content.

Below specific steps for bugs found in different platforms.

**on macOS**
1. Have the window not maximized
2. Move mouse over navigation content.
3. urlbar is active, that's ok
4. Move mouse out of window
5. titleMode should be active (urlbar should be hidden)

**on Windows**
1. Have the window not maximized
2. Move mouse over navigation content.
3. urlbar is active, that's ok
4. Move mouse out of window
5. titleMode is active, that's ok 
6. Move mouse from top of the window up to website's title
7. titleMode should be removed (urlbar should be active)

**alert active**
1. Open jsFiddle.net and type under js console `alert()`
2. Alert is open
3. titleMode should be active (no visible urlbar)

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


