### PR TITLE
Fixes tab page index after tab close

### DIFF
--- a/app/renderer/components/tabs/content/tabIcon.js
+++ b/app/renderer/components/tabs/content/tabIcon.js
@@ -30,12 +30,22 @@ class TabIcon extends ImmutableComponent {
       }
     })
 
+    let altProps
+    if (!this.props.symbol) {
+      altProps = {
+        'data-test-id': this.props['data-test-id'],
+        'data-test2-id': this.props['data-test2-id']
+      }
+    }
+
     return <div
       className={this.props.className}
       data-test-favicon={this.props['data-test-favicon']}
       onDragStart={this.props.onDragStart}
       draggable={this.props.draggable}
-      onClick={this.props.onClick}>
+      onClick={this.props.onClick}
+      {...altProps}
+    >
       {
         this.props.symbol
           ? <span

--- a/test/tab-components/tabPagesTest.js
+++ b/test/tab-components/tabPagesTest.js
@@ -13,7 +13,8 @@ const {
   tabPage2,
   activeWebview,
   activeTab,
-  tabsTab
+  tabsTab,
+  closeTab
 } = require('../lib/selectors')
 
 describe('tab pages', function () {
@@ -58,11 +59,10 @@ describe('tab pages', function () {
 
     it('shows the right number of tabs after closing with mouse', function * () {
       const numTabsPerPage = appConfig.defaultSettings[settings.TABS_PER_PAGE]
-      const firstTabOfNewPageIndex = numTabsPerPage
       yield this.app.client.click(newFrameButton)
         .waitForElementCount(tabPage, 2)
-        .closeTabWithMouse()
-        .closeTabByIndex(firstTabOfNewPageIndex)
+        .moveToObject(activeTab)
+        .click(closeTab)
         // No tab page indicator elements when 1 page
         .waitForElementCount(tabPage, 0)
         .waitForElementCount(tabsTabs, numTabsPerPage)


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Resolves #9922

Auditors: @cezaraugusto

Test Plan:
-  open two tab pages
- close the last tab in the tab page


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


