### PR TITLE
Fix autoplay test

### DIFF
--- a/test/bravery-components/notificationBarTest.js
+++ b/test/bravery-components/notificationBarTest.js
@@ -342,6 +342,7 @@ describe('Autoplay test', function () {
           })
       })
       .windowByUrl(Brave.browserWindowUrl)
+      .activateURLMode()
       .click(reloadButton)
       .tabByUrl(url)
       .waitUntil(function () {
@@ -363,6 +364,7 @@ describe('Autoplay test', function () {
       })
       .windowByUrl(Brave.browserWindowUrl)
       .closeTabByIndex(0)
+      .activateURLMode()
       .click(reloadButton)
       .waitForExist(notificationBar)
       .waitUntil(function () {
@@ -396,6 +398,7 @@ describe('Autoplay test', function () {
           })
       })
       .windowByUrl(Brave.browserWindowUrl)
+      .activateURLMode()
       .click(reloadButton)
       .tabByUrl(url)
       .waitUntil(function () {
@@ -417,6 +420,7 @@ describe('Autoplay test', function () {
       })
       .windowByUrl(Brave.browserWindowUrl)
       .closeTabByIndex(0)
+      .activateURLMode()
       .click(reloadButton)
       .tabByUrl(url)
       .waitUntil(function () {
@@ -445,6 +449,7 @@ describe('Autoplay test', function () {
       })
       .click('button=No')
       .windowByUrl(Brave.browserWindowUrl)
+      .activateURLMode()
       .click(reloadButton)
       .tabByUrl(url)
       .waitUntil(function () {


### PR DESCRIPTION
activate URL mode before click reload button

Auditors: @NejcZdovc, @bsclifton

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
```
# **window 1**
npm run watch-all

# **window 2**
npm run test -- --grep="Autoplay test"
```

Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


