### PR TITLE
Locks webdiver version to 4.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "style-loader": "^0.13.0",
     "uglify-js-harmony": "^2.7.5",
     "uuid": "^3.0.1",
-    "webdriverio": "4.8.0",
+    "webdriverio": "4.7.1",
     "webpack": "^1.12.9",
     "webpack-dev-server": "^1.14.0",
     "webpack-notifier": "^1.2.1",


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Resolves #10072

Auditors: @bsclifton


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


