### PR TITLE
check for destroyed before sending to webContents

### DIFF
--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -270,8 +270,11 @@ class AppStore extends EventEmitter {
     if (lastEmittedState) {
       const d = diff(lastEmittedState, appState)
       if (!d.isEmpty()) {
-        BrowserWindow.getAllWindows().forEach((wnd) =>
-          wnd.webContents.send(messages.APP_STATE_CHANGE, { stateDiff: d.toJS() }))
+        BrowserWindow.getAllWindows().forEach((wnd) => {
+          if (wnd.webContents && !wnd.webContents.isDestroyed()) {
+            wnd.webContents.send(messages.APP_STATE_CHANGE, { stateDiff: d.toJS() })
+          }
+        })
         lastEmittedState = appState
         this.emit(CHANGE_EVENT, d.toJS())
       }


### PR DESCRIPTION
Submitter Checklist:

This is hard to reliably replicate, but sometimes on shutdown or window close it will try to send an update to a destroyed webContents

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


