### PR TITLE
Tests should pass with npm5

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "cross-env": "^3.1.4",
     "css-loader": "^0.23.0",
     "electron-builder": "^17.1.1",
+    "electron-chromedriver": "^1.7.1",
     "electron-packager": "brave/electron-packager",
     "electron-prebuilt": "brave/electron-prebuilt",
     "empty-port": "0.0.2",


### PR DESCRIPTION
I can't run tests on my macOS or my linux because of electron-chromedriver not found. I think it is because of npm5 so adding it as a dep

Fix #9628

Auditors: @cezaraugusto

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


