### PR TITLE
fix noscript allow-once for selective scripts

### DIFF
--- a/app/renderer/components/frame/frame.js
+++ b/app/renderer/components/frame/frame.js
@@ -157,7 +157,8 @@ class Frame extends React.Component {
     }
     const noScriptExceptions = activeSiteSettings.get('noScriptExceptions')
     if (noScriptExceptions) {
-      appActions.noScriptExceptionsAdded(origin, noScriptExceptions.filter((value, host) => value !== 0))
+      appActions.noScriptExceptionsAdded(origin,
+        noScriptExceptions.map(value => value === 0 ? false : value))
     }
   }
 

--- a/test/bravery-components/noScriptTest.js
+++ b/test/bravery-components/noScriptTest.js
@@ -98,6 +98,52 @@ describe('noscript info', function () {
       .windowByUrl(Brave.browserWindowUrl)
       .waitForVisible(noScriptNavButton)
   })
+
+  it('can selectively allow scripts once', function * () {
+    yield this.app.client
+      .tabByIndex(0)
+      .url(this.url)
+      .windowByUrl(Brave.browserWindowUrl)
+      .waitForVisible(noScriptNavButton)
+      .click(noScriptNavButton)
+      .waitForVisible(noScriptInfo)
+      .waitUntil(function () {
+        return this.getText('.blockedOriginsList')
+          .then((text) => {
+            return text.includes('https://cdnjs.cloudflare.com') && text.includes('http://localhost:')
+          })
+      })
+      .click('[for="checkbox-for-https://cdnjs.cloudflare.com"]') // keep blocking cloudflare
+      .waitForVisible(noScriptAllowOnceButton)
+      .click(noScriptAllowOnceButton)
+      .tabByIndex(0)
+      .url(this.url)
+      .windowByUrl(Brave.browserWindowUrl)
+      .waitForVisible(noScriptNavButton)
+      .click(noScriptNavButton)
+      .waitForVisible(noScriptInfo)
+      .waitUntil(function () {
+        return this.getText('.blockedOriginsList')
+          .then((text) => {
+            return text.includes('https://cdnjs.cloudflare.com') && !text.includes('http://localhost:')
+          })
+      })
+      .newTab()
+      .closeTabByIndex(0)
+      .pause(10) // wait for appstate changes
+      .tabByUrl(Brave.newTabUrl)
+      .url(this.url)
+      .windowByUrl(Brave.browserWindowUrl)
+      .waitForVisible(noScriptNavButton)
+      .click(noScriptNavButton)
+      .waitForVisible(noScriptInfo)
+      .waitUntil(function () {
+        return this.getText('.blockedOriginsList')
+          .then((text) => {
+            return text.includes('https://cdnjs.cloudflare.com') && text.includes('http://localhost:')
+          })
+      })
+  })
 })
 
 describe('noscript', function () {


### PR DESCRIPTION
fix #9150

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
    1. block scripts globally
    2. go to twitter.com
    3. click the noscript icon, make sure only 'twitter.com' is checked, click 'allow once'
    4. close the tab
    5. open twitter.com in a new tab
    3. click the noscript icon. 'twitter.com' should appear in the list.


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


