### PR TITLE
Optimizes fs-extra `require`.

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -11,7 +11,6 @@
 // - When all state is collected save it to a JSON file and close the app
 // - NODE_ENV of ‘test’ bypassing session state or else they all fail.
 
-const fs = require('fs-extra')
 const path = require('path')
 const electron = require('electron')
 const os = require('os')
@@ -705,7 +704,10 @@ module.exports.runImportDefaultSettings = (data) => {
  */
 module.exports.loadAppState = () => {
   return new Promise((resolve, reject) => {
+    const fs = require('fs')
+
     let data
+
     try {
       data = fs.readFileSync(getStoragePath())
     } catch (e) {}
@@ -768,6 +770,7 @@ module.exports.loadAppState = () => {
  * Called when session is suspected for corruption; this will move it out of the way
  */
 module.exports.backupSession = () => {
+  const fs = require('fs-extra')
   const src = getStoragePath()
   const dest = getTempStoragePath('backup')
 

--- a/test/unit/app/sessionStoreTest.js
+++ b/test/unit/app/sessionStoreTest.js
@@ -78,6 +78,7 @@ describe('sessionStore unit tests', function () {
       useCleanCache: true
     })
     mockery.registerMock('fs-extra', fakeFileSystem)
+    mockery.registerMock('fs', fakeFileSystem)
     mockery.registerMock('electron', fakeElectron)
     mockery.registerMock('./locale', fakeLocale)
     mockery.registerMock('./autofill', fakeAutofill)


### PR DESCRIPTION
To improve performance at load time, fs-extra, which
has been taking 40 ms to require, is loaded at the time
it’s needed, no sooner.

The fs-extra module was also referenced where fs can
do the job, so fs-extra has been replaced by fs in that
instance.

