### PR TITLE
Don't allow tab preview after close if config is off

### DIFF
--- a/app/renderer/reducers/frameReducer.js
+++ b/app/renderer/reducers/frameReducer.js
@@ -20,6 +20,8 @@ const frameStateUtil = require('../../../js/state/frameStateUtil')
 const {getCurrentWindowId} = require('../currentWindow')
 const {getSourceAboutUrl, getSourceMagnetUrl} = require('../../../js/lib/appUrlUtil')
 const {isURL, isPotentialPhishingUrl, getUrlFromInput} = require('../../../js/lib/urlutil')
+const settings = require('../../../js/constants/settings')
+const {getSetting} = require('../../../js/settings')
 
 const setFullScreen = (state, action) => {
   const index = frameStateUtil.getFrameIndex(state, action.frameProps.get('key'))
@@ -30,6 +32,7 @@ const setFullScreen = (state, action) => {
 }
 
 const closeFrame = (state, action) => {
+  const activeFrameIndex = frameStateUtil.getActiveFrameIndex(state)
   const index = frameStateUtil.getFrameIndex(state, action.frameKey)
   if (index === -1) {
     return state
@@ -37,6 +40,7 @@ const closeFrame = (state, action) => {
 
   const frameProps = frameStateUtil.getFrameByKey(state, action.frameKey)
   const hoverState = state.getIn(['frames', index, 'hoverState'])
+  const framePreviewEnabled = getSetting(settings.SHOW_TAB_PREVIEWS)
 
   state = state.merge(frameStateUtil.removeFrame(
     state,
@@ -52,14 +56,14 @@ const closeFrame = (state, action) => {
 
   const nextFrame = frameStateUtil.getFrameByIndex(state, index)
 
-  if (nextFrame) {
-    // After closing a tab, preview the next frame as long as there is one
-    windowActions.setPreviewFrame(nextFrame.get('key'))
+  if (nextFrame && hoverState) {
     // Copy the hover state if tab closed with mouse as long as we have a next frame
     // This allow us to have closeTab button visible for sequential frames closing,
     // until onMouseLeave event happens.
-    if (hoverState) {
-      windowActions.setTabHoverState(nextFrame.get('key'), hoverState)
+    windowActions.setTabHoverState(nextFrame.get('key'), hoverState)
+    if (framePreviewEnabled && index !== activeFrameIndex) {
+      // After closing a tab, preview the next frame as long as there is one
+      windowActions.setPreviewFrame(nextFrame.get('key'))
     }
   }
 

--- a/test/tab-components/tabTest.js
+++ b/test/tab-components/tabTest.js
@@ -370,6 +370,74 @@ describe('tab tests', function () {
     })
   })
 
+  describe('webview previews the next tab when current hovered tab is closed', function () {
+    Brave.beforeAll(this)
+    before(function * () {
+      const page1 = Brave.server.url('adblock2.html')
+      const page2 = Brave.server.url('red_bg.html')
+      const page3 = Brave.server.url('page_favicon_not_found.html')
+      const page4 = Brave.server.url('yellow_header.html')
+      const page5 = Brave.server.url('page1.html')
+      const page6 = Brave.server.url('page2.html')
+      yield setup(this.app.client)
+      yield this.app.client
+        .newTab({ url: page1 })
+        .waitForUrl(page1)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist('[data-test-id="tab"][data-frame-key="2"]')
+        .newTab({ url: page2 })
+        .waitForUrl(page2)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist('[data-test-id="tab"][data-frame-key="3"]')
+        .newTab({ url: page3 })
+        .waitForUrl(page3)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist('[data-test-id="tab"][data-frame-key="4"]')
+        .newTab({ url: page4 })
+        .waitForUrl(page4)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist('[data-test-id="tab"][data-frame-key="5"]')
+        .newTab({ url: page5 })
+        .waitForUrl(page5)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist('[data-test-id="tab"][data-frame-key="6"]')
+        .newTab({ url: page6 })
+        .waitForUrl(page6)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist('[data-test-id="tab"][data-frame-key="7"]')
+    })
+
+    it('show active tab content if next tab does not exist', function * () {
+      yield this.app.client
+        .moveToObject('[data-test-id="tab"][data-frame-key="2"]')
+        .click('[data-test-id="tab"][data-frame-key="2"]')
+        .moveToObject('[data-test-id="tab"][data-frame-key="7"]')
+        .middleClick('[data-test-id="tab"][data-frame-key="7"]')
+        // no preview should be shown
+        .waitForVisible('.frameWrapper.isPreview webview', 500, true)
+    })
+    it('preview the next tab if preview option is on', function * () {
+      yield this.app.client
+        .moveToObject('[data-test-id="tab"][data-frame-key="2"]')
+        .click('[data-test-id="tab"][data-frame-key="2"]')
+        .moveToObject('[data-test-id="tab"][data-frame-key="4"]')
+        .middleClick('[data-test-id="tab"][data-frame-key="4"]')
+        .waitForExist('.frameWrapper.isPreview webview[data-frame-key="5"]')
+        .waitForVisible('.frameWrapper.isPreview webview[data-frame-key="5"]')
+    })
+    it('do not preview the next tab if preview option is off', function * () {
+      yield this.app.client.changeSetting(settings.SHOW_TAB_PREVIEWS, false)
+      yield this.app.client
+        .moveToObject('[data-test-id="tab"][data-frame-key="2"]')
+        .click('[data-test-id="tab"][data-frame-key="2"]')
+        .moveToObject('[data-test-id="tab"][data-frame-key="5"]')
+        .middleClick('[data-test-id="tab"][data-frame-key="5"]')
+        .waitForExist('.frameWrapper.isPreview webview')
+        // no preview should be shown
+        .waitForVisible('.frameWrapper.isPreview webview', 500, true)
+    })
+  })
+
   describe('new tabs open per the switch to new tabs setting', function () {
     Brave.beforeAll(this)
     before(function * () {


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Issue first reported in https://github.com/brave/browser-laptop/issues/9306#issuecomment-308908661. cc @jonathansampson 

Test Plan:

```
npm run test -- --grep="webview previews the next tab when current hovered tab is closed"
```

Manual Test Plan:

1. Disable tab previews
2. Open three tabs
3. Set first as active
4. Hover over second, close
5. Third should not be previewed
6. Enable tab preview again and start from 2.
7. It should preview

Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


