### PR TITLE
siteInfo should close when navigating away from data: URL

### DIFF
--- a/app/renderer/reducers/frameReducer.js
+++ b/app/renderer/reducers/frameReducer.js
@@ -163,12 +163,8 @@ const frameReducer = (state, action, immutableAction) => {
           fingerprintingProtection: {}
         })
       }
-
       // For potential phishing pages, show a warning
-      if (isPotentialPhishingUrl(action.location)) {
-        state = state.setIn(['ui', 'siteInfo', 'isVisible'], true)
-      }
-
+      state = state.setIn(['ui', 'siteInfo', 'isVisible'], isPotentialPhishingUrl(action.location))
       break
     case windowConstants.WINDOW_CLOSE_FRAMES:
       let closedFrames = new Immutable.List()

--- a/test/navbar-components/siteInfoTest.js
+++ b/test/navbar-components/siteInfoTest.js
@@ -53,4 +53,21 @@ describe('siteInfo component tests', function () {
         .waitForElementCount(viewCertificateButton, 1)
     })
   })
+
+  describe('siteInfo warning on phishing URLs', function () {
+    Brave.beforeEach(this)
+    beforeEach(function * () {
+      yield setup(this.app.client)
+    })
+
+    it('siteInfo popup closes when navigating from data: to https:', function * () {
+      const page1 = 'data:text/html,<meta http-equiv="refresh" content="1; url=https://example.com/">'
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(page1)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForElementCount(siteInfoDialog, 1)
+        .waitForElementCount(siteInfoDialog, 0)
+    })
+  })
 })


### PR DESCRIPTION
fix #10039

Test Plan:
1. go to data:text/html,<meta http-equiv="refresh" content="1; url=https://example.com/">
2. confirm that the siteinfo popup appears for a second then disappears when the site changes to example.com

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


