### PR TITLE
Fix url parsing bug

### DIFF
--- a/app/common/lib/siteSuggestions.js
+++ b/app/common/lib/siteSuggestions.js
@@ -92,14 +92,6 @@ const tokenizeInput = (data) => {
       parts = parts.concat(parsedUrl.pathname.split(/[.\s\\/]/))
     }
     if (parsedUrl.query) {
-      // I think fast-url-parser has a bug in it where it returns an object for query
-      // instead of a string.  Object is supported but only when you pass in true
-      // for the second value of parse which we don't do.
-      // We can remove this when we change away from using fast-url-parser in favour of the
-      // Chrome URL parser.
-      if (parsedUrl.query.constructor !== String) {
-        parsedUrl.query = Object.entries(parsedUrl.query).map((x) => x.join('=')).join('&')
-      }
       parts = parts.concat(parsedUrl.query.split(/[&=]/))
     }
     if (parsedUrl.protocol) {

--- a/app/common/urlParse.js
+++ b/app/common/urlParse.js
@@ -3,7 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const LRUCache = require('lru-cache')
-const urlParse = require('fast-url-parser').parse
+const urlParse = require('url').parse
 const config = require('../../js/constants/config')
 let cachedUrlParse = new LRUCache(config.cache.urlParse)
 
@@ -14,23 +14,7 @@ module.exports = (url, ...args) => {
     return Object.assign({}, parsedUrl)
   }
 
-  // In fast-url-parser href, port, prependSlash, protocol, and query
-  // are lazy so access them.
-  const raw = urlParse(url, ...args)
-  parsedUrl = {
-    auth: raw.auth,
-    hash: raw.hash,
-    host: raw.host,
-    hostname: raw.hostname,
-    href: raw.href,
-    path: raw.path,
-    pathname: raw.pathname,
-    port: raw.port,
-    protocol: raw.protocol,
-    query: raw.query,
-    search: raw.search,
-    slashes: raw.slashes
-  }
+  parsedUrl = urlParse(url, ...args)
   cachedUrlParse.set(url, parsedUrl)
   return parsedUrl
 }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "clipboard-copy": "^1.0.0",
     "electron-localshortcut": "^0.6.0",
     "electron-squirrel-startup": "brave/electron-squirrel-startup",
-    "fast-url-parser": "^1.1.3",
     "file-loader": "^0.8.5",
     "font-awesome": "^4.5.0",
     "font-awesome-webpack": "0.0.4",


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/9500

test plan:
1. merge or rebase this on top of 0.17.x. verify that https://longextendedsubdomainnamewithoutdashesinordertotestwordwrapping.badssl.com/ shows the true URL origin in titleMode.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


