### PR TITLE
Apply panelItem to addFunds button

### DIFF
--- a/app/renderer/components/preferences/payment/enabledContent.js
+++ b/app/renderer/components/preferences/payment/enabledContent.js
@@ -41,11 +41,12 @@ class EnabledContent extends ImmutableComponent {
       ? this.props.showOverlay.bind(this, 'addFunds')
       : (ledgerData.get('creating') ? () => {} : this.createWallet())
 
-    return <BrowserButton primaryColor
+    return <BrowserButton
+      primaryColor
+      panelItem
       testId={buttonText}
       test2Id={'addFunds'}
       l10nId={buttonText}
-      custom={styles.addFunds}
       onClick={onButtonClick.bind(this)}
       disabled={ledgerData.get('creating')}
     />
@@ -272,14 +273,6 @@ const styles = StyleSheet.create({
 
   settingsListContainer: {
     marginBottom: 0
-  },
-
-  addFunds: {
-    minWidth: '180px',
-    width: 'auto',
-    marginTop: 0,
-    paddingTop: '6px',
-    paddingBottom: '6px'
   },
 
   balance: {


### PR DESCRIPTION
Closes #10141

Auditors: @cezaraugusto

Test Plan:
1. Open `about:prefences#payments`
2. Make sure `Add funds...` button looks same as the buttons on add funds modal dialog

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


