### PR TITLE
Hide pre-release preference, since Linux builds don't auto-update

### DIFF
--- a/app/renderer/components/preferences/advancedTab.js
+++ b/app/renderer/components/preferences/advancedTab.js
@@ -21,14 +21,26 @@ const {scaleSize} = require('../../../common/constants/toolbarUserInterfaceScale
 
 // Utils
 const {changeSetting} = require('../../lib/settingsUtil')
+const platformUtil = require('../../../common/lib/platformUtil')
 
 class AdvancedTab extends ImmutableComponent {
+  previewReleases () {
+    return platformUtil.isLinux()
+      ? null
+      : <SettingCheckbox
+        dataL10nId='updateToPreviewReleases'
+        data-test-id='update-to-preview-releases'
+        prefKey={settings.UPDATE_TO_PREVIEW_RELEASES}
+        settings={this.props.settings}
+        onChangeSetting={this.props.onChangeSetting} />
+  }
+
   render () {
     return <section>
       <main className={css(styles.advancedTabMain)}>
         <DefaultSectionTitle data-l10n-id='contentSettings' />
         <SettingsList>
-          <SettingCheckbox dataL10nId='updateToPreviewReleases' prefKey={settings.UPDATE_TO_PREVIEW_RELEASES} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
+          {this.previewReleases()}
           <SettingCheckbox dataL10nId='useHardwareAcceleration' prefKey={settings.HARDWARE_ACCELERATION_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
           <SettingCheckbox dataL10nId='useSmoothScroll' prefKey={settings.SMOOTH_SCROLL_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
           <SettingCheckbox dataL10nId='sendCrashReports' prefKey={settings.SEND_CRASH_REPORTS} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />

--- a/test/unit/app/renderer/components/preferences/advancedTabTest.js
+++ b/test/unit/app/renderer/components/preferences/advancedTabTest.js
@@ -1,0 +1,76 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* global describe, before, after, it */
+
+const mockery = require('mockery')
+const {mount} = require('enzyme')
+const assert = require('assert')
+const fakeElectron = require('../../../../lib/fakeElectron')
+let AdvancedTab
+require('../../../../braveUnit')
+
+describe('AdvancedTab component', function () {
+  before(function () {
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    })
+    mockery.registerMock('../../less/switchControls.less', {})
+    mockery.registerMock('../../less/about/preferences.less', {})
+    mockery.registerMock('../../less/forms.less', {})
+    mockery.registerMock('../../less/button.less', {})
+    mockery.registerMock('../../node_modules/font-awesome/css/font-awesome.css', {})
+    mockery.registerMock('../../../extensions/brave/img/caret_down_grey.svg')
+
+    // default platformUtil to non-Linux
+    mockery.registerMock('../../../common/lib/platformUtil', {isLinux: () => false})
+
+    mockery.registerMock('electron', fakeElectron)
+    window.chrome = fakeElectron
+
+    AdvancedTab = require('../../../../../../app/renderer/components/preferences/advancedTab')
+  })
+  after(function () {
+    mockery.disable()
+  })
+
+  describe('AdvancedTab', function () {
+    describe('previewReleases', function () {
+      describe('on macOS', function () {
+        it('is shown', function () {
+          const wrapper = mount(
+            <AdvancedTab onChangeSetting={null} />
+          )
+          const instance = wrapper.instance()
+          assert(instance.previewReleases())
+        })
+      })
+
+      describe('on Linux', function () {
+        before(function () {
+          mockery.deregisterMock('../../../common/lib/platformUtil')
+          mockery.registerMock('../../../common/lib/platformUtil', {isLinux: () => true})
+          mockery.resetCache()
+          AdvancedTab = require('../../../../../../app/renderer/components/preferences/advancedTab')
+        })
+
+        after(function () {
+          mockery.deregisterMock('../../../common/lib/platformUtil')
+          mockery.registerMock('../../../common/lib/platformUtil', {isLinux: () => false})
+          mockery.resetCache()
+          AdvancedTab = require('../../../../../../app/renderer/components/preferences/advancedTab')
+        })
+
+        it('is hidden', function () {
+          const wrapper = mount(
+            <AdvancedTab onChangeSetting={null} />
+          )
+          const instance = wrapper.instance()
+          assert.equal(instance.previewReleases(), null)
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Automated test plan
```
npm run unittest -- --grep="AdvancedTab component"
```

## Test plan
1. Open about:preferences#advanced on a linux distibution
2. Make sure that "update to preview release" is not there


## Description 
Fixes https://github.com/brave/browser-laptop/issues/9631

Auditors: @luixxiul, @bbondy

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Reviewer Checklist:

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


