### PR TITLE
Show right number of tabs when closing with mouse on first tab in new…

### DIFF
--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -695,7 +695,8 @@ const doAction = (action) => {
       }
       break
     case windowConstants.WINDOW_TAB_CLOSED_WITH_MOUSE:
-      if (frameStateUtil.getNonPinnedFrameCount(windowState) % getSetting(settings.TABS_PER_PAGE) === 0) {
+      const frameCountAfterClose = frameStateUtil.getNonPinnedFrameCount(windowState) - 1
+      if (frameCountAfterClose % getSetting(settings.TABS_PER_PAGE) === 0) {
         windowState = windowState.deleteIn(['ui', 'tabs', 'fixTabWidth'])
       } else {
         windowState = windowState.setIn(['ui', 'tabs', 'fixTabWidth'], action.data.fixTabWidth)

--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -535,6 +535,13 @@ var exports = {
       })
     })
 
+    this.app.client.addCommand('closeTabWithMouse', function () {
+      logVerbose('closeTabWithMouse()')
+      return this.execute(function () {
+        return devTools('electron').testData.windowActions.onTabClosedWithMouse()
+      })
+    })
+
     this.app.client.addCommand('waitForInputText', function (selector, input) {
       logVerbose('waitForInputText("' + selector + '", "' + input + '")')
       return this

--- a/test/tab-components/tabPagesTest.js
+++ b/test/tab-components/tabPagesTest.js
@@ -55,6 +55,18 @@ describe('tab pages', function () {
       yield this.app.client.waitForVisible('[data-test-active-tab]')
     })
 
+    it('shows the right number of tabs after closing with mouse', function * () {
+      const numTabsPerPage = appConfig.defaultSettings[settings.TABS_PER_PAGE]
+      const firstTabOfNewPageIndex = numTabsPerPage
+      yield this.app.client.click(newFrameButton)
+        .waitForElementCount(tabPage, 2)
+        .closeTabWithMouse()
+        .closeTabByIndex(firstTabOfNewPageIndex)
+        // No tab page indicator elements when 1 page
+        .waitForElementCount(tabPage, 0)
+        .waitForElementCount(tabsTabs, numTabsPerPage)
+    })
+
     describe('allows changing to tab pages', function () {
       beforeEach(function * () {
         // Make sure there are 2 tab pages


### PR DESCRIPTION
… tab page

Fix #9561

Auditors: @bsclifton

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Automated test plan
```
npm run test -- --grep="shows the right number of tabs after closing with mouse"
```

## Reviewer Checklist:

Tests

- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


