### PR TITLE
Align paymentsMessage and paymentsSidebar with flex instead of float

### DIFF
--- a/app/renderer/components/preferences/payment/disabledContent.js
+++ b/app/renderer/components/preferences/payment/disabledContent.js
@@ -20,8 +20,8 @@ const CoinBase2 = require('../../../../extensions/brave/img/coinbase_2x.png')
 
 class DisabledContent extends ImmutableComponent {
   render () {
-    return <section data-test-id='disabledContent'>
-      <div className={css(styles.paymentsMessage, styles.walletBarMargin)} data-test-id='paymentsMessage'>
+    return <section className={css(styles.disabledContent)} data-test-id='disabledContent'>
+      <div className={css(styles.paymentsMessage)} data-test-id='paymentsMessage'>
         <h3 className={css(styles.h3)} data-l10n-id='paymentsWelcomeTitle' />
         <div className={css(styles.text)} data-l10n-id='paymentsWelcomeText1' />
         <div className={css(styles.boldText, styles.text)} data-l10n-id='paymentsWelcomeText2' />
@@ -48,6 +48,13 @@ class DisabledContent extends ImmutableComponent {
 }
 
 const styles = StyleSheet.create({
+  disabledContent: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+    marginTop: globalStyles.spacing.panelMargin
+  },
+
   paymentsMessage: {
     backgroundColor: globalStyles.color.lightGray,
     borderRadius: globalStyles.radius.borderRadiusUIbox,
@@ -55,8 +62,7 @@ const styles = StyleSheet.create({
     fontSize: paymentStyles.font.regular,
     lineHeight: '1.8em',
     color: globalStyles.color.mediumGray,
-    width: '500px',
-    float: 'left'
+    width: '500px'
   },
 
   text: {
@@ -66,10 +72,6 @@ const styles = StyleSheet.create({
   textSide: {
     fontSize: paymentStyles.font.regular,
     margin: '50px 0 20px 12px'
-  },
-
-  walletBarMargin: {
-    marginTop: globalStyles.spacing.panelMargin
   },
 
   h3: {
@@ -89,7 +91,6 @@ const styles = StyleSheet.create({
   paymentsSidebar: {
     opacity: 0.8,
     width: '200px',
-    float: 'left',
     marginLeft: '23px'
   },
 


### PR DESCRIPTION
Fixes #10153

Auditors: @cezaraugusto

Test Plan:
1. Open about:preferences#payments
2. Enable and disable Payments
3. Make sure that the margin between the title wrapper and the content does not change

![margin](https://user-images.githubusercontent.com/3362943/28621712-cee9dbfa-724c-11e7-86b1-c0c58e29d1ff.gif)

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


