### PR TITLE
Show full URL for tooltip inside braveryPanel

### DIFF
--- a/app/renderer/components/main/braveryPanel.js
+++ b/app/renderer/components/main/braveryPanel.js
@@ -208,7 +208,7 @@ class BraveryPanel extends ImmutableComponent {
         styles.braveryPanel_compact__header__bottom
       )}>
         <div data-l10n-id='braveryPanelTitle' className={css(styles.braveryPanel_compact__header__bottom__title)} />
-        <div title={this.displayHost} className={css(styles.braveryPanel_compact__header__bottom__displayHost)}>{this.displayHost}</div>
+        <div title={this.props.lastCommittedURL} className={css(styles.braveryPanel_compact__header__bottom__displayHost)}>{this.displayHost}</div>
       </div>
     </section>
   }
@@ -218,7 +218,7 @@ class BraveryPanel extends ImmutableComponent {
     return <section className={css(styles.braveryPanel__header)}>
       <div className={css(styles.braveryPanel__header__left)}>
         <div data-l10n-id='braveryPanelTitle' />
-        <div title={this.displayHost} className={css(styles.braveryPanel__header__left__displayHost)}>{this.displayHost}</div>
+        <div title={this.props.lastCommittedURL} className={css(styles.braveryPanel__header__left__displayHost)}>{this.displayHost}</div>
       </div>
       <div className={css(styles.braveryPanel__header__right)}>
         <SwitchControl large
@@ -731,7 +731,11 @@ const styles = StyleSheet.create({
     borderTopRightRadius: globalStyles.radius.borderRadius
   },
   braveryPanel__header__left: {
-    minWidth: 0
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    marginRight: '10px'
   },
   braveryPanel__header__right: {
     marginLeft: 'auto'


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Auditors: @luixxiul, @diracdeltas
Close #9089

Test plan:

Both compact and full bravery panel should have the full URL described in host's title as a tooltip (element title).

@luixxiul I went ahead and aligned top-left header as well, pls review.

STR: 
1. visit https://longextendedsubdomainnamewithoutdashesinordertotestwordwrapping.badssl.com/
2. Open Bravery Panel
3. Hover over host
4. Tooltip should show full url

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


