### PR TITLE
Fixes parentFolderId Issues Troubling Dragging Bookmarks Into & From Their Folders

### DIFF
--- a/app/common/state/bookmarksState.js
+++ b/app/common/state/bookmarksState.js
@@ -263,10 +263,6 @@ const bookmarksState = {
 
     // Move bookmark to destination folder.
     if (moveIntoParent || destinationItem.get('parentFolderId') !== bookmark.get('parentFolderId')) {
-      // Get the destination folder's ID.
-      const parentFolderId = destinationItem.get('type') === siteTags.BOOKMARK
-        ? destinationItem.get('parentFolderId')
-        : destinationItem.get('folderId')
       // Remove bookmark from cache.
       state = bookmarkOrderCache.removeCacheKey(state, bookmark.get('parentFolderId'), bookmarkKey)
       // Update parent folder ID to new folder.

--- a/app/common/state/bookmarksState.js
+++ b/app/common/state/bookmarksState.js
@@ -252,25 +252,32 @@ const bookmarksState = {
     state = validateState(state)
 
     const bookmarkUtil = require('../lib/bookmarkUtil')
+    // Get bookmark.
     let bookmark = bookmarksState.getBookmark(state, bookmarkKey)
+    // Create the new bookmark.
     let destinationItem = bookmarksState.findBookmark(state, destinationKey)
 
     if (bookmark.isEmpty()) {
       return state
     }
 
-    // move bookmark into a new folder
+    // Move bookmark to destination folder.
     if (moveIntoParent || destinationItem.get('parentFolderId') !== bookmark.get('parentFolderId')) {
+      // Get the destination folder's ID.
       const parentFolderId = destinationItem.get('type') === siteTags.BOOKMARK
         ? destinationItem.get('parentFolderId')
         : destinationItem.get('folderId')
-
+      // Remove bookmark from cache.
       state = bookmarkOrderCache.removeCacheKey(state, bookmark.get('parentFolderId'), bookmarkKey)
-      bookmark = bookmark.set('parentFolderId', ~~parentFolderId)
+      // Update parent folder ID to new folder.
+      bookmark = bookmark.set('parentFolderId', destinationKey)
+      // Create the updated bookmark.
       const newKey = bookmarkUtil.getKey(bookmark)
+      // Delete old bookmark.
       state = state.deleteIn([STATE_SITES.BOOKMARKS, bookmarkKey])
+      // Add new bookmark to cache.
       state = bookmarkOrderCache.addBookmarkToCache(state, bookmark.get('parentFolderId'), newKey)
-      bookmark = bookmark.set('key', newKey)
+      // Save the bookmark to the destination folder.
       return state.setIn([STATE_SITES.BOOKMARKS, newKey], bookmark)
     }
 

--- a/test/bookmark-components/bookmarksTest.js
+++ b/test/bookmark-components/bookmarksTest.js
@@ -442,5 +442,11 @@ describe('bookmark tests', function () {
           })
         })
     })
+
+    // @TODO Create the following tests.
+    describe.skip('moves bookmark in & out of Other Bookmarks', () => {
+      it('via drag')
+      it('via edit form')
+    })
   })
 })


### PR DESCRIPTION
Fixes #10157

Bookmarks could not be moved to the Other Bookmarks folder, where archived bookmarks reside. The reason surrounded two issues, as follows:

The first issue was in the renderer process, which did not correctly set the parentFolderId on the keys of bookmarks in child folders. e.g. Bookmarks Toolbar > Test Folder > Bookmark.

The second issue was in the main process, which was not updating the `parentFolderId` property of the old bookmark before setting it anew.

I’ve set two placeholder tests, skipped for now, as I don’t want to hold up value for the user while I find my way around what tests already exist.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


