### PR TITLE
Fix Sync after sites refactor

### DIFF
--- a/app/browser/reducers/bookmarkFoldersReducer.js
+++ b/app/browser/reducers/bookmarkFoldersReducer.js
@@ -9,6 +9,7 @@ const bookmarkFoldersState = require('../../common/state/bookmarkFoldersState')
 
 // Constants
 const appConstants = require('../../../js/constants/appConstants')
+const {STATE_SITES} = require('../../../js/constants/stateConstants')
 
 // Utils
 const {makeImmutable} = require('../../common/state/immutableUtil')
@@ -29,17 +30,11 @@ const bookmarkFoldersReducer = (state, action, immutableAction) => {
         if (Immutable.List.isList(folder)) {
           action.get('folderDetails', Immutable.List()).forEach((folder) => {
             state = bookmarkFoldersState.addFolder(state, folder, closestKey)
-
-            if (syncUtil.syncEnabled()) {
-              state = syncUtil.updateSiteCache(state, folder)
-            }
+            state = syncUtil.updateObjectCache(state, folder, STATE_SITES.BOOKMARK_FOLDERS)
           })
         } else {
           state = bookmarkFoldersState.addFolder(state, folder, closestKey)
-
-          if (syncUtil.syncEnabled()) {
-            state = syncUtil.updateSiteCache(state, folder)
-          }
+          state = syncUtil.updateObjectCache(state, folder, STATE_SITES.BOOKMARK_FOLDERS)
         }
         break
       }
@@ -53,10 +48,7 @@ const bookmarkFoldersReducer = (state, action, immutableAction) => {
         }
 
         state = bookmarkFoldersState.editFolder(state, key, folder)
-
-        if (syncUtil.syncEnabled()) {
-          state = syncUtil.updateSiteCache(state, folder)
-        }
+        state = syncUtil.updateObjectCache(state, folder, STATE_SITES.BOOKMARK_FOLDERS)
 
         break
       }
@@ -76,10 +68,8 @@ const bookmarkFoldersReducer = (state, action, immutableAction) => {
           action.get('moveIntoParent')
         )
 
-        if (syncUtil.syncEnabled()) {
-          const destinationDetail = state.getIn(['sites', action.get('destinationKey')])
-          state = syncUtil.updateSiteCache(state, destinationDetail)
-        }
+        const destinationDetail = bookmarkFoldersState.getFolder(state, action.get('destinationKey'))
+        state = syncUtil.updateObjectCache(state, destinationDetail, STATE_SITES.BOOKMARK_FOLDERS)
         break
       }
     case appConstants.APP_REMOVE_BOOKMARK_FOLDER:
@@ -90,7 +80,9 @@ const bookmarkFoldersReducer = (state, action, immutableAction) => {
           break
         }
 
+        const folder = state.getIn([STATE_SITES.BOOKMARK_FOLDERS, key])
         state = bookmarkFoldersState.removeFolder(state, key)
+        state = syncUtil.updateObjectCache(state, folder, STATE_SITES.BOOKMARK_FOLDERS)
         break
       }
   }

--- a/app/browser/reducers/bookmarksReducer.js
+++ b/app/browser/reducers/bookmarksReducer.js
@@ -9,6 +9,7 @@ const bookmarksState = require('../../common/state/bookmarksState')
 
 // Constants
 const appConstants = require('../../../js/constants/appConstants')
+const {STATE_SITES} = require('../../../js/constants/stateConstants')
 
 // Utils
 const {makeImmutable} = require('../../common/state/immutableUtil')
@@ -34,17 +35,11 @@ const bookmarksReducer = (state, action, immutableAction) => {
         if (Immutable.List.isList(bookmark)) {
           action.get('siteDetail', Immutable.List()).forEach((bookmark) => {
             state = bookmarksState.addBookmark(state, bookmark, closestKey)
-
-            if (syncUtil.syncEnabled()) {
-              state = syncUtil.updateSiteCache(state, bookmark)
-            }
+            state = syncUtil.updateObjectCache(state, bookmark, STATE_SITES.BOOKMARKS)
           })
         } else {
           state = bookmarksState.addBookmark(state, bookmark, closestKey)
-
-          if (syncUtil.syncEnabled()) {
-            state = syncUtil.updateSiteCache(state, bookmark)
-          }
+          state = syncUtil.updateObjectCache(state, bookmark, STATE_SITES.BOOKMARKS)
         }
 
         state = bookmarkUtil.updateActiveTabBookmarked(state)
@@ -60,10 +55,7 @@ const bookmarksReducer = (state, action, immutableAction) => {
         }
 
         state = bookmarksState.editBookmark(state, key, bookmark)
-
-        if (syncUtil.syncEnabled()) {
-          state = syncUtil.updateSiteCache(state, bookmark)
-        }
+        state = syncUtil.updateObjectCache(state, bookmark, STATE_SITES.BOOKMARKS)
 
         state = bookmarkUtil.updateActiveTabBookmarked(state)
         break
@@ -84,10 +76,8 @@ const bookmarksReducer = (state, action, immutableAction) => {
           action.get('moveIntoParent')
         )
 
-        if (syncUtil.syncEnabled()) {
-          const destinationDetail = state.getIn(['sites', action.get('destinationKey')])
-          state = syncUtil.updateSiteCache(state, destinationDetail)
-        }
+        const destinationDetail = bookmarksState.getBookmark(state, action.get('destinationKey'))
+        state = syncUtil.updateObjectCache(state, destinationDetail, STATE_SITES.BOOKMARKS)
         break
       }
     case appConstants.APP_REMOVE_BOOKMARK:

--- a/app/browser/reducers/historyReducer.js
+++ b/app/browser/reducers/historyReducer.js
@@ -10,6 +10,7 @@ const aboutHistoryState = require('../../common/state/aboutHistoryState')
 
 // Constants
 const appConstants = require('../../../js/constants/appConstants')
+const {STATE_SITES} = require('../../../js/constants/stateConstants')
 
 // Utils
 const {makeImmutable} = require('../../common/state/immutableUtil')
@@ -33,21 +34,16 @@ const historyReducer = (state, action, immutableAction) => {
       }
     case appConstants.APP_ADD_HISTORY_SITE:
       {
-        const isSyncEnabled = syncUtil.syncEnabled()
         const detail = action.get('siteDetail')
 
         if (Immutable.List.isList(detail)) {
           detail.forEach((item) => {
             state = historyState.addSite(state, item)
-            if (isSyncEnabled) {
-              state = syncUtil.updateSiteCache(state, item)
-            }
+            state = syncUtil.updateObjectCache(state, item, STATE_SITES.HISTORY_SITES)
           })
         } else {
           state = historyState.addSite(state, detail)
-          if (isSyncEnabled) {
-            state = syncUtil.updateSiteCache(state, detail)
-          }
+          state = syncUtil.updateObjectCache(state, detail, STATE_SITES.HISTORY_SITES)
         }
 
         calculateTopSites(true)
@@ -60,18 +56,14 @@ const historyReducer = (state, action, immutableAction) => {
         if (Immutable.List.isList(action.get('historyKey'))) {
           action.get('historyKey', Immutable.List()).forEach((key) => {
             state = historyState.removeSite(state, key)
+            // TODO: Implement Sync history site removal
+            // state = syncUtil.updateObjectCache(state, action.get('siteDetail'), STATE_SITES.HISTORY_SITES)
           })
         } else {
           state = historyState.removeSite(state, action.get('historyKey'))
+          // TODO: Implement Sync history site removal
+          // state = syncUtil.updateObjectCache(state, action.get('siteDetail'), STATE_SITES.HISTORY_SITES)
         }
-
-        // TODO fix sync
-        /*
-        if (syncUtil.syncEnabled()) {
-          //syncActions.removeSite(historyState.getSite(state, action.get('historyKey')))
-          //state = syncUtil.updateSiteCache(state, action.get('siteDetail'))
-        }
-        */
 
         calculateTopSites(true)
         state = aboutHistoryState.setHistory(state, historyState.getSites(state))

--- a/app/browser/reducers/pinnedSitesReducer.js
+++ b/app/browser/reducers/pinnedSitesReducer.js
@@ -8,6 +8,7 @@ const tabState = require('../../common/state/tabState')
 
 // Constants
 const appConstants = require('../../../js/constants/appConstants')
+const {STATE_SITES} = require('../../../js/constants/stateConstants')
 
 // Utils
 const {makeImmutable} = require('../../common/state/immutableUtil')
@@ -34,9 +35,7 @@ const pinnedSitesReducer = (state, action, immutableAction) => {
           } else {
             state = pinnedSitesState.removePinnedSite(state, siteDetail)
           }
-          if (syncUtil.syncEnabled()) {
-            state = syncUtil.updateSiteCache(state, siteDetail)
-          }
+          state = syncUtil.updateObjectCache(state, siteDetail, STATE_SITES.PINNED_SITES)
         }
         break
       }
@@ -50,18 +49,16 @@ const pinnedSitesReducer = (state, action, immutableAction) => {
       }
     case appConstants.APP_ON_PINNED_TAB_REORDER:
       {
+        const siteKey = action.get('siteKey')
         state = pinnedSitesState.reOrderSite(
           state,
-          action.get('siteKey'),
+          siteKey,
           action.get('destinationKey'),
           action.get('prepend')
         )
 
-        // TODO do we need this for pinned sites?
-        if (syncUtil.syncEnabled()) {
-          const newSite = state.getIn(['pinnedSites', action.siteKey])
-          state = syncUtil.updateSiteCache(state, newSite)
-        }
+        const newSite = pinnedSitesState.getSite(state, siteKey)
+        state = syncUtil.updateObjectCache(state, newSite, STATE_SITES.PINNED_SITES)
         break
       }
   }

--- a/app/common/state/bookmarkFoldersState.js
+++ b/app/common/state/bookmarkFoldersState.js
@@ -11,6 +11,7 @@ const syncActions = require('../../../js/actions/syncActions')
 // Constants
 const settings = require('../../../js/constants/settings')
 const siteTags = require('../../../js/constants/siteTags')
+const {STATE_SITES} = require('../../../js/constants/stateConstants')
 
 // State
 const bookmarkOrderCache = require('../cache/bookmarkOrderCache')
@@ -24,20 +25,20 @@ const {getSetting} = require('../../../js/settings')
 const validateState = function (state) {
   state = makeImmutable(state)
   assert.ok(isMap(state), 'state must be an Immutable.Map')
-  assert.ok(isMap(state.get('bookmarkFolders')), 'state must contain an Immutable.Map of bookmarkFolders')
+  assert.ok(isMap(state.get(STATE_SITES.BOOKMARK_FOLDERS)), 'state must contain an Immutable.Map of bookmarkFolders')
   return state
 }
 
 const bookmarkFoldersState = {
   getFolders: (state) => {
     state = validateState(state)
-    return state.get('bookmarkFolders', Immutable.Map())
+    return state.get(STATE_SITES.BOOKMARK_FOLDERS, Immutable.Map())
   },
 
   getFolder: (state, folderKey) => {
     state = validateState(state)
     folderKey = folderKey.toString()
-    return state.getIn(['bookmarkFolders', folderKey], Immutable.Map())
+    return state.getIn([STATE_SITES.BOOKMARK_FOLDERS, folderKey], Immutable.Map())
   },
 
   getFoldersByParentId: (state, parentFolderId) => {
@@ -67,7 +68,7 @@ const bookmarkFoldersState = {
       type: siteTags.BOOKMARK_FOLDER
     })
 
-    state = state.setIn(['bookmarkFolders', key.toString()], newFolder)
+    state = state.setIn([STATE_SITES.BOOKMARK_FOLDERS, key.toString()], newFolder)
     state = bookmarkOrderCache.addFolderToCache(state, newFolder.get('parentFolderId'), key, destinationKey)
     return state
   },
@@ -90,7 +91,7 @@ const bookmarkFoldersState = {
       state = bookmarkOrderCache.addFolderToCache(state, newFolder.get('parentFolderId'), editKey)
     }
 
-    state = state.setIn(['bookmarkFolders', editKey.toString()], newFolder)
+    state = state.setIn([STATE_SITES.BOOKMARK_FOLDERS, editKey.toString()], newFolder)
     return state
   },
 
@@ -118,7 +119,7 @@ const bookmarkFoldersState = {
     state = bookmarksState.removeBookmarksByParentId(state, folderKey)
     state = bookmarkOrderCache.removeCacheParent(state, folderKey)
     state = bookmarkOrderCache.removeCacheKey(state, folder.get('parentFolderId'), folderKey)
-    return state.deleteIn(['bookmarkFolders', folderKey.toString()])
+    return state.deleteIn([STATE_SITES.BOOKMARK_FOLDERS, folderKey.toString()])
   },
 
   /**
@@ -169,9 +170,9 @@ const bookmarkFoldersState = {
       state = bookmarkOrderCache.removeCacheKey(state, folder.get('parentFolderId'), folderKey)
       folder = folder.set('parentFolderId', ~~parentFolderId)
       const newKey = siteUtil.getSiteKey(folder)
-      state = state.deleteIn(['bookmarkFolders', folderKey])
+      state = state.deleteIn([STATE_SITES.BOOKMARK_FOLDERS, folderKey])
       state = bookmarkOrderCache.addFolderToCache(state, folder.get('parentFolderId'), newKey)
-      return state.setIn(['bookmarkFolders', newKey.toString()], folder)
+      return state.setIn([STATE_SITES.BOOKMARK_FOLDERS, newKey.toString()], folder)
     }
 
     state = bookmarkOrderCache.removeCacheKey(state, folder.get('parentFolderId'), folderKey)

--- a/app/common/state/bookmarksState.js
+++ b/app/common/state/bookmarksState.js
@@ -8,6 +8,7 @@ const Immutable = require('immutable')
 // Constants
 const settings = require('../../../js/constants/settings')
 const siteTags = require('../../../js/constants/siteTags')
+const {STATE_SITES} = require('../../../js/constants/stateConstants')
 const newTabData = require('../../../js/data/newTabData')
 
 // State
@@ -29,19 +30,19 @@ const {makeImmutable, isMap} = require('./immutableUtil')
 const validateState = function (state) {
   state = makeImmutable(state)
   assert.ok(isMap(state), 'state must be an Immutable.Map')
-  assert.ok(isMap(state.get('bookmarks')), 'state must contain an Immutable.Map of bookmarks')
+  assert.ok(isMap(state.get(STATE_SITES.BOOKMARKS)), 'state must contain an Immutable.Map of bookmarks')
   return state
 }
 
 const bookmarksState = {
   getBookmarks: (state) => {
     state = validateState(state)
-    return state.get('bookmarks')
+    return state.get(STATE_SITES.BOOKMARKS)
   },
 
   getBookmark: (state, key) => {
     state = validateState(state)
-    return state.getIn(['bookmarks', key], Immutable.Map())
+    return state.getIn([STATE_SITES.BOOKMARKS, key], Immutable.Map())
   },
 
   /**
@@ -126,12 +127,12 @@ const bookmarksState = {
       return state
     }
 
-    if (!state.hasIn(['bookmarks', key])) {
+    if (!state.hasIn([STATE_SITES.BOOKMARKS, key])) {
       state = bookmarkLocationCache.addCacheKey(state, location, key)
       state = bookmarkOrderCache.addBookmarkToCache(state, bookmark.get('parentFolderId'), key, destinationKey)
     }
 
-    state = state.setIn(['bookmarks', key], bookmark)
+    state = state.setIn([STATE_SITES.BOOKMARKS, key], bookmark)
     return state
   },
 
@@ -158,13 +159,13 @@ const bookmarksState = {
     }
 
     if (editKey !== newKey) {
-      state = state.deleteIn(['bookmarks', editKey])
+      state = state.deleteIn([STATE_SITES.BOOKMARKS, editKey])
       state = bookmarkOrderCache.removeCacheKey(state, oldBookmark.get('parentFolderId'), editKey)
       state = bookmarkOrderCache.addBookmarkToCache(state, newBookmark.get('parentFolderId'), newKey)
       newBookmark = newBookmark.set('key', newKey)
     }
 
-    state = state.setIn(['bookmarks', newKey], newBookmark)
+    state = state.setIn([STATE_SITES.BOOKMARKS, newKey], newBookmark)
     state = bookmarkLocationCache.removeCacheKey(state, oldBookmark.get('location'), editKey)
     state = bookmarkLocationCache.addCacheKey(state, location, newKey)
     return state
@@ -186,7 +187,7 @@ const bookmarksState = {
     state = bookmarkLocationCache.removeCacheKey(state, bookmark.get('location'), bookmarkKey)
     state = bookmarkOrderCache.removeCacheKey(state, bookmark.get('parentFolderId'), bookmarkKey)
 
-    return state.deleteIn(['bookmarks', bookmarkKey])
+    return state.deleteIn([STATE_SITES.BOOKMARKS, bookmarkKey])
   },
 
   /**
@@ -205,7 +206,7 @@ const bookmarksState = {
     const bookmarks = bookmarksState.getBookmarks(state)
       .filter(bookmark => bookmark.get('parentFolderId') !== ~~parentFolderId)
 
-    return state.set('bookmarks', bookmarks)
+    return state.set(STATE_SITES.BOOKMARKS, bookmarks)
   },
 
   /**
@@ -230,7 +231,7 @@ const bookmarksState = {
     }
 
     siteKeys.forEach((siteKey) => {
-      state = state.setIn(['bookmarks', siteKey, 'favicon'], favicon)
+      state = state.setIn([STATE_SITES.BOOKMARKS, siteKey, 'favicon'], favicon)
     })
     return state
   },
@@ -252,10 +253,10 @@ const bookmarksState = {
       state = bookmarkOrderCache.removeCacheKey(state, bookmark.get('parentFolderId'), bookmarkKey)
       bookmark = bookmark.set('parentFolderId', ~~parentFolderId)
       const newKey = siteUtil.getSiteKey(bookmark)
-      state = state.deleteIn(['bookmarks', bookmarkKey])
+      state = state.deleteIn([STATE_SITES.BOOKMARKS, bookmarkKey])
       state = bookmarkOrderCache.addBookmarkToCache(state, bookmark.get('parentFolderId'), newKey)
       bookmark = bookmark.set('key', newKey)
-      return state.setIn(['bookmarks', newKey], bookmark)
+      return state.setIn([STATE_SITES.BOOKMARKS, newKey], bookmark)
     }
 
     // move bookmark to another place

--- a/app/common/state/historyState.js
+++ b/app/common/state/historyState.js
@@ -5,6 +5,7 @@
 const assert = require('assert')
 const Immutable = require('immutable')
 const siteUtil = require('../../../js/state/siteUtil')
+const {STATE_SITES} = require('../../../js/constants/stateConstants')
 const historyUtil = require('../lib/historyUtil')
 const urlUtil = require('../../../js/lib/urlutil')
 const {makeImmutable, isMap} = require('./immutableUtil')
@@ -12,19 +13,19 @@ const {makeImmutable, isMap} = require('./immutableUtil')
 const validateState = function (state) {
   state = makeImmutable(state)
   assert.ok(isMap(state), 'state must be an Immutable.Map')
-  assert.ok(isMap(state.get('historySites')), 'state must contain an Immutable.Map of historySites')
+  assert.ok(isMap(state.get(STATE_SITES.HISTORY_SITES)), 'state must contain an Immutable.Map of historySites')
   return state
 }
 
 const historyState = {
   getSites: (state) => {
     state = validateState(state)
-    return state.get('historySites', Immutable.Map())
+    return state.get(STATE_SITES.HISTORY_SITES, Immutable.Map())
   },
 
   getSite: (state, key) => {
     state = validateState(state)
-    return state.getIn(['historySites', key], Immutable.Map())
+    return state.getIn([STATE_SITES.HISTORY_SITES, key], Immutable.Map())
   },
 
   addSite: (state, siteDetail) => {
@@ -47,18 +48,18 @@ const historyState = {
       site = historyUtil.prepareHistoryEntry(siteDetail)
     }
 
-    state = state.setIn(['historySites', siteKey], site)
+    state = state.setIn([STATE_SITES.HISTORY_SITES, siteKey], site)
     return state
   },
 
   removeSite: (state, siteKey) => {
     // TODO should we remove this only when a tab with this siteKey is not opened
     // if not, we are deleting data that is use for bookmarking
-    return state.deleteIn(['historySites', siteKey])
+    return state.deleteIn([STATE_SITES.HISTORY_SITES, siteKey])
   },
 
   clearSites: (state) => {
-    return state.set('historySites', Immutable.Map())
+    return state.set(STATE_SITES.HISTORY_SITES, Immutable.Map())
   },
 
   updateFavicon: (state, siteDetails, favIcon) => {
@@ -74,7 +75,7 @@ const historyState = {
 
     historyItem = historyItem.set('favicon', favIcon)
 
-    return state.setIn(['historySites', historyKey], historyItem)
+    return state.setIn([STATE_SITES.HISTORY_SITES, historyKey], historyItem)
   }
 }
 

--- a/app/common/state/pinnedSitesState.js
+++ b/app/common/state/pinnedSitesState.js
@@ -5,25 +5,26 @@
 const assert = require('assert')
 const Immutable = require('immutable')
 const siteUtil = require('../../../js/state/siteUtil')
+const {STATE_SITES} = require('../../../js/constants/stateConstants')
 const urlUtil = require('../../../js/lib/urlutil')
 const {makeImmutable, isMap} = require('./immutableUtil')
 
 const validateState = function (state) {
   state = makeImmutable(state)
   assert.ok(isMap(state), 'state must be an Immutable.Map')
-  assert.ok(isMap(state.get('pinnedSites')), 'state must contain an Immutable.Map of pinnedSites')
+  assert.ok(isMap(state.get(STATE_SITES.PINNED_SITES)), 'state must contain an Immutable.Map of pinnedSites')
   return state
 }
 
 const pinnedSiteState = {
   getSites: (state) => {
     state = validateState(state)
-    return state.get('pinnedSites')
+    return state.get(STATE_SITES.PINNED_SITES)
   },
 
   getSite: (state, key) => {
     state = validateState(state)
-    return state.getIn(['pinnedSites', key], Immutable.Map())
+    return state.getIn([STATE_SITES.PINNED_SITES, key], Immutable.Map())
   },
 
   /**
@@ -47,7 +48,7 @@ const pinnedSiteState = {
       return state
     }
 
-    state = state.setIn(['pinnedSites', key], site)
+    state = state.setIn([STATE_SITES.PINNED_SITES, key], site)
     return state
   },
 
@@ -65,7 +66,7 @@ const pinnedSiteState = {
       return state
     }
 
-    const stateKey = ['pinnedSites', key]
+    const stateKey = [STATE_SITES.PINNED_SITES, key]
     let site = state.getIn(stateKey)
     if (!site) {
       return state
@@ -87,7 +88,7 @@ const pinnedSiteState = {
    */
   reOrderSite: (state, sourceKey, destinationKey, prepend) => {
     state = validateState(state)
-    let sites = state.get('pinnedSites')
+    let sites = state.get(STATE_SITES.PINNED_SITES)
     let sourceSite = sites.get(sourceKey, Immutable.Map())
     const destinationSite = sites.get(destinationKey, Immutable.Map())
 
@@ -102,7 +103,7 @@ const pinnedSiteState = {
       --newIndex
     }
 
-    state = state.set('pinnedSites', state.get('pinnedSites').map((site, index) => {
+    state = state.set(STATE_SITES.PINNED_SITES, state.get(STATE_SITES.PINNED_SITES).map((site, index) => {
       const siteOrder = site.get('order')
       if (index === sourceKey) {
         return site
@@ -118,7 +119,7 @@ const pinnedSiteState = {
     }))
 
     sourceSite = sourceSite.set('order', newIndex)
-    return state.setIn(['pinnedSites', sourceKey], sourceSite)
+    return state.setIn([STATE_SITES.PINNED_SITES, sourceKey], sourceSite)
   }
 }
 

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -116,7 +116,7 @@ module.exports = {
     testS3Url: 'https://brave-sync-test.s3.dualstack.us-west-2.amazonaws.com/',
     s3Url: isProduction ? 'https://brave-sync.s3.dualstack.us-west-2.amazonaws.com' : 'https://brave-sync-staging.s3.dualstack.us-west-2.amazonaws.com',
     fetchInterval: isProduction ? (1000 * 60 * 3) : (1000 * 60),
-    fetchOffset: 30, // seconds; reduce syncUtil.now() by this amount to compensate for records pending S3 consistency. See brave/sync #139
+    fetchOffset: isTest ? 0 : 30, // seconds; reduce syncUtil.now() by this amount to compensate for records pending S3 consistency. See brave/sync #139
     resendPendingRecordInterval: isProduction ? (1000 * 60 * 12) : (1000 * 60 * 4)
   },
   urlSuggestions: {

--- a/js/constants/stateConstants.js
+++ b/js/constants/stateConstants.js
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const STATE_SITES = {
+  BOOKMARKS: 'bookmarks',
+  BOOKMARK_FOLDERS: 'bookmarkFolders',
+  HISTORY_SITES: 'historySites',
+  PINNED_SITES: 'pinnedSites'
+}
+
+module.exports = {
+  STATE_SITES
+}

--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -784,16 +784,27 @@ var exports = {
     })
 
     /**
-     * Removes a site from the sites list, or removes a bookmark.
+     * Removes a bookmark.
      *
-     * @param {object} siteDetail - Properties for the frame to add
-     * @param {string} tag - A site tag from js/constants/siteTags.js
+     * @param bookmarkKey {string|Immutable.List} - Bookmark key that we want to remove. This could also be list of keys
      */
-    this.app.client.addCommand('removeSite', function (siteDetail, tag) {
-      logVerbose('removeSite("' + siteDetail + '", "' + tag + '")')
-      return this.execute(function (siteDetail, tag) {
-        return devTools('appActions').removeSite(siteDetail, tag)
-      }, siteDetail, tag).then((response) => response.value)
+    this.app.client.addCommand('removeBookmark', function (bookmarkKey) {
+      logVerbose('removeBookmark("' + bookmarkKey + '")')
+      return this.execute(function (bookmarkKey) {
+        return devTools('appActions').removeBookmark(bookmarkKey)
+      }, bookmarkKey).then((response) => response.value)
+    })
+
+    /**
+     * Removes a bookmark folder.
+     *
+     * @param {object} folderKey folder key to remove
+     */
+    this.app.client.addCommand('removeBookmarkFolder', function (folderKey) {
+      logVerbose('removeBookmarkFolder("' + folderKey + '")')
+      return this.execute(function (folderKey) {
+        return devTools('appActions').removeBookmarkFolder(folderKey)
+      }, folderKey).then((response) => response.value)
     })
 
     /**

--- a/test/misc-components/syncTest.js
+++ b/test/misc-components/syncTest.js
@@ -3,7 +3,6 @@
 const crypto = require('crypto')
 const settings = require('../../js/constants/settings')
 const {newTabMode} = require('../../app/common/constants/settingsEnums')
-const siteTags = require('../../js/constants/siteTags')
 const Brave = require('../lib/brave')
 const Immutable = require('immutable')
 const {adsBlockedControl, allowAllCookiesOption, bookmarksToolbar, braveMenu, braveryPanel, braveryPanelContainer, cookieControl, doneButton, fpSwitch, httpsEverywhereSwitch, navigatorBookmarked, navigatorNotBookmarked, noScriptSwitch, urlInput, removeButton, safeBrowsingSwitch, showAdsOption, syncTab, syncSwitch, bookmarkNameInput} = require('../lib/selectors')
@@ -405,8 +404,7 @@ describe('Syncing bookmarks', function () {
     const folder2Id = 2 // XXX: Hardcoded
     yield Brave.app.client
     yield bookmarkUrl(this.folder2Page1Url, this.folder2Page1Title, folder2Id)
-    yield Brave.app.client
-      .removeSite({ folderId: folder2Id }, siteTags.BOOKMARK_FOLDER)
+    yield Brave.app.client.removeBookmarkFolder(folder2Id)
 
     // XXX: Wait for sync to upload records to S3
     yield Brave.app.client.pause(1000)
@@ -538,6 +536,7 @@ describe('Syncing bookmarks from an existing profile', function () {
       .click(navigatorBookmarked)
       .waitForVisible(doneButton)
       .waitForInputText(bookmarkNameInput, this.page2TitleUpdated)
+      .click(doneButton)
 
     // Create folder then add a bookmark
     yield addBookmarkFolder(this.folder1Title)

--- a/test/unit/app/browser/api/topSitesTest.js
+++ b/test/unit/app/browser/api/topSitesTest.js
@@ -8,6 +8,7 @@ const assert = require('assert')
 const sinon = require('sinon')
 const mockery = require('mockery')
 const siteUtil = require('../../../../../js/state/siteUtil')
+const {STATE_SITES} = require('../../../../../js/constants/stateConstants')
 
 let getStateValue
 
@@ -155,7 +156,7 @@ describe('topSites api', function () {
     it('respects position of pinned items when populating results', function () {
       const allPinned = Immutable.fromJS([site1, site4])
       const stateWithPinnedSites = defaultAppState
-        .set('historySites', generateMap(site1, site2, site3, site4))
+        .set(STATE_SITES.HISTORY_SITES, generateMap(site1, site2, site3, site4))
         .setIn(['about', 'newtab', 'pinnedTopSites'], allPinned)
       this.topSites.calculateTopSites(stateWithPinnedSites)
       // checks:
@@ -188,7 +189,7 @@ describe('topSites api', function () {
     })
 
     it('only includes one result for a domain (the one with the highest count)', function () {
-      const stateWithDuplicateDomains = defaultAppState.set('historySites', generateMap(
+      const stateWithDuplicateDomains = defaultAppState.set(STATE_SITES.HISTORY_SITES, generateMap(
         site1.set('location', 'https://example1.com/test').set('count', 12),
         site1.set('location', 'https://example1.com/about').set('count', 7)))
       this.topSites.calculateTopSites(stateWithDuplicateDomains)
@@ -211,7 +212,7 @@ describe('topSites api', function () {
 
     describe('when fetching unpinned results', function () {
       it('sorts results by `count` DESC', function () {
-        const stateWithSites = defaultAppState.set('historySites', generateMap(site1, site2, site3, site4))
+        const stateWithSites = defaultAppState.set(STATE_SITES.HISTORY_SITES, generateMap(site1, site2, site3, site4))
         this.topSites.calculateTopSites(stateWithSites)
         getStateValue = stateWithSites
         this.clock.tick(calculateTopSitesClockTime)
@@ -256,7 +257,7 @@ describe('topSites api', function () {
       })
 
       it('sorts results by `lastAccessedTime` DESC if `count` is the same', function () {
-        const stateWithSites = defaultAppState.set('historySites', generateMap(site1, site3, site5))
+        const stateWithSites = defaultAppState.set(STATE_SITES.HISTORY_SITES, generateMap(site1, site3, site5))
         this.topSites.calculateTopSites(stateWithSites)
         getStateValue = stateWithSites
         this.clock.tick(calculateTopSitesClockTime)
@@ -304,7 +305,7 @@ describe('topSites api', function () {
               .set('bookmarked', false)
           )
         }
-        const stateWithTooManySites = defaultAppState.set('historySites', tooManySites)
+        const stateWithTooManySites = defaultAppState.set(STATE_SITES.HISTORY_SITES, tooManySites)
         this.topSites.calculateTopSites(stateWithTooManySites)
 
         getStateValue = stateWithTooManySites
@@ -318,7 +319,7 @@ describe('topSites api', function () {
       it('does not include items marked as ignored', function () {
         const ignoredSites = Immutable.List().push('https://example1.com/|0|0').push('https://example3.com/|0|0')
         const stateWithIgnoredSites = defaultAppState
-          .set('historySites', generateMap(site1, site2, site3, site4))
+          .set(STATE_SITES.HISTORY_SITES, generateMap(site1, site2, site3, site4))
           .setIn(['about', 'newtab', 'ignoredTopSites'], ignoredSites)
         this.topSites.calculateTopSites(stateWithIgnoredSites)
         getStateValue = stateWithIgnoredSites

--- a/test/unit/app/browser/reducers/bookmarkFoldersReducerTest.js
+++ b/test/unit/app/browser/reducers/bookmarkFoldersReducerTest.js
@@ -10,6 +10,7 @@ const sinon = require('sinon')
 
 const appConstants = require('../../../../../js/constants/appConstants')
 const siteTags = require('../../../../../js/constants/siteTags')
+const {STATE_SITES} = require('../../../../../js/constants/stateConstants')
 require('../../../braveUnit')
 
 describe('bookmarkFoldersReducer unit test', function () {
@@ -249,7 +250,7 @@ describe('bookmarkFoldersReducer unit test', function () {
         },
         editKey: '1'
       })
-      const expectedState = stateWithData.setIn(['bookmarkFolders', '1', 'title'], 'folder1 new')
+      const expectedState = stateWithData.setIn([STATE_SITES.BOOKMARK_FOLDERS, '1', 'title'], 'folder1 new')
       assert.equal(spy.calledOnce, true)
       assert.deepEqual(newState.toJS(), expectedState.toJS())
     })
@@ -326,7 +327,7 @@ describe('bookmarkFoldersReducer unit test', function () {
             type: siteTags.BOOKMARK_FOLDER
           }
         ]))
-        .deleteIn(['bookmarkFolders', '1'])
+        .deleteIn([STATE_SITES.BOOKMARK_FOLDERS, '1'])
       assert.equal(spy.calledOnce, true)
       assert.deepEqual(newState.toJS(), expectedState.toJS())
     })

--- a/test/unit/app/common/cache/bookmarkLocationCacheTest.js
+++ b/test/unit/app/common/cache/bookmarkLocationCacheTest.js
@@ -2,6 +2,7 @@
 
 const siteTags = require('../../../../../js/constants/siteTags')
 const siteCache = require('../../../../../app/common/cache/bookmarkLocationCache')
+const {STATE_SITES} = require('../../../../../js/constants/stateConstants')
 const siteUtil = require('../../../../../js/state/siteUtil')
 const assert = require('assert')
 const Immutable = require('immutable')
@@ -103,7 +104,7 @@ describe('bookmarkLocationCache unit test', function () {
         type: siteTags.BOOKMARK
       })
       const siteKey = siteUtil.getSiteKey(site)
-      let state = baseState.setIn(['bookmarks', siteKey], site)
+      let state = baseState.setIn([STATE_SITES.BOOKMARKS, siteKey], site)
       state = siteCache.generateCache(state)
 
       // Sanity

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -2,6 +2,7 @@
 
 const siteTags = require('../../../js/constants/siteTags')
 const siteUtil = require('../../../js/state/siteUtil')
+const {STATE_SITES} = require('../../../js/constants/stateConstants')
 const assert = require('assert')
 const Immutable = require('immutable')
 const bookmarkFoldersState = require('../../../app/common/state/bookmarkFoldersState')
@@ -117,32 +118,32 @@ describe('siteUtil', function () {
       let state = bookmarkFoldersState.addFolder(emptyState, folderMinFields)
       const folderMinFieldsWithId = folderMinFields.set('folderId', 1)
       const processedKey = siteUtil.getSiteKey(folderMinFieldsWithId)
-      const folderId = state.getIn(['bookmarkFolders', processedKey, 'folderId'])
+      const folderId = state.getIn([STATE_SITES.BOOKMARK_FOLDERS, processedKey, 'folderId'])
       // Add a bookmark into that folder
       state = bookmarksStaate.addBookmark(state, bookmarkAllFields.set('parentFolderId', folderId))
-      const bookmarkFolder = state.getIn(['bookmarkFolders', processedKey])
+      const bookmarkFolder = state.getIn([STATE_SITES.BOOKMARK_FOLDERS, processedKey])
       // Should NOT be able to move bookmark folder into itself
-      assert.equal(false, siteUtil.isMoveAllowed(state.get('bookmarkFolders'), bookmarkFolder, bookmarkFolder))
+      assert.equal(false, siteUtil.isMoveAllowed(state.get(STATE_SITES.BOOKMARK_FOLDERS), bookmarkFolder, bookmarkFolder))
     })
     it('does not allow you to move an ancestor folder into a descendant folder', function () {
       // Add a new bookmark folder
       let state = bookmarkFoldersState.addFolder(emptyState, folderMinFields)
       const folderMinFieldsWithId1 = folderMinFields.set('folderId', 1)
       const processedKey1 = siteUtil.getSiteKey(folderMinFieldsWithId1)
-      const folderId1 = state.getIn(['bookmarkFolders', processedKey1, 'folderId'])
+      const folderId1 = state.getIn([STATE_SITES.BOOKMARK_FOLDERS, processedKey1, 'folderId'])
       // Add a child below that folder
       state = bookmarkFoldersState.addFolder(state, folderMinFields.set('parentFolderId', folderId1))
       const folderMinFieldsWithId2 = folderMinFields.set('folderId', 2)
       const processedKey2 = siteUtil.getSiteKey(folderMinFieldsWithId2)
-      const folderId2 = state.getIn(['bookmarkFolders', processedKey2, 'folderId'])
+      const folderId2 = state.getIn([STATE_SITES.BOOKMARK_FOLDERS, processedKey2, 'folderId'])
       // Add a folder below the previous child
       state = bookmarkFoldersState.addFolder(state, folderMinFields.set('parentFolderId', folderId2))
       const folderMinFieldsWithId3 = folderMinFields.set('folderId', 3)
       const processedKey3 = siteUtil.getSiteKey(folderMinFieldsWithId3)
-      const bookmarkFolder1 = state.getIn(['bookmarkFolders', processedKey1])
-      const bookmarkFolder3 = state.getIn(['bookmarkFolders', processedKey3])
+      const bookmarkFolder1 = state.getIn([STATE_SITES.BOOKMARK_FOLDERS, processedKey1])
+      const bookmarkFolder3 = state.getIn([STATE_SITES.BOOKMARK_FOLDERS, processedKey3])
       // Should NOT be able to move grandparent folder into its grandchild
-      assert.equal(false, siteUtil.isMoveAllowed(state.get('bookmarkFolders'), bookmarkFolder1, bookmarkFolder3))
+      assert.equal(false, siteUtil.isMoveAllowed(state.get(STATE_SITES.BOOKMARK_FOLDERS), bookmarkFolder1, bookmarkFolder3))
     })
   })
 

--- a/test/unit/state/syncUtilTest.js
+++ b/test/unit/state/syncUtilTest.js
@@ -143,10 +143,10 @@ describe.skip('syncUtil', () => {
   describe('getExistingObject', function () {
   })
 
-  describe('createSiteCache', function () {
+  describe('createObjectCache', function () {
   })
 
-  describe('updateSiteCache', function () {
+  describe('updateObjectCache', function () {
   })
 
   describe('now', function () {


### PR DESCRIPTION
See also: #10136 (sites refactor)

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
0. Prepare a user profile with 1k+ bookmarks for Pyramid 0.
1. Start Pyramid 0 and enable Sync.
2. Start Pyramid 1 and join the Sync profile.
3. Wait for syncing to complete. To confirm, you can check both pyramids's consoles for "got 0 bookmarks".
4. Export bookmarks from both pyramids and compare with https://github.com/brave/browser-laptop/pull/10166 – they should be identical.

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


