### PR TITLE
Sync: Fix initial sync of empty folders

### DIFF
--- a/app/sync.js
+++ b/app/sync.js
@@ -264,7 +264,12 @@ module.exports.onSyncReady = (isFirstRun, e) => {
   const folderToObjectId = {}
   const bookmarksToSync = []
   const shouldSyncBookmark = (site) => {
-    if (!site) { return false }
+    if (!site) {
+      return false
+    }
+    if (siteUtil.isSiteBookmarked(sites, site) !== true && siteUtil.isFolder(site) !== true) {
+      return false
+    }
     // originalSeed is set on reset to prevent synced bookmarks on a device
     // from being  re-synced.
     const originalSeed = site.get('originalSeed')
@@ -299,7 +304,7 @@ module.exports.onSyncReady = (isFirstRun, e) => {
 
   // Sync bookmarks that have not been synced yet.
   sites.forEach((site) => {
-    if (siteUtil.isSiteBookmarked(sites, site) !== true || shouldSyncBookmark(site) !== true) {
+    if (shouldSyncBookmark(site) !== true) {
       return
     }
     syncBookmark(site)


### PR DESCRIPTION
Fix https://github.com/brave/sync/issues/134

Test Plan:
1. Between two Pyramids, enable Sync and join the same profile.
2. On Pyramid 0 toggle Sync off.
3. On Pyramid 0 add a bookmark folder and bookmark, both top level items on the bookmarks toolbar.
4. On Pyramid 0 toggle Sync on.
5. Change to Pyramid 1 and wait for syncing; both folder and bookmark should sync over.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

cc @LaurenWags 
