### PR TITLE
Don't overwrite existing files when DOWNLOAD_ALWAYS_ASK is false

### DIFF
--- a/test/lib/selectors.js
+++ b/test/lib/selectors.js
@@ -123,6 +123,7 @@ module.exports = {
   downloadPause: '[data-test-id="pauseButton"]',
   downloadResume: '[data-test-id="resumeButton"]',
   downloadCancel: '[data-test-id="cancelButton"]',
+  downloadComplete: '.downloadItem.completed',
   downloadReDownload: '[data-test-id="redownloadButton"]',
   downloadDelete: '[data-test-id="deleteButton"]',
   downloadDeleteConfirm: '[data-test-id="confirmDeleteButton"]',

--- a/test/misc-components/downloadItemTest.js
+++ b/test/misc-components/downloadItemTest.js
@@ -1,8 +1,11 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
-/* global describe, it, before */
+/* global describe, it, before, after */
 
+const os = require('os')
+const path = require('path')
+const fs = require('fs-extra')
 const Brave = require('../lib/brave')
 const {
   urlInput,
@@ -11,11 +14,13 @@ const {
   downloadPause,
   downloadResume,
   downloadCancel,
+  downloadComplete,
   downloadReDownload,
   downloadRemoveFromList,
   downloadDelete,
   downloadDeleteConfirm
 } = require('../lib/selectors')
+const settingsConst = require('../../js/constants/settings')
 
 function * setup (client) {
   yield client
@@ -24,75 +29,123 @@ function * setup (client) {
     .waitForVisible(urlInput)
 }
 
-describe('downloadItem test', function () {
-  Brave.beforeAll(this)
-  before(function * () {
-    this.downloadSite = 'http://releases.ubuntu.com/16.04.2/ubuntu-16.04.2-desktop-amd64.iso'
-    yield setup(this.app.client)
+describe('Downloads', function () {
+  describe('Location and file naming tests', function () {
+    let tempDownloadPath
+    Brave.beforeAll(this)
+    before(function * () {
+      tempDownloadPath = path.join(os.tmpdir(), 'brave-test', 'downloads')
+      this.downloadFile = 'Brave_proudly-partner_badges.zip'
+      this.downloadSite = `https://brave.com/about/${this.downloadFile}`
+      this.renamedFile = this.downloadFile.slice(0, this.downloadFile.indexOf('.')) + ' (1)' + this.downloadFile.slice(this.downloadFile.indexOf('.'))
 
-    yield this.app.client
-      .waitForUrl(Brave.newTabUrl)
-      .url(this.downloadSite)
+      yield setup(this.app.client)
+
+      yield this.app.client
+        .waitForUrl(Brave.newTabUrl)
+    })
+
+    after(function * () {
+      yield new Promise((resolve, reject) => {
+        return fs.remove(tempDownloadPath, (err) => err ? reject(err) : resolve())
+      })
+    })
+
+    it('check if first download completes', function * () {
+      yield this.app.client
+        .windowByUrl(Brave.browserWindowUrl)
+        .changeSetting(settingsConst.DOWNLOAD_DEFAULT_PATH, tempDownloadPath)
+        .url(this.downloadSite)
+        .waitForElementCount(downloadComplete, 1)
+
+      yield new Promise((resolve, reject) => {
+        return fs.exists(path.join(tempDownloadPath, this.downloadFile), (res) => res ? resolve(res) : reject(res))
+      }).should.eventually.be.true
+    })
+
+    it('check if second download completes and is renamed', function * () {
+      yield this.app.client
+        .windowByUrl(Brave.browserWindowUrl)
+        .changeSetting(settingsConst.DOWNLOAD_DEFAULT_PATH, tempDownloadPath)
+        .url(this.downloadSite)
+        .waitForElementCount(downloadComplete, 2)
+
+      yield new Promise((resolve, reject) => {
+        return fs.exists(path.join(tempDownloadPath, this.renamedFile), (res) => res ? resolve(res) : reject(res))
+      }).should.eventually.be.true
+    })
   })
 
-  it('check if download bar is shown', function * () {
-    yield this.app.client
-      .windowByUrl(Brave.browserWindowUrl)
-      .waitForElementCount(downloadBar, 1)
-  })
+  describe('Item and bar tests', function () {
+    Brave.beforeAll(this)
+    before(function * () {
+      this.downloadSite = 'http://releases.ubuntu.com/16.04.2/ubuntu-16.04.2-desktop-amd64.iso'
+      yield setup(this.app.client)
 
-  it('check if you can pause download', function * () {
-    yield this.app.client
-      .moveToObject(downloadItem)
-      .waitForElementCount(downloadPause, 1)
-      .click(downloadPause)
-      .waitForElementCount(downloadResume, 1)
-  })
+      yield this.app.client
+        .waitForUrl(Brave.newTabUrl)
+        .url(this.downloadSite)
+    })
 
-  it('check if you can resume download', function * () {
-    yield this.app.client
-      .waitForElementCount(downloadResume, 1)
-      .click(downloadResume)
-      .waitForElementCount(downloadPause, 1)
-  })
+    it('check if download bar is shown', function * () {
+      yield this.app.client
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForElementCount(downloadBar, 1)
+    })
 
-  it('check if you can cancel download', function * () {
-    yield this.app.client
-      .waitForElementCount(downloadPause, 1)
-      .click(downloadCancel)
-      .waitForElementCount(downloadReDownload, 1)
-  })
+    it('check if you can pause download', function * () {
+      yield this.app.client
+        .moveToObject(downloadItem)
+        .waitForElementCount(downloadPause, 1)
+        .click(downloadPause)
+        .waitForElementCount(downloadResume, 1)
+    })
 
-  it('check if you can re-download', function * () {
-    yield this.app.client
-      .waitForElementCount(downloadReDownload, 1)
-      .click(downloadReDownload)
-      .waitForElementCount(downloadPause, 1)
-  })
+    it('check if you can resume download', function * () {
+      yield this.app.client
+        .waitForElementCount(downloadResume, 1)
+        .click(downloadResume)
+        .waitForElementCount(downloadPause, 1)
+    })
 
-  it('check if you can remove item from the list', function * () {
-    yield this.app.client
-      .moveToObject(downloadItem)
-      .waitForElementCount(downloadPause, 1)
-      .click(downloadCancel)
-      .waitForElementCount(downloadReDownload, 1)
-      .click(downloadRemoveFromList)
-      .waitForElementCount(downloadBar, 0)
-  })
+    it('check if you can cancel download', function * () {
+      yield this.app.client
+        .waitForElementCount(downloadPause, 1)
+        .click(downloadCancel)
+        .waitForElementCount(downloadReDownload, 1)
+    })
 
-  it('check if you can delete downloaded item', function * () {
-    yield this.app.client
-      .tabByIndex(0)
-      .url(this.downloadSite)
-      .windowByUrl(Brave.browserWindowUrl)
-      .waitForElementCount(downloadBar, 1)
-      .moveToObject(downloadItem)
-      .waitForElementCount(downloadPause, 1)
-      .click(downloadCancel)
-      .waitForElementCount(downloadReDownload, 1)
-      .click(downloadDelete)
-      .waitForElementCount(downloadDeleteConfirm, 1)
-      .click(downloadDeleteConfirm)
-      .waitForElementCount(downloadBar, 0)
+    it('check if you can re-download', function * () {
+      yield this.app.client
+        .waitForElementCount(downloadReDownload, 1)
+        .click(downloadReDownload)
+        .waitForElementCount(downloadPause, 1)
+    })
+
+    it('check if you can remove item from the list', function * () {
+      yield this.app.client
+        .moveToObject(downloadItem)
+        .waitForElementCount(downloadPause, 1)
+        .click(downloadCancel)
+        .waitForElementCount(downloadReDownload, 1)
+        .click(downloadRemoveFromList)
+        .waitForElementCount(downloadBar, 0)
+    })
+
+    it('check if you can delete downloaded item', function * () {
+      yield this.app.client
+        .tabByIndex(0)
+        .url(this.downloadSite)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForElementCount(downloadBar, 1)
+        .moveToObject(downloadItem)
+        .waitForElementCount(downloadPause, 1)
+        .click(downloadCancel)
+        .waitForElementCount(downloadReDownload, 1)
+        .click(downloadDelete)
+        .waitForElementCount(downloadDeleteConfirm, 1)
+        .click(downloadDeleteConfirm)
+        .waitForElementCount(downloadBar, 0)
+    })
   })
 })


### PR DESCRIPTION
Fixes #7764

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
- Tested that the file was downloaded to the location specified in the settings
- Tested that a second downloaded file would not replace an existing file of the same name

Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


