### PR TITLE
add proper margin around buttons in about:error page

### DIFF
--- a/js/about/errorPage.js
+++ b/js/about/errorPage.js
@@ -39,7 +39,7 @@ class ErrorPage extends React.Component {
       </div>
       <div className='buttons'>
         {this.showBackButton ? <BrowserButton actionItem l10nId='back' onClick={this.goBack} /> : null}
-        {this.state.url ? <BrowserButton actionItem l10nId='errorReload' l10nArgs={{url: this.state.url}} onClick={this.reload} /> : null}
+        {this.state.url ? <BrowserButton actionItem groupedItem l10nId='errorReload' l10nArgs={{url: this.state.url}} onClick={this.reload} /> : null}
       </div>
     </div>
   }


### PR DESCRIPTION
Fix #9916 

STR: 

1. Visit a crazy website like http://ahwihsduhai.sjidhfsjhdf
2. Error page is shown
3. Ensure buttons are separated