### PR TITLE
Update getDetailFromTab to consider pinnedLocation (BEFORE site split)

### DIFF
--- a/app/renderer/reducers/frameReducer.js
+++ b/app/renderer/reducers/frameReducer.js
@@ -100,7 +100,12 @@ const frameReducer = (state, action, immutableAction) => {
       const pinned = immutableAction.getIn(['changeInfo', 'pinned'])
       if (pinned != null) {
         if (pinned) {
-          state = state.setIn(['frames', index, 'pinnedLocation'], tab.get('url'))
+          const history = state.getIn(['frames', index, 'history'])
+          if (history && history.size !== 0) {
+            state = state.setIn(['frames', index, 'pinnedLocation'], history.first())
+          } else {
+            state = state.setIn(['frames', index, 'pinnedLocation'], tab.get('url'))
+          }
         } else {
           state = state.deleteIn(['frames', index, 'pinnedLocation'])
         }
@@ -110,7 +115,12 @@ const frameReducer = (state, action, immutableAction) => {
       if (url != null && tab.get('pinned') === true) {
         const pinnedLocation = state.getIn(['frames', index, 'pinnedLocation'])
         if (!pinnedLocation || pinnedLocation === 'about:blank' || pinnedLocation === '') {
-          state = state.setIn(['frames', index, 'pinnedLocation'], tab.get('url'))
+          const history = state.getIn(['frames', index, 'history'])
+          if (history && history.size !== 0) {
+            state = state.setIn(['frames', index, 'pinnedLocation'], history.first())
+          } else {
+            state = state.setIn(['frames', index, 'pinnedLocation'], tab.get('url'))
+          }
         }
       }
 

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -513,6 +513,18 @@ module.exports.runPostMigrations = (data) => {
     data.sites = sites
   }
 
+  // sites trailing slash migration
+  if (typeof data.sites === 'object') {
+    for (let key in data.sites) {
+      if (/.+|\d+|\d+/.test(key)) {
+        const site = data.sites[key]
+        const newKey = siteUtil.getSiteKey(Immutable.fromJS(site))
+        data.sites[newKey] = site
+        delete data.sites[key]
+      }
+    }
+  }
+
   return data
 }
 

--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -76,6 +76,9 @@ module.exports.getSiteKey = function (siteDetail) {
     return folderId.toString()
   } else if (location) {
     location = UrlUtil.getLocationIfPDF(location)
+    if (location && location[location.length - 1] === '/') {
+      location = location.slice(0, -1)
+    }
     return location + '|' +
       (siteDetail.get('partitionNumber') || 0) + '|' +
       (siteDetail.get('parentFolderId') || 0)
@@ -583,6 +586,23 @@ module.exports.getDetailFromTab = function (tab, tag, sites) {
       if (provisionalLocation && provisionalLocation !== location) {
         siteKey = module.exports.getSiteKey(makeImmutable({
           location: provisionalLocation,
+          partitionNumber
+        }))
+        results = results.merge(getSitesBySubkey(sites, siteKey, tag))
+      }
+    }
+
+    if (results.size === 0 && tag === siteTags.PINNED) {
+      let pinnedLocation = tab.getIn(['frame', 'pinnedLocation'])
+      if (!pinnedLocation) {
+        const history = tab.getIn(['frame', 'history'])
+        if (history && history.size !== 0) {
+          pinnedLocation = history.first()
+        }
+      }
+      if (pinnedLocation && pinnedLocation !== location) {
+        siteKey = module.exports.getSiteKey(makeImmutable({
+          location: pinnedLocation,
           partitionNumber
         }))
         results = results.merge(getSitesBySubkey(sites, siteKey, tag))

--- a/test/unit/app/common/state/siteCacheTest.js
+++ b/test/unit/app/common/state/siteCacheTest.js
@@ -7,8 +7,8 @@ const assert = require('assert')
 const Immutable = require('immutable')
 
 describe('siteCache', function () {
-  const testUrl1 = 'https://brave.com/'
-  const testUrl2 = 'http://example.com/'
+  const testUrl1 = 'https://brave.com'
+  const testUrl2 = 'http://example.com'
   const bookmark = Immutable.fromJS({
     lastAccessedTime: 123,
     objectId: [210, 115, 31, 176, 57, 212, 167, 120, 104, 88, 88, 27, 141, 36, 235, 226],

--- a/test/unit/app/sessionStoreTest.js
+++ b/test/unit/app/sessionStoreTest.js
@@ -911,4 +911,27 @@ describe('sessionStore unit tests', function () {
       }
     })
   })
+
+  describe('runPostMigrations', function () {
+    it('sites trailing slash migration', function () {
+      const data = {
+        sites: {
+          'https://brave.com/|0|0': {
+            location: 'https://brave.com/',
+            partitionNumber: 0
+          }
+        }
+      }
+      const expectedResult = {
+        sites: {
+          'https://brave.com|0|0': {
+            location: 'https://brave.com/',
+            partitionNumber: 0
+          }
+        }
+      }
+      const result = sessionStore.runPostMigrations(data)
+      assert.deepEqual(result, expectedResult)
+    })
+  })
 })

--- a/test/unit/state/siteUtilTest.js
+++ b/test/unit/state/siteUtilTest.js
@@ -8,8 +8,10 @@ const mockery = require('mockery')
 const settings = require('../../../js/constants/settings')
 
 describe('siteUtil', function () {
-  const testUrl1 = 'https://brave.com/'
-  const testUrl2 = 'http://example.com/'
+  const testUrl1Slash = 'https://brave.com/'
+  const testUrl1 = 'https://brave.com'
+  const testUrl2Slash = 'http://example.com/'
+  const testUrl2 = 'http://example.com'
   const testFavicon1 = 'https://brave.com/favicon.ico'
   const emptyState = Immutable.fromJS({sites: {}})
   const bookmarkAllFields = Immutable.fromJS({
@@ -40,6 +42,14 @@ describe('siteUtil', function () {
     it('returns null if siteDetail is falsey', function () {
       const key = siteUtil.getSiteKey(null)
       assert.equal(key, null)
+    })
+    it('remove trailing slash as key', function () {
+      const siteDetail = Immutable.fromJS({
+        location: testUrl1Slash,
+        partitionNumber: 0
+      })
+      const key = siteUtil.getSiteKey(siteDetail)
+      assert.equal(key, testUrl1 + '|0|0')
     })
     describe('matching `BOOKMARK_FOLDER`', function () {
       it('returns key if folderId matches', function () {
@@ -570,7 +580,7 @@ describe('siteUtil', function () {
           location: testUrl1
         }
         const expectedSites = {
-          'https://brave.com/|0|0': {
+          'https://brave.com|0|0': {
             tags: [siteTags.PINNED],
             location: testUrl1
           }
@@ -587,7 +597,7 @@ describe('siteUtil', function () {
           location: testUrl1
         }
         const expectedSites = {
-          'https://brave.com/|0|0': {
+          'https://brave.com|0|0': {
             tags: [siteTags.BOOKMARK],
             location: testUrl1
           }
@@ -716,7 +726,7 @@ describe('siteUtil', function () {
           lastAccessedTime: 123
         }
         const expectedSites = {
-          'https://brave.com/|0|0': {
+          'https://brave.com|0|0': {
             tags: [],
             location: testUrl1,
             lastAccessedTime: 123
@@ -740,7 +750,7 @@ describe('siteUtil', function () {
           lastAccessedTime: 456
         }
         const expectedSites = {
-          'http://example.com/|0|0': addedSite
+          'http://example.com|0|0': addedSite
         }
         const siteKey = siteUtil.getSiteKey(Immutable.fromJS(addedSite))
         let sites = {}
@@ -790,10 +800,10 @@ describe('siteUtil', function () {
   describe('moveSite', function () {
     describe('order test', function () {
       describe('back to front', function () {
-        const destinationKey = 'https://brave.com/|0|0'
+        const destinationKey = 'https://brave.com|0|0'
         const sourceKey = 'http://example.com/4|0|0'
         const sites = {
-          'https://brave.com/|0|0': {
+          'https://brave.com|0|0': {
             location: testUrl1,
             partitionNumber: 0,
             parentFolderId: 0,
@@ -806,13 +816,13 @@ describe('siteUtil', function () {
             order: 1
           },
           'https://brave.com/3|0|0': {
-            location: testUrl1 + '3',
+            location: testUrl1Slash + '3',
             partitionNumber: 0,
             parentFolderId: 0,
             order: 2
           },
           'http://example.com/4|0|0': {
-            location: testUrl2 + '4',
+            location: testUrl2Slash + '4',
             partitionNumber: 0,
             parentFolderId: 0,
             order: 3
@@ -822,12 +832,12 @@ describe('siteUtil', function () {
         it('prepend target', function () {
           const expectedSites = {
             'http://example.com/4|0|0': {
-              location: testUrl2 + '4',
+              location: testUrl2Slash + '4',
               partitionNumber: 0,
               parentFolderId: 0,
               order: 0
             },
-            'https://brave.com/|0|0': {
+            'https://brave.com|0|0': {
               location: testUrl1,
               partitionNumber: 0,
               parentFolderId: 0,
@@ -840,7 +850,7 @@ describe('siteUtil', function () {
               order: 2
             },
             'https://brave.com/3|0|0': {
-              location: testUrl1 + '3',
+              location: testUrl1Slash + '3',
               partitionNumber: 0,
               parentFolderId: 0,
               order: 3
@@ -854,12 +864,12 @@ describe('siteUtil', function () {
         it('not prepend target', function () {
           const expectedSites = {
             'http://example.com/4|0|0': {
-              location: testUrl2 + '4',
+              location: testUrl2Slash + '4',
               partitionNumber: 0,
               parentFolderId: 0,
               order: 1
             },
-            'https://brave.com/|0|0': {
+            'https://brave.com|0|0': {
               location: testUrl1,
               partitionNumber: 0,
               parentFolderId: 0,
@@ -872,7 +882,7 @@ describe('siteUtil', function () {
               order: 2
             },
             'https://brave.com/3|0|0': {
-              location: testUrl1 + '3',
+              location: testUrl1Slash + '3',
               partitionNumber: 0,
               parentFolderId: 0,
               order: 3
@@ -885,10 +895,10 @@ describe('siteUtil', function () {
         })
       })
       describe('front to back', function () {
-        const sourceKey = 'https://brave.com/|0|0'
+        const sourceKey = 'https://brave.com|0|0'
         const destinationKey = 'http://example.com/4|0|0'
         const sites = {
-          'https://brave.com/|0|0': {
+          'https://brave.com|0|0': {
             location: testUrl1,
             partitionNumber: 0,
             parentFolderId: 0,
@@ -901,13 +911,13 @@ describe('siteUtil', function () {
             order: 1
           },
           'https://brave.com/3|0|0': {
-            location: testUrl1 + '3',
+            location: testUrl1Slash + '3',
             partitionNumber: 0,
             parentFolderId: 0,
             order: 2
           },
           'http://example.com/4|0|0': {
-            location: testUrl2 + '4',
+            location: testUrl2Slash + '4',
             partitionNumber: 0,
             parentFolderId: 0,
             order: 3
@@ -923,19 +933,19 @@ describe('siteUtil', function () {
               order: 0
             },
             'https://brave.com/3|0|0': {
-              location: testUrl1 + '3',
+              location: testUrl1Slash + '3',
               partitionNumber: 0,
               parentFolderId: 0,
               order: 1
             },
-            'https://brave.com/|0|0': {
+            'https://brave.com|0|0': {
               location: testUrl1,
               partitionNumber: 0,
               parentFolderId: 0,
               order: 2
             },
             'http://example.com/4|0|0': {
-              location: testUrl2 + '4',
+              location: testUrl2Slash + '4',
               partitionNumber: 0,
               parentFolderId: 0,
               order: 3
@@ -955,18 +965,18 @@ describe('siteUtil', function () {
               order: 0
             },
             'https://brave.com/3|0|0': {
-              location: testUrl1 + '3',
+              location: testUrl1Slash + '3',
               partitionNumber: 0,
               parentFolderId: 0,
               order: 1
             },
             'http://example.com/4|0|0': {
-              location: testUrl2 + '4',
+              location: testUrl2Slash + '4',
               partitionNumber: 0,
               parentFolderId: 0,
               order: 2
             },
-            'https://brave.com/|0|0': {
+            'https://brave.com|0|0': {
               location: testUrl1,
               partitionNumber: 0,
               parentFolderId: 0,
@@ -981,7 +991,7 @@ describe('siteUtil', function () {
       })
     })
     it('destination is parent', function () {
-      const sourceKey = 'https://brave.com/|0|0'
+      const sourceKey = 'https://brave.com|0|0'
       const sourceDetail = {
         location: testUrl1,
         partitionNumber: 0,
@@ -996,11 +1006,11 @@ describe('siteUtil', function () {
       }
       const sites = {
         1: destinationDetail,
-        'https://brave.com/|0|0': sourceDetail
+        'https://brave.com|0|0': sourceDetail
       }
       const expectedSites = {
         1: destinationDetail,
-        'https://brave.com/|0|1': {
+        'https://brave.com|0|1': {
           location: testUrl1,
           partitionNumber: 0,
           parentFolderId: 1,
@@ -1027,11 +1037,11 @@ describe('siteUtil', function () {
       }
       const sites = {
         1: destinationDetail,
-        'https://brave.com/|0|1': sourceDetail
+        'https://brave.com|0|1': sourceDetail
       }
       const expectedSites = {
         1: destinationDetail,
-        'https://brave.com/|0|0': {
+        'https://brave.com|0|0': {
           location: testUrl1,
           partitionNumber: 0,
           parentFolderId: 0,
@@ -1039,7 +1049,7 @@ describe('siteUtil', function () {
         }
       }
       const state = siteUtil.moveSite(Immutable.fromJS({sites}),
-        'https://brave.com/|0|1',
+        'https://brave.com|0|1',
         '1', false, false, false)
       assert.deepEqual(state.get('sites').toJS(), expectedSites)
     })
@@ -1283,6 +1293,70 @@ describe('siteUtil', function () {
             partitionNumber: tab.get('partitionNumber'),
             parentFolderId: siteWithFolder.get('parentFolderId')
           }
+        )
+      })
+    })
+
+    describe('when considering pinned tab', function () {
+      const siteUrl = 'https://brave.com'
+      const siteRedirectUrl = 'https://brave.com/welcome'
+      const title = 'brave'
+      const sites = {
+        'https://brave.com|0|0': {
+          location: siteUrl,
+          title: title,
+          partitionNumber: 0,
+          lastAccessedTime: 123,
+          tags: [siteTags.PINNED, siteTags.BOOKMARK],
+          parentFolderId: 0
+        }
+      }
+      const expectedResult = {
+        location: siteUrl,
+        title: title,
+        tags: [siteTags.PINNED]
+      }
+      it('location same as pinnedLocation', function () {
+        const tab = Immutable.fromJS({
+          url: siteUrl,
+          title: title,
+          frame: {
+            pinnedLocation: siteUrl,
+            history: [siteUrl, siteRedirectUrl]
+          }
+        })
+        assert.deepEqual(
+          siteUtil.getDetailFromTab(tab, siteTags.PINNED, Immutable.fromJS(sites)).toJS(),
+          expectedResult
+        )
+      })
+
+      it('location different than pinnedLocation', function () {
+        const tab = Immutable.fromJS({
+          url: siteRedirectUrl,
+          title: title,
+          frame: {
+            pinnedLocation: siteUrl,
+            history: [siteUrl, siteRedirectUrl]
+          }
+        })
+        assert.deepEqual(
+          siteUtil.getDetailFromTab(tab, siteTags.PINNED, Immutable.fromJS(sites)).toJS(),
+          expectedResult
+        )
+      })
+
+      it('location different than pinnedLocation which is unavailable', function () {
+        const tab = Immutable.fromJS({
+          url: siteRedirectUrl,
+          title: title,
+          frame: {
+            history: [siteUrl, siteRedirectUrl]
+          }
+        })
+        assert.deepEqual(
+          siteUtil.getDetailFromTab(tab, siteTags.PINNED, Immutable.fromJS(sites)).toJS(),
+          expectedResult
         )
       })
     })


### PR DESCRIPTION
also normalize site key without trailing slash

fix #10241

Auditors: @bsclifton, @bbondy

Test Plan:
1. Go to feedly.com
2. Pin the tab
3. Bookmark it and change the location to https://feedly.com
4. Unpin the pinned tab
5. Relaunch Brave
6. There shouldn't be any pinned tab

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


