### PR TITLE
Converts CheckDefaultBrowserDialog into redux component

### DIFF
--- a/app/renderer/components/main/checkDefaultBrowserDialog.js
+++ b/app/renderer/components/main/checkDefaultBrowserDialog.js
@@ -6,10 +6,15 @@ const React = require('react')
 const {StyleSheet, css} = require('aphrodite/no-important')
 
 // Components
-const ImmutableComponent = require('../immutableComponent')
+const ReduxComponent = require('../reduxComponent')
 const Dialog = require('../common/dialog')
 const BrowserButton = require('../common/browserButton')
 const SwitchControl = require('../common/switchControl')
+const {
+  CommonFormMedium,
+  CommonFormSection,
+  CommonFormButtonWrapper
+} = require('../common/commonForm')
 
 // Actions
 const appActions = require('../../../../js/actions/appActions')
@@ -18,51 +23,73 @@ const windowActions = require('../../../../js/actions/windowActions')
 // Constants
 const settings = require('../../../../js/constants/settings')
 
+// Utils
+const {getSetting} = require('../../../../js/settings')
+
 // Styles
 const globalStyles = require('../styles/global')
 const braveAbout = require('../../../extensions/brave/img/braveAbout.png')
 
-const {
-  CommonFormMedium,
-  CommonFormSection,
-  CommonFormButtonWrapper
-} = require('../common/commonForm')
-
-class CheckDefaultBrowserDialog extends ImmutableComponent {
+class CheckDefaultBrowserDialog extends React.Component {
   constructor () {
     super()
     this.onCheckDefaultOnStartup = this.onCheckDefaultOnStartup.bind(this)
     this.onNotNow = this.onNotNow.bind(this)
+    this.onClick = this.onClick.bind(this)
     this.onUseBrave = this.onUseBrave.bind(this)
   }
 
   onCheckDefaultOnStartup (e) {
-    windowActions.setModalDialogDetail('checkDefaultBrowserDialog', {checkDefaultOnStartup: e.target.value})
+    windowActions.setModalDialogDetail('checkDefaultBrowserDialog', {
+      checkDefaultOnStartup: e.target.value
+    })
   }
   onNotNow () {
     appActions.defaultBrowserUpdated(false)
     appActions.defaultBrowserCheckComplete()
     appActions.changeSetting(settings.CHECK_DEFAULT_ON_STARTUP, this.props.checkDefaultOnStartup)
-    this.props.onHide()
+    this.onHide()
   }
   onUseBrave () {
     appActions.defaultBrowserUpdated(true)
     appActions.defaultBrowserCheckComplete()
     appActions.changeSetting(settings.CHECK_DEFAULT_ON_STARTUP, this.props.checkDefaultOnStartup)
-    this.props.onHide()
+    this.onHide()
   }
+
+  onHide () {
+    windowActions.setModalDialogDetail('checkDefaultBrowserDialog')
+  }
+
+  onClick (e) {
+    e.stopPropagation()
+  }
+
+  mergeProps (state, ownProps) {
+    const currentWindow = state.get('currentWindow')
+
+    const props = {}
+    props.checkDefaultOnStartup = currentWindow.getIn(['modalDialogDetail', 'checkDefaultBrowserDialog']) === undefined
+      ? getSetting(settings.CHECK_DEFAULT_ON_STARTUP)
+      : currentWindow.getIn(['modalDialogDetail', 'checkDefaultBrowserDialog', 'checkDefaultOnStartup'])
+
+    return props
+  }
+
   render () {
     return <Dialog className='checkDefaultBrowserDialog'>
-      <CommonFormMedium onClick={(e) => e.stopPropagation()}>
+      <CommonFormMedium onClick={this.onClick}>
         <CommonFormSection>
           <div className={css(styles.flexAlignCenter)}>
             <div className={css(styles.section__braveIcon)} />
             <div>
               <div className={css(styles.section__title)} data-l10n-id='makeBraveDefault' />
-              <SwitchControl className={css(styles.section__switchControl)}
+              <SwitchControl
+                className={css(styles.section__switchControl)}
                 rightl10nId='checkDefaultOnStartup'
                 checkedOn={this.props.checkDefaultOnStartup}
-                onClick={this.onCheckDefaultOnStartup} />
+                onClick={this.onCheckDefaultOnStartup}
+              />
             </div>
           </div>
         </CommonFormSection>
@@ -82,6 +109,8 @@ class CheckDefaultBrowserDialog extends ImmutableComponent {
     </Dialog>
   }
 }
+
+module.exports = ReduxComponent.connect(CheckDefaultBrowserDialog)
 
 const styles = StyleSheet.create({
   flexAlignCenter: {
@@ -105,5 +134,3 @@ const styles = StyleSheet.create({
     marginTop: `calc(${globalStyles.spacing.dialogInsideMargin} / 2)`
   }
 })
-
-module.exports = CheckDefaultBrowserDialog

--- a/app/renderer/components/main/main.js
+++ b/app/renderer/components/main/main.js
@@ -84,7 +84,6 @@ class Main extends ImmutableComponent {
     this.onHideAutofillCreditCardPanel = this.onHideAutofillCreditCardPanel.bind(this)
     this.onHideNoScript = this.onHideNoScript.bind(this)
     this.onHideReleaseNotes = this.onHideReleaseNotes.bind(this)
-    this.onHideCheckDefaultBrowserDialog = this.onHideCheckDefaultBrowserDialog.bind(this)
     this.onTabContextMenu = this.onTabContextMenu.bind(this)
     this.onFind = this.onFind.bind(this)
     this.onFindHide = this.onFindHide.bind(this)
@@ -568,10 +567,6 @@ class Main extends ImmutableComponent {
     windowActions.setReleaseNotesVisible(false)
   }
 
-  onHideCheckDefaultBrowserDialog () {
-    windowActions.setModalDialogDetail('checkDefaultBrowserDialog')
-  }
-
   onMouseDown (e) {
     // TODO(bsclifton): update this to use eventUtil.eventElHasAncestorWithClasses
     let node = e.target
@@ -799,13 +794,7 @@ class Main extends ImmutableComponent {
         }
         {
           checkDefaultBrowserDialogIsVisible
-            ? <CheckDefaultBrowserDialog
-              checkDefaultOnStartup={
-                this.props.windowState.getIn(['modalDialogDetail', 'checkDefaultBrowserDialog']) === undefined
-                ? getSetting(settings.CHECK_DEFAULT_ON_STARTUP)
-                : this.props.windowState.getIn(['modalDialogDetail', 'checkDefaultBrowserDialog', 'checkDefaultOnStartup'])
-              }
-              onHide={this.onHideCheckDefaultBrowserDialog} />
+            ? <CheckDefaultBrowserDialog />
             : null
         }
 


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Resolves #9449

Auditors: @bsclifton @bridiver

Test Plan:
- close brave
- change you default browser to something else (Safari for example)
- re-run browser
- dialog for default browser should be displayed and you can set it to brave or cancel it

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


