### PR TITLE
WebTorrent: Restrict torrent server to same origin

### DIFF
--- a/js/webtorrent/entry.js
+++ b/js/webtorrent/entry.js
@@ -132,7 +132,11 @@ function initTorrent (torrent) {
   torrent.on('warning', onWarning)
   torrent.on('error', onError)
 
-  server = torrent.createServer()
+  server = torrent.createServer({
+    // Only allow requests from this origin ('chrome-extension://...) so websites
+    // cannot violate same-origin policy by reading contents of active torrents.
+    origin: window.location.origin
+  })
   server.listen(onServerListening)
 
   // These event listeners aren't strictly required, but it's better to update the

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "tracking-protection": "1.1.x",
     "underscore": "1.8.3",
     "url-loader": "^0.5.7",
-    "webtorrent-remote": "^2.0.0"
+    "webtorrent-remote": "^2.0.2"
   },
   "devDependencies": {
     "asar": "^0.11.0",


### PR DESCRIPTION
Before this PR, another origin could make an XHR or fetch request to the localhost torrent server URL, if they could guess the server address + port + url, which isn't very hard through enumeration.

This would require a torrent tab to be open and actively torrenting, and a malicious script on another origin (and in another tab) to also be active. It would reveal the raw bits of the torrent contents (i.e. video content, etc.) to the malicious page, violating the same origin policy.

Relies on this new WebTorrent option: https://github.com/webtorrent/webtorrent/pull/1096/files and on `webtorrent-remote` 2.0.2.

Auditors:

Test Plan:

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


