### PR TITLE
Add alternative dependencies for RPM

### DIFF
--- a/res/linuxPackaging.json
+++ b/res/linuxPackaging.json
@@ -18,8 +18,8 @@
     "x-scheme-handler/ftp"
   ],
   "requires": [
-    "GConf2",
-    "libXScrnSaver",
+    "(GConf2 or gconf2)",
+    "(libXScrnSaver or libXss1)",
     "lsb"
   ],
   "depends": [


### PR DESCRIPTION
Addresses #6946

RPM 4.13.0 was released on 2016-11-03, and it is available on [all supported Fedora versions](https://apps.fedoraproject.org/packages/rpm) and openSUSE Tumbleweed. It added support for boolean dependencies, which we can use to resolve the installation issue on openSUSE Tumbleweed.

This PR does not fix the installation issue on openSUSE Leap. openSUSE Leap users will have to install [the unofficial update](https://build.opensuse.org/package/show/home%3ALedest%3Arpm/rpm).

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
 - Make sure this command installs brave on openSUSE Tumbleweed: `LANG=C sudo zypper in '~/.brave-0.20.0.x86_64.rpm'`
- Make sure this command installs brave on Fedora: `LANG=C sudo dnf install '~/.brave-0.20.0.x86_64.rpm'`


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


