### PR TITLE
Update file-loader to 0.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "electron-localshortcut": "^0.6.0",
     "electron-squirrel-startup": "brave/electron-squirrel-startup",
     "emoji-regex": "^6.5.1",
-    "file-loader": "^0.8.5",
+    "file-loader": "0.11.2",
     "font-awesome": "^4.5.0",
     "font-awesome-webpack": "0.0.4",
     "fs-extra": "^2.1.2",


### PR DESCRIPTION
Closes #10203

Test Plan:
1. `rm -rf node_modules && rm -rf ~/.electron && npm i`
2. `npm run watch`
3. `npm start`
4. Make sure the images are properly displayed on the browser

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


