### PR TITLE
Converts ContextMenu into redux component

### DIFF
--- a/app/renderer/components/main/main.js
+++ b/app/renderer/components/main/main.js
@@ -701,10 +701,7 @@ class Main extends ImmutableComponent {
       onClick={this.onClickWindow}>
       {
         contextMenuDetail
-        ? <ContextMenu
-          lastZoomPercentage={activeFrame && activeFrame.get('lastZoomPercentage')}
-          contextMenuDetail={contextMenuDetail}
-          selectedIndex={customTitlebar.contextMenuSelectedIndex} />
+        ? <ContextMenu />
         : null
       }
       {


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Resolves #9482

Auditors: @bsclifton @bridiver

Note: I could refactor really small portion of things that should be done, because the way context menu is done. This PR will enable us to refactor `Main` component, but not improved context menu a lot. Is a good starting point for next iterations.

Test Plan:
- right click on a tab and check if context menu is displayed
- try to zoom in hamburger menu


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


