### PR TITLE
Disable new tab background for tests

### DIFF
--- a/docs/tests.md
+++ b/docs/tests.md
@@ -34,6 +34,21 @@ You can run a subset of tests which match a `description` or `it` with:
 
 Where `expression` could be for example `^tabs` to match all tests which start with the word tabs. This works for all testing modes (test, unittest).
 
+## Things you should know
+
+### Background image for new tab page is disabled by default
+
+To speed-up tests, background image for new tab page is disabled by default. If your new webdriver test needs the background to be visible you'll need to enable this setting again, for example:
+
+```js
+it('shows new tab page background', function * () {
+  yield this.app.client
+    // enable setting again:
+    .changeSetting('tabs.show-dashboard-images', true)
+    // keep testing...
+})
+```
+
 ## Best practices for writing tests
 
 - If you do anything that opens a new tab, you have to validate that the tab has opened before trying to switch to

--- a/js/entry.js
+++ b/js/entry.js
@@ -26,6 +26,7 @@ const webFrame = electron.webFrame
 const windowStore = require('./stores/windowStore')
 const appStoreRenderer = require('./stores/appStoreRenderer')
 const windowActions = require('./actions/windowActions')
+const appActions = require('./actions/appActions')
 const messages = require('./constants/messages')
 const Immutable = require('immutable')
 const patch = require('immutablepatch')
@@ -46,6 +47,7 @@ if (process.env.NODE_ENV === 'test') {
     windowActions,
     windowStore
   }
+  appActions.changeSetting('tabs.show-dashboard-images', false)
 }
 
 ipc.on(messages.APP_STATE_CHANGE, (e, action) => {


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Auditors: @bsclifton
Fix: #9240

Most tests were created while new tab was a blank page and/or before we had the option to show gradient background.

Test Plan:
1. While running tests, new tab background should be shown as background gradient rather than the background image.
2. No test regressions should happen

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


