### PR TITLE
Added download count/badge and progress (closes #3023)

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -496,8 +496,8 @@ function registerPermissionHandler (session, partition) {
   })
 }
 
-function updateDownloadState (downloadId, item, state) {
-  updateElectronDownloadItem(downloadId, item, state)
+function updateDownloadState (win, downloadId, item, state) {
+  updateElectronDownloadItem(win, downloadId, item, state)
 
   if (!item) {
     appActions.mergeDownloadDetail(downloadId, { state: downloadStates.INTERRUPTED })
@@ -554,16 +554,16 @@ function registerForDownloadListener (session) {
     appActions.changeSetting(settings.DEFAULT_DOWNLOAD_SAVE_PATH, path.dirname(savePath))
 
     const downloadId = uuid.v4()
-    updateDownloadState(downloadId, item, downloadStates.PENDING)
+    updateDownloadState(win, downloadId, item, downloadStates.PENDING)
     if (win) {
       win.webContents.send(messages.SHOW_DOWNLOADS_TOOLBAR)
     }
     item.on('updated', function () {
       const state = item.isPaused() ? downloadStates.PAUSED : downloadStates.IN_PROGRESS
-      updateDownloadState(downloadId, item, state)
+      updateDownloadState(win, downloadId, item, state)
     })
     item.on('done', function (e, state) {
-      updateDownloadState(downloadId, item, state)
+      updateDownloadState(win, downloadId, item, state)
     })
   })
 }


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Closes #3023

Test Plan:
- I tested manually. There didn't appear to be any unit tests for `/app/browser/updateElectronDownloadItem.js`
  1. Go to https://brave.com/downloads.html
  2. Download one of the builds
  3. Notice the taskbar icon has a progress bar. If macOS, a badge is shown with # of concurrent downloads

- I can add tests that check the badge count (`app.getBadgeCount`), if you think it's necessary...although it feels like we're testing electron code with that
- I can write unit tests for the progress calculations, if you think it's necessary

Notes:
- I'm not sure I like having to pass `win` into the `updateDownloadState` and `updateElectronDownloadItem` functions....but there didn't seem to be a better way. If you've got a better approach...I'm happy to refactor.

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


