### PR TITLE
Remove a duping secondaryColor button on about:styles

### DIFF
--- a/app/renderer/components/common/browserButton.js
+++ b/app/renderer/components/common/browserButton.js
@@ -194,8 +194,6 @@ const styles = StyleSheet.create({
     // TODO: remove !important and check advancedSettings.js
     // once preferences is fully refactored
 
-    // 'mm' assures theoretically the equal width of margin
-    // on every platform with any display monitor resolution.
     // 7.5px = 1/12 inch
     marginLeft: '7.5px !important',
 

--- a/js/about/styles.js
+++ b/js/about/styles.js
@@ -257,11 +257,6 @@ class AboutStyle extends ImmutableComponent {
           &lt;BrowserButton l10nId='browserButton' onClick={'{this.onRemoveBookmark}'} />
         </Code></Pre>
 
-        <BrowserButton secondaryColor l10nId='secondaryColor' onClick={this.onRemoveBookmark} />
-        <Pre><Code>
-          &lt;BrowserButton secondaryColor l10nId='secondaryColor' onClick={'{this.onRemoveBookmark}'} />
-        </Code></Pre>
-
         <BrowserButton primaryColor l10nId='primaryColor' onClick={this.onRemoveBookmark} />
         <Pre><Code>
           &lt;BrowserButton primaryColor l10nId='cancel' onClick={'{this.onRemoveBookmark}'} />


### PR DESCRIPTION
https://github.com/brave/browser-laptop/blob/3dfc59890c2f19a376f72b3430a070bdd125e49b/js/about/styles.js#L260-L263

Closes #9559

Auditors:

Test Plan:
1. Open about:styles#buttons
2. Make sure there isn't Secondary Button between Browser Button and Primary Button

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


