### PR TITLE
Update keytar from ^3.0.0 to 4.0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "7"
+  - "8"
 dist: trusty
 sudo: required
 group: edge

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "immutable": "^3.7.5",
     "immutablediff": "^0.4.2",
     "immutablepatch": "brave/immutable-js-patch",
-    "keytar": "^3.0.0",
+    "keytar": "4.0.4",
     "l20n": "^3.5.1",
     "ledger-balance": "^0.9.1",
     "ledger-client": "^0.9.18",


### PR DESCRIPTION
Closes #10226

Version `4.0.0` consists of commits on https://github.com/atom/node-keytar/pull/63, where `nan` was updated and `gnome-keyring` was replaced with `libsecret`.

`4.0.1` and `4.0.2` updated the documentation only.
`4.0.3` updated .gitignore and .npmignore.
`4.0.4` added support unicode account names on windows: https://github.com/atom/node-keytar/pull/66

For changelog from 4.0.0 to 4.0.4, see: https://github.com/atom/node-keytar/compare/v4.0.0...v4.0.4

Auditors: @diracdeltas

Test Plan: automated tests should pass

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


