### PR TITLE
Add accelerator keys to create new session tabs

### DIFF
--- a/app/common/commonMenu.js
+++ b/app/common/commonMenu.js
@@ -89,6 +89,7 @@ module.exports.newPrivateTabMenuItem = () => {
 module.exports.newPartitionedTabMenuItem = () => {
   const newPartitionedMenuItem = (partitionNumber) => ({
     label: `${locale.translation('newSessionTab')} ${partitionNumber}`,
+    accelerator: 'CmdOrCtrl+Alt+' + partitionNumber,
     click: (item, focusedWindow) => {
       ensureAtLeastOneWindow({
         partitionNumber


### PR DESCRIPTION
Auditors: @bsclifton

Test Plan:

  1. Ensure 'File > New Session Tab' sub-entries have accelerator labels
  2. Ensure new sub-entries menu items create session tabs
  3. Ensure accelerator keys for new session tabs work as expected

Fixes: #10363

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


