### PR TITLE
Refactors UrlBarIcon into redux

### DIFF
--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -428,17 +428,16 @@ class UrlBar extends React.Component {
   mergeProps (state, ownProps) {
     const currentWindow = state.get('currentWindow')
     const activeFrame = frameStateUtil.getActiveFrame(currentWindow) || Immutable.Map()
-    const activeTabId = activeFrame.get('tabId') || tabState.TAB_ID_NONE
+    const activeTabId = activeFrame.get('tabId', tabState.TAB_ID_NONE)
 
     const location = tabState.getVisibleURL(state, activeTabId)
     const frameLocation = activeFrame.get('location') || ''
     const displayEntry = tabState.getVisibleEntry(state, activeTabId) || Immutable.Map()
     const displayURL = tabState.getVisibleVirtualURL(state, activeTabId) || ''
     const hostValue = displayEntry.get('host', '')
-    const protocol = displayEntry.get('protocol', '')
 
     const baseUrl = getBaseUrl(location)
-    const urlbar = activeFrame.getIn(['navbar', 'urlbar']) || Immutable.Map()
+    const urlbar = activeFrame.getIn(['navbar', 'urlbar'], Immutable.Map())
     const urlbarLocation = urlbar.get('location')
     const selectedIndex = urlbar.getIn(['suggestions', 'selectedIndex'])
     const allSiteSettings = siteSettingsState.getAllSiteSettings(state, activeFrame.get('isPrivate'))
@@ -464,8 +463,6 @@ class UrlBar extends React.Component {
       searchURL = provider.get('search')
     }
 
-    const isHTTPPage = protocol === 'http' || protocol === 'https'
-
     const props = {}
 
     props.activeTabId = activeTabId
@@ -473,18 +470,16 @@ class UrlBar extends React.Component {
     props.frameLocation = frameLocation
     props.displayURL = displayURL
     props.hostValue = hostValue
-    props.title = activeFrame.get('title') || ''
+    props.title = activeFrame.get('title', '')
     props.scriptsBlocked = activeFrame.getIn(['noScript', 'blocked'])
     props.enableNoScript = siteSettingsState.isNoScriptEnabled(state, braverySettings)
     props.showNoScriptInfo = props.enableNoScript && props.scriptsBlocked && props.scriptsBlocked.size
-    props.isSecure = activeFrame.getIn(['security', 'isSecure'])
     props.hasSuggestionMatch = urlbar.getIn(['suggestions', 'hasSuggestionMatch'])
     props.startLoadTime = activeFrame.get('startLoadTime')
     props.endLoadTime = activeFrame.get('endLoadTime')
     props.loading = activeFrame.get('loading')
     props.noScriptIsVisible = currentWindow.getIn(['ui', 'noScriptInfo', 'isVisible']) || false
     props.menubarVisible = ownProps.menubarVisible
-    props.activeTabShowingMessageBox = tabState.isShowingMessageBox(state, activeTabId)
     props.noBorderRadius = isPublisherButtonEnabled
     props.onStop = ownProps.onStop
     props.titleMode = ownProps.titleMode
@@ -498,9 +493,7 @@ class UrlBar extends React.Component {
     props.isActive = urlbar.get('active')
     props.isSelected = urlbar.get('selected')
     props.isFocused = urlbar.get('focused')
-    props.isHTTPPage = isHTTPPage
     props.isWideURLbarEnabled = getSetting(settings.WIDE_URL_BAR)
-    props.activateSearchEngine = activateSearchEngine
     props.searchSelectEntry = urlbarSearchDetail
     props.autocompleteEnabled = urlbar.getIn(['suggestions', 'autocompleteEnabled'])
     props.searchURL = searchURL
@@ -519,21 +512,10 @@ class UrlBar extends React.Component {
         noBorderRadius: this.props.noBorderRadius
       })}
       action='#'
-      id='urlbar'
-      ref='urlbar'>
+      id='urlbar'>
       <div className='urlbarIconContainer'>
         <UrlBarIcon
-          activateSearchEngine={this.props.activateSearchEngine}
-          active={this.props.isActive}
-          isSecure={this.props.isSecure}
-          isHTTPPage={this.props.isHTTPPage}
-          loading={this.props.loading}
-          location={this.props.displayURL}
-          searchSelectEntry={this.props.searchSelectEntry}
-          title={this.props.title}
           titleMode={this.props.titleMode}
-          isSearching={this.props.displayURL !== this.props.urlbarLocation}
-          activeTabShowingMessageBox={this.props.activeTabShowingMessageBox}
         />
       </div>
       {

--- a/test/unit/app/renderer/components/navigation/urlBarIconTest.js
+++ b/test/unit/app/renderer/components/navigation/urlBarIconTest.js
@@ -4,72 +4,105 @@
 /* global describe, before, after, it */
 
 const React = require('react')
+const Immutable = require('immutable')
 const mockery = require('mockery')
 const {mount} = require('enzyme')
 const sinon = require('sinon')
 const assert = require('assert')
-let UrlBarIcon, windowActions
+const fakeElectron = require('../../../../lib/fakeElectron')
 require('../../../../braveUnit')
 
+const tabId = 1
+const frameKey = 0
+
+const fakeAppStoreRenderer = Immutable.fromJS({
+  windows: [{
+    windowId: 1,
+    windowUUID: 'uuid'
+  }],
+  tabs: [{
+    tabId: tabId,
+    windowId: 1,
+    windowUUID: 'uuid',
+    url: 'https://brave.com',
+    messageBoxDetail: false
+  }],
+  tabsInternal: {
+    index: {
+      1: 0
+    }
+  }
+})
+
+const defaultWindowStore = Immutable.fromJS({
+  activeFrameKey: frameKey,
+  frames: [{
+    key: frameKey,
+    tabId: tabId,
+    location: 'https://brave.com',
+    security: {
+      isSecure: true
+    },
+    navbar: {
+      urlbar: {
+        location: 'https://brave.com',
+        active: false,
+        searchDetail: {
+          activateSearchEngine: true
+        }
+      }
+    },
+    title: 'Brave Software'
+  }],
+  tabs: [{
+    key: frameKey
+  }]
+})
+
 describe('UrlBarIcon component unit tests', function () {
+  let UrlBarIcon, windowActions, windowStore, appStore
+
   before(function () {
     mockery.enable({
       warnOnReplace: false,
       warnOnUnregistered: false,
       useCleanCache: true
     })
-    mockery.registerMock('electron', require('../../../../lib/fakeElectron'))
+    mockery.registerMock('electron', fakeElectron)
     UrlBarIcon = require('../../../../../../app/renderer/components/navigation/urlBarIcon')
     windowActions = require('../../../../../../js/actions/windowActions')
+    windowStore = require('../../../../../../js/stores/windowStore')
+    appStore = require('../../../../../../js/stores/appStoreRenderer')
   })
 
   after(function () {
     mockery.disable()
   })
 
-  const props = {
-    activateSearchEngine: false,
-    active: false,
-    isSecure: true,
-    isHTTPPage: true,
-    loading: false,
-    location: 'https://brave.com/',
-    title: 'UrlBarIcon unit test',
-    titleMode: true,
-    isSearching: false,
-    activeTabShowingMessageBox: false
-  }
-
   it('sets element as draggable', function () {
-    const wrapper = mount(
-      <UrlBarIcon {...props} />
-    )
+    appStore.state = fakeAppStoreRenderer
+    windowStore.state = defaultWindowStore
+    const wrapper = mount(<UrlBarIcon titleMode />)
     assert.equal(wrapper.find('span[draggable]').length, 1)
   })
 
   it('shows site information when clicked', function () {
     const spy = sinon.spy(windowActions, 'setSiteInfoVisible')
-    const wrapper = mount(
-      <UrlBarIcon {...props} />
-    )
+    const wrapper = mount(<UrlBarIcon titleMode />)
     wrapper.find('[data-test-id="urlBarIcon"]').simulate('click')
     assert.equal(spy.calledOnce, true)
     windowActions.setSiteInfoVisible.restore()
   })
 
   describe('when user is searching', function () {
-    const props2 = Object.assign({}, props)
-
     before(function () {
-      props2.isSearching = true
-      props2.titleMode = false
+      appStore.state = fakeAppStoreRenderer
+      windowStore.state = defaultWindowStore.setIn(['frames', 0, 'navbar', 'urlbar', 'location'], 'https://clifton.io')
     })
 
     it('does not show site information when clicked', function () {
       const spy = sinon.spy(windowActions, 'setSiteInfoVisible')
-      const wrapper = mount(
-        <UrlBarIcon {...props2} />
-      )
+      const wrapper = mount(<UrlBarIcon titleMode={false} />)
       wrapper.find('[data-test-id="urlBarIcon"]').simulate('click')
       assert.equal(spy.notCalled, true)
       windowActions.setSiteInfoVisible.restore()
@@ -77,24 +110,19 @@ describe('UrlBarIcon component unit tests', function () {
   })
 
   describe('when active tab is showing a message box', function () {
-    const props2 = Object.assign({}, props)
-
     before(function () {
-      props2.activeTabShowingMessageBox = true
+      appStore.state = fakeAppStoreRenderer.setIn(['tabs', 0, 'messageBoxDetail'], true)
+      windowStore.state = defaultWindowStore
     })
 
     it('does not set element as draggable', function () {
-      const wrapper = mount(
-        <UrlBarIcon {...props2} />
-      )
+      const wrapper = mount(<UrlBarIcon titleMode />)
       assert.equal(wrapper.find('span[draggable]').length, 0)
     })
 
     it('does not respond to clicks', function () {
       const spy = sinon.spy(windowActions, 'setSiteInfoVisible')
-      const wrapper = mount(
-        <UrlBarIcon {...props2} />
-      )
+      const wrapper = mount(<UrlBarIcon titleMode />)
       wrapper.find('[data-test-id="urlBarIcon"]').simulate('click')
       assert.equal(spy.notCalled, true)
       windowActions.setSiteInfoVisible.restore()


### PR DESCRIPTION
## Test Plan
- type `:g ` into url bar -> google icon is shown
- when you open new tab search icon is loaded
- when you load a site that has certificate, lock icon should be shown
- when you load a http site, unlock icon should be shown

## Description
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Resolves #9340

Auditors: @bsclifton @bridiver

Reviewer Checklist:

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


