### PR TITLE
Bitwarden disable 0.17.x

### DIFF
--- a/app/renderer/lib/extensionsUtil.js
+++ b/app/renderer/lib/extensionsUtil.js
@@ -28,12 +28,8 @@ const honey = config.honeyExtensionId
  * Properties such as name and description are referenced like keys for proper l10n
  */
 const dummyData = [
+  // { id: bitwarden, // TBD },
   {
-    id: bitwarden,
-    name: 'bitwarden',
-    description: 'bitwardenDesc',
-    icon: 'img/extensions/bitwarden-128.png'
-  }, {
     id: dashlane,
     name: 'dashlane',
     description: 'dashlaneDesc',

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -620,7 +620,7 @@ class SecurityTab extends ImmutableComponent {
             <option data-l10n-id='onePassword' value={passwordManagers.ONE_PASSWORD} />
             <option data-l10n-id='dashlane' value={passwordManagers.DASHLANE} />
             <option data-l10n-id='lastPass' value={passwordManagers.LAST_PASS} />
-            <option data-l10n-id='bitwarden' value={passwordManagers.BITWARDEN} />
+            { /* <option data-l10n-id='bitwarden' value={passwordManagers.BITWARDEN} /> */ }
             { /* <option data-l10n-id='enpass' value={passwordManagers.ENPASS} /> */ }
             <option data-l10n-id='doNotManageMyPasswords' value={passwordManagers.UNMANAGED} />
           </SettingDropdown>

--- a/test/unit/app/renderer/components/preferences/extensionsTabTest.js
+++ b/test/unit/app/renderer/components/preferences/extensionsTabTest.js
@@ -173,35 +173,6 @@ describe('ExtensionsTab component', function () {
           assert.equal(wrapper.find('[data-extension-enabled=false]').length, 1)
         })
       })
-      describe('bitwarden', function () {
-        it('shows on UI by default', function () {
-          const wrapper = mount(
-            <ExtensionsTab
-              extensions={extensions(passwordManagers.BITWARDEN, false, false)}
-              settings={Immutable.Map()}
-              onChangeSetting={null} />
-          )
-          assert.equal(wrapper.find(`[data-extension-id="${passwordManagers.BITWARDEN}"]`).length, 1)
-        })
-        it('can be enabled', function () {
-          const wrapper = mount(
-            <ExtensionsTab
-              extensions={extensions(passwordManagers.BITWARDEN, true, false)}
-              settings={Immutable.Map()}
-              onChangeSetting={null} />
-          )
-          assert.equal(wrapper.find('[data-extension-enabled=true]').length, 1)
-        })
-        it('can be disabled', function () {
-          const wrapper = mount(
-            <ExtensionsTab
-              extensions={extensions(passwordManagers.BITWARDEN, false, false)}
-              settings={Immutable.Map()}
-              onChangeSetting={null} />
-          )
-          assert.equal(wrapper.find('[data-extension-enabled=false]').length, 1)
-        })
-      })
     })
     describe('common extensions', function () {
       describe('brave', function () {


### PR DESCRIPTION
Note: This PR is against 0.17.x only. All that needs to be done is merge.
No action should be done for 0.18.x and master.

Fix #9619 