### PR TITLE
Converts BraveryPanel into redux component

### DIFF
--- a/app/common/lib/braveryPanelUtil.js
+++ b/app/common/lib/braveryPanelUtil.js
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const Immutable = require('immutable')
+
+const getRedirectedResources = (redirectedResources) => {
+  let result = new Immutable.List()
+  if (redirectedResources) {
+    redirectedResources.forEach((urls) => {
+      urls.forEach((url) => {
+        result = result.push(url)
+      })
+    })
+  }
+  return result
+}
+
+module.exports = {
+  getRedirectedResources
+}

--- a/app/renderer/components/main/main.js
+++ b/app/renderer/components/main/main.js
@@ -76,7 +76,6 @@ class Main extends ImmutableComponent {
     this.onMouseDown = this.onMouseDown.bind(this)
     this.onClickWindow = this.onClickWindow.bind(this)
     this.onHideSiteInfo = this.onHideSiteInfo.bind(this)
-    this.onHideBraveryPanel = this.onHideBraveryPanel.bind(this)
     this.onTabContextMenu = this.onTabContextMenu.bind(this)
     this.checkForTitleMode = debounce(this.checkForTitleMode.bind(this), 20)
     this.resetAltMenuProcessing()
@@ -524,10 +523,6 @@ class Main extends ImmutableComponent {
     windowActions.setSiteInfoVisible(false)
   }
 
-  onHideBraveryPanel () {
-    windowActions.setBraveryPanelDetail()
-  }
-
   onMouseDown (e) {
     // TODO(bsclifton): update this to use eventUtil.eventElHasAncestorWithClasses
     let node = e.target
@@ -604,8 +599,6 @@ class Main extends ImmutableComponent {
     // can be passed everywhere other than the Frame elements.
     const sortedFrames = frameStateUtil.getSortedFrames(this.props.windowState)
     const activeFrame = frameStateUtil.getActiveFrame(this.props.windowState)
-    const lastCommittedURL = frameStateUtil.getLastCommittedURL(activeFrame)
-    const activeSiteSettings = this.frameSiteSettings(lastCommittedURL)
     const nonPinnedFrames = frameStateUtil.getNonPinnedFrames(this.props.windowState)
     const tabsPerPage = Number(getSetting(settings.TABS_PER_PAGE))
     const showBookmarksToolbar = getSetting(settings.SHOW_BOOKMARKS_TOOLBAR)
@@ -625,7 +618,6 @@ class Main extends ImmutableComponent {
     const releaseNotesIsVisible = this.props.windowState.getIn(['ui', 'releaseNotes', 'isVisible'])
     const checkDefaultBrowserDialogIsVisible =
       isFocused() && defaultBrowserState.shouldDisplayDialog(this.props.appState)
-    const braverySettings = siteSettings.activeSettings(activeSiteSettings, this.props.appState, appConfig)
     const loginRequiredDetail = activeFrame ? basicAuthState.getLoginRequiredDetail(this.props.appState, activeFrame.get('tabId')) : null
     const customTitlebar = this.customTitlebar
     const contextMenuDetail = this.props.windowState.get('contextMenuDetail')
@@ -664,12 +656,7 @@ class Main extends ImmutableComponent {
         }
         {
           braveryPanelIsVisible
-          ? <BraveryPanel frameProps={activeFrame}
-            lastCommittedURL={lastCommittedURL}
-            braveryPanelDetail={this.props.windowState.get('braveryPanelDetail')}
-            braverySettings={braverySettings}
-            activeSiteSettings={activeSiteSettings}
-            onHide={this.onHideBraveryPanel} />
+          ? <BraveryPanel />
           : null
         }
         {

--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -401,6 +401,15 @@ const UrlUtil = {
 
     const localFileOrigins = ['file:', 'blob:', 'data:', 'chrome-extension:', 'chrome:']
     return origin && localFileOrigins.some((localFileOrigin) => origin.startsWith(localFileOrigin))
+  },
+
+  getDisplayHost: (url) => {
+    const parsedUrl = urlParse(url)
+    if (parsedUrl.protocol === 'https:' || parsedUrl.protocol === 'http:') {
+      return parsedUrl.host
+    }
+
+    return url
   }
 }
 

--- a/test/unit/app/common/lib/braveryPanelUtilTest.js
+++ b/test/unit/app/common/lib/braveryPanelUtilTest.js
@@ -1,0 +1,30 @@
+/* global describe, it */
+const braveryPanelUtil = require('../../../../../app/common/lib/braveryPanelUtil')
+const assert = require('assert')
+const Immutable = require('immutable')
+
+require('../../../braveUnit')
+
+describe('braveryPanelUtil test', function () {
+  describe('getRedirectedResources', function () {
+    const data = Immutable.fromJS({
+      'BootstrapCDN.xml': [
+        'http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css',
+        'http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css'
+      ],
+      'GoogleAPIs.xml': [
+        'http://fonts.googleapis.com/css?family=Source+Sans+Pro'
+      ]
+    })
+
+    it('returns empty Immutable list if you dont provide resources', function () {
+      const result = braveryPanelUtil.getRedirectedResources()
+      assert.equal(result, Immutable.List())
+    })
+
+    it('merge all resources into one list', function () {
+      const result = braveryPanelUtil.getRedirectedResources(data)
+      assert.equal(result.size, 3)
+    })
+  })
+})

--- a/test/unit/lib/urlutilTest.js
+++ b/test/unit/lib/urlutilTest.js
@@ -318,4 +318,21 @@ describe('urlutil', function () {
       })
     })
   })
+
+  describe('getDisplayHost', function () {
+    it('url is http', function () {
+      const result = UrlUtil.getDisplayHost('http://brave.com')
+      assert.equal(result, 'brave.com')
+    })
+
+    it('url is https', function () {
+      const result = UrlUtil.getDisplayHost('https://brave.com')
+      assert.equal(result, 'brave.com')
+    })
+
+    it('url is file', function () {
+      const result = UrlUtil.getDisplayHost('file://brave.text')
+      assert.equal(result, 'file://brave.text')
+    })
+  })
 })


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Resolves #9454

Auditors: @bsclifton @bridiver

Test Plan:
- `npm run test -- --grep='Bravery Panel'`
- check if bravery panel is opened when you click on lion head
- check if you can toggle all checkboxes
- check if blocking numbers are correct


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


