### PR TITLE
Use a forked version of electron-installer for debian/redhat which pr…

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,8 +192,8 @@
     "xml2js": "^0.4.15"
   },
   "optionalDependencies": {
-    "electron-installer-debian": "^0.3.0",
-    "electron-installer-redhat": "^0.5.0"
+    "electron-installer-debian": "brave/electron-installer-debian",
+    "electron-installer-redhat": "brave/electron-installer-redhat"
   },
   "standard": {
     "global": [


### PR DESCRIPTION
…operly sets `Exec` line

Forking the repo isn't ideal- I'm going to try to upstream these changes too 😄 
See the following commits for the actual fix:
https://github.com/brave/electron-installer-redhat/commit/43c39174b3a78bec2724af50ddb601ae690e22df
https://github.com/brave/electron-installer-debian/commit/746d8a6d06865d075ebc8a1917b9e317f9fd6ea8

Fixes https://github.com/brave/browser-laptop/issues/9193

Auditors: @DivineOmega, @Aninstance

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Test Plan:
1. If there is no RPM/DEB available, run the following after cloning the repo on Linux:
```
npm install
CHANNEL=dev npm run build-package
CHANNEL=dev npm run build-installer
```
2. On a RedHat OS (ex: Fedora) install the RPM
  - Launch Brave and set it as the default browser
  - Setup ThunderBird (or another app)
  - Follow a link in email and confirm that it opens in a new tab in Brave

3. On a Debian OS (ex: Ubuntu) install the DEB package
  - Launch Brave and set it as the default browser
  - Setup ThunderBird (or another app)
  - Follow a link in email and confirm that it opens in a new tab in Brave

## Reviewer Checklist:

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header
