### PR TITLE
Check for no frame info in tab content components

### DIFF
--- a/app/renderer/components/tabs/content/audioTabIcon.js
+++ b/app/renderer/components/tabs/content/audioTabIcon.js
@@ -4,6 +4,7 @@
 
 const React = require('react')
 const {StyleSheet, css} = require('aphrodite/no-important')
+const Immutable = require('immutable')
 
 // Components
 const ReduxComponent = require('../../reduxComponent')
@@ -43,7 +44,10 @@ class AudioTabIcon extends React.Component {
 
   mergeProps (state, dispatchProps, ownProps) {
     const currentWindow = state.get('currentWindow')
-    const frame = frameStateUtil.getFrameByKey(currentWindow, ownProps.frameKey)
+
+    // AudioIcon will never be created if there is no frameKey, but for consistency
+    // across other components I added teh || Immutable.Map()
+    const frame = frameStateUtil.getFrameByKey(currentWindow, ownProps.frameKey) || Immutable.Map()
 
     const props = {}
     // used in other functions

--- a/app/renderer/components/tabs/content/closeTabIcon.js
+++ b/app/renderer/components/tabs/content/closeTabIcon.js
@@ -4,6 +4,7 @@
 
 const React = require('react')
 const {StyleSheet, css} = require('aphrodite/no-important')
+const Immutable = require('immutable')
 
 // Components
 const ReduxComponent = require('../../reduxComponent')
@@ -51,7 +52,7 @@ class CloseTabIcon extends React.Component {
   mergeProps (state, dispatchProps, ownProps) {
     const currentWindow = state.get('currentWindow')
     const isPinnedTab = frameStateUtil.isPinned(currentWindow, ownProps.frameKey)
-    const frame = frameStateUtil.getFrameByKey(currentWindow, ownProps.frameKey)
+    const frame = frameStateUtil.getFrameByKey(currentWindow, ownProps.frameKey) || Immutable.Map()
 
     const props = {}
     // used in renderer

--- a/app/renderer/components/tabs/content/newSessionIcon.js
+++ b/app/renderer/components/tabs/content/newSessionIcon.js
@@ -4,6 +4,7 @@
 
 const React = require('react')
 const {StyleSheet, css} = require('aphrodite/no-important')
+const Immutable = require('immutable')
 
 // Components
 const ReduxComponent = require('../../reduxComponent')
@@ -25,7 +26,7 @@ const newSessionSvg = require('../../../../extensions/brave/img/tabs/new_session
 class NewSessionIcon extends React.Component {
   mergeProps (state, dispatchProps, ownProps) {
     const currentWindow = state.get('currentWindow')
-    const frame = frameStateUtil.getFrameByKey(currentWindow, ownProps.frameKey)
+    const frame = frameStateUtil.getFrameByKey(currentWindow, ownProps.frameKey) || Immutable.Map()
     const partition = frame.get('partitionNumber')
 
     const props = {}

--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -4,6 +4,7 @@
 
 const React = require('react')
 const {StyleSheet, css} = require('aphrodite')
+const Immutable = require('immutable')
 
 // Components
 const ReduxComponent = require('../reduxComponent')
@@ -230,7 +231,7 @@ class Tab extends React.Component {
 
   mergeProps (state, dispatchProps, ownProps) {
     const currentWindow = state.get('currentWindow')
-    const frame = frameStateUtil.getFrameByKey(currentWindow, ownProps.frameKey)
+    const frame = frameStateUtil.getFrameByKey(currentWindow, ownProps.frameKey) || Immutable.Map()
     const notifications = state.get('notifications')
     const notificationOrigins = notifications ? notifications.map(bar => bar.get('frameOrigin')) : false
     const notificationBarActive = frame.get('location') && notificationOrigins &&

--- a/test/unit/app/renderer/components/tabs/content/audioTabIconTest.js
+++ b/test/unit/app/renderer/components/tabs/content/audioTabIconTest.js
@@ -13,6 +13,7 @@ require('../../../../../braveUnit')
 
 const tabId = 1
 const frameKey = 1
+const invalidFrameKey = 71
 
 const fakeAppStoreRenderer = {
   state: Immutable.fromJS({
@@ -94,6 +95,12 @@ describe('Tabs content - AudioTabIcon', function () {
       })
       const wrapper = mount(<Tab frameKey={frameKey} />)
       assert.equal(wrapper.find('AudioTabIcon TabIcon').props().symbol, globalStyles.appIcons.volumeOff)
+    })
+    it('passing in a frame key which does not exist does not fail', function () {
+      windowStore.state = defaultWindowStore
+      const wrapper = mount(<Tab frameKey={invalidFrameKey} />)
+      // No audio icon is rendered in this case so just check for Tab
+      assert(wrapper.find('Tab'))
     })
   })
 

--- a/test/unit/app/renderer/components/tabs/content/closeTabIconTest.js
+++ b/test/unit/app/renderer/components/tabs/content/closeTabIconTest.js
@@ -12,6 +12,7 @@ require('../../../../../braveUnit')
 
 const tabId = 1
 const frameKey = 1
+const invalidFrameKey = 71
 
 const fakeAppStoreRenderer = {
   state: Immutable.fromJS({
@@ -134,6 +135,12 @@ describe('Tabs content - CloseTabIcon', function () {
       })
       const wrapper = mount(<CloseTabIcon frameKey={frameKey} />)
       assert.equal(wrapper.find('TabIcon').props()['data-test2-id'], 'close-icon-on')
+    })
+
+    it('passing in a frame key which does not exist does not fail', function () {
+      windowStore.state = defaultWindowStore
+      const wrapper = mount(<CloseTabIcon frameKey={invalidFrameKey} />)
+      assert.equal(wrapper.find('TabIcon').props()['data-test2-id'], 'close-icon-off')
     })
   })
 

--- a/test/unit/app/renderer/components/tabs/content/newSessionIconTest.js
+++ b/test/unit/app/renderer/components/tabs/content/newSessionIconTest.js
@@ -13,6 +13,7 @@ require('../../../../../braveUnit')
 
 const tabId = 1
 const frameKey = 1
+const invalidFrameKey = 71
 
 const fakeAppStoreRenderer = {
   state: Immutable.fromJS({
@@ -144,6 +145,11 @@ describe('Tabs content - NewSessionIcon', function () {
       })
       const wrapper = mount(<NewSessionIcon frameKey={frameKey} />)
       assert.equal(wrapper.find('TabIcon').props().symbolContent, tabs.maxAllowedNewSessions)
+    })
+    it('passing in a frame key which does not exist does not fail', function () {
+      windowStore.state = defaultWindowStore
+      const wrapper = mount(<NewSessionIcon frameKey={invalidFrameKey} />)
+      assert(wrapper.find('TabIcon'))
     })
   })
 

--- a/test/unit/app/renderer/components/tabs/content/tabTitleTest.js
+++ b/test/unit/app/renderer/components/tabs/content/tabTitleTest.js
@@ -15,6 +15,7 @@ const url1 = 'https://brave.com'
 const pageTitle1 = 'Brave Software'
 const tabId = 1
 const frameKey = 1
+const invalidFrameKey = 71
 
 const fakeAppStoreRenderer = {
   state: Immutable.fromJS({
@@ -137,6 +138,11 @@ describe('Tabs content - Title', function () {
       })
       const wrapper = mount(<Tab frameKey={frameKey} />)
       assert.equal(wrapper.find('TabTitle div').text(), pageTitle1)
+    })
+    it('passing in a frame key which does not exist does not fail', function () {
+      windowStore.state = defaultWindowStore
+      const wrapper = mount(<Tab frameKey={invalidFrameKey} />)
+      assert.equal(wrapper.find('TabTitle div').text(), '')
     })
   })
 


### PR DESCRIPTION
NOTE FOR MERGE: This is a PR against 0.17.x because unit tests are currently failing too much on other branches. So when merging merge it to 0.18.x, and master.

Auditors: @NejcZdovc

Fix #9686

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


