### PR TITLE
replace yes/no to allow/deny for notifcation bar

### DIFF
--- a/app/browser/reducers/autoplayReducer.js
+++ b/app/browser/reducers/autoplayReducer.js
@@ -31,8 +31,8 @@ const showAutoplayMessageBox = (state, tabId) => {
 
   appActions.showNotification({
     buttons: [
-      {text: locale.translation('yes')},
-      {text: locale.translation('no')}
+      {text: locale.translation('allow')},
+      {text: locale.translation('deny')}
     ],
     message,
     frameOrigin: origin,

--- a/app/browser/reducers/passwordManagerReducer.js
+++ b/app/browser/reducers/passwordManagerReducer.js
@@ -102,8 +102,8 @@ const savePassword = (username, origin, tabId) => {
     // Notification not shown already
     appActions.showNotification({
       buttons: [
-        {text: locale.translation('yes')},
-        {text: locale.translation('no')},
+        {text: locale.translation('allow')},
+        {text: locale.translation('deny')},
         {text: locale.translation('neverForThisSite')}
       ],
       options: {
@@ -149,8 +149,8 @@ const updatePassword = (username, origin, tabId) => {
     // Notification not shown already
     appActions.showNotification({
       buttons: [
-        {text: locale.translation('yes')},
-        {text: locale.translation('no')}
+        {text: locale.translation('allow')},
+        {text: locale.translation('deny')}
       ],
       options: {
         persist: false,

--- a/app/index.js
+++ b/app/index.js
@@ -226,8 +226,8 @@ app.on('ready', () => {
       } else {
         appActions.showNotification({
           buttons: [
-            {text: locale.translation('yes')},
-            {text: locale.translation('no')}
+            {text: locale.translation('allow')},
+            {text: locale.translation('deny')}
           ],
           options: {
             persist: false

--- a/js/about/styles.js
+++ b/js/about/styles.js
@@ -294,8 +294,8 @@ class AboutStyle extends ImmutableComponent {
         <BrowserButton groupedItem secondaryColor notificationItem l10nId='notificationItem' onClick={this.onEnableAutoplay} />
         <BrowserButton groupedItem secondaryColor notificationItem l10nId='notificationItem' onClick={this.onEnableAutoplay} />
         <Pre><Code>
-          &lt;BrowserButton groupedItem secondaryColor notificationItem l10nId='Yes' onClick={'{this.onEnableAutoplay}'} />{'\n'}
-          &lt;BrowserButton groupedItem secondaryColor notificationItem l10nId='No' onClick={'{this.onEnableAutoplay}'} />
+          &lt;BrowserButton groupedItem secondaryColor notificationItem l10nId='Allow' onClick={'{this.onEnableAutoplay}'} />{'\n'}
+          &lt;BrowserButton groupedItem secondaryColor notificationItem l10nId='Deny' onClick={'{this.onEnableAutoplay}'} />
         </Code></Pre>
 
         <BrowserButton iconOnly iconClass={globalStyles.appIcons.moreInfo} size='30px' color='rebeccapurple' />

--- a/test/bravery-components/notificationBarTest.js
+++ b/test/bravery-components/notificationBarTest.js
@@ -126,7 +126,7 @@ describe('notificationBar passwords', function () {
         return this.getText(notificationBar).then((val) => {
           return val.includes('brave') && val.includes('brave_user')
         })
-      }).click('button=No')
+      }).click('button=Deny')
   })
 
   it('does not include a password in the notification bar', function * () {
@@ -144,7 +144,7 @@ describe('notificationBar passwords', function () {
         return this.getText(notificationBar).then((val) => {
           return val.includes('your password') && !val.includes('secret')
         })
-      }).click('button=No')
+      }).click('button=Deny')
   })
 
   it('autofills remembered password on login form', function * () {
@@ -159,7 +159,7 @@ describe('notificationBar passwords', function () {
       .waitForExist(notificationBar)
       .waitUntil(function () {
         return this.getText(notificationBar).then((val) => val.includes('brave') && val.includes('brave_user'))
-      }).click('button=Yes')
+      }).click('button=Allow')
       .tabByIndex(0)
       .loadUrl('about:passwords')
       .waitForExist('[data-test-id="passwordItem"]')
@@ -189,7 +189,7 @@ describe('notificationBar passwords', function () {
       .waitForExist(notificationBar)
       .waitUntil(function () {
         return this.getText(notificationBar).then((val) => val.includes('brave') && val.includes('brave_user'))
-      }).click('button=Yes')
+      }).click('button=Allow')
       .tabByIndex(0)
       .loadUrl('about:passwords')
       .waitForExist('[data-test-id="passwordItem"]')
@@ -206,7 +206,7 @@ describe('notificationBar passwords', function () {
       .waitForExist(notificationBar)
       .waitUntil(function () {
         return this.getText(notificationBar).then((val) => val.includes('brave') && val.includes('brave_user') && val.includes('update'))
-      }).click('button=Yes')
+      }).click('button=Allow')
       .tabByIndex(0)
       .url(this.loginUrl1)
       .waitForExist('#acctmgr_loginform')
@@ -334,7 +334,7 @@ describe('Autoplay test', function () {
         .waitUntil(function () {
           return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
         })
-        .click('button=Yes')
+        .click('button=Allow')
         .tabByUrl(url)
         .waitUntil(function () {
           return this.getText('div[id="status"]')
@@ -368,7 +368,7 @@ describe('Autoplay test', function () {
           return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
         })
         .click('[data-l10n-id=rememberDecision]')
-        .click('button=Yes')
+        .click('button=Allow')
         .tabByUrl(url)
         .waitUntil(function () {
           return this.getText('div[id="status"]')
@@ -426,7 +426,7 @@ describe('Autoplay test', function () {
         .waitUntil(function () {
           return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
         })
-        .click('button=No')
+        .click('button=Deny')
         .windowByUrl(Brave.browserWindowUrl)
         .activateURLMode()
         .click(reloadButton)
@@ -458,7 +458,7 @@ describe('Autoplay test', function () {
           return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
         })
         .click('[data-l10n-id=rememberDecision]')
-        .click('button=No')
+        .click('button=Deny')
         .windowByUrl(Brave.browserWindowUrl)
         .click(reloadButton)
         .tabByUrl(url)
@@ -522,7 +522,7 @@ describe('Autoplay test', function () {
         .waitUntil(function () {
           return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
         })
-        .click('button=Yes')
+        .click('button=Allow')
         .tabByUrl(url)
         .waitUntil(function () {
           return this.getText('div[id="status"]')
@@ -556,7 +556,7 @@ describe('Autoplay test', function () {
           return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
         })
         .click('[data-l10n-id=rememberDecision]')
-        .click('button=Yes')
+        .click('button=Allow')
         .tabByUrl(url)
         .waitUntil(function () {
           return this.getText('div[id="status"]')
@@ -614,7 +614,7 @@ describe('Autoplay test', function () {
         .waitUntil(function () {
           return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
         })
-        .click('button=No')
+        .click('button=Deny')
         .windowByUrl(Brave.browserWindowUrl)
         .activateURLMode()
         .click(reloadButton)
@@ -646,7 +646,7 @@ describe('Autoplay test', function () {
           return this.getText(notificationBar).then((val) => val.includes('autoplay media'))
         })
         .click('[data-l10n-id=rememberDecision]')
-        .click('button=No')
+        .click('button=Deny')
         .windowByUrl(Brave.browserWindowUrl)
         .click(reloadButton)
         .tabByUrl(url)

--- a/test/unit/app/browser/reducers/autoplayReducerTest.js
+++ b/test/unit/app/browser/reducers/autoplayReducerTest.js
@@ -20,8 +20,8 @@ describe('autoplayReducer unit tests', function () {
   const message = `Allow ${origin} to autoplay media?`
   const showNotificationArg = {
     buttons: [
-      {text: 'Yes'},
-      {text: 'No'}
+      {text: 'Allow'},
+      {text: 'Deny'}
     ],
     message,
     frameOrigin: origin,
@@ -58,11 +58,11 @@ describe('autoplayReducer unit tests', function () {
       translation: (msg, arg) => {
         let retMsg = ''
         switch (msg) {
-          case 'yes':
-            retMsg += 'Yes'
+          case 'allow':
+            retMsg += 'Allow'
             break
-          case 'no':
-            retMsg += 'No'
+          case 'deny':
+            retMsg += 'Deny'
             break
           case 'allowAutoplay':
             retMsg += `Allow ${arg.origin} to autoplay media?`
@@ -116,8 +116,8 @@ describe('autoplayReducer unit tests', function () {
 
     it('calls local.translation', function () {
       assert(translationSpy.withArgs('allowAutoplay', {origin}).called)
-      assert(translationSpy.withArgs('yes').called)
-      assert(translationSpy.withArgs('no').called)
+      assert(translationSpy.withArgs('allow').called)
+      assert(translationSpy.withArgs('deny').called)
     })
 
     it('calls appActions.showNotification', function () {
@@ -154,8 +154,8 @@ describe('autoplayReducer unit tests', function () {
 
     it('calls local.translation', function () {
       assert(translationSpy.withArgs('allowAutoplay', {origin}).called)
-      assert(translationSpy.withArgs('yes').called)
-      assert(translationSpy.withArgs('no').called)
+      assert(translationSpy.withArgs('allow').called)
+      assert(translationSpy.withArgs('deny').called)
     })
 
     it('calls appActions.showNotification', function () {
@@ -188,8 +188,8 @@ describe('autoplayReducer unit tests', function () {
 
     it('calls local.translation', function () {
       assert(translationSpy.withArgs('allowAutoplay', {origin}).called)
-      assert(translationSpy.withArgs('yes').called)
-      assert(translationSpy.withArgs('no').called)
+      assert(translationSpy.withArgs('allow').called)
+      assert(translationSpy.withArgs('deny').called)
     })
 
     it('calls appActions.showNotification', function () {
@@ -218,8 +218,8 @@ describe('autoplayReducer unit tests', function () {
 
     it('calls local.translation', function () {
       assert(translationSpy.withArgs('allowAutoplay', {origin}).called)
-      assert(translationSpy.withArgs('yes').called)
-      assert(translationSpy.withArgs('no').called)
+      assert(translationSpy.withArgs('allow').called)
+      assert(translationSpy.withArgs('deny').called)
     })
 
     it('calls appActions.showNotification', function () {


### PR DESCRIPTION
<hr>

### dear reviewer, do not land before #10178. thanks!

<hr>

/cc @bradleyrichter pls see screenshots below. maybe we want to change strings for some questions too?

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Auditors: @luixxiul, @srirambv
close #9750

Test Plan:

notifications bar test should pass

```
npm run test -- --grep="notificationBar permissions"
```

### Autoplay:
got to prefs->security and set autoplay to "always ask"
go to https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_video_autoplay
<img width="1277" alt="screen shot 2017-07-27 at 3 23 33 pm" src="https://user-images.githubusercontent.com/4672033/28695203-32ced58c-7304-11e7-953e-32ceb0a62be4.png">


### Restart:
go to  prefs->general and try to switch languages.

<img width="1280" alt="screen shot 2017-07-27 at 3 14 43 pm" src="https://user-images.githubusercontent.com/4672033/28695207-3b479168-7304-11e7-8303-2c34d1bbf49f.png">

### Autofill:
go to prefs->security and set pw manager to _built-in_
go to any page that you have to write things so Brave can ask to save that for you
<img width="1280" alt="screen shot 2017-07-27 at 3 13 33 pm" src="https://user-images.githubusercontent.com/4672033/28695221-4947ebbe-7304-11e7-886b-7fabe391b841.png">

Reviewer Checklist:

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


