### PR TITLE
fix deleting history entry from History menu

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -672,8 +672,15 @@ const doAction = (state, action) => {
       }
     case windowConstants.WINDOW_CLEAR_CLOSED_FRAMES:
       {
-        closedFrames = new Immutable.OrderedMap()
-        lastClosedUrl = null
+        if (!action.location) {
+          closedFrames = new Immutable.OrderedMap()
+          lastClosedUrl = null
+        } else {
+          closedFrames = closedFrames.delete(action.location)
+          if (lastClosedUrl === action.location) {
+            lastClosedUrl = null
+          }
+        }
         updateRecentlyClosedMenuItems(state)
         break
       }

--- a/js/actions/windowActions.js
+++ b/js/actions/windowActions.js
@@ -214,10 +214,12 @@ const windowActions = {
 
   /**
    * Dispatches a message to the store to clear closed frames
+   * @param {string=} location - only clear frames with this location
    */
-  clearClosedFrames: function () {
+  clearClosedFrames: function (location) {
     dispatch({
-      actionType: windowConstants.WINDOW_CLEAR_CLOSED_FRAMES
+      actionType: windowConstants.WINDOW_CLEAR_CLOSED_FRAMES,
+      location
     })
   },
 

--- a/js/entry.js
+++ b/js/entry.js
@@ -70,8 +70,8 @@ ipc.on(messages.APP_STATE_CHANGE, (e, action) => {
     : appStoreRenderer.state = Immutable.fromJS(action.state)
 })
 
-ipc.on(messages.CLEAR_CLOSED_FRAMES, () => {
-  windowActions.clearClosedFrames()
+ipc.on(messages.CLEAR_CLOSED_FRAMES, (e, location) => {
+  windowActions.clearClosedFrames(location)
 })
 
 window.addEventListener('beforeunload', function (e) {

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -368,7 +368,12 @@ const doAction = (action) => {
       }
       break
     case windowConstants.WINDOW_CLEAR_CLOSED_FRAMES:
-      windowState = windowState.set('closedFrames', new Immutable.List())
+      if (!action.location) {
+        windowState = windowState.set('closedFrames', new Immutable.List())
+      } else {
+        windowState = windowState.set('closedFrames',
+          windowState.get('closedFrames').filterNot((frame) => frame.get('location') === action.location))
+      }
       break
     case windowConstants.WINDOW_SET_PREVIEW_FRAME:
       windowState = frameStateUtil.setPreviewFrameKey(windowState, action.frameKey, true)


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/10328

Test Plan:
open a tab, go to any site
close the tab. notice that the site appears in the History menu.
go to about:history and delete the visited site.
it should disappear from the History menu

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


