### PR TITLE
don't set tab preview for the active frame

### DIFF
--- a/app/renderer/reducers/frameReducer.js
+++ b/app/renderer/reducers/frameReducer.js
@@ -119,9 +119,13 @@ const frameReducer = (state, action, immutableAction) => {
 
       // TODO fix race condition in Muon more info in #9000
       const active = immutableAction.getIn(['tabValue', 'active'])
+      const hasTabInHoverState = state.getIn(['ui', 'tabs', 'hoverTabIndex'])
       if (active != null) {
         if (active) {
           state = state.set('activeFrameKey', frame.get('key'))
+          if (hasTabInHoverState != null) {
+            state = state.set('previewFrameKey', null)
+          }
           if (frame.getIn(['ui', 'tabs', 'hoverTabPageIndex']) == null) {
             state = state.deleteIn(['ui', 'tabs', 'previewTabPageIndex'])
           }

--- a/test/tab-components/tabTest.js
+++ b/test/tab-components/tabTest.js
@@ -390,6 +390,16 @@ describe('tab tests', function () {
         .waitForExist('.frameWrapper.isPreview webview[data-frame-key="2"]')
         .moveToObject(urlInput)
     })
+    it('does not show preview in the active tab', function * () {
+      yield this.app.client
+        .moveToObject('[data-test-id="tab"][data-frame-key="2"]')
+        .waitForTextValue('[data-test-id="tab"][data-frame-key="2"]', 'Page 1')
+        .waitForExist('.frameWrapper.isPreview webview[data-frame-key="2"]')
+        .moveToObject('[data-test-id="tab"][data-frame-key="1"]')
+        .click('[data-test-id="tab"][data-frame-key="1"]')
+        .waitForExist('[data-test-active-tab][data-frame-key="1"]')
+        .waitForElementCount('.frameWrapper.isPreview webview[data-frame-key="1"]', 0)
+    })
     it('does not show tab previews when setting is off', function * () {
       yield this.app.client.changeSetting(settings.SHOW_TAB_PREVIEWS, false)
       yield this.app.client


### PR DESCRIPTION
Auditors: @bbondy, @bsclifton
Fix #9929
Test Plan:
covered by automated tests:
`npm run test -- --grep="does not show preview in the active tab`