### PR TITLE
fix PDF pinned tabs being duplicated

### DIFF
--- a/app/browser/windows.js
+++ b/app/browser/windows.js
@@ -5,6 +5,7 @@
 const {app, BrowserWindow, ipcMain} = require('electron')
 const appActions = require('../../js/actions/appActions')
 const appUrlUtil = require('../../js/lib/appUrlUtil')
+const {getLocationIfPDF} = require('../../js/lib/urlutil')
 const debounce = require('../../js/lib/debounce')
 const {getSetting} = require('../../js/settings')
 const locale = require('../locale')
@@ -75,7 +76,7 @@ const updatePinnedTabs = (win) => {
 
   pinnedSites.filter((site) =>
     pinnedTabs.find((tab) =>
-      tab.get('url') === site.get('location') &&
+      getLocationIfPDF(tab.get('url')) === site.get('location') &&
       (tab.get('partitionNumber') || 0) === (site.get('partitionNumber') || 0))).forEach((site) => {
         win.__alreadyPinnedSites = win.__alreadyPinnedSites.add(site)
       })

--- a/test/tab-components/pinnedTabTest.js
+++ b/test/tab-components/pinnedTabTest.js
@@ -51,6 +51,17 @@ describe('pinnedTabs', function () {
         .waitForElementCount(pinnedTabsTabs, 1)
         .waitForElementCount(tabsTabs, 1)
     })
+    it('can pin a PDF', function * () {
+      const pdfUrl = 'http://orimi.com/pdf-test.pdf'
+      yield this.app.client
+        .tabByIndex(0)
+        .url(pdfUrl)
+        .pause(1000) // wait for PDF load
+        .windowByUrl(Brave.browserWindowUrl)
+        .pinTabByIndex(0, true)
+        .waitForElementCount(pinnedTabsTabs, 2)
+        .waitForElementCount(tabsTabs, 0)
+    })
   })
 
   describe('Pinning with partitions', function () {


### PR DESCRIPTION
fix #9954

Test Plan:
`npm run test -- --grep='Pins an existing frame'`
try pinning a PDF frame. it should not be duplicated

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


