### PR TITLE
Editing custom selection from autocomplete can clear URL suffix

### DIFF
--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -261,18 +261,21 @@ class UrlBar extends React.Component {
       this.lastSuffix = ''
     }
 
+    const selectionStart = this.urlInput.selectionStart
+    const selectionEnd = this.urlInput.selectionEnd
+
     // if there is no selection then we are not in autocomplete
     // so make sure that this.lastValue is set to urlInput.value
-    if (this.urlInput.selectionStart === this.urlInput.selectionEnd) {
+    if (selectionStart === selectionEnd) {
       this.lastVal = this.urlInput.value
       this.lastSuffix = ''
     }
 
-    const selectionStart = this.urlInput.selectionStart
+    const lastValueWithSuffix = this.getValue()
     const newValue = [
-      this.lastVal.slice(0, selectionStart),
+      lastValueWithSuffix.slice(0, selectionStart),
       String.fromCharCode(e.which),
-      this.lastVal.slice(this.urlInput.selectionEnd)
+      lastValueWithSuffix.slice(selectionEnd)
     ].join('')
 
     if (!this.updateAutocomplete(newValue)) {

--- a/test/navbar-components/urlBarTest.js
+++ b/test/navbar-components/urlBarTest.js
@@ -752,4 +752,37 @@ describe('urlBar tests', function () {
         .waitForInputText(urlInput, this.page2Url)
     })
   })
+
+  describe('keeps url text separate from suffix text', function () {
+    Brave.beforeAll(this)
+    before(function * () {
+      yield setup(this.app.client)
+      yield this.app.client.waitForExist(urlInput)
+      yield this.app.client.waitForElementFocus(urlInput)
+      yield this.app.client
+        .onClearBrowsingData({browserHistory: true})
+        .addSite({ location: 'https://github.com/brave/browser-laptop', title: 'browser-laptop' })
+        .addSite({ location: 'https://github.com/brave/ad-block', title: 'Muon' })
+    })
+
+    it('changes only the selection', function * () {
+      yield this.app.client
+        .setInputText(urlInput, 'git')
+        .waitForSelectedText('hub.com')
+        // Select next suggestion
+        .keys(Brave.keys.DOWN)
+        .waitForSelectedText('hub.com/brave/browser-laptop')
+        // Remove selection of suffix
+        .keys(Brave.keys.RIGHT)
+        // Move to the left and create a new selection
+        .keys(Brave.keys.LEFT)
+        .keys(Brave.keys.LEFT)
+        .keys(Brave.keys.LEFT)
+        .keys(Brave.keys.SHIFT)
+        .keys(Brave.keys.LEFT)
+        .keys(Brave.keys.SHIFT)
+        .keys('s')
+        .waitForInputText(urlInput, 'github.com/brave/browser-lastop')
+    })
+  })
 })


### PR DESCRIPTION
Fix #9322

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Automated test plan
```
npm run test -- --grep="keeps url text separate from suffix text"
```

## Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


