### PR TITLE
do not error if createSiteData cannot build a siteKey

### DIFF
--- a/js/state/syncUtil.js
+++ b/js/state/syncUtil.js
@@ -481,7 +481,10 @@ module.exports.createSiteData = (site, appState) => {
   const immutableSite = Immutable.fromJS(site)
   const siteKey = siteUtil.getSiteKey(immutableSite) || siteUtil.getSiteKey(Immutable.fromJS(siteData))
   if (siteKey === null) {
-    throw new Error('Sync could not create siteKey')
+    // May happen if this is called before the appStore object has its location
+    // field populated
+    console.log(`Ignoring entry because we can't create site key: ${JSON.stringify(site)}`)
+    return
   }
   if (module.exports.isSyncable('bookmark', immutableSite)) {
     const objectId = site.objectId || module.exports.newObjectId(['sites', siteKey])


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/9430

Test Plan:
1. enable sync
2. visit https://www.google.com/#q=test
3. enable the setting to clear browsing history when Brave is closed in about:preferences#security
4. close and restart Brave
5. you should see 'Ignoring entry because we can't create site key' in the console but no errors

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


