### PR TITLE
Add a null check for framePath in WINDOW_SET_LINK_HOVER_PREVIEW

### DIFF
--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -413,11 +413,16 @@ const doAction = (action) => {
         break
       }
     case windowConstants.WINDOW_SET_LINK_HOVER_PREVIEW:
-      windowState = windowState.mergeIn(frameStateUtil.activeFrameStatePath(windowState), {
-        hrefPreview: action.href,
-        showOnRight: action.showOnRight
-      })
-      break
+      {
+        const framePath = frameStateUtil.activeFrameStatePath(windowState)
+        if (framePath) {
+          windowState = windowState.mergeIn(framePath, {
+            hrefPreview: action.href,
+            showOnRight: action.showOnRight
+          })
+        }
+        break
+      }
     case windowConstants.WINDOW_SET_THEME_COLOR:
       {
         const frameKey = action.frameProps.get('key')


### PR DESCRIPTION
Fixes browser lockup due to invalid activeFrameKey (various causes) mentioned in #9502 

Auditors:
@bridiver

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


