### PR TITLE
Add groupedItem to BrowserButton on noScriptInfo.js

### DIFF
--- a/app/renderer/components/main/noScriptInfo.js
+++ b/app/renderer/components/main/noScriptInfo.js
@@ -153,6 +153,7 @@ class NoScriptInfo extends React.Component {
             />
             <div>
               <BrowserButton
+                groupedItem
                 actionItem
                 l10nId='allowScriptsOnce'
                 onClick={this.onAllow.bind(this, 0)}
@@ -160,6 +161,7 @@ class NoScriptInfo extends React.Component {
               {
                 !this.props.isPrivate
                 ? <BrowserButton
+                  groupedItem
                   subtleItem
                   l10nId='allowScriptsTemp'
                   onClick={this.onAllow.bind(this, 1)}

--- a/less/forms.less
+++ b/less/forms.less
@@ -31,26 +31,27 @@ select {
     .truncate {
       margin-bottom: 5px;
     }
+
     .noScriptCheckbox {
       text-align: left;
       font-size: 110%;
+
       input[type=checkbox] {
         margin: 5px;
       }
     }
+
     .clickable {
       text-align: left;
       color: #5B5B5B;
+      text-decoration: underline;
+      margin: 10px 0;
+
       &:hover {
         color: #000;
       }
-      text-decoration: underline;
-      margin-top: 10px;
     }
-    button {
-      margin: 2px;
-      margin-top: 10px;
-    }
+
     label {
       margin-left: 2px;
     }


### PR DESCRIPTION
Closes #9981

Auditors:

Test Plan:
1. Open twitter.com
2. `Block Scripts`
3. Click the NoScript button on the URL bar
4. Make sure the margin exists between the buttons

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


