### PR TITLE
Fix URL parsing consistency issue

### DIFF
--- a/app/browser/webtorrent.js
+++ b/app/browser/webtorrent.js
@@ -4,7 +4,7 @@ const appUrlUtil = require('../../js/lib/appUrlUtil')
 const appActions = require('../../js/actions/appActions')
 const messages = require('../../js/constants/messages')
 const Filtering = require('../filtering')
-const urlParse = require('url').parse
+const urlParse = require('../common/urlParse')
 
 // Set to see communication between WebTorrent and torrent viewer tabs
 const DEBUG_IPC = false

--- a/app/common/urlParse.js
+++ b/app/common/urlParse.js
@@ -3,8 +3,17 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const LRUCache = require('lru-cache')
-const urlParse = require('url').parse
 const config = require('../../js/constants/config')
+
+// muon.url.parse is not available in all environments (ex: unittests)
+let urlParse
+try {
+  urlParse = muon.url.parse
+} catch (e) {
+  // TODO: move to the new node URL API: https://nodejs.org/api/url.html#url_url
+  urlParse = require('url').parse
+}
+
 let cachedUrlParse = new LRUCache(config.cache.urlParse)
 
 module.exports = (url, ...args) => {

--- a/js/webtorrent/entry.js
+++ b/js/webtorrent/entry.js
@@ -6,11 +6,12 @@ const path = require('path')
 const querystring = require('querystring')
 const React = require('react')
 const ReactDOM = require('react-dom')
-const url = require('url')
+const urlFormat = require('url').format
 const WebTorrentRemoteClient = require('webtorrent-remote/client')
 
 const App = require('./components/app')
 const messages = require('../constants/messages')
+const urlParse = require('../../app/common/urlParse')
 
 // Stylesheets
 require('../../less/webtorrent.less')
@@ -37,7 +38,7 @@ window.addEventListener('hashchange', init)
 function init () {
   store.torrentId = window.decodeURIComponent(window.location.hash.substring(1))
 
-  const parsedUrl = url.parse(store.torrentId)
+  const parsedUrl = urlParse(store.torrentId)
   store.torrentIdProtocol = parsedUrl.protocol
 
   // `ix` param can be set by query param or hash, e.g. ?ix=1 or #ix=1
@@ -182,10 +183,10 @@ function stop () {
 }
 
 function saveTorrentFile () {
-  const parsedUrl = url.parse(store.torrentId, true)
+  const parsedUrl = urlParse(store.torrentId, true)
   parsedUrl.query.download = true
   const name = path.basename(parsedUrl.pathname) || 'untitled.torrent'
-  const href = url.format(parsedUrl)
+  const href = urlFormat(parsedUrl)
 
   const a = document.createElement('a')
   a.rel = 'noopener'


### PR DESCRIPTION
Fix https://github.com/brave/browser-laptop/issues/10270 by preferring muon.url.parse over Node's legacy (and non-standards compliant) URL parser. This is subobtimal because unit tests are running a different URL parser from the actual browser, but seems like the best trade off for now.

Also fixes https://github.com/brave/browser-laptop/issues/6098

Test Plan:
1. go to brave.com and disable shields
2. go to http://brave.com%60x.code-fu.org/. shields should not be disabled.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


