### PR TITLE
Set bookmark parent ID to 0 if parentFolderObjectId is empty

### DIFF
--- a/js/state/syncUtil.js
+++ b/js/state/syncUtil.js
@@ -120,8 +120,10 @@ module.exports.getSiteDataFromRecord = (record, appState, records) => {
     if (parentFolderObjectId && parentFolderObjectId.length > 0) {
       siteProps.parentFolderId =
         getFolderIdByObjectId(new Immutable.List(parentFolderObjectId), appState, records)
-    } else if (siteProps.hideInToolbar === true) {
-      siteProps.parentFolderId = -1
+    } else {
+      // Null or empty parentFolderObjectId on a record corresponds to
+      // a top-level bookmark. -1 indicates a hidden bookmark.
+      siteProps.parentFolderId = siteProps.hideInToolbar ? -1 : 0
     }
   }
   const siteDetail = new Immutable.Map(pickFields(siteProps, SITE_FIELDS))


### PR DESCRIPTION
fix https://github.com/brave/sync/issues/107

Test Plan:
follow test plan in https://github.com/brave/sync/issues/107

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


