### PR TITLE
Cache history sites in main process with a score-sorted set

### DIFF
--- a/app/browser/reducers/sitesReducer.js
+++ b/app/browser/reducers/sitesReducer.js
@@ -40,7 +40,7 @@ const updateActiveTabBookmarked = (state) => {
 const sitesReducer = (state, action, immutableAction) => {
   switch (action.actionType) {
     case appConstants.APP_SET_STATE:
-      state = siteCache.loadLocationSiteKeysCache(state)
+      state = siteCache.loadSiteKeyCaches(state)
       break
     case appConstants.APP_ON_CLEAR_BROWSING_DATA:
       {

--- a/app/common/lib/historyUtil.js
+++ b/app/common/lib/historyUtil.js
@@ -5,22 +5,14 @@
 
 const Immutable = require('immutable')
 const {makeImmutable} = require('../state/immutableUtil')
-const siteUtil = require('../../../js/state/siteUtil')
+const historyCache = require('../state/historyCache')
 const aboutHistoryMaxEntries = 500
 
 module.exports.maxEntries = aboutHistoryMaxEntries
 
-const sortTimeDescending = (left, right) => {
-  if (left.get('lastAccessedTime') < right.get('lastAccessedTime')) return 1
-  if (left.get('lastAccessedTime') > right.get('lastAccessedTime')) return -1
-  return 0
-}
-
 module.exports.getHistory = (sites) => {
-  sites = makeImmutable(sites) ? makeImmutable(sites).toList() : new Immutable.List()
-  return sites.filter((site) => siteUtil.isHistoryEntry(site))
-      .sort(sortTimeDescending)
-      .slice(0, aboutHistoryMaxEntries)
+  const siteKeys = makeImmutable(historyCache.getSiteKeys(aboutHistoryMaxEntries))
+  return siteKeys.map(key => sites.get(key))
 }
 
 const getDayString = (entry, locale) => {

--- a/app/common/state/historyCache.js
+++ b/app/common/state/historyCache.js
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const siteUtil = require('../../../js/state/siteUtil')
+const SortedSet = require('redis-sorted-set')
+let siteKeys = new SortedSet()
+
+/**
+ * Add siteKey to cache if it's a history site. Note the cache is process-
+ * specific.
+ * @param siteKey {string}
+ * @param site {Immutable.Map} siteDetail from app state sites
+ */
+module.exports.addSiteKey = (siteKey, site) => {
+  if (!siteUtil.isHistoryEntry(site)) {
+    return false
+  }
+  // Sort most recent at index 0
+  const score = -1 * site.get('lastAccessedTime')
+  return siteKeys.set(siteKey, score)
+}
+
+/**
+ * Remove siteKey from cache.
+ * @param siteKey {string}
+ */
+module.exports.removeSiteKey = (siteKey) => {
+  return siteKeys.del(siteKey)
+}
+
+/**
+ * Get history siteKeys, sorted by lastAccessedTime descending.
+ * @param limit {number}
+ * @returns {Array.<string>} siteDetail from app state sites
+ */
+module.exports.getSiteKeys = (limit) => {
+  const indexEnd = limit ? (limit - 1) : -1
+  if (indexEnd <= -2) { throw new Error('Invalid siteKey limit') }
+  return siteKeys.range(0, indexEnd)
+}
+
+/**
+ * Reset the cache. Useful for testing.
+ */
+module.exports.reset = () => {
+  siteKeys = new SortedSet()
+}

--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "react-dnd": "^2.1.4",
     "react-dnd-html5-backend": "^2.1.2",
     "react-dom": "^15.5.4",
+    "redis-sorted-set": "^2.0.0",
     "string.prototype.endswith": "^0.2.0",
     "string.prototype.startswith": "^0.2.0",
     "tablesort": "5.0.0",

--- a/test/unit/app/common/lib/historyUtilTest.js
+++ b/test/unit/app/common/lib/historyUtilTest.js
@@ -1,11 +1,25 @@
 /* global describe, it */
 const assert = require('assert')
 const Immutable = require('immutable')
+// const historyCache = require('../../../../../app/common/state/historyCache')
+const historyCache = require('../../../../../app/common/state/historyCache')
 const historyUtil = require('../../../../../app/common/lib/historyUtil')
+const siteCache = require('../../../../../app/common/state/siteCache')
+const siteUtil = require('../../../../../js/state/siteUtil')
 
 require('../../../braveUnit')
 
 describe('historyUtil', function () {
+  const initState = (sitesList) => {
+    let state = new Immutable.Map()
+    sitesList.forEach(site => {
+      const siteKey = siteUtil.getSiteKey(site)
+      state = state.setIn(['sites', siteKey], site)
+    })
+    historyCache.reset()
+    siteCache.loadSiteKeyCaches(state)
+    return state
+  }
   const historyDayOne = Immutable.fromJS({
     lastAccessedTime: 1477944718876,
     location: 'https://brave.com/page1',
@@ -36,13 +50,16 @@ describe('historyUtil', function () {
   }])
   const historyMultipleDays = historyDayThree.push(historyDayTwo, historyDayOne)
 
+  // TODO: Fix these tests
   describe('getHistory', function () {
     it('returns the result as an Immutable.List', function () {
-      const result = historyUtil.getHistory(historyMultipleDays)
+      const state = initState(historyMultipleDays)
+      const result = historyUtil.getHistory(state.get('sites'))
       assert.equal(Immutable.List.isList(result), true)
     })
     it('sorts the items by date/time DESC', function () {
-      const result = historyUtil.getHistory(historyMultipleDays)
+      const state = initState(historyMultipleDays)
+      const result = historyUtil.getHistory(state.get('sites'))
       const expectedResult = historyDayThree.toJS().reverse()
       expectedResult.push(historyDayTwo.toJS())
       expectedResult.push(historyDayOne.toJS())
@@ -51,10 +68,17 @@ describe('historyUtil', function () {
     it('only returns `historyUtil.maxEntries` results', function () {
       let tooManyEntries = new Immutable.List().push(historyDayOne)
       for (let i = 0; i < historyUtil.maxEntries; i++) {
-        tooManyEntries = tooManyEntries.push(historyDayOne)
+        const site = Immutable.fromJS({
+          lastAccessedTime: 1477944718876,
+          location: `https://brave.com/page${i}`,
+          title: `sample ${i}`,
+          tags: []
+        })
+        tooManyEntries = tooManyEntries.push(site)
       }
       assert.equal(tooManyEntries.size, (historyUtil.maxEntries + 1))
-      const result = historyUtil.getHistory(tooManyEntries)
+      const state = initState(tooManyEntries)
+      const result = historyUtil.getHistory(state.get('sites'))
       assert.equal(result.size, historyUtil.maxEntries)
     })
   })

--- a/test/unit/app/common/state/siteCacheTest.js
+++ b/test/unit/app/common/state/siteCacheTest.js
@@ -48,24 +48,24 @@ describe('siteCache', function () {
         [bookmark.get('location')]: [bookmarkKey],
         [historySite.get('location')]: [historySiteKey]
       }
-      const state = siteCache.loadLocationSiteKeysCache(baseState)
+      const state = siteCache.loadSiteKeyCaches(baseState)
       assert.deepEqual(state.get('locationSiteKeysCache').toJS(), expectedCache)
     })
   })
 
   describe('getLocationSiteKeys', function () {
     it('returns cached siteKeys', function () {
-      const state = siteCache.loadLocationSiteKeysCache(baseState)
+      const state = siteCache.loadSiteKeyCaches(baseState)
       const cachedKeys = siteCache.getLocationSiteKeys(state, bookmark.get('location'))
       assert.deepEqual(cachedKeys.toJS(), [bookmarkKey])
     })
     it('returns null when location is not cached', function () {
-      const state = siteCache.loadLocationSiteKeysCache(baseState)
+      const state = siteCache.loadSiteKeyCaches(baseState)
       const cachedKeys = siteCache.getLocationSiteKeys(state, 'https://archive.org')
       assert.equal(cachedKeys, null)
     })
     it('returns null when location is undefined', function () {
-      const state = siteCache.loadLocationSiteKeysCache(baseState)
+      const state = siteCache.loadSiteKeyCaches(baseState)
       const cachedKeys = siteCache.getLocationSiteKeys(state, undefined)
       assert.equal(cachedKeys, null)
     })
@@ -81,7 +81,7 @@ describe('siteCache', function () {
         tags: [siteTags.BOOKMARK]
       })
       const siteKey = siteUtil.getSiteKey(site)
-      let state = siteCache.loadLocationSiteKeysCache(baseState)
+      let state = siteCache.loadSiteKeyCaches(baseState)
       state = siteCache.addLocationSiteKey(state, bookmarkLocation, siteKey)
       const cachedKeys = siteCache.getLocationSiteKeys(state, bookmarkLocation)
       assert.deepEqual(cachedKeys.toJS(), [bookmarkKey, siteKey])
@@ -95,7 +95,7 @@ describe('siteCache', function () {
         tags: [siteTags.BOOKMARK]
       })
       const siteKey = siteUtil.getSiteKey(site)
-      let state = siteCache.loadLocationSiteKeysCache(baseState)
+      let state = siteCache.loadSiteKeyCaches(baseState)
       state = siteCache.addLocationSiteKey(state, location, siteKey)
       const cachedKeys = siteCache.getLocationSiteKeys(state, location)
       assert.deepEqual(cachedKeys.toJS(), [siteKey])
@@ -122,7 +122,7 @@ describe('siteCache', function () {
       })
       const siteKey = siteUtil.getSiteKey(site)
       let state = baseState.setIn(['sites', siteKey], site)
-      state = siteCache.loadLocationSiteKeysCache(state)
+      state = siteCache.loadSiteKeyCaches(state)
 
       // Sanity
       let cachedKeys = siteCache.getLocationSiteKeys(state, bookmarkLocation)
@@ -134,7 +134,7 @@ describe('siteCache', function () {
     })
 
     it('when removing the last siteKey, removes location', function () {
-      let state = siteCache.loadLocationSiteKeysCache(baseState)
+      let state = siteCache.loadSiteKeyCaches(baseState)
       state = siteCache.removeLocationSiteKey(state, bookmarkLocation, bookmarkKey)
       const cachedKeys = siteCache.getLocationSiteKeys(state, bookmarkLocation)
       assert.deepEqual(cachedKeys, undefined)


### PR DESCRIPTION
Relies on https://github.com/axelpale/redis-sorted-set

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


