### PR TITLE
Command+L when in url bar with URL bar suggestion should select full URL

### DIFF
--- a/docs/windowActions.md
+++ b/docs/windowActions.md
@@ -336,13 +336,9 @@ This is sometimes only temporarily disabled, e.g. a user is pressing backspace.
 
 
 
-### setUrlBarSelected(isSelected) 
+### urlBarSelected() 
 
-Marks the URL bar text as selected or not
-
-**Parameters**
-
-**isSelected**: `boolean`, Whether or not the URL bar text input should be selected
+Indicates the URLbar has been selected
 
 
 

--- a/js/actions/windowActions.js
+++ b/js/actions/windowActions.js
@@ -411,14 +411,11 @@ const windowActions = {
   },
 
   /**
-   * Marks the URL bar text as selected or not
-   *
-   * @param {boolean} isSelected - Whether or not the URL bar text input should be selected
+   * Indicates the URLbar has been selected
    */
-  setUrlBarSelected: function (selected) {
+  urlBarSelected: function (selected) {
     dispatch({
-      actionType: windowConstants.WINDOW_SET_URL_BAR_SELECTED,
-      selected
+      actionType: windowConstants.WINDOW_URL_BAR_SELECTED
     })
   },
 

--- a/js/constants/windowConstants.js
+++ b/js/constants/windowConstants.js
@@ -40,7 +40,7 @@ const windowConstants = {
   WINDOW_URL_BAR_ON_BLUR: _,
   WINDOW_URL_BAR_ON_FOCUS: _,
   WINDOW_TAB_ON_FOCUS: _,
-  WINDOW_SET_URL_BAR_SELECTED: _,
+  WINDOW_URL_BAR_SELECTED: _,
   WINDOW_SET_FIND_DETAIL: _,
   WINDOW_SET_BOOKMARK_DETAIL: _, // If set, also indicates that add/edit is shown
   WINDOW_SET_CONTEXT_MENU_DETAIL: _, // If set, also indicates that the context menu is shown

--- a/test/navbar-components/navigationBarTest.js
+++ b/test/navbar-components/navigationBarTest.js
@@ -98,7 +98,7 @@ describe('navigationBar tests', function () {
           .newTab({ url: page1Url })
           .waitUntil(function () {
             return this.getWindowState().then((val) => {
-              return val.value.frames.length === 2
+              return val.value.frames.length === 3
             })
           })
           .waitForElementFocus(activeWebview)
@@ -214,6 +214,7 @@ describe('navigationBar tests', function () {
       it('remains cleared when onChange is fired but not onKeyUp', function * () {
         yield this.app.client
           .windowByUrl(Brave.browserWindowUrl)
+          .activateURLMode()
           .waitForVisible(urlInput)
           .setValue(urlInput, '')
           .moveToObject(activeWebview)
@@ -610,7 +611,7 @@ describe('navigationBar tests', function () {
         })
         .windowByUrl(Brave.browserWindowUrl)
         .waitForExist(urlbarIcon + '.fa-lock')
-        .click(urlbarIcon)
+        .click(urlbarIcon + '.fa-lock')
         .waitForVisible('[data-test-id="secureConnection"]')
         .waitForVisible('[data-test-id="runInsecureContentWarning"]')
         .waitForVisible(dismissAllowRunInsecureContentButton)
@@ -913,10 +914,9 @@ describe('navigationBar tests', function () {
         yield setup(this.app.client)
         yield this.app.client
           .waitForExist(urlInput)
-        yield this.app.client
           .keys(this.page1)
-        yield this.app.client
           .keys(Brave.keys.ENTER)
+          .activateURLMode()
       })
 
       it('shows search icon when input is empty', function * () {
@@ -1002,6 +1002,7 @@ describe('navigationBar tests', function () {
           .keys(Brave.keys.ENTER)
           .tabByUrl('about:about')
           .windowByUrl(Brave.browserWindowUrl)
+          .activateURLMode()
           .waitForInputText(urlInput, 'about:about')
           .waitForExist('.urlbarIcon.fa-list')
       })
@@ -1223,20 +1224,25 @@ describe('navigationBar tests', function () {
   })
 
   describe('shortcut-focus-url', function () {
-    Brave.beforeAll(this)
+    Brave.beforeEach(this)
 
-    before(function * () {
+    beforeEach(function * () {
       yield setup(this.app.client)
       yield blur(this.app.client)
       yield this.app.client.ipcSend('shortcut-focus-url')
+      yield this.app.client.waitForElementFocus(urlInput)
     })
 
     it('has an empty url with placeholder', function * () {
       yield defaultUrlInputValue(this.app.client)
     })
 
-    it('has focus', function * () {
-      yield this.app.client.waitForElementFocus(urlInput)
+    it('selects full url when autocompleting with partial selection', function * () {
+      yield this.app.client
+        .keys('about:bra')
+      yield selectsText(this.app.client, 've')
+      yield this.app.client.ipcSend('shortcut-focus-url')
+      yield selectsText(this.app.client, 'about:brave')
     })
   })
 

--- a/test/navbar-components/urlBarTest.js
+++ b/test/navbar-components/urlBarTest.js
@@ -5,6 +5,7 @@ const Brave = require('../lib/brave')
 const {urlInput, urlBarSuggestions, urlbarIcon, reloadButton} = require('../lib/selectors')
 const searchProviders = require('../../js/data/searchProviders')
 const config = require('../../js/constants/config')
+const settings = require('../../js/constants/settings')
 
 describe('urlBar tests', function () {
   function * setup (client) {
@@ -708,6 +709,7 @@ describe('urlBar tests', function () {
       this.page1Url = Brave.server.url('page1.html')
       yield setup(this.app.client)
       yield this.app.client
+        .changeSetting(settings.DISABLE_TITLE_MODE, false)
         .waitForExist(urlInput)
         .waitForElementFocus(urlInput)
         .tabByIndex(0)
@@ -767,7 +769,7 @@ describe('urlBar tests', function () {
 
     it('changes only the selection', function * () {
       yield this.app.client
-        .setInputText(urlInput, 'git')
+        .keys('git')
         .waitForSelectedText('hub.com')
         // Select next suggestion
         .keys(Brave.keys.DOWN)


### PR DESCRIPTION
There was also a lot of other fixes which moves things out of the
component and into the store.

Note that there are no state functions in use yet for the window
renderer so I didn't create them yet as part of this task and just
used immutableJS directly.

I also fixed some intermittents with this fix.

Fix #9914

Auditors: @bsclifton

## Test Plan:
1. Fully test url bar and suggestions thoroughly
2. Type in some chars that lead to a autocomplete selection, press
command+L and make sure it selects all text.

## Automated test plan
`npm run test -- --grep="selects full url when autocompleting with partial selection"`

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).


## Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


