### PR TITLE
Autoplay refactoring

### DIFF
--- a/app/renderer/components/frame/frame.js
+++ b/app/renderer/components/frame/frame.js
@@ -779,6 +779,7 @@ class Frame extends React.Component {
       if (this.frame.isEmpty()) {
         return
       }
+      appActions.autoplayDismissed(this.props.tabId)
       windowActions.setAudioPlaybackActive(this.frame, true)
     })
     this.webview.addEventListener('media-paused', ({title}) => {

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -1293,6 +1293,17 @@ const appActions = {
   },
 
   /**
+   * Notifies autoplay notification can be dismissed
+   * @param {number} tabId - Tab id of current frame
+   */
+  autoplayDismissed: function (tabId) {
+    dispatch({
+      actionType: appConstants.APP_AUTOPLAY_DISMISSED,
+      tabId
+    })
+  },
+
+  /**
    * Handle 'save-password' event from muon
    */
   savePassword: function (username, origin, tabId) {

--- a/js/constants/appConstants.js
+++ b/js/constants/appConstants.js
@@ -125,6 +125,7 @@ const appConstants = {
   APP_ON_GO_BACK_LONG: _,
   APP_ON_GO_FORWARD_LONG: _,
   APP_AUTOPLAY_BLOCKED: _,
+  APP_AUTOPLAY_DISMISSED: _,
   APP_SAVE_PASSWORD: _,
   APP_UPDATE_PASSWORD: _,
   APP_ADD_PASSWORD: _, /** @param {Object} passwordDetail */

--- a/js/state/contentSettings.js
+++ b/js/state/contentSettings.js
@@ -17,6 +17,7 @@ const urlParse = require('../../app/common/urlParse')
 const siteSettings = require('./siteSettings')
 const {registerUserPrefs} = require('./userPrefs')
 const {getSetting} = require('../settings')
+const {autoplayOption} = require('../../app/common/constants/settingsEnums')
 const {getFlashResourceId} = require('../flash')
 const net = require('net')
 
@@ -70,7 +71,7 @@ const getDefaultUserPrefContentSettings = (braveryDefaults, appSettings, appConf
   braveryDefaults = makeImmutable(braveryDefaults)
   return Immutable.fromJS({
     autoplay: [{
-      setting: 'block',
+      setting: getSetting(settings.AUTOPLAY_MEDIA) === autoplayOption.ALWAYS_ALLOW ? 'allow' : 'block',
       primaryPattern: '*'
     }],
     cookies: getDefault3rdPartyStorageSettings(braveryDefaults, appSettings, appConfig),

--- a/test/bravery-components/notificationBarTest.js
+++ b/test/bravery-components/notificationBarTest.js
@@ -285,211 +285,379 @@ describe('Autoplay test', function () {
     yield setup(this.app.client)
   })
 
-  it('default always ask and block', function * () {
-    const url = Brave.server.url('autoplay.html')
-    yield this.app.client
-      .tabByIndex(0)
-      .loadUrl(url)
-      .waitUntil(function () {
-        return this.getText('div[id="status"]')
-          .then((status) => {
-            return status === ''
-          })
-      })
-      .windowByUrl(Brave.browserWindowUrl)
-      .waitForExist(notificationBar)
-      .waitUntil(function () {
-        return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
-      })
+  describe('autoplay', function () {
+    it('default always ask and block', function * () {
+      const url = Brave.server.url('autoplay.html')
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === ''
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist(notificationBar)
+        .waitUntil(function () {
+          return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
+        })
+    })
+
+    it('always allow', function * () {
+      const url = Brave.server.url('autoplay.html')
+      yield this.app.client
+        .changeSetting('security.autoplay.media', autoplayOption.ALWAYS_ALLOW)
+        .tabByIndex(0)
+        .loadUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === 'Autoplay playing'
+            })
+        })
+    })
+
+    it('allow autoplay once', function * () {
+      const url = Brave.server.url('autoplay.html')
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === ''
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist(notificationBar)
+        .waitUntil(function () {
+          return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
+        })
+        .click('button=Yes')
+        .tabByUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === 'Autoplay playing'
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .activateURLMode()
+        .click(reloadButton)
+        .waitForExist(notificationBar)
+        .waitUntil(function () {
+          return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
+        })
+    })
+
+    it('allow autoplay and remember', function * () {
+      const url = Brave.server.url('autoplay.html')
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === ''
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist(notificationBar)
+        .waitUntil(function () {
+          return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
+        })
+        .click('[data-l10n-id=rememberDecision]')
+        .click('button=Yes')
+        .tabByUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === 'Autoplay playing'
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .activateURLMode()
+        .click(reloadButton)
+        .tabByUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === 'Autoplay playing'
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .newTab({ url })
+        .waitForTabCount(2)
+        .waitForUrl(url)
+        .tabByUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === 'Autoplay playing'
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .closeTabByIndex(0)
+        .activateURLMode()
+        .click(reloadButton)
+        .tabByUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === 'Autoplay playing'
+            })
+        })
+    })
+
+    it('keep blocking autoplay', function * () {
+      const url = Brave.server.url('autoplay.html')
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === ''
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist(notificationBar)
+        .waitUntil(function () {
+          return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
+        })
+        .click('button=No')
+        .windowByUrl(Brave.browserWindowUrl)
+        .activateURLMode()
+        .click(reloadButton)
+        .tabByUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === ''
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist(notificationBar)
+    })
+
+    it('keep blocking autoplay and remember', function * () {
+      const url = Brave.server.url('autoplay.html')
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === ''
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist(notificationBar)
+        .waitUntil(function () {
+          return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
+        })
+        .click('[data-l10n-id=rememberDecision]')
+        .click('button=No')
+        .windowByUrl(Brave.browserWindowUrl)
+        .click(reloadButton)
+        .tabByUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === ''
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForElementCount('.notificationItem', 0)
+    })
   })
 
-  it('always allow', function * () {
-    const url = Brave.server.url('autoplay.html')
-    yield this.app.client
-      .changeSetting('security.autoplay.media', autoplayOption.ALWAYS_ALLOW)
-      .tabByIndex(0)
-      .loadUrl(url)
-      .waitUntil(function () {
-        return this.getText('div[id="status"]')
-          .then((status) => {
-            return status === 'Autoplay playing'
-          })
-      })
-  })
+  describe('auto-click-play', function () {
+    it('default always ask and block', function * () {
+      const url = Brave.server.url('auto-click-play.html')
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === ''
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist(notificationBar)
+        .waitUntil(function () {
+          return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
+        })
+    })
 
-  it('allow autoplay until tab closed', function * () {
-    const url = Brave.server.url('autoplay.html')
-    yield this.app.client
-      .tabByIndex(0)
-      .loadUrl(url)
-      .waitUntil(function () {
-        return this.getText('div[id="status"]')
-          .then((status) => {
-            return status === ''
-          })
-      })
-      .windowByUrl(Brave.browserWindowUrl)
-      .waitForExist(notificationBar)
-      .waitUntil(function () {
-        return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
-      })
-      .click('button=Yes')
-      .tabByUrl(url)
-      .waitUntil(function () {
-        return this.getText('div[id="status"]')
-          .then((status) => {
-            return status === 'Autoplay playing'
-          })
-      })
-      .windowByUrl(Brave.browserWindowUrl)
-      .activateURLMode()
-      .click(reloadButton)
-      .tabByUrl(url)
-      .waitUntil(function () {
-        return this.getText('div[id="status"]')
-          .then((status) => {
-            return status === 'Autoplay playing'
-          })
-      })
-      .windowByUrl(Brave.browserWindowUrl)
-      .newTab({ url })
-      .waitForTabCount(2)
-      .waitForUrl(url)
-      .tabByUrl(url)
-      .waitUntil(function () {
-        return this.getText('div[id="status"]')
-          .then((status) => {
-            return status === 'Autoplay playing'
-          })
-      })
-      .windowByUrl(Brave.browserWindowUrl)
-      .closeTabByIndex(0)
-      .activateURLMode()
-      .click(reloadButton)
-      .waitForExist(notificationBar)
-      .waitUntil(function () {
-        return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
-      })
-  })
+    it('always allow', function * () {
+      const url = Brave.server.url('auto-click-play.html')
+      yield this.app.client
+        .changeSetting('security.autoplay.media', autoplayOption.ALWAYS_ALLOW)
+        .tabByIndex(0)
+        .loadUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === 'Autoplay playing'
+            })
+        })
+    })
 
-  it('allow autoplay and remember', function * () {
-    const url = Brave.server.url('autoplay.html')
-    yield this.app.client
-      .tabByIndex(0)
-      .loadUrl(url)
-      .waitUntil(function () {
-        return this.getText('div[id="status"]')
-          .then((status) => {
-            return status === ''
-          })
-      })
-      .windowByUrl(Brave.browserWindowUrl)
-      .waitForExist(notificationBar)
-      .waitUntil(function () {
-        return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
-      })
-      .click('[data-l10n-id=rememberDecision]')
-      .click('button=Yes')
-      .tabByUrl(url)
-      .waitUntil(function () {
-        return this.getText('div[id="status"]')
-          .then((status) => {
-            return status === 'Autoplay playing'
-          })
-      })
-      .windowByUrl(Brave.browserWindowUrl)
-      .activateURLMode()
-      .click(reloadButton)
-      .tabByUrl(url)
-      .waitUntil(function () {
-        return this.getText('div[id="status"]')
-          .then((status) => {
-            return status === 'Autoplay playing'
-          })
-      })
-      .windowByUrl(Brave.browserWindowUrl)
-      .newTab({ url })
-      .waitForTabCount(2)
-      .waitForUrl(url)
-      .tabByUrl(url)
-      .waitUntil(function () {
-        return this.getText('div[id="status"]')
-          .then((status) => {
-            return status === 'Autoplay playing'
-          })
-      })
-      .windowByUrl(Brave.browserWindowUrl)
-      .closeTabByIndex(0)
-      .activateURLMode()
-      .click(reloadButton)
-      .tabByUrl(url)
-      .waitUntil(function () {
-        return this.getText('div[id="status"]')
-          .then((status) => {
-            return status === 'Autoplay playing'
-          })
-      })
-  })
+    it('allow autoplay once', function * () {
+      const url = Brave.server.url('auto-click-play.html')
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === ''
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist(notificationBar)
+        .waitUntil(function () {
+          return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
+        })
+        .click('button=Yes')
+        .tabByUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === 'Autoplay playing'
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .activateURLMode()
+        .click(reloadButton)
+        .waitForExist(notificationBar)
+        .waitUntil(function () {
+          return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
+        })
+    })
 
-  it('keep blocking autoplay', function * () {
-    const url = Brave.server.url('autoplay.html')
-    yield this.app.client
-      .tabByIndex(0)
-      .loadUrl(url)
-      .waitUntil(function () {
-        return this.getText('div[id="status"]')
-          .then((status) => {
-            return status === ''
-          })
-      })
-      .windowByUrl(Brave.browserWindowUrl)
-      .waitForExist(notificationBar)
-      .waitUntil(function () {
-        return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
-      })
-      .click('button=No')
-      .windowByUrl(Brave.browserWindowUrl)
-      .activateURLMode()
-      .click(reloadButton)
-      .tabByUrl(url)
-      .waitUntil(function () {
-        return this.getText('div[id="status"]')
-          .then((status) => {
-            return status === ''
-          })
-      })
-      .windowByUrl(Brave.browserWindowUrl)
-      .waitForExist(notificationBar)
-  })
+    it('allow autoplay and remember', function * () {
+      const url = Brave.server.url('auto-click-play.html')
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === ''
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist(notificationBar)
+        .waitUntil(function () {
+          return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
+        })
+        .click('[data-l10n-id=rememberDecision]')
+        .click('button=Yes')
+        .tabByUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === 'Autoplay playing'
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .activateURLMode()
+        .click(reloadButton)
+        .tabByUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === 'Autoplay playing'
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .newTab({ url })
+        .waitForTabCount(2)
+        .waitForUrl(url)
+        .tabByUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === 'Autoplay playing'
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .closeTabByIndex(0)
+        .activateURLMode()
+        .click(reloadButton)
+        .tabByUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === 'Autoplay playing'
+            })
+        })
+    })
 
-  it('keep blocking autoplay and remember', function * () {
-    const url = Brave.server.url('autoplay.html')
-    yield this.app.client
-      .tabByIndex(0)
-      .loadUrl(url)
-      .waitUntil(function () {
-        return this.getText('div[id="status"]')
-          .then((status) => {
-            return status === ''
-          })
-      })
-      .windowByUrl(Brave.browserWindowUrl)
-      .waitForExist(notificationBar)
-      .waitUntil(function () {
-        return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
-      })
-      .click('[data-l10n-id=rememberDecision]')
-      .click('button=No')
-      .windowByUrl(Brave.browserWindowUrl)
-      .click(reloadButton)
-      .tabByUrl(url)
-      .waitUntil(function () {
-        return this.getText('div[id="status"]')
-          .then((status) => {
-            return status === ''
-          })
-      })
-      .windowByUrl(Brave.browserWindowUrl)
-      .waitForElementCount('.notificationItem', 0)
+    it('keep blocking autoplay', function * () {
+      const url = Brave.server.url('auto-click-play.html')
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === ''
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist(notificationBar)
+        .waitUntil(function () {
+          return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
+        })
+        .click('button=No')
+        .windowByUrl(Brave.browserWindowUrl)
+        .activateURLMode()
+        .click(reloadButton)
+        .tabByUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === ''
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist(notificationBar)
+    })
+
+    it('keep blocking autoplay and remember', function * () {
+      const url = Brave.server.url('auto-click-play.html')
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === ''
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForExist(notificationBar)
+        .waitUntil(function () {
+          return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
+        })
+        .click('[data-l10n-id=rememberDecision]')
+        .click('button=No')
+        .windowByUrl(Brave.browserWindowUrl)
+        .click(reloadButton)
+        .tabByUrl(url)
+        .waitUntil(function () {
+          return this.getText('div[id="status"]')
+            .then((status) => {
+              return status === ''
+            })
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForElementCount('.notificationItem', 0)
+    })
   })
 })

--- a/test/fixtures/auto-click-play.html
+++ b/test/fixtures/auto-click-play.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Autoplay</title>
+  </head>
+  <body onload="autoplay()">
+
+    <video id="autoplay" width="320" height="240" controls onplay="playing()">
+      <source src="video/autoplay.mp4" type="video/mp4">
+    </video>
+
+    <div id='status'></div>
+
+    <script>
+      function playing () {
+        let status = document.getElementById('status')
+        status.textContent = 'Autoplay playing'
+      }
+    </script>
+
+  </body>
+  <script>
+    function autoplay () {
+      var video = document.getElementById("autoplay");
+      video.play()
+    }
+  </script>
+</html>

--- a/test/unit/app/browser/reducers/autoplayReducerTest.js
+++ b/test/unit/app/browser/reducers/autoplayReducerTest.js
@@ -1,0 +1,292 @@
+/* global describe, it, before, after */
+const mockery = require('mockery')
+const sinon = require('sinon')
+const Immutable = require('immutable')
+const assert = require('assert')
+const fakeElectron = require('../../../lib/fakeElectron')
+
+const appConstants = require('../../../../../js/constants/appConstants')
+const messages = require('../../../../../js/constants/messages')
+require('../../../braveUnit')
+
+describe('autoplayReducer unit tests', function () {
+  let autoplayReducer
+  let fakeWebContents, fakeAppActions, fakeLocale
+  let showNotificationSpy, hideNotificationSpy, translationSpy,
+    removeListenerSpy, changeSiteSettingSpy, removeSiteSettingSpy
+  const tabId = 123
+  const url = 'https://www.brave.com/niceplay'
+  const origin = 'https://www.brave.com'
+  const message = `Allow ${origin} to autoplay media?`
+  const showNotificationArg = {
+    buttons: [
+      {text: 'Yes'},
+      {text: 'No'}
+    ],
+    message,
+    frameOrigin: origin,
+    options: {
+      persist: true
+    }
+  }
+
+  before(function () {
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    })
+
+    fakeWebContents = {
+      isDestroyed: () => false,
+      reload: () => {},
+      on: (e, cb) => { cb(e) },
+      removeListener: (e, cb) => {},
+      getURL: () => {
+        return url
+      }
+    }
+
+    fakeAppActions = {
+      showNotification: (arg) => {},
+      hideNotification: (msg) => {},
+      changeSiteSetting: (hostPattern, key, value) => {},
+      removeSiteSetting: (hostPattern, key) => {}
+    }
+
+    fakeLocale = {
+      translation: (msg, arg) => {
+        let retMsg = ''
+        switch (msg) {
+          case 'yes':
+            retMsg += 'Yes'
+            break
+          case 'no':
+            retMsg += 'No'
+            break
+          case 'allowAutoplay':
+            retMsg += `Allow ${arg.origin} to autoplay media?`
+            break
+        }
+        return retMsg
+      }
+    }
+
+    fakeElectron.webContents = {
+      fromTabID: (tabId) => {
+        return fakeWebContents
+      }
+    }
+
+    showNotificationSpy = sinon.spy(fakeAppActions, 'showNotification')
+    hideNotificationSpy = sinon.spy(fakeAppActions, 'hideNotification')
+    translationSpy = sinon.spy(fakeLocale, 'translation')
+    removeListenerSpy = sinon.spy(fakeElectron.ipcMain, 'removeListener')
+    changeSiteSettingSpy = sinon.spy(fakeAppActions, 'changeSiteSetting')
+    removeSiteSettingSpy = sinon.spy(fakeAppActions, 'removeSiteSetting')
+
+    mockery.registerMock('electron', fakeElectron)
+    mockery.registerMock('../../../js/actions/appActions', fakeAppActions)
+    mockery.registerMock('../../locale', fakeLocale)
+
+    autoplayReducer = require('../../../../../app/browser/reducers/autoplayReducer')
+  })
+
+  after(function () {
+    showNotificationSpy.restore()
+    hideNotificationSpy.restore()
+    translationSpy.restore()
+    removeListenerSpy.restore()
+    changeSiteSettingSpy.restore()
+    removeSiteSettingSpy.restore()
+    mockery.deregisterAll()
+    mockery.disable()
+  })
+
+  describe('Allow autoplay once', function () {
+    before(function () {
+      autoplayReducer(Immutable.fromJS({
+        siteSettings: {}
+      }), Immutable.fromJS({
+        actionType: appConstants.APP_AUTOPLAY_BLOCKED,
+        tabId: tabId
+      }))
+      fakeElectron.ipcMain.send(messages.NOTIFICATION_RESPONSE, {}, message, 0, false)
+    })
+
+    it('calls local.translation', function () {
+      assert(translationSpy.withArgs('allowAutoplay', {origin}).called)
+      assert(translationSpy.withArgs('yes').called)
+      assert(translationSpy.withArgs('no').called)
+    })
+
+    it('calls appActions.showNotification', function () {
+      assert(showNotificationSpy.withArgs(showNotificationArg).called)
+    })
+
+    it('calls appActions.hideNotification', function () {
+      assert(hideNotificationSpy.withArgs(message).called)
+    })
+
+    it('calls appActions.changeSiteSetting', function () {
+      assert(changeSiteSettingSpy.withArgs(origin, 'autoplay', true).called)
+    })
+
+    it('calls appActions.removeSiteSetting', function () {
+      assert(removeSiteSettingSpy.withArgs(origin, 'autoplay').called)
+    })
+
+    it('calls ipcMain.removeListener', function () {
+      assert(removeListenerSpy.called)
+    })
+  })
+
+  describe('Allow autoplay and remember', function () {
+    before(function () {
+      autoplayReducer(Immutable.fromJS({
+        siteSettings: {}
+      }), Immutable.fromJS({
+        actionType: appConstants.APP_AUTOPLAY_BLOCKED,
+        tabId: tabId
+      }))
+      fakeElectron.ipcMain.send(messages.NOTIFICATION_RESPONSE, {}, message, 0, true)
+    })
+
+    it('calls local.translation', function () {
+      assert(translationSpy.withArgs('allowAutoplay', {origin}).called)
+      assert(translationSpy.withArgs('yes').called)
+      assert(translationSpy.withArgs('no').called)
+    })
+
+    it('calls appActions.showNotification', function () {
+      assert(showNotificationSpy.withArgs(showNotificationArg).called)
+    })
+
+    it('calls appActions.hideNotification', function () {
+      assert(hideNotificationSpy.withArgs(message).called)
+    })
+
+    it('calls appActions.changeSiteSetting', function () {
+      assert(changeSiteSettingSpy.withArgs(origin, 'autoplay', true).called)
+    })
+
+    it('calls ipcMain.removeListener', function () {
+      assert(removeListenerSpy.called)
+    })
+  })
+
+  describe('Deny autoplay once', function () {
+    before(function () {
+      autoplayReducer(Immutable.fromJS({
+        siteSettings: {}
+      }), Immutable.fromJS({
+        actionType: appConstants.APP_AUTOPLAY_BLOCKED,
+        tabId: tabId
+      }))
+      fakeElectron.ipcMain.send(messages.NOTIFICATION_RESPONSE, {}, message, 1, false)
+    })
+
+    it('calls local.translation', function () {
+      assert(translationSpy.withArgs('allowAutoplay', {origin}).called)
+      assert(translationSpy.withArgs('yes').called)
+      assert(translationSpy.withArgs('no').called)
+    })
+
+    it('calls appActions.showNotification', function () {
+      assert(showNotificationSpy.withArgs(showNotificationArg).called)
+    })
+
+    it('calls appActions.hideNotification', function () {
+      assert(hideNotificationSpy.withArgs(message).called)
+    })
+
+    it('calls ipcMain.removeListener', function () {
+      assert(removeListenerSpy.called)
+    })
+  })
+
+  describe('Deny autoplay and remember', function () {
+    before(function () {
+      autoplayReducer(Immutable.fromJS({
+        siteSettings: {}
+      }), Immutable.fromJS({
+        actionType: appConstants.APP_AUTOPLAY_BLOCKED,
+        tabId: tabId
+      }))
+      fakeElectron.ipcMain.send(messages.NOTIFICATION_RESPONSE, {}, message, 1, true)
+    })
+
+    it('calls local.translation', function () {
+      assert(translationSpy.withArgs('allowAutoplay', {origin}).called)
+      assert(translationSpy.withArgs('yes').called)
+      assert(translationSpy.withArgs('no').called)
+    })
+
+    it('calls appActions.showNotification', function () {
+      assert(showNotificationSpy.withArgs(showNotificationArg).called)
+    })
+
+    it('calls appActions.hideNotification', function () {
+      assert(hideNotificationSpy.withArgs(message).called)
+    })
+
+    it('calls appActions.changeSiteSetting', function () {
+      assert(changeSiteSettingSpy.withArgs(origin, 'autoplay', false).called)
+    })
+
+    it('calls ipcMain.removeListener', function () {
+      assert(removeListenerSpy.called)
+    })
+  })
+
+  describe('Calling with exsting deny rules', function () {
+    before(function () {
+      showNotificationSpy.reset()
+      autoplayReducer(Immutable.fromJS({
+        siteSettings: {
+          'https://www.brave.com': {
+            autoplay: false
+          }
+        }
+      }), Immutable.fromJS({
+        actionType: appConstants.APP_AUTOPLAY_BLOCKED,
+        tabId: tabId
+      }))
+      autoplayReducer(Immutable.Map(), Immutable.fromJS({
+        actionType: appConstants.APP_AUTOPLAY_DISMISSED,
+        tabId: tabId
+      }))
+
+      it('never calls appActions.showNotification', function () {
+        assert(showNotificationSpy.neverCalledWith(showNotificationArg))
+      })
+    })
+  })
+
+  describe('APP_AUTOPLAY_DISMISSED', function () {
+    before(function () {
+      autoplayReducer(Immutable.fromJS({
+        siteSettings: {}
+      }), Immutable.fromJS({
+        actionType: appConstants.APP_AUTOPLAY_BLOCKED,
+        tabId: tabId
+      }))
+      autoplayReducer(Immutable.Map(), Immutable.fromJS({
+        actionType: appConstants.APP_AUTOPLAY_DISMISSED,
+        tabId: tabId
+      }))
+    })
+
+    it('calls local.translation', function () {
+      assert(translationSpy.withArgs('allowAutoplay', {origin}).called)
+    })
+
+    it('calls appActions.hideNotification', function () {
+      assert(hideNotificationSpy.withArgs(message).called)
+    })
+
+    it('calls ipcMain.removeListener', function () {
+      assert(removeListenerSpy.called)
+    })
+  })
+})


### PR DESCRIPTION
fixes #9143 - Autoplay notification should be dismissed if user ignores notification and continues stream
fixes #9008 - Playing media on a site adds it to the autoplay site permission list (even when defaulted to "always allow")
fixes #9171 - Notification bar - buttons not responding

Auditors: @bsclifton, @bridiver, @cezaraugusto

## Test Plan:
(see top of each issue for steps to test)

## Automated test plan
Covered by automated tests (see travis-ci output)

Tests added by this PR:
`npm run test -- --grep="autoplay"`
`npm run unittest -- --grep="autoplayReducer unit tests"`


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).


## Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


