### PR TITLE
do not show up loading icon for about pages

### DIFF
--- a/app/renderer/components/tabs/content/favIcon.js
+++ b/app/renderer/components/tabs/content/favIcon.js
@@ -16,6 +16,7 @@ const tabState = require('../../../../common/state/tabState')
 
 // Utils
 const frameStateUtil = require('../../../../../js/state/frameStateUtil')
+const {isSourceAboutUrl} = require('../../../../../js/lib/appUrlUtil')
 
 // Styles
 const globalStyles = require('../../styles/global')
@@ -38,8 +39,11 @@ class Favicon extends React.Component {
     const tabId = frame.get('tabId', tabState.TAB_ID_NONE)
 
     const props = {}
+
     // used in renderer
-    props.isTabLoading = isTabLoading
+
+    // there's no need to show loading icon for about pages
+    props.isTabLoading = !isSourceAboutUrl(frame.get('location')) && isTabLoading
     props.favicon = !isTabLoading && frame.get('icon')
     props.isPinnedTab = tabState.isTabPinned(state, tabId)
     props.tabIconColor = tabContentState.getTabIconColor(currentWindow, frameKey)


### PR DESCRIPTION
Auditors: @bsclifton
fix #10303

each new tab created renders the loading animation and cause unnecessary paint junk and there's not a real need as about pages are rendered almost instantly.