### PR TITLE
Add sync version to about:brave

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -426,10 +426,11 @@ const setVersionInformation = (data) => {
     ['os.release', require('os').release],
     ['os.arch', require('os').arch]
   ]
-  const versionInformation = []
+  const versionInformation = {}
 
   versionFields.forEach((field) => {
-    versionInformation.push(safeGetVersion(field[0], field[1]))
+    const versionField = safeGetVersion(field[0], field[1])
+    versionInformation[versionField.name] = versionField.version
   })
 
   data.about = data.about || {}

--- a/app/sync.js
+++ b/app/sync.js
@@ -376,7 +376,10 @@ module.exports.init = function (appState) {
     reset()
   })
   // GET_INIT_DATA is the first message sent by the sync-client when it starts
-  ipcMain.on(syncMessages.GET_INIT_DATA, (e) => {
+  ipcMain.on(syncMessages.GET_INIT_DATA, (e, syncVersion) => {
+    if (syncVersion) {
+      appActions.setVersionInfo('Brave Sync', syncVersion)
+    }
     // Set the message sender
     backgroundSender = e.sender
     // Clear any old errors

--- a/docs/state.md
+++ b/docs/state.md
@@ -21,10 +21,9 @@ AppStore
   },
   about: {
     brave: {
-      versionInformation: [{
-        name: string,
-        version: string
-      }] // used on about:brave. not persisted (removed on save)
+      versionInformation: {
+        [name]: string
+      } // map of property name to version. used on about:brave. not persisted (removed on save)
     },
     history: {
       entries: [object] // used on about:history. not persisted (removed on save)

--- a/js/about/brave.js
+++ b/js/about/brave.js
@@ -25,12 +25,12 @@ require('../../node_modules/font-awesome/css/font-awesome.css')
 
 const tranformVersionInfoToString = (versionInformation) =>
   versionInformation
-    .reduce((coll, entry) => `${coll} \n${entry.get('name')}: ${entry.get('version')}`, '')
+    .reduce((coll, version, name) => `${coll} \n${name}: ${version}`, '')
 
 class AboutBrave extends React.Component {
   constructor (props) {
     super(props)
-    this.state = { versionInformation: Immutable.fromJS([]) }
+    this.state = { versionInformation: new Immutable.Map() }
     ipc.on(messages.VERSION_INFORMATION_UPDATED, (e, versionInformation) => {
       if (this.state.versionInformation.size === 0) {
         this.setState({versionInformation: Immutable.fromJS(versionInformation)})
@@ -60,7 +60,7 @@ class AboutBrave extends React.Component {
         <div>
           <span data-l10n-id='relNotesInfo1' />
           &nbsp;
-          <a className='linkText' href={`https://github.com/brave/browser-laptop/releases/tag/v${this.state.versionInformation.getIn([0, 'version'])}dev`} target='_blank' data-l10n-id='relNotesInfo2' />
+          <a className='linkText' href={`https://github.com/brave/browser-laptop/releases/tag/v${this.state.versionInformation.get('Brave')}dev`} target='_blank' data-l10n-id='relNotesInfo2' />
           &nbsp;
           <span data-l10n-id='relNotesInfo3' />
         </div>
@@ -76,16 +76,16 @@ class AboutBrave extends React.Component {
 
         <SortableTable
           headings={['Name', 'Version']}
-          rows={this.state.versionInformation.map((entry) => [
+          rows={this.state.versionInformation.map((version, name) => [
             {
-              html: entry.get('name'),
-              value: entry.get('name')
+              html: name,
+              value: name
             },
             {
-              html: entry.get('name') === 'rev'
-                ? <a target='_blank' href={`https://github.com/brave/browser-laptop/commit/${entry.get('version')}`}>{(entry.get('version') && entry.get('version').substring(0, 7)) || ''}</a>
-                : entry.get('version'),
-              value: entry.get('version')
+              html: name === 'rev'
+                ? <a target='_blank' href={`https://github.com/brave/browser-laptop/commit/${version}`}>{(version && version.substring(0, 7)) || ''}</a>
+                : version,
+              value: version
             }
           ])}
         />

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -1515,6 +1515,14 @@ const appActions = {
       word,
       tabId
     })
+  },
+
+  setVersionInfo: function (name, version) {
+    dispatch({
+      actionType: appConstants.APP_SET_VERSION_INFO,
+      name,
+      version
+    })
   }
 }
 

--- a/js/constants/appConstants.js
+++ b/js/constants/appConstants.js
@@ -143,7 +143,8 @@ const appConstants = {
   APP_DEBUG_NO_REPORT_STATE_MODE_CLICKED: _,
   APP_SPELLING_SUGGESTED: _,
   APP_LEARN_SPELLING: _,
-  APP_FORGET_LEARNED_SPELLING: _
+  APP_FORGET_LEARNED_SPELLING: _,
+  APP_SET_VERSION_INFO: _
 }
 
 module.exports = mapValuesByKeys(appConstants)

--- a/js/constants/sync/messages.js
+++ b/js/constants/sync/messages.js
@@ -24,9 +24,10 @@ const messages = {
   SYNC_SETUP_ERROR: _, /* @param {string} error */
   /**
    * webview -> browser
+   * emits the version of sync that is currently running
    * browser sends GOT_INIT_DATA with the saved values
    */
-  GET_INIT_DATA: _,
+  GET_INIT_DATA: _, /* @param {string} syncVersion */
   /**
    * browser -> webview
    * browser must send null for seed or deviceId if a value has not yet been

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -861,6 +861,11 @@ const handleAppAction = (action) => {
       appState.setIn(['sync', 'devices'], {})
       appState.setIn(['sync', 'objectsById'], {})
       break
+    case appConstants.APP_SET_VERSION_INFO:
+      if (action.name && action.version) {
+        appState = appState.setIn(['about', 'brave', 'versionInformation', action.name], action.version)
+      }
+      break
     case appConstants.APP_SHOW_DOWNLOAD_DELETE_CONFIRMATION:
       appState = appState.set('deleteConfirmationVisible', true)
       break


### PR DESCRIPTION
fixes https://github.com/brave/sync/issues/128

Test Plan:
open about:brave. it should show the Brave Sync version

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


