### PR TITLE
Send isSecure false instead of null when an insecure site has passive mixed content

### DIFF
--- a/app/renderer/components/frame/frame.js
+++ b/app/renderer/components/frame/frame.js
@@ -707,12 +707,11 @@ class Frame extends React.Component {
         isSecure = false
         const parsedUrl = urlParse(this.props.location)
         ipc.send(messages.CHECK_CERT_ERROR_ACCEPTED, parsedUrl.host, this.props.frameKey)
-      } else if (this.props.isSecure !== false &&
-        ['warning', 'passive-mixed-content'].includes(e.securityState)) {
+      } else if (['warning', 'passive-mixed-content'].includes(e.securityState)) {
         // Passive mixed content should not upgrade an insecure connection to a
         // partially-secure connection. It can only downgrade a secure
         // connection.
-        isSecure = 1
+        isSecure = this.props.isSecure !== false ? 1 : false
       }
       windowActions.setSecurityState(this.frame, {
         secure: runInsecureContent ? false : isSecure,


### PR DESCRIPTION

Fix https://github.com/brave/browser-laptop/issues/9652

If a site is already insecure and receives passive mixed content, the security state should remain insecure instead of changing to unknown.

Test Plan:
1. go to https://video.foxbusiness.com/v/5068842750001/?#sp=show-clips
2. click 'allow ads' so that the video will play
3. the URL bar icon should not disappear when the video starts

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


