### PR TITLE
Fix system menu History :: Recently closed items for Windows

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -354,11 +354,11 @@ const updateRecentlyClosedMenuItems = () => {
 
   // Update in-memory menu template (Windows)
   const oldTemplate = appStore.getState().getIn(['menu', 'template'])
-  const historySubmenuKey = oldTemplate.findKey(value =>
+  const historyMenuKey = oldTemplate.findKey(value =>
     value.get('label') === locale.translation('history')
   )
-  const newSubmenu = Immutable.fromJS(createHistorySubmenu())
-  const newTemplate = oldTemplate.set(historySubmenuKey, newSubmenu)
+  const newSubmenu = createHistorySubmenu()
+  const newTemplate = oldTemplate.setIn([historyMenuKey, 'submenu'], newSubmenu)
   appActions.setMenubarTemplate(newTemplate)
 }
 


### PR DESCRIPTION
History menu currently (20d570b9917f478987ae67a0dc88e9c0e1b87664) unusable on Windows, so this is important.

Fix #9471 

Test Plan:

0. Be on Windows
1. Open the History menu and note Recently closed is not there.
2. Go to https://archive.org
3. Open a new tab and go to https://wikipedia.org
4. Close the tab
5. Examine the menu History > Recently closed; it should have Wikipedia
6. Close the archive.org tab
7. Examine the Recently closed menu; it should have the Internet archive
8. Use the menu item "Reopen last closed tab" or use the shortcut
9. Examine the Recently closed menu; it should be hidden now.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


