### PR TITLE
Add support for dynamic breakpoint for tabs

### DIFF
--- a/app/common/state/tabContentState.js
+++ b/app/common/state/tabContentState.js
@@ -146,7 +146,7 @@ const tabContentState = {
       isActive &&
       // Larger sizes still have a relative closeIcon
       // We don't resize closeIcon as we do with favicon so don't show it (smallest)
-      !hasBreakpoint(frame.get('breakpoint'), ['default', 'large', 'smallest'])
+      !hasBreakpoint(frame.get('breakpoint'), ['dynamic', 'default', 'large', 'smallest'])
     )
   },
 
@@ -161,7 +161,7 @@ const tabContentState = {
     }
 
     return frameStateUtil.getTabHoverState(state, frameKey) &&
-      hasBreakpoint(frame.get('breakpoint'), ['default', 'large'])
+      hasBreakpoint(frame.get('breakpoint'), ['dynamic', 'default', 'large'])
   },
 
   /**

--- a/app/renderer/components/styles/global.js
+++ b/app/renderer/components/styles/global.js
@@ -35,6 +35,7 @@ const globalStyles = {
     breakpointTinyWin32: '500px',
     breakpointNewPrivateTab: '890px',
     tab: {
+      dynamic: '99999px', // add a large number as new spec will set tab width based on window size
       default: '184px', // match tabArea max-width
       large: '120px',
       largeMedium: '83px',

--- a/app/renderer/lib/tabUtil.js
+++ b/app/renderer/lib/tabUtil.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const styles = require('../components/styles/global')
+const tabBreakpoint = require('../components/styles/global').breakpoint.tab
 
 /**
  * Get tab's breakpoint name for current tab size.
@@ -10,11 +10,11 @@ const styles = require('../components/styles/global')
  * @returns {String} The matching breakpoint.
  */
 module.exports.getTabBreakpoint = (tabWidth) => {
-  const sizes = ['default', 'large', 'largeMedium', 'medium', 'mediumSmall', 'small', 'extraSmall', 'smallest']
+  const sizes = Object.keys(tabBreakpoint)
   let currentSize
 
   sizes.map(size => {
-    if (tabWidth <= Number.parseInt(styles.breakpoint.tab[size], 10)) {
+    if (tabWidth <= Number.parseInt(tabBreakpoint[size], 10)) {
       currentSize = size
       return false
     }

--- a/test/unit/app/common/state/tabContentStateTest.js
+++ b/test/unit/app/common/state/tabContentStateTest.js
@@ -429,6 +429,18 @@ describe('tabContentState unit tests', function () {
       })
       assert.equal(tabContentState.hasFixedCloseIcon(), false)
     })
+
+    it('frame is active and breakpoint is dynamic', function () {
+      getFrameByKeyMock = sinon.stub(frameStateUtil, 'getFrameByKey', () => {
+        return Immutable.fromJS({
+          breakpoint: 'dynamic'
+        })
+      })
+      isFrameKeyActive = sinon.stub(frameStateUtil, 'isFrameKeyActive', () => {
+        return true
+      })
+      assert.equal(tabContentState.hasFixedCloseIcon(), false)
+    })
   })
 
   describe('hasRelativeCloseIcon', function () {
@@ -457,6 +469,16 @@ describe('tabContentState unit tests', function () {
       getFrameByKeyMock = sinon.stub(frameStateUtil, 'getFrameByKey', () => {
         return Immutable.fromJS({
           breakpoint: 'default'
+        })
+      })
+      assert.equal(tabContentState.hasRelativeCloseIcon(state, frameKey), true)
+    })
+
+    it('if hovering (tabIndex === hoverTabIndex) and break point is dynamic', function () {
+      const state = defaultWindowStore
+      getFrameByKeyMock = sinon.stub(frameStateUtil, 'getFrameByKey', () => {
+        return Immutable.fromJS({
+          breakpoint: 'dynamic'
         })
       })
       assert.equal(tabContentState.hasRelativeCloseIcon(state, frameKey), true)

--- a/test/unit/lib/tabUtilTest.js
+++ b/test/unit/lib/tabUtilTest.js
@@ -1,0 +1,49 @@
+/* global describe, it */
+const tabUtil = require('../../../app/renderer/lib/tabUtil')
+const tabBreakpoint = require('../../../app/renderer/components/styles/global').breakpoint.tab
+const assert = require('assert')
+
+require('../braveUnit')
+
+describe('tabUtil', function () {
+  describe('getTabBreakpoint', function () {
+    let size
+
+    it('returns `dynamic` if `dynamic` size matches', function () {
+      size = Number.parseInt(tabBreakpoint.dynamic, 10)
+      assert.equal(tabUtil.getTabBreakpoint(size), 'dynamic')
+    })
+    it('returns `default` if `default` size matches', function () {
+      size = Number.parseInt(tabBreakpoint.default, 10)
+      assert.equal(tabUtil.getTabBreakpoint(size), 'default')
+    })
+    it('returns `large` if `large` size matches', function () {
+      size = Number.parseInt(tabBreakpoint.large, 10)
+      assert.equal(tabUtil.getTabBreakpoint(size), 'large')
+    })
+    it('returns `largeMedium` if `largeMedium` size matches', function () {
+      size = Number.parseInt(tabBreakpoint.largeMedium, 10)
+      assert.equal(tabUtil.getTabBreakpoint(size), 'largeMedium')
+    })
+    it('returns `medium` if `medium` size matches', function () {
+      size = Number.parseInt(tabBreakpoint.medium, 10)
+      assert.equal(tabUtil.getTabBreakpoint(size), 'medium')
+    })
+    it('returns `mediumSmall` if `mediumSmall` size matches', function () {
+      size = Number.parseInt(tabBreakpoint.mediumSmall, 10)
+      assert.equal(tabUtil.getTabBreakpoint(size), 'mediumSmall')
+    })
+    it('returns `small` if `small` size matches', function () {
+      size = Number.parseInt(tabBreakpoint.small, 10)
+      assert.equal(tabUtil.getTabBreakpoint(size), 'small')
+    })
+    it('returns `extraSmall` if `extraSmall` size matches', function () {
+      size = Number.parseInt(tabBreakpoint.extraSmall, 10)
+      assert.equal(tabUtil.getTabBreakpoint(size), 'extraSmall')
+    })
+    it('returns `smallest` if `smallest` size matches', function () {
+      size = Number.parseInt(tabBreakpoint.smallest, 10)
+      assert.equal(tabUtil.getTabBreakpoint(size), 'smallest')
+    })
+  })
+})


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:

Please see #9779 for integrated manual test plan;

1. Set max tabs to 6
2. Open 7 tabs
3. Two tab sets, close the only tab in 2nd tab set
4. Tabs in first tab set should not have a fixed close icon

```
npm run test -- --grep="tabUtil"
npm run test -- --grep="hasFixedCloseIcon"
npm run test -- --grep="hasRelativeCloseIcon"
```

Reviewer Checklist:

Tests

- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


