### PR TITLE
Take no action for middle click over pinned tabs

### DIFF
--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -176,7 +176,12 @@ class Tab extends React.Component {
         return
       case 1:
         // Close tab with middle click
-        this.onTabClosedWithMouse(e)
+        // This is ignored for pinned tabs
+        // TODO: @cezaraugusto remove conditional
+        // when #4063 is resolved
+        if (!this.props.isPinnedTab) {
+          this.onTabClosedWithMouse(e)
+        }
         break
       default:
         e.stopPropagation()


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Auditors: @bsclifton
Fix #9492

repeating comments left in https://github.com/brave/browser-laptop/issues/9492#issuecomment-309101922:

Middle click over pinnedTabs shouldn't be allowed until #4063 is solved. Doing it was leading to a weird update over tabs, setting unpinned tabs to the smallest breakpoint, which is visually similar to pinned tabs but with close button replacing icon while active.

for clarification, this pull-request copy the same behavior as Opera, which may not be our intention given FF, Chrome and Safari all close the tab. However, leave the discussion open until #4063.

Test plan:
1. Pin 2 tabs, have 1-2 unpinned
2. Middle click over a pinned tab
3. Should do nothing

/cc @srirambv 

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


