### PR TITLE
Option to log reducer runtimes

### DIFF
--- a/app/common/lib/logUtil.js
+++ b/app/common/lib/logUtil.js
@@ -1,0 +1,40 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+
+module.exports.HrtimeLogger = class {
+  /**
+   * @param path {string} Path to log file.
+   * @param threshold {number=} Nanoseconds; only log events which took longer than this.
+   */
+  constructor (path, threshold) {
+    this.path = path
+    this.threshold = threshold
+  }
+
+  /**
+   * @param value {number} Nanoseconds; time of an event
+   */
+  shouldLogValue (value) {
+    return (typeof this.threshold === 'number') && (value > this.threshold)
+  }
+
+  /**
+   * @param hrtimeResult {Array.<number>} Result of the second call to process.hrtime
+   * @param label {string} Label
+   */
+  log (hrtimeResult, label) {
+    const time = process.hrtime(hrtimeResult)
+    const msTime = (1e3 * time[0]) + (time[1] / 1e6)
+    if (this.shouldLogValue(msTime) !== true) { return }
+    const data = `${Date.now()},${label},${msTime}`
+    fs.appendFile(this.path, data + os.EOL, (err) => {
+      if (err) { console.log(err) }
+    })
+  }
+}

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,27 @@
+# Performance
+
+## Reducer logging
+
+One source of blocking lag is when the main process runs slow code in reducers. To look for this, enable reducer runtime logs by running Brave with the env variable `REDUCER_TIME_LOG_THRESHOLD={time in ms}`.
+
+Log runtimes slower than 5 ms in development:
+
+```sh
+REDUCER_TIME_LOG_THRESHOLD=5 npm run start
+```
+
+In a MacOS packaged build:
+
+```
+REDUCER_TIME_LOG_THRESHOLD=5 {path to Brave.app}/Contents/MacOS/Brave
+```
+
+Logs are written to `{userProfile}/reducer-time-{ISO datetime}.log` by default. You can override this with the env var `REDUCER_TIME_LOG_PATH={path}`.
+
+Log format is `{unix timestamp (ms)},{label},{run time (ms)}`, one event per line:
+
+```
+1500588837179,app-add-site,231
+1500588855676,app-frame-changed,16
+1500588909915,window-set-popup-window-detail,7
+```


### PR DESCRIPTION
Fix #10079

Enable reducer logging with env var REDUCER_TIME_LOG_THRESHOLD={time in ns}
By default logs to {userProfile}/reducer-time-{ISO datetime}.log
Specify log path with REDUCER_TIME_LOG_PATH={file path}
Log format: `{unix timestamp (ms)},{label},{run time (ns)}`

Example output from package built from this PR (running `REDUCER_TIME_LOG_THRESHOLD=5000000 ./browser-laptop/Brave-darwin-x64/Brave.app/Contents/MacOS/Brave`):
```
1500588837179,app-add-site,231026979
1500588838127,app-add-site,209187303
1500588855676,app-frame-changed,16606127
1500588856582,app-add-site,245766558
1500588879839,app-frame-changed,9642523
1500588897508,app-frame-changed,5565819
1500588904574,app-add-site,255137766
1500588909054,app-add-site,223211891
1500588909915,window-set-popup-window-detail,7043392
```

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
1. Load up a big user profile and run `REDUCER_TIME_LOG_THRESHOLD=5000000 npm run start`
2. Examine the log file

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


