### PR TITLE
Fix bravery panel width from increasing

### DIFF
--- a/app/renderer/components/main/braveryPanel.js
+++ b/app/renderer/components/main/braveryPanel.js
@@ -935,13 +935,16 @@ const styles = StyleSheet.create({
     marginBottom: '.75rem'
   },
   braveryPanel_compact__body__ul: {
-    padding: '0 .5rem',
-    margin: '0 0 .75rem 0',
-    wordBreak: 'break-all',
+    padding: '0 .5rem 1rem',
+    margin: '0 0 .25rem 0',
     maxHeight: '10vh'
   },
   braveryPanel_compact__body__ul__li: {
     padding: '5px 0',
+
+    // #9839: Avoid the panel width from increasing
+    width: 0,
+    whiteSpace: 'nowrap',
 
     ':first-of-type': {
       paddingTop: 0


### PR DESCRIPTION
Closes #9839
Addresses #9016

Auditors:

Test Plan:
1. Open twitter.com
2. Enable `Block Scripts`
3. Click the counter
4. Make sure the panel width does not increase

![twitter](https://user-images.githubusercontent.com/3362943/27772619-24484b4a-5fa1-11e7-9f4d-4ae1fd23bce3.gif)

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


