### PR TITLE
Remove tooltips on minimize/maximize/close buttons in favor of an aria-label

### DIFF
--- a/app/renderer/components/navigation/windowCaptionButtons.js
+++ b/app/renderer/components/navigation/windowCaptionButtons.js
@@ -74,7 +74,7 @@ class WindowCaptionButtons extends ImmutableComponent {
             minimize: true
           })}
           onClick={this.onMinimizeClick}
-          title={locale.translation('windowCaptionButtonMinimize')}>
+          aria-label={locale.translation('windowCaptionButtonMinimize')}>
           <div className='widget' />
         </button>
         <button
@@ -86,7 +86,7 @@ class WindowCaptionButtons extends ImmutableComponent {
             maximize: true
           })}
           onClick={this.onMaximizeClick}
-          title={locale.translation(this.maximizeTitle)}>
+          aria-label={locale.translation(this.maximizeTitle)}>
           <div className='widget'>
             <div className='widget1' />
             <div className='widget2' />
@@ -102,7 +102,7 @@ class WindowCaptionButtons extends ImmutableComponent {
             close: true
           })}
           onClick={this.onCloseClick}
-          title={locale.translation('windowCaptionButtonClose')}>
+          aria-label={locale.translation('windowCaptionButtonClose')}>
           <div className='widget' />
         </button>
       </div>


### PR DESCRIPTION
Because the underlying issue is in Chromium, I put together a fix we can use until that is fixed. The fix is to simply remove the tooltip. Under the hood, there is still an aria-label in the case that a screenreader is looking for information

Fixes https://github.com/brave/browser-laptop/issues/8697

Auditors: @jonathansampson, @bradleyrichter

NOTE: this change goes against standard Windows behavior.
However, I did notice Firefox also doesn't show the tooltips on these buttons.

The root cause in our case (driving this commit) is captured here:
https://bugs.chromium.org/p/chromium/issues/detail?id=724538

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


