### PR TITLE
Fix scroll bar issues on bravery panel

### DIFF
--- a/app/renderer/components/main/braveryPanel.js
+++ b/app/renderer/components/main/braveryPanel.js
@@ -878,15 +878,15 @@ const styles = StyleSheet.create({
   braveryPanel__body__ul: {
     fontSize: 'smaller',
     maxHeight: '300px',
-    overflowY: 'scroll',
+    overflowY: 'auto',
     marginTop: '-20px',
     padding: '10px',
-    userSelect: 'initial',
-    cursor: 'text'
+    userSelect: 'initial'
   },
   braveryPanel__body__ul__li: {
     listStyleType: 'none',
-    padding: '10px 0'
+    padding: '10px 0',
+    cursor: 'text'
   },
   braveryPanel__body__hr: {
     background: globalStyles.braveryPanel.body.hr.background,


### PR DESCRIPTION
Fixes #9802 
Fixes #9296

Auditors: @cezaraugusto

Test Plan:
1. Open twitter.com
2. Open the bravery panel
3. Expand a resouce list
4. Hover on the scroll bar
5. Make sure the cursor does not become `cursor:text`

Test Plan 2:
1. Open https://https-everywhere.badssl.com/
2. Expand a resouce list
3. Make sure that the scroll bar does not appear

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


