### PR TITLE
Fix platformUtil usage in app/browser/menu.js 

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -36,7 +36,9 @@ const menuUtil = require('../common/lib/menuUtil')
 const {getSetting} = require('../../js/settings')
 const locale = require('../locale')
 const {isLocationBookmarked} = require('../../js/state/siteUtil')
-const {isDarwin, isLinux} = require('../common/lib/platformUtil')
+const platformUtil = require('../common/lib/platformUtil')
+const isDarwin = platformUtil.isDarwin()
+const isLinux = platformUtil.isLinux()
 
 let appMenu = null
 let closedFrames = new Immutable.OrderedMap()

--- a/app/common/lib/platformUtil.js
+++ b/app/common/lib/platformUtil.js
@@ -35,12 +35,12 @@ module.exports.getPathFromFileURI = (fileURI) => {
 
 module.exports.isDarwin = () => {
   return process.platform === 'darwin' ||
-    navigator.platform === 'MacIntel'
+    (navigator && navigator.platform === 'MacIntel')
 }
 
 module.exports.isWindows = () => {
   return process.platform === 'win32' ||
-    navigator.platform === 'Win32'
+    (navigator && navigator.platform === 'Win32')
 }
 
 module.exports.isLinux = () => {

--- a/app/common/state/menuBarState.js
+++ b/app/common/state/menuBarState.js
@@ -2,13 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const {isWindows} = require('../lib/platformUtil')
+const isWindows = require('../lib/platformUtil').isWindows()
 const {getSetting} = require('../../../js/settings')
 const settings = require('../../../js/constants/settings')
 
 const api = {
   isMenuBarVisible: (windowState) => {
-    return isWindows() && (!getSetting(settings.AUTO_HIDE_MENU) || windowState.getIn(['ui', 'menubar', 'isVisible']))
+    return isWindows && (!getSetting(settings.AUTO_HIDE_MENU) || windowState.getIn(['ui', 'menubar', 'isVisible']))
   }
 }
 

--- a/app/renderer/components/bookmarks/bookmarksToolbar.js
+++ b/app/renderer/components/bookmarks/bookmarksToolbar.js
@@ -29,7 +29,7 @@ const contextMenus = require('../../../../js/contextMenus')
 const cx = require('../../../../js/lib/classSet')
 const dnd = require('../../../../js/dnd')
 const dndData = require('../../../../js/dndData')
-const {isWindows} = require('../../../common/lib/platformUtil')
+const isWindows = require('../../../common/lib/platformUtil').isWindows()
 const frameStateUtil = require('../../../../js/state/frameStateUtil')
 const bookmarkUtil = require('../../../common/lib/bookmarkUtil')
 
@@ -145,7 +145,7 @@ class BookmarksToolbar extends React.Component {
     props.showOnlyFavicon = bookmarkUtil.showOnlyFavicon()
     props.showFavicon = bookmarkUtil.showFavicon()
     props.shouldAllowWindowDrag = windowState.shouldAllowWindowDrag(state, currentWindow, activeFrame, isFocused()) &&
-      !isWindows()
+      !isWindows
     props.visibleBookmarks = bookmarks.visibleBookmarks
     props.hiddenBookmarks = bookmarks.hiddenBookmarks
 

--- a/app/renderer/components/main/main.js
+++ b/app/renderer/components/main/main.js
@@ -66,7 +66,10 @@ const cx = require('../../../../js/lib/classSet')
 const eventUtil = require('../../../../js/lib/eventUtil')
 const {isSourceAboutUrl} = require('../../../../js/lib/appUrlUtil')
 const {getCurrentWindowId, isMaximized, isFocused, isFullScreen} = require('../../currentWindow')
-const {isDarwin, isWindows, isLinux} = require('../../../common/lib/platformUtil')
+const platformUtil = require('../../../common/lib/platformUtil')
+const isDarwin = platformUtil.isDarwin()
+const isWindows = platformUtil.isWindows()
+const isLinux = platformUtil.isLinux()
 
 class Main extends React.Component {
   constructor (props) {
@@ -85,7 +88,7 @@ class Main extends React.Component {
           this.exitFullScreen()
           break
         case keyCodes.F12:
-          if (!isDarwin()) {
+          if (!isDarwin) {
             ipc.emit(messages.SHORTCUT_ACTIVE_FRAME_TOGGLE_DEV_TOOLS)
           }
           break
@@ -530,7 +533,7 @@ class Main extends React.Component {
     // used in renderer
     props.isFullScreen = activeFrame.get('isFullScreen', false)
     props.isMaximized = isMaximized() || isFullScreen()
-    props.captionButtonsVisible = isWindows()
+    props.captionButtonsVisible = isWindows
     props.showContextMenu = !!currentWindow.get('contextMenuDetail')
     props.showPopupWindow = !!currentWindow.get('popupWindowDetail')
     props.showSiteInfo = currentWindow.getIn(['ui', 'siteInfo', 'isVisible']) &&
@@ -539,7 +542,7 @@ class Main extends React.Component {
       !!currentWindow.get('braveryPanelDetail')
     props.showClearData = !!currentWindow.getIn(['ui', 'isClearBrowsingDataPanelVisible'])
     props.showImportData = !!currentWindow.get('importBrowserDataDetail')
-    props.showWidevine = currentWindow.getIn(['widevinePanelDetail', 'shown']) && !isLinux()
+    props.showWidevine = currentWindow.getIn(['widevinePanelDetail', 'shown']) && !isLinux
     props.showAutoFillAddress = !!currentWindow.get('autofillAddressDetail')
     props.showAutoFillCC = !!currentWindow.get('autofillCreditCardDetail')
     props.showLogin = !!loginRequiredDetails
@@ -568,7 +571,7 @@ class Main extends React.Component {
 
     // used in other functions
     props.menubarSelectedIndex = currentWindow.getIn(['ui', 'menubar', 'selectedIndex'])
-    props.showCustomTitleBar = isWindows()
+    props.showCustomTitleBar = isWindows
     props.menubarVisible = menuBarState.isMenuBarVisible(currentWindow)
     props.mouseInFrame = currentWindow.getIn(['ui', 'mouseInFrame'])
     props.braveShieldEnabled = shieldState.braveShieldsEnabled(activeFrame)

--- a/app/renderer/components/main/siteInfo.js
+++ b/app/renderer/components/main/siteInfo.js
@@ -23,7 +23,7 @@ const tabState = require('../../../common/state/tabState')
 const cx = require('../../../../js/lib/classSet')
 const {isPotentialPhishingUrl} = require('../../../../js/lib/urlutil')
 const siteUtil = require('../../../../js/state/siteUtil')
-const platformUtil = require('../../../common/lib/platformUtil')
+const isLinux = require('../../../common/lib/platformUtil').isLinux()
 const frameStateUtil = require('../../../../js/state/frameStateUtil')
 
 // Styles
@@ -135,7 +135,7 @@ class SiteInfo extends React.Component {
 
   get viewCertificateButton () {
     // TODO(Anthony): Hide it until muon support linux
-    if (!platformUtil.isLinux()) {
+    if (!isLinux) {
       return <div className={css(styles.flexJustifyEnd, styles.viewCertificateButton__wrapper)}>
         <Button
           l10nId='viewCertificate'

--- a/app/renderer/components/navigation/navigator.js
+++ b/app/renderer/components/navigation/navigator.js
@@ -29,7 +29,7 @@ const windowState = require('../../../common/state/windowState')
 
 // Util
 const {getCurrentWindowId, isMaximized, isFullScreen, isFocused} = require('../../currentWindow')
-const {isWindows} = require('../../../common/lib/platformUtil')
+const isWindows = require('../../../common/lib/platformUtil').isWindows()
 const {braveShieldsEnabled} = require('../../../common/state/shieldState')
 const eventUtil = require('../../../../js/lib/eventUtil')
 const {isNavigatableAboutPage, getBaseUrl} = require('./../../../../js/lib/appUrlUtil')
@@ -180,7 +180,7 @@ class Navigator extends React.Component {
     props.shieldEnabled = braveShieldsEnabled(activeFrame)
     props.menuBarVisible = menuBarState.isMenuBarVisible(currentWindow)
     props.isMaximized = isMaximized() || isFullScreen()
-    props.isCaptionButton = isWindows() && !props.menuBarVisible
+    props.isCaptionButton = isWindows && !props.menuBarVisible
     props.activeTabShowingMessageBox = activeTabShowingMessageBox
     props.extensionBrowserActions = extensionBrowserActions
     props.showBrowserActions = !activeTabShowingMessageBox &&
@@ -319,7 +319,7 @@ class Navigator extends React.Component {
                 this.props.isCounterEnabled
                   ? <div className={css(
                       styles.lionBadge,
-                      (this.props.menuBarVisible || !isWindows()) && styles.lionBadgeRight,
+                      (this.props.menuBarVisible || !isWindows) && styles.lionBadgeRight,
                       // delay badge show-up.
                       // this is also set for extension badge
                       // in a way that both can appear at the same time.

--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -36,7 +36,7 @@ const {eventElHasAncestorWithClasses, isForSecondaryAction} = require('../../../
 const {getBaseUrl, isUrl} = require('../../../../js/lib/appUrlUtil')
 const {getCurrentWindowId} = require('../../currentWindow')
 const {normalizeLocation, getNormalizedSuggestion} = require('../../../common/lib/suggestion')
-const {isDarwin} = require('../../../common/lib/platformUtil')
+const isDarwin = require('../../../common/lib/platformUtil').isDarwin()
 const publisherUtil = require('../../../common/lib/publisherUtil')
 
 // Icons
@@ -123,7 +123,7 @@ class UrlBar extends React.Component {
               (this.props.urlbarLocationSuffix && this.props.autocompleteEnabled))) {
             // Hack to make alt enter open a new tab for url bar suggestions when hitting enter on them.
             if (e.altKey) {
-              if (isDarwin()) {
+              if (isDarwin) {
                 e.metaKey = true
               } else {
                 e.ctrlKey = true

--- a/app/renderer/components/preferences/advancedTab.js
+++ b/app/renderer/components/preferences/advancedTab.js
@@ -22,10 +22,12 @@ const {scaleSize} = require('../../../common/constants/toolbarUserInterfaceScale
 // Utils
 const {changeSetting} = require('../../lib/settingsUtil')
 const platformUtil = require('../../../common/lib/platformUtil')
+const isDarwin = platformUtil.isDarwin()
+const isLinux = platformUtil.isLinux()
 
 class AdvancedTab extends ImmutableComponent {
   previewReleases () {
-    return platformUtil.isLinux()
+    return isLinux
       ? null
       : <SettingCheckbox
         dataL10nId='updateToPreviewReleases'
@@ -36,7 +38,7 @@ class AdvancedTab extends ImmutableComponent {
   }
 
   get swipeNavigationDistanceSetting () {
-    if (platformUtil.isDarwin()) {
+    if (isDarwin) {
       return <div>
         <DefaultSectionTitle data-l10n-id='swipeNavigationDistance' />
         <SettingsList listClassName={css(styles.swipeNavigation)}>

--- a/app/renderer/components/preferences/pluginsTab.js
+++ b/app/renderer/components/preferences/pluginsTab.js
@@ -8,7 +8,10 @@ const aboutActions = require('../../../../js/about/aboutActions')
 const getSetting = require('../../../../js/settings').getSetting
 const settings = require('../../../../js/constants/settings')
 const appConfig = require('../../../../js/constants/appConfig')
-const {isWindows, isDarwin, isLinux} = require('../../../common/lib/platformUtil')
+const platformUtil = require('../../../common/lib/platformUtil')
+const isDarwin = platformUtil.isDarwin()
+const isLinux = platformUtil.isLinux()
+const isWindows = platformUtil.isLinux()
 
 const WidevineInfo = require('../main/widevineInfo')
 const flash = appConfig.resourceNames.FLASH
@@ -55,7 +58,7 @@ class PluginsTab extends ImmutableComponent {
         <SettingCheckbox checked={this.flashInstalled ? this.props.braveryDefaults.get('flash') : false} dataL10nId='enableFlash' onChange={this.onToggleFlash} disabled={!this.flashInstalled} />
         <div className='subtext flashText'>
           {
-            isDarwin() || isWindows()
+            isDarwin || isWindows
             ? <div>
               {this.infoCircle(appConfig.flash.installUrl)}
               <span data-l10n-id='enableFlashSubtext' />&nbsp;
@@ -81,7 +84,7 @@ class PluginsTab extends ImmutableComponent {
         </div>
       </SettingsList>
       {
-        !isLinux()
+        !isLinux
           ? <div>
             <DefaultSectionTitle data-l10n-id='widevineSection' />
             <SettingsList>

--- a/app/renderer/components/tabs/content/tabTitle.js
+++ b/app/renderer/components/tabs/content/tabTitle.js
@@ -12,7 +12,9 @@ const ReduxComponent = require('../../reduxComponent')
 const tabContentState = require('../../../../common/state/tabContentState')
 
 // Utils
-const {isWindows, isDarwin} = require('../../../../common/lib/platformUtil')
+const platformUtil = require('../../../../common/lib/platformUtil')
+const isWindows = platformUtil.isWindows()
+const isDarwin = platformUtil.isDarwin()
 
 // Styles
 const globalStyles = require('../../styles/global')
@@ -25,7 +27,7 @@ class TabTitle extends React.Component {
 
     const props = {}
     // used in renderer
-    props.enforceFontVisibility = isDarwin() && tabIconColor === 'white'
+    props.enforceFontVisibility = isDarwin && tabIconColor === 'white'
     props.tabIconColor = tabIconColor
     props.displayTitle = tabContentState.getDisplayTitle(currentWindow, frameKey)
 
@@ -49,7 +51,7 @@ class TabTitle extends React.Component {
         titleStyles.gradientText,
         this.props.enforceFontVisibility && styles.enforceFontVisibility,
         // Windows specific style
-        isWindows() && styles.tabTitleForWindows
+        isWindows && styles.tabTitleForWindows
       )}>
       {this.props.displayTitle}
     </div>

--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -42,7 +42,7 @@ const dnd = require('../../../../js/dnd')
 const throttle = require('../../../../js/lib/throttle')
 const frameStateUtil = require('../../../../js/state/frameStateUtil')
 const {getTabBreakpoint, tabUpdateFrameRate} = require('../../lib/tabUtil')
-const {isWindows} = require('../../../common/lib/platformUtil')
+const isWindows = require('../../../common/lib/platformUtil').isWindows()
 const {getCurrentWindowId} = require('../../currentWindow')
 const UrlUtil = require('../../../../js/lib/urlutil')
 const {hasBreakpoint} = require('../../lib/tabUtil')
@@ -295,7 +295,7 @@ class Tab extends React.Component {
         className={css(
           styles.tab,
           // Windows specific style
-          isWindows() && styles.tabForWindows,
+          isWindows && styles.tabForWindows,
           this.props.isPinnedTab && styles.isPinned,
           this.props.isActive && styles.active,
           this.props.isPlayIndicatorBreakpoint && this.props.canPlayAudio && styles.narrowViewPlayIndicator,

--- a/js/lib/eventUtil.js
+++ b/js/lib/eventUtil.js
@@ -2,11 +2,11 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const {isDarwin} = require('../../app/common/lib/platformUtil')
+const isDarwin = require('../../app/common/lib/platformUtil').isDarwin()
 
 module.exports.isForSecondaryAction = (e) =>
-  (e.ctrlKey && !isDarwin()) ||
-  (e.metaKey && isDarwin()) ||
+  (e.ctrlKey && !isDarwin) ||
+  (e.metaKey && isDarwin) ||
   e.button === 1
 
 module.exports.eventElHasAncestorWithClasses = (e, classesToCheck) => {


### PR DESCRIPTION
...and standardize usage of platformUtil

When https://github.com/brave/browser-laptop/pull/9678 was merged, unfortunately menu.js was not updated to call the function.
Instead of updating to call the function, I updated all usage to resolve the value at the top of each file (preventing multiple unneeded calls)

Auditors: @NejcZdovc

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


