### PR TITLE
Add pre-push for lint and unittest

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
     "node-static": "^0.7.7",
     "nsp": "^2.2.0",
     "pre-commit": "brave/pre-commit",
+    "pre-push": "^0.1.1",
     "react-addons-perf": "^15.2.1",
     "react-addons-test-utils": "^15.4.1",
     "react-test-renderer": "^15.5.4",
@@ -222,10 +223,15 @@
   },
   "pre-commit": {
     "run": [
-      "lint",
       "docs"
     ],
     "template": "COMMIT_TEMPLATE"
+  },
+  "pre-push": {
+    "run": [
+      "lint",
+      "unittest"
+    ]
   },
   "engineStrict": true,
   "engines": {

--- a/tools/lib/ignoredPaths.js
+++ b/tools/lib/ignoredPaths.js
@@ -3,6 +3,8 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 module.exports = [
+  'pre-comit',
+  'pre-push',
   'test/',
   'docs/',
   'tools/',


### PR DESCRIPTION
**Note to the person merging: This is a PR against 0.17.x, so please merge to 0.18.x and master.**

Fix #9688

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


