### PR TITLE
Fix syncing of bookmark imports while Sync is on

### DIFF
--- a/app/common/lib/bookmarkFoldersUtil.js
+++ b/app/common/lib/bookmarkFoldersUtil.js
@@ -58,7 +58,8 @@ const isFolder = (folder) => {
     return false
   }
 
-  return folder.get('type') === siteTags.BOOKMARK_FOLDER
+  return (folder.get('type') === siteTags.BOOKMARK_FOLDER) ||
+    (typeof folder.get('folderId') === 'number')
 }
 
 const getKey = (folderDetails) => {

--- a/app/common/state/bookmarkFoldersState.js
+++ b/app/common/state/bookmarkFoldersState.js
@@ -105,7 +105,7 @@ const bookmarkFoldersState = {
     }
 
     if (getSetting(settings.SYNC_ENABLED) === true) {
-      syncActions.removeSite(folder)
+      syncActions.removeSites([folder.toJS()])
     }
 
     folders.filter(folder => folder.get('parentFolderId') === ~~folderKey)

--- a/app/common/state/bookmarksState.js
+++ b/app/common/state/bookmarksState.js
@@ -184,7 +184,7 @@ const bookmarksState = {
     }
 
     if (getSetting(settings.SYNC_ENABLED) === true) {
-      syncActions.removeSite(bookmark)
+      syncActions.removeSites([bookmark.toJS()])
     }
 
     state = bookmarkLocationCache.removeCacheKey(state, bookmark.get('location'), bookmarkKey)
@@ -207,17 +207,21 @@ const bookmarksState = {
     }
 
     const syncEnabled = getSetting(settings.SYNC_ENABLED) === true
+    const removedBookmarks = []
     const bookmarks = bookmarksState.getBookmarks(state)
       .filter(bookmark => {
         if (bookmark.get('parentFolderId') !== ~~parentFolderId) {
           return true
         }
         if (syncEnabled) {
-          syncActions.removeSite(bookmark)
+          removedBookmarks.push(bookmark.toJS())
         }
         return false
       })
 
+    if (syncEnabled && removedBookmarks.length) {
+      syncActions.removeSites(removedBookmarks)
+    }
     return state.set(STATE_SITES.BOOKMARKS, bookmarks)
   },
 

--- a/js/actions/syncActions.js
+++ b/js/actions/syncActions.js
@@ -7,10 +7,17 @@ const AppDispatcher = require('../dispatcher/appDispatcher')
 const syncConstants = require('../constants/syncConstants')
 
 const syncActions = {
-  removeSite: function (item) {
+  addSites: function (items) {
     AppDispatcher.dispatch({
-      actionType: syncConstants.SYNC_REMOVE_SITE,
-      item
+      actionType: syncConstants.SYNC_ADD_SITES,
+      items
+    })
+  },
+
+  removeSites: function (items) {
+    AppDispatcher.dispatch({
+      actionType: syncConstants.SYNC_REMOVE_SITES,
+      items
     })
   },
 

--- a/js/constants/syncConstants.js
+++ b/js/constants/syncConstants.js
@@ -6,7 +6,8 @@ const mapValuesByKeys = require('../lib/functional').mapValuesByKeys
 
 const _ = null
 const syncConstants = {
-  SYNC_REMOVE_SITE: _,  /** @param {Immutable.Map} item */
+  SYNC_ADD_SITES: _,  /** @param {Array.<Object>} items */
+  SYNC_REMOVE_SITES: _,  /** @param {Array.<Object>} items */
   SYNC_CLEAR_HISTORY: _,
   SYNC_CLEAR_SITE_SETTINGS: _
 }


### PR DESCRIPTION
The bookmarks importer leads to jumbled app state diffs as received by app/sync.js. To fix this, I propose we sync directly in the importer.
This adds (back) `syncActions.addSites()` and uses it in the bookmarks importer only, and sets skipSync for imported sites.

Fix https://github.com/brave/sync/issues/158

Test Plan:
1. Sync Pyramid 0 to Pyramid 1.
2. In Pyramid 0 import a bookmarks file (100s of bookmarks with nested folders)
3. Observe Pyramid 1, waiting for bookmarks to sync over.
4. Compare bookmarks between pyramids. They should be the same.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


