### PR TITLE
allow website access with long press on backbutton

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -798,7 +798,8 @@ const api = {
 
   goToIndex: (tabId, index) => {
     const tab = getWebContents(tabId)
-    if (tab && !tab.isDestroyed() && tab.canGoToIndex(index)) {
+    const validIndex = index >= 0 && index < tab.getEntryCount()
+    if (tab && !tab.isDestroyed() && validIndex) {
       tab.goToIndex(index)
     }
   },


### PR DESCRIPTION
Auditors: @bridiver, @luixxiul
Fix #9852

STR: 

1. Open github.com
2. select any link
3. press the back button long
4. select github from pulldown
5. Actual result: page should load
