### PR TITLE
Sync: Fix some tests

### DIFF
--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -11,6 +11,7 @@ const adHost = process.env.AD_HOST || 'https://oip.brave.com'
 
 const buildConfig = require('./buildConfig')
 const isProduction = buildConfig.nodeEnv === 'production'
+const isTest = process.env.NODE_ENV === 'test'
 const {fullscreenOption, autoplayOption} = require('../../app/common/constants/settingsEnums')
 
 module.exports = {
@@ -113,7 +114,11 @@ module.exports = {
     debug: !isProduction,
     testS3Url: 'https://brave-sync-test.s3.dualstack.us-west-2.amazonaws.com/',
     s3Url: isProduction ? 'https://brave-sync.s3.dualstack.us-west-2.amazonaws.com' : 'https://brave-sync-staging.s3.dualstack.us-west-2.amazonaws.com',
-    fetchInterval: isProduction ? 1000 * 60 * 3 : 1000 * 60
+    fetchInterval: isProduction
+      ? 1000 * 60 * 3
+      : isTest
+        ? 500
+        : 1000 * 60
   },
   urlSuggestions: {
     ageDecayConstant: 50


### PR DESCRIPTION
Fix https://github.com/brave/sync/issues/136

No longer using test helper waitForBookmarkDetail.

Test failures were related to https://github.com/brave/browser-laptop/commit/4538db1a55cee6de542e10c1734adcab3de04c20

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


