### PR TITLE
Concat css inside cx on dialog.js

### DIFF
--- a/app/renderer/components/common/dialog.js
+++ b/app/renderer/components/common/dialog.js
@@ -42,8 +42,7 @@ class Dialog extends ImmutableComponent {
 
   render () {
     return <div className={cx({
-      [css(styles.dialog)]: true,
-      [css(styles.dialog_isNotClickDismiss)]: !this.props.isClickDismiss,
+      [css(styles.dialog, !this.props.isClickDismiss && styles.dialog_isNotClickDismiss)]: true,
       [this.props.className]: !!this.props.className
     })}
       data-test-id={this.props.testId}
@@ -80,6 +79,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center'
   },
+
   dialog_isNotClickDismiss: {
     background: 'rgba(0, 0, 0, 0.15)'
   }


### PR DESCRIPTION
Closes #10144

Test Plan 1:
1. Disable widevine
2. Open netflix.com
3. Make sure widevine dialog with the dark background appears

Test Plan 2:
1. Click Bravery panel button next to the URL bar
2. Make sure darkening effect does not occur

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


