### PR TITLE
Polish pinnedInput

### DIFF
--- a/app/renderer/components/preferences/payment/ledgerTable.js
+++ b/app/renderer/components/preferences/payment/ledgerTable.js
@@ -117,7 +117,7 @@ class LedgerTable extends ImmutableComponent {
       css(styles.tableTd),                    // include
       css(styles.tableTd, styles.alignRight), // views
       css(styles.tableTd, styles.alignRight), // time spent
-      css(styles.tableTd, styles.alignRight, styles.percTd), // percentage
+      css(styles.tableTd, styles.alignRight, styles.tableTd_percentage), // percentage
       css(styles.tableTd, styles.alignLeft)   // actions
     ]
   }
@@ -369,9 +369,10 @@ const styles = StyleSheet.create({
     padding: '0 0 0 15px'
   },
 
-  percTd: {
-    width: '45px',
-    paddingLeft: '5px'
+  // Ref: pinnedInput on pinnedInput.js
+  tableTd_percentage: {
+    width: '4ch', // 3ch (for '100') + 1ch (padding)
+    padding: '0 2ch 0 1ch'
   },
 
   hideTd: {

--- a/app/renderer/components/preferences/payment/pinnedInput.js
+++ b/app/renderer/components/preferences/payment/pinnedInput.js
@@ -3,7 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const React = require('react')
-const {StyleSheet, css} = require('aphrodite')
+const {StyleSheet, css} = require('aphrodite/no-important')
 
 // components
 const ImmutableComponent = require('../../immutableComponent')
@@ -43,26 +43,25 @@ class PinnedInput extends ImmutableComponent {
       defaultValue={this.props.defaultValue}
       onBlur={this.pinPercentage.bind(this, this.props.patern)}
       onKeyPress={this.keyPress.bind(this)}
-      className={css(styles.percInput)}
+      className={css(styles.pinnedInput)}
     />
   }
 }
 
 const styles = StyleSheet.create({
-  percInput: {
-    height: '22px',
-    width: '50px',
+  // Ref: tableTd_percentage on ledgetTable.js
+  pinnedInput: {
+    width: 'calc(100% + 1ch)',
+    border: `1px solid #c4c5c5`,
     borderRadius: globalStyles.radius.borderRadius,
     textAlign: 'right',
-    backgroundColor: 'transparent',
+    background: 'transparent',
     outline: 'none',
-    border: `1px solid #c4c5c5`,
-    padding: '0 9px',
+    padding: '0 1ch',
     fontSize: '16px',
-    marginRight: '-10px',
 
     ':focus': {
-      backgroundColor: '#fff',
+      background: '#fff',
       borderColor: globalStyles.color.highlightBlue
     }
   }


### PR DESCRIPTION
Closes #10356

Auditors:

Test Plan:
1. Run `npm run add-simulated-synopsis-visits 100`
2. Open about:preferences#payments
3. Pin some sites
4. Make sure margin around the input field and the padding inside it is `1ch` (which should be 8px). Please ignore the padding in the cells on Action column (it will be adjusted after this PR).

<img width="74" alt="screenshot 2017-08-10 16 01 34" src="https://user-images.githubusercontent.com/3362943/29158251-4895351e-7de5-11e7-8ee8-36a0d643adda.png">

This shows that margin around the field and padding inside it is set equally:

<img width="84" alt="screenshot 2017-08-10 15 58 56" src="https://user-images.githubusercontent.com/3362943/29158250-48950aa8-7de5-11e7-8ee2-479243c83f17.png">

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


