### PR TITLE
Add space between attributes of element

### DIFF
--- a/app/extensions/brave/about-about.html
+++ b/app/extensions/brave/about-about.html
@@ -8,7 +8,7 @@
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">
     <meta name="referrer" content="no-referrer">
-    <link rel="shortcut icon"type="image/x-icon" href="data:image/x-icon;,">
+    <link rel="shortcut icon" type="image/x-icon" href="data:image/x-icon;,">
     <title data-l10n-id="aboutPages"></title>
     <script src="ext/l20n.min.js"></script>
     <script src="gen/aboutPages.entry.js" async></script>


### PR DESCRIPTION
Added a space between two attributes of element, as implied in [Style guidelines](https://github.com/brave/browser-laptop/blob/master/docs/style.md)