### PR TITLE
Fixes close tabs to the left/right

### DIFF
--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -202,7 +202,7 @@ var exports = {
     const initialized = []
 
     this.app.client.addCommand('ipcSend', function (message, ...param) {
-      logVerbose('ipcSend(' + message + ')')
+      logVerbose('ipcSend(' + message + ', "' + param + '")')
       return this.execute(function (message, ...param) {
         return devTools('electron').remote.getCurrentWindow().webContents.send(message, ...param)
       }, message, ...param).then((response) => response.value)

--- a/test/tab-components/tabPagesTest.js
+++ b/test/tab-components/tabPagesTest.js
@@ -3,6 +3,7 @@
 const Brave = require('../lib/brave')
 const appConfig = require('../../js/constants/appConfig')
 const settings = require('../../js/constants/settings')
+const messages = require('../../js/constants/messages')
 const {
   urlInput,
   newFrameButton,
@@ -66,6 +67,25 @@ describe('tab pages', function () {
         // No tab page indicator elements when 1 page
         .waitForElementCount(tabPage, 0)
         .waitForElementCount(tabsTabs, numTabsPerPage)
+    })
+
+    it('closing tabs with close-to-left option', function * () {
+      let tabId = 0
+      yield this.app.client
+        .click(newFrameButton)
+        .waitForElementCount(tabPage, 2)
+        .waitUntil(function () {
+          return this.getAppState().then((state) => {
+            const length = state.value.tabs.length
+            tabId = state.value.tabs[length - 1].id
+            return true
+          })
+        })
+        .waitUntil(function () {
+          return this.ipcSend(messages.SHORTCUT_CLOSE_OTHER_FRAMES, tabId, false, true)
+        })
+        .waitForElementCount(tabPage, 0)
+        .waitForElementCount(tabsTabs, 1)
     })
 
     describe('allows changing to tab pages', function () {


### PR DESCRIPTION
when you have multiple tab pages

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Resolves #9789

Auditors: @bsclifton

Test Plan:
- open so many tabs that you have at least two tab pages
- right click on the last tab
- select "Close tabs to the left"

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


