### PR TITLE
fix intermittent Pinned tab navigation tests

### DIFF
--- a/test/tab-components/pinnedTabTest.js
+++ b/test/tab-components/pinnedTabTest.js
@@ -168,6 +168,7 @@ describe('pinnedTabs', function () {
       yield setup(this.app.client)
       this.page1 = Brave.server.url('page1.html')
       yield this.app.client
+        .activateURLMode()
         .newTab({ url: this.page1 })
         .waitForUrl(this.page1)
         .windowByUrl(Brave.browserWindowUrl)


### PR DESCRIPTION
Auditors: @bsclifton, @nejczdovc
fix #10311
Test Plan: npm run test -- --grep="Pinned tab navigation"