### PR TITLE
Remove deprecated UA spoofing code

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -189,7 +189,6 @@ AppStore
     'general.newtab-mode': string,  // one of: newTabPage, homePage, defaultSearchEngine
     'general.show-home-button': boolean, // true if the home button should be shown
     'general.startup-mode': string, // one of: lastTime, homePage, newTabPage
-    'general.useragent.value': (undefined|string), // custom user agent value
     'notification-add-funds-timestamp': number, // timestamp on which we decide if we will show notification Add founds
     'notification-reconcile-soon-timestamp': number, // timestamp
     'payments.contribution-amount': number, // in USD

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -129,7 +129,6 @@ module.exports = {
     'general.homepage': 'https://www.brave.com',
     'general.newtab-mode': 'newTabPage',
     'general.show-home-button': false,
-    'general.useragent.value': null, // Set at runtime
     'general.autohide-menu': true,
     'general.wide-url-bar': false,
     'general.check-default-on-startup': true,

--- a/js/data/siteHacks.js
+++ b/js/data/siteHacks.js
@@ -64,14 +64,6 @@ module.exports.siteHacks = {
       }
     }
   },
-  'cityam.com': {
-    onBeforeSendHeaders: function (details) {
-      details.requestHeaders['User-Agent'] = 'Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2228.0 Safari/537.36 Googlebot'
-      return {
-        requestHeaders: details.requestHeaders
-      }
-    }
-  },
   // For links like: https://player.twitch.tv/?channel=iwilldominate
   'player.twitch.tv': {
     enableForAll: true


### PR DESCRIPTION
It's no longer needed since Brave isn't in the UA by default since https://github.com/brave/muon/commit/84e85e7e84412ad14b0782e308e8a8831bd779a8.
fix https://github.com/brave/browser-laptop/issues/10252

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


