### PR TITLE
rely on compositor properties for tab previews

### DIFF
--- a/less/window.less
+++ b/less/window.less
@@ -83,6 +83,7 @@ html,
     height: 100%;
     width: 100%;
     &.isPreview {
+      will-change: opacity;
       opacity: 0.5;
       animation: tabFadeIn 0.75s ease-in-out;
       animation-fill-mode: forwards;


### PR DESCRIPTION
Auditors: @bsclifton, @luixxiul
close #10291

**before checking out this PR**

1. clear session
2. open two tabs
3. open devtools (shift+f8)
4. go to performance tab, record profile
5. back to tabs, hover over one tab until preview is fired
6. cancel preview
7. stop recording profile
8. go to the profile timeline and select the frames right before and right after preview happens
9. go to the event log
10. sort by total time
11. Keep record (print?) of those numbers

check out this PR and repeat above operation.

numbers should be lower

**before**
<img width="550" alt="screen shot 2017-08-04 at 12 03 55 am" src="https://user-images.githubusercontent.com/4672033/28955319-842443c0-78ab-11e7-80e1-f52c726f5aaf.png">

**after** 
<img width="547" alt="screen shot 2017-08-04 at 12 01 36 am" src="https://user-images.githubusercontent.com/4672033/28955322-863e5c40-78ab-11e7-857c-5c8e9a53dc18.png">