### PR TITLE
Change per-frame hoverState to a single hoverTabIndex key

### DIFF
--- a/app/common/state/tabContentState.js
+++ b/app/common/state/tabContentState.js
@@ -114,6 +114,7 @@ const tabContentState = {
   getTabIconColor: (state, frameKey) => {
     const frame = frameStateUtil.getFrameByKey(state, frameKey)
     const isActive = frameStateUtil.isFrameKeyActive(state, frameKey)
+    const hoverState = frameStateUtil.getTabHoverState(state, frameKey)
 
     if (frame == null) {
       return ''
@@ -121,7 +122,7 @@ const tabContentState = {
 
     const themeColor = frame.get('themeColor') || frame.get('computedThemeColor')
     const activeNonPrivateTab = !frame.get('isPrivate') && isActive
-    const isPrivateTab = frame.get('isPrivate') && (isActive || frame.get('hoverState'))
+    const isPrivateTab = frame.get('isPrivate') && (isActive || hoverState)
     const defaultColor = isPrivateTab ? styles.color.white100 : styles.color.black100
     const isPaintTabs = getSetting(settings.PAINT_TABS)
 
@@ -159,7 +160,8 @@ const tabContentState = {
       return false
     }
 
-    return frame.get('hoverState') && hasBreakpoint(frame.get('breakpoint'), ['default', 'large'])
+    return frameStateUtil.getTabHoverState(state, frameKey) &&
+      hasBreakpoint(frame.get('breakpoint'), ['default', 'large'])
   },
 
   /**

--- a/app/renderer/reducers/frameReducer.js
+++ b/app/renderer/reducers/frameReducer.js
@@ -37,7 +37,7 @@ const closeFrame = (state, action) => {
   }
 
   const frameProps = frameStateUtil.getFrameByKey(state, action.frameKey)
-  const hoverState = state.getIn(['frames', index, 'hoverState'])
+  const hoverState = frameStateUtil.getTabHoverState(state, action.frameKey)
 
   state = state.merge(frameStateUtil.removeFrame(
     state,
@@ -117,12 +117,13 @@ const frameReducer = (state, action, immutableAction) => {
         state = state.setIn(['frames', index, 'title'], title)
       }
 
+      const hoverState = frameStateUtil.getTabHoverState(state, frame.get('key'))
       // TODO fix race condition in Muon more info in #9000
       const active = immutableAction.getIn(['tabValue', 'active'])
       if (active != null) {
         if (active) {
           state = state.set('activeFrameKey', frame.get('key'))
-          if (frame.get('hoverState')) {
+          if (hoverState) {
             state = state.set('previewFrameKey', null)
           }
           if (frame.getIn(['ui', 'tabs', 'hoverTabPageIndex']) == null) {

--- a/docs/state.md
+++ b/docs/state.md
@@ -458,7 +458,6 @@ WindowStore
     history: array, // navigation history
     hrefPreview: string, // show hovered link preview
     httpsEverywhere: Object<string, Array<string>>, // map of XML rulesets name to redirected resources
-    hoverState: boolean, // wheter or not tab is being hovered
     icon: string, // favicon url
     isFullScreen: boolean, // true if the frame should be shown as full screen
     isPrivate: boolean, // private browsing tab
@@ -665,6 +664,7 @@ WindowStore
     },
     size: array, // last known window size [x, y]
     tabs: {
+      hoverTabIndex: number, // index of the current hovered tab
       tabPageIndex: number, // index of the current tab page
       previewTabPageIndex: number // index of the tab being previewed
     },

--- a/js/state/frameStateUtil.js
+++ b/js/state/frameStateUtil.js
@@ -590,9 +590,10 @@ const setPreviewFrameKey = (state, frameKey, immediate = false) => {
   const frame = getFrameByKey(state, frameKey)
   const isActive = isFrameKeyActive(state, frameKey)
   const previewTabs = getSetting(settings.SHOW_TAB_PREVIEWS)
+  const hoverState = getTabHoverState(state, frameKey)
   let newPreviewFrameKey = frameKey
 
-  if (!previewTabs || frame == null || !frame.get('hoverState') || isActive) {
+  if (!previewTabs || frame == null || !hoverState || isActive) {
     newPreviewFrameKey = null
   }
 
@@ -638,10 +639,59 @@ const setTabPageHoverState = (state, tabPageIndex, hoverState) => {
   return state
 }
 
+/**
+ * Checks if the current tab index is being hovered
+ * @param state {Object} - Application state
+ * @param frameKey {Number} - The current tab's frameKey
+ * @return Boolean - wheter or not hoverState is true
+ */
+const getTabHoverState = (state, frameKey) => {
+  const index = getFrameIndex(state, frameKey)
+  return getHoverTabIndex(state) === index
+}
+
+/**
+ * Gets the hovered tab index state
+ * This check will return null if no tab is being hovered
+ * and is used getTabHoverState to check if current index is being hovered.
+ * If the method to apply for does not know the right index
+ * this should be used instead of getTabHoverState
+ * @param state {Object} - Application state
+ * @return Immutable top level application state for hoverTabIndex
+ */
+const getHoverTabIndex = (state) => {
+  return state.getIn(['ui', 'tabs', 'hoverTabIndex'])
+}
+
+/**
+ * Sets the hover state for current tab index in top level state
+ * @param state {Object} - Application state
+ * @param frameKey {Number} - The current tab's frameKey
+ * @param hoverState {Boolean} - True if the current tab is being hovered.
+ * @return Immutable top level application state for hoverTabIndex
+ */
+const setHoverTabIndex = (state, frameKey, hoverState) => {
+  const frameIndex = getFrameIndex(state, frameKey)
+  if (!hoverState) {
+    state = state.setIn(['ui', 'tabs', 'hoverTabIndex'], null)
+    return state
+  }
+  return state.setIn(['ui', 'tabs', 'hoverTabIndex'], frameIndex)
+}
+
+/**
+ * Gets values from the window setTabHoverState action from the store
+ * and is used to apply both hoverState and previewFrameKey
+ * @param state {Object} - Application state
+ * @param frameKey {Number} - The current tab's frameKey
+ * @param hoverState {Boolean} - True if the current tab is being hovered.
+ * @return Immutable top level application state for hoverTabIndex
+ */
+
 const setTabHoverState = (state, frameKey, hoverState) => {
   const frameIndex = getFrameIndex(state, frameKey)
   if (frameIndex !== -1) {
-    state = state.setIn(['frames', frameIndex, 'hoverState'], hoverState)
+    state = setHoverTabIndex(state, frameKey, hoverState)
     state = setPreviewFrameKey(state, frameKey)
   }
   return state
@@ -650,6 +700,7 @@ const setTabHoverState = (state, frameKey, hoverState) => {
 module.exports = {
   setTabPageHoverState,
   setPreviewTabPageIndex,
+  getTabHoverState,
   setTabHoverState,
   setPreviewFrameKey,
   getPreviewFrameKey,

--- a/test/unit/app/common/state/tabContentStateTest.js
+++ b/test/unit/app/common/state/tabContentStateTest.js
@@ -13,6 +13,7 @@ const {braveExtensionId} = require('../../../../../js/constants/config')
 const styles = require('../../../../../app/renderer/components/styles/global')
 
 const frameKey = 1
+const index = 0
 const defaultWindowStore = Immutable.fromJS({
   activeFrameKey: frameKey,
   frames: [{
@@ -21,7 +22,8 @@ const defaultWindowStore = Immutable.fromJS({
     location: 'http://brave.com'
   }],
   tabs: [{
-    key: frameKey
+    key: frameKey,
+    index: index
   }],
   framesInternal: {
     index: {
@@ -29,6 +31,11 @@ const defaultWindowStore = Immutable.fromJS({
     },
     tabIndex: {
       1: 0
+    }
+  },
+  ui: {
+    tabs: {
+      hoverTabIndex: index
     }
   }
 })
@@ -340,6 +347,7 @@ describe('tabContentState unit tests', function () {
     })
 
     it('tab is private and active', function () {
+      const state = defaultWindowStore
       getFrameByKeyMock = sinon.stub(frameStateUtil, 'getFrameByKey', () => {
         return Immutable.fromJS({
           isPrivate: true
@@ -348,10 +356,11 @@ describe('tabContentState unit tests', function () {
       isFrameKeyActive = sinon.stub(frameStateUtil, 'isFrameKeyActive', () => {
         return true
       })
-      assert.equal(tabContentState.getTabIconColor(), styles.color.white100)
+      assert.equal(tabContentState.getTabIconColor(state), styles.color.white100)
     })
 
     it('tab is not private and active, but paint is disabled', function () {
+      const state = defaultWindowStore
       getFrameByKeyMock = sinon.stub(frameStateUtil, 'getFrameByKey', () => {
         return Immutable.fromJS({
           isPrivate: false
@@ -361,10 +370,11 @@ describe('tabContentState unit tests', function () {
         return true
       })
       defaultValue = false
-      assert.equal(tabContentState.getTabIconColor(), styles.color.black100)
+      assert.equal(tabContentState.getTabIconColor(state), styles.color.black100)
     })
 
     it('all valid', function () {
+      const state = defaultWindowStore
       getFrameByKeyMock = sinon.stub(frameStateUtil, 'getFrameByKey', () => {
         return Immutable.fromJS({
           isPrivate: false,
@@ -374,7 +384,7 @@ describe('tabContentState unit tests', function () {
       isFrameKeyActive = sinon.stub(frameStateUtil, 'isFrameKeyActive', () => {
         return true
       })
-      assert.equal(tabContentState.getTabIconColor(), 'white')
+      assert.equal(tabContentState.getTabIconColor(state), 'white')
     })
   })
 
@@ -427,33 +437,29 @@ describe('tabContentState unit tests', function () {
       assert.equal(tabContentState.hasRelativeCloseIcon(state), false)
     })
 
-    it('if not hovering', function () {
-      getFrameByKeyMock = sinon.stub(frameStateUtil, 'getFrameByKey', () => {
-        return Immutable.fromJS({
-          hoverState: false
-        })
-      })
-      assert.equal(tabContentState.hasRelativeCloseIcon(), false)
+    it('if not hovering (tabIndex !== hoverTabIndex)', function () {
+      const state = defaultWindowStore.setIn(['ui', 'tabs', 'hoverTabIndex'], null)
+      assert.equal(tabContentState.hasRelativeCloseIcon(state, frameKey), false)
     })
 
-    it('if hovering and break point is small', function () {
+    it('if hovering (tabIndex === hoverTabIndex) and break point is small', function () {
+      const state = defaultWindowStore
       getFrameByKeyMock = sinon.stub(frameStateUtil, 'getFrameByKey', () => {
         return Immutable.fromJS({
-          hoverState: true,
           breakpoint: 'small'
         })
       })
-      assert.equal(tabContentState.hasRelativeCloseIcon(), false)
+      assert.equal(tabContentState.hasRelativeCloseIcon(state, frameKey), false)
     })
 
-    it('if hovering and break point is default', function () {
+    it('if hovering (tabIndex === hoverTabIndex) and break point is default', function () {
+      const state = defaultWindowStore
       getFrameByKeyMock = sinon.stub(frameStateUtil, 'getFrameByKey', () => {
         return Immutable.fromJS({
-          hoverState: true,
           breakpoint: 'default'
         })
       })
-      assert.equal(tabContentState.hasRelativeCloseIcon(), true)
+      assert.equal(tabContentState.hasRelativeCloseIcon(state, frameKey), true)
     })
   })
 

--- a/test/unit/app/renderer/components/tabs/content/closeTabIconTest.js
+++ b/test/unit/app/renderer/components/tabs/content/closeTabIconTest.js
@@ -10,6 +10,7 @@ const Immutable = require('immutable')
 const fakeElectron = require('../../../../../lib/fakeElectron')
 require('../../../../../braveUnit')
 
+const index = 0
 const tabId = 1
 const frameKey = 1
 const invalidFrameKey = 71
@@ -39,7 +40,8 @@ const defaultWindowStore = Immutable.fromJS({
     location: 'http://brave.com'
   }],
   tabs: [{
-    key: frameKey
+    key: frameKey,
+    index: index
   }],
   framesInternal: {
     index: {
@@ -47,6 +49,11 @@ const defaultWindowStore = Immutable.fromJS({
     },
     tabIndex: {
       1: 0
+    }
+  },
+  ui: {
+    tabs: {
+      hoverTabIndex: index
     }
   }
 })

--- a/test/unit/app/renderer/components/tabs/content/newSessionIconTest.js
+++ b/test/unit/app/renderer/components/tabs/content/newSessionIconTest.js
@@ -11,6 +11,7 @@ const {tabs} = require('../../../../../../../js/constants/config')
 const fakeElectron = require('../../../../../lib/fakeElectron')
 require('../../../../../braveUnit')
 
+const index = 0
 const tabId = 1
 const frameKey = 1
 const invalidFrameKey = 71
@@ -40,7 +41,8 @@ const defaultWindowStore = Immutable.fromJS({
     location: 'http://brave.com'
   }],
   tabs: [{
-    key: frameKey
+    key: frameKey,
+    index: index
   }],
   framesInternal: {
     index: {
@@ -48,6 +50,11 @@ const defaultWindowStore = Immutable.fromJS({
     },
     tabIndex: {
       1: 0
+    }
+  },
+  ui: {
+    tabs: {
+      hoverTabIndex: index
     }
   }
 })
@@ -80,29 +87,51 @@ describe('Tabs content - NewSessionIcon', function () {
 
   describe('should show', function () {
     it('icon if current tab is a new session tab', function () {
-      windowStore.state = defaultWindowStore.mergeIn(['frames', 0], {
-        partitionNumber: 1,
-        breakpoint: 'default'
+      windowStore.state = defaultWindowStore.merge({
+        activeFrameKey: 0,
+        frames: [{
+          partitionNumber: 1,
+          breakpoint: 'default'
+        }],
+        ui: {
+          tabs: {
+            hoverTabIndex: null
+          }
+        }
       })
       const wrapper = mount(<Tab frameKey={frameKey} />)
       assert.equal(wrapper.find('NewSessionIcon').length, 1)
     })
 
     it('icon if mouse is not over tab and breakpoint is default', function () {
-      windowStore.state = defaultWindowStore.mergeIn(['frames', 0], {
-        partitionNumber: 1,
-        hoverState: false,
-        breakpoint: 'default'
+      windowStore.state = defaultWindowStore.merge({
+        activeFrameKey: 0,
+        frames: [{
+          partitionNumber: 1,
+          breakpoint: 'default'
+        }],
+        ui: {
+          tabs: {
+            hoverTabIndex: null
+          }
+        }
       })
       const wrapper = mount(<Tab frameKey={frameKey} />)
       assert.equal(wrapper.find('NewSessionIcon').length, 1)
     })
 
     it('icon if mouse is not over tab and breakpoint is large', function () {
-      windowStore.state = defaultWindowStore.mergeIn(['frames', 0], {
-        partitionNumber: 1,
-        hoverState: false,
-        breakpoint: 'large'
+      windowStore.state = defaultWindowStore.merge({
+        activeFrameKey: 0,
+        frames: [{
+          partitionNumber: 1,
+          breakpoint: 'large'
+        }],
+        ui: {
+          tabs: {
+            hoverTabIndex: null
+          }
+        }
       })
       const wrapper = mount(<Tab frameKey={frameKey} />)
       assert.equal(wrapper.find('NewSessionIcon').length, 1)
@@ -113,9 +142,13 @@ describe('Tabs content - NewSessionIcon', function () {
         activeFrameKey: 0,
         frames: [{
           partitionNumber: 1,
-          hoverState: false,
           breakpoint: 'largeMedium'
-        }]
+        }],
+        ui: {
+          tabs: {
+            hoverTabIndex: null
+          }
+        }
       })
       const wrapper = mount(<Tab frameKey={frameKey} />)
       assert.equal(wrapper.find('NewSessionIcon').length, 1)

--- a/test/unit/app/renderer/components/tabs/content/privateIconTest.js
+++ b/test/unit/app/renderer/components/tabs/content/privateIconTest.js
@@ -10,6 +10,7 @@ const assert = require('assert')
 const fakeElectron = require('../../../../../lib/fakeElectron')
 require('../../../../../braveUnit')
 
+const index = 0
 const tabId = 1
 const frameKey = 1
 
@@ -38,6 +39,7 @@ const defaultWindowStore = Immutable.fromJS({
     location: 'http://brave.com'
   }],
   tabs: [{
+    index: index,
     key: frameKey
   }],
   framesInternal: {
@@ -46,6 +48,11 @@ const defaultWindowStore = Immutable.fromJS({
     },
     tabIndex: {
       1: 0
+    }
+  },
+  ui: {
+    tabs: {
+      hoverTabIndex: index
     }
   }
 })
@@ -77,9 +84,17 @@ describe('Tabs content - PrivateIcon', function () {
 
   describe('should show icon', function () {
     it('if current tab is private', function () {
-      windowStore.state = defaultWindowStore.mergeIn(['frames', 0], {
-        isPrivate: true,
-        breakpoint: 'default'
+      windowStore.state = defaultWindowStore.merge({
+        activeFrameKey: 0,
+        frames: [{
+          isPrivate: true,
+          breakpoint: 'default'
+        }],
+        ui: {
+          tabs: {
+            hoverTabIndex: null
+          }
+        }
       })
       const wrapper = mount(<Tab frameKey={frameKey} />)
       assert.equal(wrapper.find('PrivateIcon').length, 1)
@@ -99,20 +114,34 @@ describe('Tabs content - PrivateIcon', function () {
     })
 
     it('if mouse is not over tab and breakpoint is large', function () {
-      windowStore.state = defaultWindowStore.mergeIn(['frames', 0], {
-        isPrivate: true,
-        hoverState: false,
-        breakpoint: 'large'
+      windowStore.state = defaultWindowStore.merge({
+        activeFrameKey: 0,
+        frames: [{
+          isPrivate: true,
+          breakpoint: 'large'
+        }],
+        ui: {
+          tabs: {
+            hoverTabIndex: null
+          }
+        }
       })
       const wrapper = mount(<Tab frameKey={frameKey} />)
       assert.equal(wrapper.find('PrivateIcon').length, 1)
     })
 
     it('if mouse is not over tab and breakpoint is default', function () {
-      windowStore.state = defaultWindowStore.mergeIn(['frames', 0], {
-        isPrivate: true,
-        hoverState: false,
-        breakpoint: 'default'
+      windowStore.state = defaultWindowStore.merge({
+        activeFrameKey: 0,
+        frames: [{
+          isPrivate: true,
+          breakpoint: 'default'
+        }],
+        ui: {
+          tabs: {
+            hoverTabIndex: null
+          }
+        }
       })
       const wrapper = mount(<Tab frameKey={frameKey} />)
       assert.equal(wrapper.find('PrivateIcon').length, 1)


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Auditors: @bridiver, @bsclifton
Close #9895
Addresses: https://github.com/brave/browser-laptop/pull/9809#discussion_r125720809

Test Plan:

All changes for this PR are covered by automated tests. Specifically unit tests, which were changed to match new state updates.

For QA interest:

This affects tab's hover state and tab previews and we have tests for all scenarios changed. For clarification manual test plan is:

1. Private/new session tabs should not show icon when tab is hovered;
2. Close tab icon should show on tab hover;
3. Tab preview should show on tab hover

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


