### PR TITLE
Fixes middle click not working for  home button

### DIFF
--- a/app/renderer/components/navigation/navigationBar.js
+++ b/app/renderer/components/navigation/navigationBar.js
@@ -48,6 +48,7 @@ class NavigationBar extends React.Component {
     this.onReload = this.onReload.bind(this)
     this.onHome = this.onHome.bind(this)
     this.onReloadLongPress = this.onReloadLongPress.bind(this)
+    this.auxHomeButtonAdded = false
   }
 
   get activeFrame () {
@@ -117,6 +118,25 @@ class NavigationBar extends React.Component {
   componentDidMount () {
     ipc.on(messages.SHORTCUT_ACTIVE_FRAME_BOOKMARK, () => this.onToggleBookmark())
     ipc.on(messages.SHORTCUT_ACTIVE_FRAME_REMOVE_BOOKMARK, () => this.onToggleBookmark())
+
+    if (this.homeButton != null) {
+      this.homeButton.addEventListener('auxclick', this.onHome)
+      this.auxHomeButtonAdded = true
+    }
+  }
+
+  componentWillUpdate () {
+    if (this.homeButton != null) {
+      if (this.props.showHomeButton && !this.auxHomeButtonAdded) {
+        this.homeButton.addEventListener('auxclick', this.onHome)
+        this.auxHomeButtonAdded = true
+      }
+
+      if (!this.props.showHomeButton && this.auxHomeButtonAdded) {
+        this.homeButton.removeEventListener('auxclick', this.onHome)
+        this.auxHomeButtonAdded = false
+      }
+    }
   }
 
   mergeProps (state, ownProps) {
@@ -168,6 +188,7 @@ class NavigationBar extends React.Component {
     props.titleMode = titleMode
     props.isWideURLbarEnabled = getSetting(settings.WIDE_URL_BAR)
     props.activeTabId = activeTabId
+    props.showHomeButton = !props.titleMode && getSetting(settings.SHOW_HOME_BUTTON)
 
     return props
   }
@@ -208,12 +229,13 @@ class NavigationBar extends React.Component {
           </span>
       }
       {
-        !this.props.titleMode && getSetting(settings.SHOW_HOME_BUTTON)
+        this.props.showHomeButton
         ? <span className='navigationButtonContainer'>
           <button
             data-test-id='homeButton'
             data-l10n-id='homeButton'
             className='normalizeButton navigationButton homeButton'
+            ref={(node) => { this.homeButton = node }}
             onClick={this.onHome} />
         </span>
         : null

--- a/test/navbar-components/navigationBarTest.js
+++ b/test/navbar-components/navigationBarTest.js
@@ -1055,6 +1055,18 @@ describe('navigationBar tests', function () {
           .waitForTabCount(2)
           .waitForUrl(page2Url)
       })
+
+      it('opens home page in a new tab when middle mouse button is clicked', function * () {
+        const page3Url = Brave.server.url('page3.html')
+
+        yield this.app.client
+          .windowByUrl(Brave.browserWindowUrl)
+          .changeSetting(settings.HOMEPAGE, page3Url)
+          .waitForVisible(homeButton)
+          .middleClick(homeButton)
+          .waitForTabCount(3)
+          .waitForUrl(page3Url)
+      })
     })
 
     describe('when disabled', function () {


### PR DESCRIPTION
## Test Plan:
- middle click on Home button
- new tab is opened

## Description
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Resolves #9562

Auditors: @bsclifton


Reviewer Checklist:

- [x] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


