### PR TITLE
Prevent Tab Close Button from allowing tab-tearoff

### DIFF
--- a/app/renderer/components/tabs/content/closeTabIcon.js
+++ b/app/renderer/components/tabs/content/closeTabIcon.js
@@ -31,6 +31,7 @@ class CloseTabIcon extends React.Component {
   constructor (props) {
     super(props)
     this.onClick = this.onClick.bind(this)
+    this.onDragStart = this.onDragStart.bind(this)
   }
 
   get frame () {
@@ -46,6 +47,10 @@ class CloseTabIcon extends React.Component {
       })
       appActions.tabCloseRequested(this.props.tabId)
     }
+  }
+
+  onDragStart (event) {
+    event.preventDefault()
   }
 
   mergeProps (state, ownProps) {
@@ -76,6 +81,8 @@ class CloseTabIcon extends React.Component {
       className={css(this.props.showCloseIcon && styles.closeTab)}
       l10nId='closeTabButton'
       onClick={this.onClick}
+      onDragStart={this.onDragStart}
+      draggable='true'
     />
   }
 }

--- a/app/renderer/components/tabs/content/tabIcon.js
+++ b/app/renderer/components/tabs/content/tabIcon.js
@@ -33,6 +33,8 @@ class TabIcon extends ImmutableComponent {
     return <div
       className={this.props.className}
       data-test-favicon={this.props['data-test-favicon']}
+      onDragStart={this.props.onDragStart}
+      draggable={this.props.draggable}
       onClick={this.props.onClick}>
       {
         this.props.symbol


### PR DESCRIPTION
Auditors: @luixxiul
Close #9511

Test Plan:
1. Tear-off a tab by dragging any part of the tab other than close button
2. It should tear-off
3. Try to tear-off a tab dragging from tab close button
4. You can't
