### PR TITLE
Set correct location in case pinned location is about:blank page

### DIFF
--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -521,8 +521,9 @@ module.exports.moveSite = function (state, sourceKey, destinationKey, prepend,
 }
 
 module.exports.getDetailFromFrame = function (frame, tag) {
+  const pinnedLocation = frame.get('pinnedLocation')
   let location = frame.get('location')
-  if (frame.get('pinnedLocation') && tag === siteTags.PINNED) {
+  if (pinnedLocation && pinnedLocation !== 'about:blank' && tag === siteTags.PINNED) {
     location = frame.get('pinnedLocation')
   }
 

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -1129,6 +1129,15 @@ describe('siteUtil', function () {
       const siteDetail = siteUtil.getDetailFromFrame(frame, siteTags.PINNED)
       assert.equal(siteDetail.get('location'), frame.get('pinnedLocation'))
     })
+    it('properly sets location for pinned sites when pinned location is blank page', function () {
+      const frame = Immutable.fromJS({
+        location: testUrl1,
+        pinnedLocation: 'about:blank',
+        tag: siteTags.PINNED
+      })
+      const siteDetail = siteUtil.getDetailFromFrame(frame, siteTags.PINNED)
+      assert.equal(siteDetail.get('location'), frame.get('location'))
+    })
   })
 
   describe('getDetailFromTab', function () {


### PR DESCRIPTION
## Test Plan

1. Close existing tabs
2. Pin some tabs,
3. Change pin order,
4. quit, re-open
5. tabs should be in the same order

## Description
`getDetailFromFrame` gets correct location from frame. For some reason it's possible that `location` might be correct, but `pinnedTabs` is `about:blank`. Due to that `location` value will be `about:blank` and `order` will not be updated in `moveSite` method.

Fix #8543

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


