### PR TITLE
Don't use the previous URL if current virtual URL is safebrowsing

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -302,7 +302,8 @@ const fixDisplayURL = (navigationEntry, controller) => {
     navigationEntry.virtualURL = getSourceAboutUrl(navigationEntry.virtualURL)
   }
 
-  if (isIntermediateAboutPage(navigationEntry.virtualURL)) {
+  if (isIntermediateAboutPage(navigationEntry.virtualURL) &&
+    !navigationEntry.virtualURL.startsWith('about:safebrowsing#')) {
     const previousEntry = controller.getEntryAtOffset(-1)
     if (!controller.canGoForward() && previousEntry) {
       navigationEntry.virtualURL = previousEntry.virtualURL


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/10143

Auditors: @diracdeltas, @alexwykoff

Test Plan:
1. open new tab
2. navigate to downloadme.org
3. notice that URL is properly "about:safebrowsing#downloadme.org"

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


