### PR TITLE
Do not delete exclusion's list website if enabled by publisherToggle

### DIFF
--- a/app/ledger.js
+++ b/app/ledger.js
@@ -1070,20 +1070,37 @@ var visibleP = (publisher) => {
     synopsis.options.showOnlyVerified = getSetting(settings.PAYMENTS_NON_VERIFIED)
   }
 
+  const publisherOptions = synopsis.publishers[publisher].options
   const onlyVerified = !synopsis.options.showOnlyVerified
 
-  return (
-      eligibleP(publisher) &&
-      (
-        synopsis.publishers[publisher].options.exclude !== true ||
-        stickyP(publisher)
-      ) &&
-      (
-        (onlyVerified && synopsis.publishers[publisher].options && synopsis.publishers[publisher].options.verified) ||
-        !onlyVerified
-      )
-    ) &&
-    !blockedP(publisher)
+  // Publisher Options
+  const excludedByUser = blockedP(publisher)
+  const eligibleByPublisherToggle = stickyP(publisher) != null
+  const eligibleByNumberOfVisits = eligibleP(publisher)
+  const isInExclusionList = publisherOptions && publisherOptions.exclude
+  const verifiedPublisher = publisherOptions && publisherOptions.verified
+
+  // websites not included in exclusion list are eligible by number of visits
+  // but can be enabled by user action in the publisher toggle
+  const isEligible = (eligibleByNumberOfVisits && !isInExclusionList) || eligibleByPublisherToggle
+
+  // If user decide to remove the website, don't show it.
+  if (excludedByUser) {
+    return false
+  }
+
+  // Unless user decided to enable publisher with publisherToggle,
+  // do not show exclusion list.
+  if (!eligibleByPublisherToggle && isInExclusionList) {
+    return false
+  }
+
+  // If verified option is set, only show verified publishers
+  if (isEligible && onlyVerified) {
+    return verifiedPublisher
+  }
+
+  return isEligible
 }
 
 var contributeP = (publisher) => {


### PR DESCRIPTION
Fix #9938

This allows websites from exclusion list to be visible if the user decides to. Usually, excluded-list websites aren't included but the user can opt-in by hitting the publisherToggle.

Test plan:

1. Enable payments;
2. Go to a verified website;
3. Website should be visible in payments;
4. Toggle on/off;
5. works, site is not excluded;
6. Go to an unverified website (not in the exclusion list), like wired.com;
7. Hit the publisherToggle;
8. Website should be visible in payments;
9. Toggle on/off;
10. works, site is not excluded;
**(now the bug that this PR fixes)**
11. Go to an excluded website (google, brave, netflix)
12. keep navigating in the website up to a point that it should match minimal visibility criteria;
13. Website **should not** be visible in payments;
14. Back to website, hit publisherToggle
15. Website should be visible in payments;
16. Toggle on/off;
17. works, site is not excluded;
18. Exclude a website by hitting the trash icon inside payments;
19. Should not be visible;
20. Go to wheel icon and disable payments for non-verified;
21. Only verified websites should be visible