### PR TITLE
Don't sort sites when adding or removing them

### DIFF
--- a/app/browser/reducers/sitesReducer.js
+++ b/app/browser/reducers/sitesReducer.js
@@ -75,12 +75,10 @@ const sitesReducer = (state, action, immutableAction) => {
           state = syncUtil.updateSiteCache(state, action.destinationDetail || action.siteDetail)
         }
       }
-      state = state.set('sites', state.get('sites').sort(siteUtil.siteSort))
       state = updateActiveTabBookmarked(state)
       break
     case appConstants.APP_REMOVE_SITE:
       state = siteUtil.removeSite(state, action.siteDetail, action.tag, true)
-      state = state.set('sites', state.get('sites').sort(siteUtil.siteSort))
       if (syncEnabled()) {
         state = syncUtil.updateSiteCache(state, action.siteDetail)
       }

--- a/app/sync.js
+++ b/app/sync.js
@@ -266,7 +266,6 @@ module.exports.onSyncReady = (isFirstRun, e) => {
 
   // Sync bookmarks that have not been synced yet.
   siteUtil.getBookmarks(sites).filter(site => shouldSyncBookmark(site))
-    .sortBy(site => site.get('order'))
     .forEach(syncBookmark)
 
   // Sync site settings that have not been synced yet


### PR DESCRIPTION
- sites is an OrderedMap sorted initially when the app starts.
- addSite sets site order to [sites.size](https://github.com/brave/browser-laptop/blob/master/js/state/siteUtil.js#L307) or [retains the original order](https://github.com/brave/browser-laptop/blob/master/js/state/siteUtil.js#L223) – in both cases iteration order is preserved.
- removeSite removes a site, also preserving iteration order.

Fix #9427

Auditors: @darkdh @bsclifton 

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


