### PR TITLE
Add new script which publishes the current release 

### DIFF
--- a/tools/publish_release.py
+++ b/tools/publish_release.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+import json
+import os
+from lib.github import GitHub
+import requests
+
+BROWSER_LAPTOP_REPO = 'brave/browser-laptop'
+TARGET_ARCH= os.environ['TARGET_ARCH'] if os.environ.has_key('TARGET_ARCH') else 'x64'
+RELEASE_NAME = 'Dev Channel Beta'
+
+def main():
+  github = GitHub(auth_token())
+  releases = github.repos(BROWSER_LAPTOP_REPO).releases.get()
+  tag = ('v' + json.load(open('package.json'))['version'] +
+    release_channel())
+  tag_exists = False
+  for release in releases:
+    if not release['draft'] and release['tag_name'] == tag:
+      tag_exists = True
+      break
+  release = create_or_get_release_draft(github, releases, tag,
+                                        tag_exists)
+
+  # Press the publish button.
+  publish_release(github, release['id'])
+
+def create_release_draft(github, tag):
+  name = '{0} {1}'.format(RELEASE_NAME, tag)
+  # TODO: Parse release notes from CHANGELOG.md
+  body = '(placeholder)'
+  if body == '':
+    sys.stderr.write('Quit due to empty release note.\n')
+    sys.exit(1)
+  data = dict(tag_name=tag, name=name, body=body, draft=True, prerelease=True)
+  r = github.repos(BROWSER_LAPTOP_REPO).releases.post(data=data)
+  return r
+
+def create_or_get_release_draft(github, releases, tag, tag_exists):
+  # Search for existing draft.
+  for release in releases:
+    if release['draft']:
+      return release
+
+  if tag_exists:
+    tag = 'do-not-publish-me'
+  return create_release_draft(github, tag)
+
+def auth_token():
+  token = os.environ['GITHUB_TOKEN']
+  message = ('Error: Please set the $GITHUB_TOKEN '
+             'environment variable, which is your personal token')
+  assert token, message
+  return token
+
+def release_channel():
+  channel = os.environ['CHANNEL']
+  message = ('Error: Please set the $CHANNEL '
+             'environment variable, which is your release channel')
+  assert channel, message
+  return channel
+
+def publish_release(github, release_id):
+  data = dict(draft=False)
+  github.repos(BROWSER_LAPTOP_REPO).releases(release_id).patch(data=data)
+
+if __name__ == '__main__':
+  import sys
+  sys.exit(main())


### PR DESCRIPTION
Add new script which publishes the current release 
(based on the version in package.json).

New script is similar to `tools/upload.py` (and we can refactor to share the code).
New method found by browsing https://github.com/electron/electron/blob/master/script/upload.py

Usage is like so:
`CHANNEL=dev GITHUB_TOKEN=<TOKEN-HERE> python tools/publish_release.py`

Auditors: @bbondy, @aekeus

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


