### PR TITLE
Unpinning tab intermittently does not display the title on tabs

### DIFF
--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -196,15 +196,13 @@ class Tab extends React.Component {
   }
 
   onUpdateTabSize () {
-    setImmediate(() => {
-      const currentSize = getTabBreakpoint(this.tabSize)
-      // Avoid updating breakpoint when user enters fullscreen (see #7301)
-      !this.props.hasTabInFullScreen && windowActions.setTabBreakpoint(this.props.frameKey, currentSize)
-    })
-  }
-
-  componentWillMount () {
-    this.onUpdateTabSize()
+    const currentSize = getTabBreakpoint(this.tabSize)
+    // Avoid updating breakpoint when user enters fullscreen (see #7301)
+    // Also there can be a race condition for pinned tabs if we update when not needed
+    // since a new tab component with the same key gets created which is not pinned.
+    if (this.props.breakpoint !== currentSize && !this.props.hasTabInFullScreen) {
+      windowActions.setTabBreakpoint(this.props.frameKey, currentSize)
+    }
   }
 
   componentDidMount () {
@@ -218,15 +216,7 @@ class Tab extends React.Component {
   }
 
   componentWillUnmount () {
-    this.onUpdateTabSize()
     window.removeEventListener('resize', this.onUpdateTabSize)
-  }
-
-  componentWillReceiveProps (nextProps) {
-    // Update breakpoint each time a new tab is open
-    if (this.props.totalTabs !== nextProps.totalTabs) {
-      this.onUpdateTabSize()
-    }
   }
 
   get fixTabWidth () {

--- a/test/tab-components/pinnedTabTest.js
+++ b/test/tab-components/pinnedTabTest.js
@@ -38,6 +38,7 @@ describe('pinnedTabs', function () {
         .waitForExist('[data-test-pinned-tab="false"][data-frame-key="2"]')
         .waitForElementCount(pinnedTabsTabs, 0)
         .waitForElementCount(tabsTabs, 2)
+        .waitForTextValue('[data-test-pinned-tab="false"][data-frame-key="2"]', 'Page 1')
     })
     it('pinning the same site again combines it', function * () {
       yield this.app.client

--- a/test/tab-components/pinnedTabTest.js
+++ b/test/tab-components/pinnedTabTest.js
@@ -208,4 +208,30 @@ describe('pinnedTabs', function () {
         .waitForExist('[data-test-active-tab][data-frame-key="1"]')
     })
   })
+
+  describe('Going back to original state after unpinning', function () {
+    Brave.beforeAll(this)
+    before(function * () {
+      yield setup(this.app.client)
+      const page1 = Brave.server.url('page1.html')
+      const page2 = Brave.server.url('page2.html')
+      yield this.app.client
+        .windowByUrl(Brave.browserWindowUrl)
+        .newTab({ url: page1, pinned: true })
+        .waitForUrl(page1)
+        .windowByUrl(Brave.browserWindowUrl)
+        .newTab({ url: page2, pinned: true })
+        .waitForUrl(page2)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForElementCount(pinnedTabsTabs, 2)
+        .waitForElementCount(tabsTabs, 1)
+    })
+    it('shows the tab title', function * () {
+      yield this.app.client
+        .pinTabByIndex(2, false)
+        .waitForExist('[data-test-id="tab"][data-frame-key="3"]')
+        .waitForVisible('[data-test-id="tab"][data-frame-key="3"]')
+        .waitForTextValue('[data-test-id="tab"][data-frame-key="3"]', 'Page 2')
+    })
+  })
 })


### PR DESCRIPTION
Fix #9608

Auditors: @cezaraugusto

Note that since it's intermittent I think the test would also pass before, but I can't find a way to get a unique test to always fail.  Same as if I test manually

The test will at least ensure that unpinning gives a title always
though.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


