### PR TITLE
Tweak tabtitle threshold w/ secondary icons on small tabs

### DIFF
--- a/app/common/state/tabContentState.js
+++ b/app/common/state/tabContentState.js
@@ -152,7 +152,8 @@ const tabContentState = {
       // If closeIcon is fixed then there's no room for another icon
       !tabContentState.hasFixedCloseIcon(state, frameKey) &&
       // completely hide it for small sizes
-      !hasBreakpoint(frame.get('breakpoint'), ['mediumSmall', 'small', 'extraSmall', 'smallest'])
+      !hasBreakpoint(frame.get('breakpoint'),
+        ['medium', 'mediumSmall', 'small', 'extraSmall', 'smallest'])
     )
   }
 }

--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -268,7 +268,7 @@ class Tab extends React.Component {
     props.partOfFullPageSet = ownProps.partOfFullPageSet
     props.showTitle = !props.isPinnedTab &&
       !(
-        (hasBreakpoint(breakpoint, 'small') && props.isActive) ||
+        (hasBreakpoint(breakpoint, ['mediumSmall', 'small']) && props.isActive) ||
         hasBreakpoint(breakpoint, ['extraSmall', 'smallest'])
       )
 

--- a/test/unit/app/renderer/components/tabs/content/newSessionIconTest.js
+++ b/test/unit/app/renderer/components/tabs/content/newSessionIconTest.js
@@ -119,19 +119,6 @@ describe('Tabs content - NewSessionIcon', function () {
       assert.equal(wrapper.find('NewSessionIcon').length, 1)
     })
 
-    it('icon if tab is not active and breakpoint is medium', function () {
-      windowStore.state = defaultWindowStore.merge({
-        activeFrameKey: 0,
-        frames: [{
-          partitionNumber: 1,
-          hoverState: false,
-          breakpoint: 'medium'
-        }]
-      })
-      const wrapper = mount(<Tab frameKey={frameKey} />)
-      assert.equal(wrapper.find('NewSessionIcon').length, 1)
-    })
-
     it('partition number for new sessions', function () {
       windowStore.state = defaultWindowStore.mergeIn(['frames', 0], {
         partitionNumber: 3,
@@ -199,10 +186,10 @@ describe('Tabs content - NewSessionIcon', function () {
       assert.equal(wrapper.find('NewSessionIcon').length, 0)
     })
 
-    it('if tab is active and breakpoint is medium', function () {
+    it('if breakpoint is medium', function () {
       windowStore.state = defaultWindowStore.mergeIn(['frames', 0], {
         partitionNumber: 1,
-        hoverState: true,
+        hoverState: false,
         breakpoint: 'medium'
       })
       const wrapper = mount(<Tab frameKey={frameKey} />)

--- a/test/unit/app/renderer/components/tabs/content/privateIconTest.js
+++ b/test/unit/app/renderer/components/tabs/content/privateIconTest.js
@@ -108,19 +108,6 @@ describe('Tabs content - PrivateIcon', function () {
       assert.equal(wrapper.find('PrivateIcon').length, 1)
     })
 
-    it('if tab is not active and breakpoint is medium', function () {
-      windowStore.state = defaultWindowStore.merge({
-        activeFrameKey: 0,
-        frames: [{
-          isPrivate: true,
-          hoverState: false,
-          breakpoint: 'medium'
-        }]
-      })
-      const wrapper = mount(<Tab frameKey={frameKey} />)
-      assert.equal(wrapper.find('PrivateIcon').length, 1)
-    })
-
     it('if mouse is not over tab and breakpoint is default', function () {
       windowStore.state = defaultWindowStore.mergeIn(['frames', 0], {
         isPrivate: true,
@@ -171,10 +158,10 @@ describe('Tabs content - PrivateIcon', function () {
       assert.equal(wrapper.find('PrivateIcon').length, 0)
     })
 
-    it('if tab is active and breakpoint is medium', function () {
+    it('if breakpoint is medium', function () {
       windowStore.state = defaultWindowStore.mergeIn(['frames', 0], {
         isPrivate: true,
-        hoverState: true,
+        hoverState: false,
         breakpoint: 'medium'
       })
       const wrapper = mount(<Tab frameKey={frameKey} />)

--- a/test/unit/app/renderer/components/tabs/content/tabTitleTest.js
+++ b/test/unit/app/renderer/components/tabs/content/tabTitleTest.js
@@ -114,11 +114,14 @@ describe('Tabs content - Title', function () {
       const wrapper = mount(<Tab frameKey={frameKey} />)
       assert.equal(wrapper.find('TabTitle div').text(), pageTitle1)
     })
-    it('if breakpoint is mediumSmall', function () {
-      windowStore.state = defaultWindowStore.mergeIn(['frames', 0], {
-        location: url1,
-        title: pageTitle1,
-        breakpoint: 'mediumSmall'
+    it('if breakpoint is mediumSmall and tab is not active', function () {
+      windowStore.state = defaultWindowStore.merge({
+        activeFrameKey: 0,
+        frames: [{
+          location: url1,
+          title: pageTitle1,
+          breakpoint: 'mediumSmall'
+        }]
       })
       const wrapper = mount(<Tab frameKey={frameKey} />)
       assert.equal(wrapper.find('TabTitle div').text(), pageTitle1)
@@ -147,7 +150,15 @@ describe('Tabs content - Title', function () {
       const wrapper = mount(<Tab frameKey={frameKey} />)
       assert.equal(wrapper.find('TabTitle').length, 0)
     })
-
+    it('if breakpoint is mediumSmall and tab is active', function () {
+      windowStore.state = defaultWindowStore.mergeIn(['frames', 0], {
+        location: url1,
+        title: pageTitle1,
+        breakpoint: 'mediumSmall'
+      })
+      const wrapper = mount(<Tab frameKey={frameKey} />)
+      assert.equal(wrapper.find('TabTitle').length, 0)
+    })
     it('if breakpoint is small and tab is active', function () {
       windowStore.state = defaultWindowStore.mergeIn(['frames', 0], {
         location: url1,


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Auditors: @bsclifton
Close #9466

## Test Plan:
covered by automated tests
```
npm run test -- --grep="Tabs content - NewSessionIcon should not show icon if breakpoint is medium"
npm run test -- --grep="Tabs content - PrivateIcon should not show icon if breakpoint is medium"
npm run test -- --grep="Tabs content - Title should show text if breakpoint is mediumSmall and tab is not active"
npm run test -- --grep="Tabs content - Title should not show text if breakpoint is mediumSmall and tab is active"
```

## Manual Test:

1. Have enough private/new session/default tabs.
2. Resize window
3. Title should not truncate with secondary icons
4. Title should be aesthetically ok if there are no secondary icons

Reviewer Checklist:

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


