### PR TITLE
Add rel='noopener' to all external links

### DIFF
--- a/app/renderer/components/preferences/payment/bitcoinDashboard.js
+++ b/app/renderer/components/preferences/payment/bitcoinDashboard.js
@@ -102,7 +102,8 @@ class BitcoinDashboard extends ImmutableComponent {
     }
     const hrefAttrs = {
       href: this.props.ledgerData.get('buyURL'),
-      target: '_blank'
+      target: '_blank',
+      rel: 'noopener'
     }
 
     if (disabled) {
@@ -193,7 +194,7 @@ class BitcoinDashboard extends ImmutableComponent {
           </div>
         </div>
         <div className={css(styles.panel__divider, styles.panel__divider_right)}>
-          <a target='_blank' href={url}>
+          <a target='_blank' rel='noopener' href={url}>
             <BrowserButton
               primaryColor
               panelItem
@@ -218,7 +219,7 @@ class BitcoinDashboard extends ImmutableComponent {
         </div>
       </div>
       <div className={css(styles.panel__divider, styles.panel__divider_right)}>
-        <a target='_blank' href='https://www.buybitcoinworldwide.com/'>
+        <a target='_blank' rel='noopener' href='https://www.buybitcoinworldwide.com/'>
           <BrowserButton
             primaryColor
             panelItem
@@ -254,7 +255,7 @@ class BitcoinDashboard extends ImmutableComponent {
             {
               ledgerData.get('hasBitcoinHandler') && ledgerData.get('paymentURL')
                 ? <div className={css(styles.panel__divider_right__bitcoinPanel__paymentURL)}>
-                  <a href={ledgerData.get('paymentURL')} target='_blank'>
+                  <a href={ledgerData.get('paymentURL')} rel='noopener' target='_blank'>
                     <BrowserButton
                       primaryColor
                       panelItem
@@ -324,14 +325,14 @@ class BitcoinDashboard extends ImmutableComponent {
     if (coinbaseCountries.indexOf(this.props.ledgerData.get('countryCode')) > -1) {
       return <section className={css(styles.modalOverlay__qrcodeOverlay__footerWrapper__footer)}>
         <div className={css(styles.coinbaseLogo)} />
-        <a target='_blank'
+        <a rel='noopener' target='_blank'
           className={css(
             styles.modalOverlay__qrcodeOverlay__footerWrapper__footer__qrcodeLogo,
             styles.modalOverlay__qrcodeOverlay__footerWrapper__footer__appstoreLogo
           )}
           href='https://itunes.apple.com/us/app/coinbase-bitcoin-wallet/id886427730?mt=8'
         />
-        <a target='_blank'
+        <a rel='noopener' target='_blank'
           className={css(
             styles.modalOverlay__qrcodeOverlay__footerWrapper__footer__qrcodeLogo,
             styles.modalOverlay__qrcodeOverlay__footerWrapper__footer__playstoreLogo

--- a/app/renderer/components/preferences/payment/disabledContent.js
+++ b/app/renderer/components/preferences/payment/disabledContent.js
@@ -30,18 +30,18 @@ class DisabledContent extends ImmutableComponent {
         <div className={css(styles.text)}data-l10n-id='paymentsWelcomeText5' />
         <div className={css(styles.text)}>
           <span data-l10n-id='paymentsWelcomeText6' />&nbsp;
-          <a className='linkText' href='https://brave.com/Payments_FAQ.html' target='_blank' data-l10n-id='paymentsWelcomeLink' />&nbsp;
+          <a className='linkText' href='https://brave.com/Payments_FAQ.html' rel='noopener' target='_blank' data-l10n-id='paymentsWelcomeLink' />&nbsp;
           <span data-l10n-id='paymentsWelcomeText7' />
         </div>
       </div>
       <div className={css(styles.paymentsSidebar)}>
         <h2 className={css(styles.sideH2)} data-l10n-id='paymentsSidebarText1' />
         <div className={css(styles.textSide)} data-l10n-id='paymentsSidebarText2' />
-        <a href='https://www.privateinternetaccess.com/' target='_blank'><span className={css(styles.paymentsSidebarPIA)} /></a>
+        <a href='https://www.privateinternetaccess.com/' rel='noopener' target='_blank'><span className={css(styles.paymentsSidebarPIA)} /></a>
         <div className={css(styles.textSide)} data-l10n-id='paymentsSidebarText3' />
-        <a href='https://www.bitgo.com/' target='_blank'><span className={css(styles.paymentsSidebarBitgo)} /></a>
+        <a href='https://www.bitgo.com/' rel='noopener' target='_blank'><span className={css(styles.paymentsSidebarBitgo)} /></a>
         <div className={css(styles.textSide)} data-l10n-id='paymentsSidebarText4' />
-        <a href='https://www.coinbase.com/' target='_blank'><span className={css(styles.paymentsSidebarCoinbase)} /></a>
+        <a href='https://www.coinbase.com/' rel='noopener' target='_blank'><span className={css(styles.paymentsSidebarCoinbase)} /></a>
       </div>
     </section>
   }

--- a/app/renderer/components/preferences/payment/history.js
+++ b/app/renderer/components/preferences/payment/history.js
@@ -88,7 +88,7 @@ class HistoryRow extends ImmutableComponent {
       <td className={css(styles.flexAlignCenter, styles.column, styles.leftRow, styles.column__narrow)} data-sort={this.timestamp}>{this.formattedDate}</td>
       <td className={css(styles.flexAlignCenter, styles.column, styles.column__amount, styles.column__narrow)} data-sort={this.satoshis}>{this.totalAmountStr}</td>
       <td className={css(styles.flexAlignCenter, styles.column, styles.column__wide)}>
-        <a href={`${aboutContributionsUrl}#${this.viewingId}`} target='_blank'>{this.receiptFileName}</a>
+        <a href={`${aboutContributionsUrl}#${this.viewingId}`} rel='noopener' target='_blank'>{this.receiptFileName}</a>
       </td>
     </tr>
   }

--- a/app/renderer/components/preferences/payment/ledgerTable.js
+++ b/app/renderer/components/preferences/payment/ledgerTable.js
@@ -164,7 +164,7 @@ class LedgerTable extends ImmutableComponent {
       },
       {
         html: <div>
-          <a className={css(styles.siteData)} href={publisherURL} target='_blank' tabIndex={-1}>
+          <a className={css(styles.siteData)} href={publisherURL} rel='noopener' target='_blank' tabIndex={-1}>
             {
               faviconURL
                 ? <img className={css(styles.favicon)} src={faviconURL} alt={site} />

--- a/app/renderer/components/preferences/syncTab.js
+++ b/app/renderer/components/preferences/syncTab.js
@@ -488,7 +488,7 @@ class SyncTab extends ImmutableComponent {
 
         <div className={css(styles.settingsListContainerMargin__bottom)}>
           <span className='settingsListTitle' data-l10n-id='syncTitleMessage' />
-          <a href='https://github.com/brave/sync/wiki/Design' target='_blank'>
+          <a href='https://github.com/brave/sync/wiki/Design' rel='noopener' target='_blank'>
             <span className={cx({
               fa: true,
               'fa-question-circle': true

--- a/js/about/brave.js
+++ b/js/about/brave.js
@@ -60,7 +60,7 @@ class AboutBrave extends React.Component {
         <div>
           <span data-l10n-id='relNotesInfo1' />
           &nbsp;
-          <a className='linkText' href={`https://github.com/brave/browser-laptop/releases/tag/v${this.state.versionInformation.get('Brave')}dev`} target='_blank' data-l10n-id='relNotesInfo2' />
+          <a className='linkText' href={`https://github.com/brave/browser-laptop/releases/tag/v${this.state.versionInformation.get('Brave')}dev`} rel='noopener' target='_blank' data-l10n-id='relNotesInfo2' />
           &nbsp;
           <span data-l10n-id='relNotesInfo3' />
         </div>
@@ -83,7 +83,7 @@ class AboutBrave extends React.Component {
             },
             {
               html: name === 'rev'
-                ? <a target='_blank' href={`https://github.com/brave/browser-laptop/commit/${version}`}>{(version && version.substring(0, 7)) || ''}</a>
+                ? <a rel='noopener' target='_blank' href={`https://github.com/brave/browser-laptop/commit/${version}`}>{(version && version.substring(0, 7)) || ''}</a>
                 : version,
               value: version
             }

--- a/js/about/newTabComponents/footerInfo.js
+++ b/js/about/newTabComponents/footerInfo.js
@@ -15,7 +15,7 @@ class FooterInfo extends ImmutableComponent {
           this.props.backgroundImage && this.props.backgroundImage.name
           ? <div>
             <div className='copyrightCredits'>
-              <span className='photoBy' data-l10n-id='photoBy' /> <a className='copyrightOwner' href={this.props.backgroundImage.link} target='_blank'>{this.props.backgroundImage.author}</a>
+              <span className='photoBy' data-l10n-id='photoBy' /> <a className='copyrightOwner' href={this.props.backgroundImage.link} rel='noopner' target='_blank'>{this.props.backgroundImage.author}</a>
             </div>
             <span className='photoName'>{this.props.backgroundImage.name}</span>
           </div>

--- a/js/webtorrent/components/torrentViewer.js
+++ b/js/webtorrent/components/torrentViewer.js
@@ -54,6 +54,7 @@ class TorrentViewer extends React.Component {
         })}
           data-l10n-id='poweredByWebTorrent'
           href='https://webtorrent.io'
+          rel='noopener'
           target='_blank'
         />
       )

--- a/js/webtorrent/entry.js
+++ b/js/webtorrent/entry.js
@@ -188,6 +188,7 @@ function saveTorrentFile () {
   const href = url.format(parsedUrl)
 
   const a = document.createElement('a')
+  a.rel = 'noopener'
   a.target = '_blank'
   a.download = name
   a.href = href


### PR DESCRIPTION
To avoid tab-nabbing attacks, all external links with
target='_blank' must have rel='noopener'

Fix #9743

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
 (I couldn't find a list of people to tag, although I did read the pull request process page.)

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


