### PR TITLE
Converts AutofillAddressPanel into redux component

### DIFF
--- a/app/autofill.js
+++ b/app/autofill.js
@@ -13,18 +13,18 @@ module.exports.init = () => {
   })
 }
 
-module.exports.addAutofillAddress = (detail, guid) => {
+module.exports.addAutofillAddress = (detail) => {
   session.defaultSession.autofill.addProfile({
-    full_name: detail.name,
-    company_name: detail.organization,
-    street_address: detail.streetAddress,
-    city: detail.city,
-    state: detail.state,
-    postal_code: detail.postalCode,
-    country_code: detail.country,
-    phone: detail.phone,
-    email: detail.email,
-    guid: guid
+    full_name: detail.get('name'),
+    company_name: detail.get('organization'),
+    street_address: detail.get('streetAddress'),
+    city: detail.get('city'),
+    state: detail.get('state'),
+    postal_code: detail.get('postalCode'),
+    country_code: detail.get('country'),
+    phone: detail.get('phone'),
+    email: detail.get('email'),
+    guid: detail.get('guid')
   })
 }
 

--- a/app/renderer/components/autofill/autofillAddressPanel.js
+++ b/app/renderer/components/autofill/autofillAddressPanel.js
@@ -3,16 +3,13 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const React = require('react')
-const ImmutableComponent = require('../immutableComponent')
+const Immutable = require('immutable')
+const {css} = require('aphrodite/no-important')
+
+// Components
+const ReduxComponent = require('../reduxComponent')
 const Dialog = require('../common/dialog')
 const Button = require('../common/button')
-const windowActions = require('../../../../js/actions/windowActions')
-const appActions = require('../../../../js/actions/appActions')
-const KeyCodes = require('../../../common/constants/keyCodes')
-
-const {css} = require('aphrodite/no-important')
-const commonStyles = require('../styles/commonStyles')
-
 const {
   CommonFormLarge,
   CommonFormSection,
@@ -21,6 +18,15 @@ const {
   commonFormStyles
 } = require('../common/commonForm')
 
+// Actions
+const windowActions = require('../../../../js/actions/windowActions')
+const appActions = require('../../../../js/actions/appActions')
+
+// Constants
+const KeyCodes = require('../../../common/constants/keyCodes')
+
+// Styles
+const commonStyles = require('../styles/commonStyles')
 const commonForm = css(
   commonStyles.formControl,
   commonStyles.textbox,
@@ -29,9 +35,9 @@ const commonForm = css(
   commonFormStyles.input__box
 )
 
-class AutofillAddressPanel extends ImmutableComponent {
-  constructor () {
-    super()
+class AutofillAddressPanel extends React.Component {
+  constructor (props) {
+    super(props)
     this.onNameChange = this.onNameChange.bind(this)
     this.onOrganizationChange = this.onOrganizationChange.bind(this)
     this.onStreetAddressChange = this.onStreetAddressChange.bind(this)
@@ -45,118 +51,100 @@ class AutofillAddressPanel extends ImmutableComponent {
     this.onSave = this.onSave.bind(this)
     this.onClick = this.onClick.bind(this)
   }
+
   onNameChange (e) {
-    let currentDetail = this.props.currentDetail
-    currentDetail = currentDetail.set('name', e.target.value)
-    if (this.nameOnAddress.value !== e.target.value) {
-      this.nameOnAddress.value = e.target.value
-    }
-    windowActions.setAutofillAddressDetail(currentDetail, this.props.originalDetail)
+    windowActions.setAutofillAddressDetail('name', e.target.value)
   }
   onOrganizationChange (e) {
-    let currentDetail = this.props.currentDetail
-    currentDetail = currentDetail.set('organization', e.target.value)
-    if (this.organization.value !== e.target.value) {
-      this.organization.value = e.target.value
-    }
-    windowActions.setAutofillAddressDetail(currentDetail, this.props.originalDetail)
+    windowActions.setAutofillAddressDetail('organization', e.target.value)
   }
   onStreetAddressChange (e) {
-    let currentDetail = this.props.currentDetail
-    currentDetail = currentDetail.set('streetAddress', e.target.value)
-    if (this.streetAddress.value !== e.target.value) {
-      this.streetAddress.value = e.target.value
-    }
-    windowActions.setAutofillAddressDetail(currentDetail, this.props.originalDetail)
+    windowActions.setAutofillAddressDetail('streetAddress', e.target.value)
   }
   onCityChange (e) {
-    let currentDetail = this.props.currentDetail
-    currentDetail = currentDetail.set('city', e.target.value)
-    windowActions.setAutofillAddressDetail(currentDetail, this.props.originalDetail)
-    if (this.city.value !== e.target.value) {
-      this.city.value = e.target.value
-    }
+    windowActions.setAutofillAddressDetail('city', e.target.value)
   }
   onStateChange (e) {
-    let currentDetail = this.props.currentDetail
-    currentDetail = currentDetail.set('state', e.target.value)
-    if (this.state.value !== e.target.value) {
-      this.state.value = e.target.value
-    }
-    windowActions.setAutofillAddressDetail(currentDetail, this.props.originalDetail)
+    windowActions.setAutofillAddressDetail('state', e.target.value)
   }
   onPostalCodeChange (e) {
-    let currentDetail = this.props.currentDetail
-    currentDetail = currentDetail.set('postalCode', e.target.value)
-    if (this.postalCode.value !== e.target.value) {
-      this.postalCode.value = e.target.value
-    }
-    windowActions.setAutofillAddressDetail(currentDetail, this.props.originalDetail)
+    windowActions.setAutofillAddressDetail('postalCode', e.target.value)
   }
   onCountryChange (e) {
-    let currentDetail = this.props.currentDetail
-    currentDetail = currentDetail.set('country', e.target.value)
-    if (this.country.value !== e.target.value) {
-      this.country.value = e.target.value
-    }
-    windowActions.setAutofillAddressDetail(currentDetail, this.props.originalDetail)
+    windowActions.setAutofillAddressDetail('country', e.target.value)
   }
   onPhoneChange (e) {
-    let currentDetail = this.props.currentDetail
-    currentDetail = currentDetail.set('phone', e.target.value)
-    if (this.phone.value !== e.target.value) {
-      this.phone.value = e.target.value
-    }
-    windowActions.setAutofillAddressDetail(currentDetail, this.props.originalDetail)
+    windowActions.setAutofillAddressDetail('phone', e.target.value)
   }
   onEmailChange (e) {
-    let currentDetail = this.props.currentDetail
-    currentDetail = currentDetail.set('email', e.target.value)
-    if (this.email.value !== e.target.value) {
-      this.email.value = e.target.value
-    }
-    windowActions.setAutofillAddressDetail(currentDetail, this.props.originalDetail)
+    windowActions.setAutofillAddressDetail('email', e.target.value)
   }
+
   onKeyDown (e) {
     switch (e.keyCode) {
       case KeyCodes.ENTER:
         this.onSave()
         break
       case KeyCodes.ESC:
-        this.props.onHide()
+        this.onHide()
         break
     }
   }
+
   onSave () {
-    appActions.addAutofillAddress(this.props.currentDetail, this.props.originalDetail)
-    this.props.onHide()
+    appActions.addAutofillAddress(Immutable.fromJS({
+      name: this.props.name,
+      organization: this.props.organization,
+      streetAddress: this.props.streetAddress,
+      city: this.props.city,
+      state: this.props.state,
+      postalCode: this.props.postalCode,
+      country: this.props.country,
+      phone: this.props.phone,
+      email: this.props.email,
+      guid: this.props.guid
+    }))
+    this.onHide()
   }
+
   onClick (e) {
     e.stopPropagation()
   }
-  get disableSaveButton () {
-    let currentDetail = this.props.currentDetail
-    if (!currentDetail.size) return true
-    if (!currentDetail.get('name') && !currentDetail.get('organization') &&
-      !currentDetail.get('streetAddress') && !currentDetail.get('city') &&
-      !currentDetail.get('state') && !currentDetail.get('country') &&
-      !currentDetail.get('phone') && !currentDetail.get('email')) return true
-    return false
-  }
+
   componentDidMount () {
     this.nameOnAddress.focus()
-    this.nameOnAddress.value = this.props.currentDetail.get('name') || ''
-    this.organization.value = this.props.currentDetail.get('organization') || ''
-    this.streetAddress.value = this.props.currentDetail.get('streetAddress') || ''
-    this.city.value = this.props.currentDetail.get('city') || ''
-    this.state.value = this.props.currentDetail.get('state') || ''
-    this.postalCode.value = this.props.currentDetail.get('postalCode') || ''
-    this.country.value = this.props.currentDetail.get('country') || ''
-    this.phone.value = this.props.currentDetail.get('phone') || ''
-    this.email.value = this.props.currentDetail.get('email') || ''
   }
+
+  onHide () {
+    windowActions.setAutofillAddressDetail()
+  }
+
+  mergeProps (state, ownProps) {
+    const currentWindow = state.get('currentWindow')
+    const detail = currentWindow.get('autofillAddressDetail', Immutable.Map())
+
+    const props = {}
+    // Used in renderer
+    props.name = detail.get('name', '')
+    props.organization = detail.get('organization', '')
+    props.streetAddress = detail.get('streetAddress', '')
+    props.city = detail.get('city', '')
+    props.state = detail.get('state', '')
+    props.postalCode = detail.get('postalCode', '')
+    props.country = detail.get('country', '')
+    props.phone = detail.get('phone', '')
+    props.email = detail.get('email', '')
+    props.guid = detail.get('guid', '-1')
+    props.disableSaveButton = !detail.get('name') && !detail.get('organization') &&
+      !detail.get('streetAddress') && !detail.get('city') &&
+      !detail.get('state') && !detail.get('country') &&
+      !detail.get('phone') && !detail.get('email')
+
+    return props
+  }
+
   render () {
-    return <Dialog onHide={this.props.onHide} testId='autofillAddressPanel' isClickDismiss>
+    return <Dialog onHide={this.onHide} testId='autofillAddressPanel' isClickDismiss>
       <CommonFormLarge onClick={this.onClick}>
         <CommonFormTitle data-l10n-id='editAddress' />
         <CommonFormSection>
@@ -173,62 +161,99 @@ class AutofillAddressPanel extends ImmutableComponent {
               <label className={css(commonFormStyles.input__marginRow)} data-l10n-id='email' htmlFor='email' />
             </div>
             <div className={css(commonFormStyles.inputWrapper, commonFormStyles.inputWrapper__input)}>
-              <input className={css(
-                commonStyles.formControl,
-                commonStyles.textbox,
-                commonStyles.textbox__outlineable,
-                commonFormStyles.input__box
-              )}
+              <input
+                className={css(
+                  commonStyles.formControl,
+                  commonStyles.textbox,
+                  commonStyles.textbox__outlineable,
+                  commonFormStyles.input__box
+                )}
                 data-test-id='nameOnAddress'
-                spellCheck='false' onKeyDown={this.onKeyDown} onChange={this.onNameChange}
-                ref={(nameOnAddress) => { this.nameOnAddress = nameOnAddress }} />
+                spellCheck='false'
+                ref={(ref) => { this.nameOnAddress = ref }}
+                onKeyDown={this.onKeyDown}
+                onChange={this.onNameChange}
+                defaultValue={this.props.name}
+              />
               <div className={css(commonFormStyles.input__marginRow)}>
-                <input className={commonForm}
+                <input
+                  className={commonForm}
                   data-test-id='organization'
-                  spellCheck='false' onKeyDown={this.onKeyDown} onChange={this.onOrganizationChange}
-                  ref={(organization) => { this.organization = organization }} />
+                  spellCheck='false'
+                  onKeyDown={this.onKeyDown}
+                  onChange={this.onOrganizationChange}
+                  defaultValue={this.props.organization}
+                />
               </div>
               <div className={css(commonFormStyles.input__marginRow)}>
-                <input className={commonForm}
+                <input
+                  className={commonForm}
                   data-test-id='streetAddress'
-                  spellCheck='false' onKeyDown={this.onKeyDown} onChange={this.onStreetAddressChange}
-                  ref={(streetAddress) => { this.streetAddress = streetAddress }} />
+                  spellCheck='false'
+                  onKeyDown={this.onKeyDown}
+                  onChange={this.onStreetAddressChange}
+                  defaultValue={this.props.streetAddress}
+                />
               </div>
               <div className={css(commonFormStyles.input__marginRow)}>
-                <input className={commonForm}
+                <input
+                  className={commonForm}
                   data-test-id='city'
-                  spellCheck='false' onKeyDown={this.onKeyDown} onChange={this.onCityChange}
-                  ref={(city) => { this.city = city }} />
+                  spellCheck='false'
+                  onKeyDown={this.onKeyDown}
+                  onChange={this.onCityChange}
+                  defaultValue={this.props.city}
+                />
               </div>
               <div className={css(commonFormStyles.input__marginRow)}>
-                <input className={commonForm}
+                <input
+                  className={commonForm}
                   data-test-id='state'
-                  spellCheck='false' onKeyDown={this.onKeyDown} onChange={this.onStateChange}
-                  ref={(state) => { this.state = state }} />
+                  spellCheck='false'
+                  onKeyDown={this.onKeyDown}
+                  onChange={this.onStateChange}
+                  defaultValue={this.props.state}
+                />
               </div>
               <div className={css(commonFormStyles.input__marginRow)}>
-                <input className={commonForm}
+                <input
+                  className={commonForm}
                   data-test-id='postalCode'
-                  spellCheck='false' onKeyDown={this.onKeyDown} onChange={this.onPostalCodeChange}
-                  ref={(postalCode) => { this.postalCode = postalCode }} />
+                  spellCheck='false'
+                  onKeyDown={this.onKeyDown}
+                  onChange={this.onPostalCodeChange}
+                  defaultValue={this.props.postalCode}
+                />
               </div>
               <div className={css(commonFormStyles.input__marginRow)}>
-                <input className={commonForm}
+                <input
+                  className={commonForm}
                   data-test-id='country'
-                  spellCheck='false' onKeyDown={this.onKeyDown} onChange={this.onCountryChange}
-                  ref={(country) => { this.country = country }} />
+                  spellCheck='false'
+                  onKeyDown={this.onKeyDown}
+                  onChange={this.onCountryChange}
+                  defaultValue={this.props.country}
+                />
               </div>
               <div className={css(commonFormStyles.input__marginRow)}>
-                <input className={commonForm}
+                <input
+                  className={commonForm}
                   data-test-id='phone'
-                  spellCheck='false' onKeyDown={this.onKeyDown} onChange={this.onPhoneChange}
-                  ref={(phone) => { this.phone = phone }} />
+                  spellCheck='false'
+                  onKeyDown={this.onKeyDown}
+                  onChange={this.onPhoneChange}
+                  defaultValue={this.props.phone}
+                />
               </div>
               <div className={css(commonFormStyles.input__marginRow)}>
-                <input className={commonForm}
+                <input
+                  className={commonForm}
                   data-test-id='email'
-                  spellCheck='false' onKeyDown={this.onKeyDown} onChange={this.onEmailChange}
-                  ref={(email) => { this.email = email }} />
+                  spellCheck='false'
+                  onKeyDown={this.onKeyDown}
+                  onChange={this.onEmailChange}
+                  defaultValue={this.props.email}
+                />
               </div>
             </div>
           </div>
@@ -237,10 +262,10 @@ class AutofillAddressPanel extends ImmutableComponent {
           <Button className='whiteButton'
             l10nId='cancel'
             testId='cancelAddressButton'
-            onClick={this.props.onHide}
+            onClick={this.onHide}
           />
           <Button className='primaryButton'
-            disabled={this.disableSaveButton}
+            disabled={this.props.disableSaveButton}
             l10nId='save'
             testId='saveAddressButton'
             onClick={this.onSave}
@@ -251,4 +276,4 @@ class AutofillAddressPanel extends ImmutableComponent {
   }
 }
 
-module.exports = AutofillAddressPanel
+module.exports = ReduxComponent.connect(AutofillAddressPanel)

--- a/app/renderer/components/frame/frame.js
+++ b/app/renderer/components/frame/frame.js
@@ -590,8 +590,8 @@ class Frame extends React.Component {
             windowActions.setClearBrowsingDataPanelVisible(true)
           break
         case messages.AUTOFILL_SET_ADDRESS:
-          method = (currentDetail, originalDetail) =>
-            windowActions.setAutofillAddressDetail(currentDetail, originalDetail)
+          method = (currentDetail) =>
+            windowActions.setAutofillAddressDetail(null, null, currentDetail)
           break
         case messages.AUTOFILL_SET_CREDIT_CARD:
           method = (currentDetail, originalDetail) =>

--- a/app/renderer/components/main/main.js
+++ b/app/renderer/components/main/main.js
@@ -78,7 +78,6 @@ class Main extends ImmutableComponent {
     this.onHideSiteInfo = this.onHideSiteInfo.bind(this)
     this.onHideBraveryPanel = this.onHideBraveryPanel.bind(this)
     this.onHideClearBrowsingDataPanel = this.onHideClearBrowsingDataPanel.bind(this)
-    this.onHideAutofillAddressPanel = this.onHideAutofillAddressPanel.bind(this)
     this.onHideAutofillCreditCardPanel = this.onHideAutofillCreditCardPanel.bind(this)
     this.onTabContextMenu = this.onTabContextMenu.bind(this)
     this.checkForTitleMode = debounce(this.checkForTitleMode.bind(this), 20)
@@ -535,10 +534,6 @@ class Main extends ImmutableComponent {
     windowActions.setClearBrowsingDataPanelVisible(false)
   }
 
-  onHideAutofillAddressPanel () {
-    windowActions.setAutofillAddressDetail()
-  }
-
   onHideAutofillCreditCardPanel () {
     windowActions.setAutofillCreditCardDetail()
   }
@@ -708,10 +703,7 @@ class Main extends ImmutableComponent {
         }
         {
          autofillAddressPanelIsVisible
-          ? <AutofillAddressPanel
-            currentDetail={this.props.windowState.getIn(['autofillAddressDetail', 'currentDetail'])}
-            originalDetail={this.props.windowState.getIn(['autofillAddressDetail', 'originalDetail'])}
-            onHide={this.onHideAutofillAddressPanel} />
+          ? <AutofillAddressPanel />
           : null
         }
         {

--- a/docs/appActions.md
+++ b/docs/appActions.md
@@ -497,15 +497,13 @@ Import browser data specified in selected
 
 
 
-### addAutofillAddress(detail, originalDetail) 
+### addAutofillAddress(detail) 
 
 Add address data
 
 **Parameters**
 
 **detail**: `object`, the address to add as per doc/state.md's autofillAddressDetail
-
-**originalDetail**: `object`, the original address before editing
 
 
 

--- a/docs/windowActions.md
+++ b/docs/windowActions.md
@@ -636,15 +636,17 @@ Widevine popup detail changed
 
 
 
-### setAutofillAddressDetail(currentDetail, originalDetail) 
+### setAutofillAddressDetail(property, newValue, wholeObject) 
 
 Sets the manage autofill address popup detail
 
 **Parameters**
 
-**currentDetail**: `Object`, Properties of the address to change to
+**property**: `string`, Property that we want change
 
-**originalDetail**: `Object`, Properties of the address to edit
+**newValue**: `string`, New value for this property
+
+**wholeObject**: `Object`, Whole object of address detail
 
 
 

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -610,13 +610,11 @@ const appActions = {
   /**
    * Add address data
    * @param {object} detail - the address to add as per doc/state.md's autofillAddressDetail
-   * @param {object} originalDetail - the original address before editing
    */
-  addAutofillAddress: function (detail, originalDetail) {
+  addAutofillAddress: function (detail) {
     dispatch({
       actionType: appConstants.APP_ADD_AUTOFILL_ADDRESS,
-      detail,
-      originalDetail
+      detail
     })
   },
 

--- a/js/actions/windowActions.js
+++ b/js/actions/windowActions.js
@@ -784,14 +784,16 @@ const windowActions = {
 
   /**
    * Sets the manage autofill address popup detail
-   * @param {Object} currentDetail - Properties of the address to change to
-   * @param {Object} originalDetail - Properties of the address to edit
+   * @param {string} property - Property that we want change
+   * @param {string} newValue - New value for this property
+   * @param {Object} wholeObject - Whole object of address detail
    */
-  setAutofillAddressDetail: function (currentDetail, originalDetail) {
+  setAutofillAddressDetail: function (property, newValue, wholeObject) {
     dispatch({
       actionType: windowConstants.WINDOW_SET_AUTOFILL_ADDRESS_DETAIL,
-      currentDetail,
-      originalDetail
+      property,
+      newValue,
+      wholeObject
     })
   },
 

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -711,8 +711,7 @@ const handleAppAction = (action) => {
         break
       }
     case appConstants.APP_ADD_AUTOFILL_ADDRESS:
-      autofill.addAutofillAddress(action.detail.toJS(),
-        action.originalDetail.get('guid') === undefined ? '-1' : action.originalDetail.get('guid'))
+      autofill.addAutofillAddress(action.detail)
       break
     case appConstants.APP_REMOVE_AUTOFILL_ADDRESS:
       autofill.removeAutofillAddress(action.detail.get('guid'))

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -569,13 +569,12 @@ const doAction = (action) => {
       }))
       break
     case windowConstants.WINDOW_SET_AUTOFILL_ADDRESS_DETAIL:
-      if (!action.currentDetail && !action.originalDetail) {
+      if (!action.property && !action.wholeObject) {
         windowState = windowState.delete('autofillAddressDetail')
+      } else if (action.wholeObject) {
+        windowState = windowState.set('autofillAddressDetail', Immutable.fromJS(action.wholeObject))
       } else {
-        windowState = windowState.mergeIn(['autofillAddressDetail'], {
-          currentDetail: action.currentDetail,
-          originalDetail: action.originalDetail
-        })
+        windowState = windowState.setIn(['autofillAddressDetail', action.property], action.newValue)
       }
       break
     case windowConstants.WINDOW_SET_AUTOFILL_CREDIT_CARD_DETAIL:

--- a/test/contents/autofillTest.js
+++ b/test/contents/autofillTest.js
@@ -82,6 +82,7 @@ describe('Autofill', function () {
         .click(emailInput)
         .typeText(emailInput, email)
         .click(saveAddressButton)
+        .windowByUrl(Brave.browserWindowUrl)
         .waitUntil(function () {
           return this.getAppState().then((val) => {
             return val.value.autofill.addresses.guid.length === 1
@@ -152,6 +153,7 @@ describe('Autofill', function () {
         .keys(Brave.keys.END)
         .typeText(emailInput, 'mm', email)
         .click(saveAddressButton)
+        .windowByUrl(Brave.browserWindowUrl)
         .waitUntil(function () {
           return this.getAppState().then((val) => {
             return val.value.autofill.addresses.guid.length === 1


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Resolves #9444

Auditors: @bsclifton @bridiver @darkdh 

Test Plan:
- try to add autofill address
- try to delete it
- try to edit it

Test Plan (l10n):
1. Install Google IME (CJK);
2. Enable it (Hiragana `ひらがな` mode)
3. Open `about:autofill`
4. Input `brave`
5. It should display the conversion candidate like this:
  <img width="167" alt="screenshot 2017-06-20 0 51 32" src="https://user-images.githubusercontent.com/3362943/27293870-a2e76912-5552-11e7-9979-ca148079370e.png">



Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


