### PR TITLE
Converts WidevinePanel into redux component

### DIFF
--- a/app/renderer/components/main/main.js
+++ b/app/renderer/components/main/main.js
@@ -68,7 +68,7 @@ const siteSettings = require('../../../../js/state/siteSettings')
 const debounce = require('../../../../js/lib/debounce')
 const {isSourceAboutUrl} = require('../../../../js/lib/appUrlUtil')
 const {getCurrentWindowId, isMaximized, isFocused, isFullScreen} = require('../../currentWindow')
-const {isDarwin, isWindows} = require('../../../common/lib/platformUtil')
+const {isDarwin, isWindows, isLinux} = require('../../../common/lib/platformUtil')
 
 class Main extends ImmutableComponent {
   constructor () {
@@ -78,7 +78,6 @@ class Main extends ImmutableComponent {
     this.onHideSiteInfo = this.onHideSiteInfo.bind(this)
     this.onHideBraveryPanel = this.onHideBraveryPanel.bind(this)
     this.onHideClearBrowsingDataPanel = this.onHideClearBrowsingDataPanel.bind(this)
-    this.onHideWidevinePanel = this.onHideWidevinePanel.bind(this)
     this.onHideAutofillAddressPanel = this.onHideAutofillAddressPanel.bind(this)
     this.onHideAutofillCreditCardPanel = this.onHideAutofillCreditCardPanel.bind(this)
     this.onHideReleaseNotes = this.onHideReleaseNotes.bind(this)
@@ -540,12 +539,6 @@ class Main extends ImmutableComponent {
     windowActions.setClearBrowsingDataPanelVisible(false)
   }
 
-  onHideWidevinePanel () {
-    windowActions.widevinePanelDetailChanged({
-      shown: false
-    })
-  }
-
   onHideAutofillAddressPanel () {
     windowActions.setAutofillAddressDetail()
   }
@@ -666,7 +659,7 @@ class Main extends ImmutableComponent {
       this.props.windowState.get('braveryPanelDetail')
     const clearBrowsingDataPanelIsVisible = this.props.windowState.getIn(['ui', 'isClearBrowsingDataPanelVisible'])
     const importBrowserDataPanelIsVisible = this.props.windowState.get('importBrowserDataDetail')
-    const widevinePanelIsVisible = this.props.windowState.getIn(['widevinePanelDetail', 'shown'])
+    const widevinePanelIsVisible = this.props.windowState.getIn(['widevinePanelDetail', 'shown']) && !isLinux()
     const autofillAddressPanelIsVisible = this.props.windowState.get('autofillAddressDetail')
     const autofillCreditCardPanelIsVisible = this.props.windowState.get('autofillCreditCardDetail')
     const noScriptIsVisible = this.props.windowState.getIn(['ui', 'noScriptInfo', 'isVisible']) &&
@@ -740,8 +733,7 @@ class Main extends ImmutableComponent {
         {
           widevinePanelIsVisible
           ? <WidevinePanel
-            widevinePanelDetail={this.props.windowState.get('widevinePanelDetail')}
-            widevineReady={this.props.appState.getIn([appConfig.resourceNames.WIDEVINE, 'ready'])}
+
             onHide={this.onHideWidevinePanel} />
           : null
         }

--- a/app/renderer/components/main/widevinePanel.js
+++ b/app/renderer/components/main/widevinePanel.js
@@ -6,7 +6,7 @@ const React = require('react')
 const {StyleSheet, css} = require('aphrodite/no-important')
 
 // Components
-const ImmutableComponent = require('../immutableComponent')
+const ReduxComponent = require('../reduxComponent')
 const Dialog = require('../common/dialog')
 const Button = require('../common/button')
 const WidevineInfo = require('./widevineInfo')
@@ -32,31 +32,44 @@ const siteUtil = require('../../../../js/state/siteUtil')
 // Styles
 const commonStyles = require('../styles/commonStyles')
 
-class WidevinePanel extends ImmutableComponent {
-  constructor () {
-    super()
+class WidevinePanel extends React.Component {
+  constructor (props) {
+    super(props)
     this.onInstallAndAllow = this.onInstallAndAllow.bind(this)
     this.onClickRememberForNetflix = this.onClickRememberForNetflix.bind(this)
   }
-  get origin () {
-    return siteUtil.getOrigin(this.props.widevinePanelDetail.get('location'))
-  }
+
   onInstallAndAllow () {
     appActions.setResourceEnabled(appConfig.resourceNames.WIDEVINE, true)
-    this.props.onHide()
+    this.onHide()
     // The site permissions that is set if this.props.widevinePanelDetail.get('alsoAddRememberSiteSetting') is handled once the resource is ready
     // in main.js.  This is so that the reload doesn't happen until it is ready.
   }
+
   onClickRememberForNetflix (e) {
     windowActions.widevinePanelDetailChanged({
       alsoAddRememberSiteSetting: e.target.value
     })
   }
+
+  onHide () {
+    windowActions.widevinePanelDetailChanged({
+      shown: false
+    })
+  }
+
+  mergeProps (state, ownProps) {
+    const currentWindow = state.get('currentWindow')
+    const widevinePanelDetail = currentWindow.get('widevinePanelDetail')
+
+    const props = {}
+    props.origin = siteUtil.getOrigin(widevinePanelDetail.get('location'))
+    props.alsoAddRememberSiteSetting = widevinePanelDetail.get('alsoAddRememberSiteSetting')
+
+    return props
+  }
+
   render () {
-    const isLinux = process.platform === 'linux'
-    if (isLinux) {
-      return null
-    }
     /*
        Removed 'isClickDismiss' from Dialog.
        Installing Widevine influences globally, not specific to a tab,
@@ -64,7 +77,7 @@ class WidevinePanel extends ImmutableComponent {
        the third party software which we discourage from using is going
        to be installed on the computer.
     */
-    return <Dialog onHide={this.props.onHide} testId='widevinePanelDialog'>
+    return <Dialog onHide={this.onHide} testId='widevinePanelDialog'>
       <CommonFormLarge onClick={(e) => e.stopPropagation()}>
         <CommonFormTitle data-l10n-id='widevinePanelTitle' />
         <CommonFormSection>
@@ -74,7 +87,7 @@ class WidevinePanel extends ImmutableComponent {
           <Button className='whiteButton'
             l10nId='cancel'
             testId='cancelButton'
-            onClick={this.props.onHide}
+            onClick={this.onHide}
           />
           <Button className='primaryButton'
             l10nId='installAndAllow'
@@ -84,12 +97,12 @@ class WidevinePanel extends ImmutableComponent {
         <CommonFormBottomWrapper>
           <div className={css(styles.flexJustifyCenter)}>
             {/* TODO: refactor switchControl.js to remove commonStyles.noPadding */}
-            <SwitchControl id={this.props.prefKey}
+            <SwitchControl
               className={css(commonStyles.noPadding)}
               rightl10nId='rememberThisDecision'
-              rightl10nArgs={JSON.stringify({origin: this.origin})}
+              rightl10nArgs={JSON.stringify({origin: this.props.origin})}
               onClick={this.onClickRememberForNetflix}
-              checkedOn={this.props.widevinePanelDetail.get('alsoAddRememberSiteSetting')} />
+              checkedOn={this.props.alsoAddRememberSiteSetting} />
           </div>
         </CommonFormBottomWrapper>
       </CommonFormLarge>
@@ -97,11 +110,11 @@ class WidevinePanel extends ImmutableComponent {
   }
 }
 
+module.exports = ReduxComponent.connect(WidevinePanel)
+
 const styles = StyleSheet.create({
   flexJustifyCenter: {
     display: 'flex',
     justifyContent: 'center'
   }
 })
-
-module.exports = WidevinePanel


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Resolves #9443

Auditors: @bsclifton @bridiver

Test Plan:
- go to netflix.com with a fresh profile
- widevine popup should be shown

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


