### PR TITLE
Disable title mode on Windows by default

### DIFF
--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -180,7 +180,11 @@ module.exports = {
     'sync.type.history': false,
     'sync.type.siteSetting': true,
     'general.downloads.default-save-path': null,
-    'general.disable-title-mode': process.platform === 'linux',
+    // Windows has issues with titlebar mode because it doesn't fire onMouseEnter events if you enter
+    // your mouse from the top of the window.  Also users with Surface tablets or Surface books that
+    // have immersive mode w/ touch makes it too hard to enter a URL.
+    // Tracking issue for that and to re-enable title mode on Windows is at #9900.
+    'general.disable-title-mode': process.platform === 'linux' || process.platform === 'win32',
     'advanced.hardware-acceleration-enabled': true,
     'advanced.default-zoom-level': null,
     'advanced.pdfjs-enabled': true,


### PR DESCRIPTION
Fix #9903

Linux already has it disabled so there shouldn't need to be any test changes.

Auditors: @bsclifton, @bradleyrichter

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


