### PR TITLE
remove calls to `focusedWindow.webContents.send`

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -1080,7 +1080,7 @@ function mainTemplateInit (nodeProps, frame, tab) {
             enabled: tab.get('canGoBack'),
             click: (item, focusedWindow) => {
               if (focusedWindow) {
-                focusedWindow.webContents.send(messages.SHORTCUT_ACTIVE_FRAME_BACK)
+                CommonMenu.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_ACTIVE_FRAME_BACK])
               }
             }
           }, {
@@ -1088,7 +1088,7 @@ function mainTemplateInit (nodeProps, frame, tab) {
             enabled: tab.get('canGoForward'),
             click: (item, focusedWindow) => {
               if (focusedWindow) {
-                focusedWindow.webContents.send(messages.SHORTCUT_ACTIVE_FRAME_FORWARD)
+                CommonMenu.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_ACTIVE_FRAME_FORWARD])
               }
             }
           }, {
@@ -1096,7 +1096,7 @@ function mainTemplateInit (nodeProps, frame, tab) {
             accelerator: 'CmdOrCtrl+R',
             click: (item, focusedWindow) => {
               if (focusedWindow) {
-                focusedWindow.webContents.send(messages.SHORTCUT_ACTIVE_FRAME_RELOAD)
+                CommonMenu.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_ACTIVE_FRAME_RELOAD])
               }
             }
           },
@@ -1117,7 +1117,7 @@ function mainTemplateInit (nodeProps, frame, tab) {
           label: locale.translation('find'),
           accelerator: 'CmdOrCtrl+F',
           click: function (item, focusedWindow) {
-            focusedWindow.webContents.send(messages.SHORTCUT_ACTIVE_FRAME_SHOW_FINDBAR)
+            CommonMenu.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_ACTIVE_FRAME_SHOW_FINDBAR])
           }
         })
 
@@ -1126,7 +1126,7 @@ function mainTemplateInit (nodeProps, frame, tab) {
             label: locale.translation('print'),
             accelerator: 'CmdOrCtrl+P',
             click: function (item, focusedWindow) {
-              focusedWindow.webContents.send(messages.SHORTCUT_ACTIVE_FRAME_PRINT)
+              CommonMenu.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_ACTIVE_FRAME_PRINT])
             }
           })
         }
@@ -1144,7 +1144,7 @@ function mainTemplateInit (nodeProps, frame, tab) {
         accelerator: 'CmdOrCtrl+Alt+U',
         click: (item, focusedWindow) => {
           if (focusedWindow) {
-            focusedWindow.webContents.send(messages.SHORTCUT_ACTIVE_FRAME_VIEW_SOURCE)
+            CommonMenu.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_ACTIVE_FRAME_VIEW_SOURCE])
           }
         }
       })


### PR DESCRIPTION
we don't want any references to `focusedWindow.webContents` that might be called from the renderer process

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

