### PR TITLE
Fix error when adding a bookmark folder

### DIFF
--- a/app/renderer/components/bookmarks/addEditBookmarkHanger.js
+++ b/app/renderer/components/bookmarks/addEditBookmarkHanger.js
@@ -3,6 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const React = require('react')
+const Immutable = require('immutable')
 
 // Components
 const ReduxComponent = require('../reduxComponent')
@@ -160,8 +161,8 @@ class AddEditBookmarkHanger extends React.Component {
 
   mergeProps (state, ownProps) {
     const currentWindow = state.get('currentWindow')
-    const bookmarkDetail = currentWindow.get('bookmarkDetail')
-    const currentDetail = bookmarkDetail.get('currentDetail')
+    const bookmarkDetail = currentWindow.get('bookmarkDetail', new Immutable.Map())
+    const currentDetail = bookmarkDetail.get('currentDetail', new Immutable.Map())
     const originalDetail = bookmarkDetail.get('originalDetail')
 
     const props = {}


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/9745

Test Plan:
1. open fresh browser profile
2. right click to add a bookmark folder
3. there should be no errors in the browser console

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


