### PR TITLE
If crashing within first 2min don't lose windows

### DIFF
--- a/app/sessionStoreShutdown.js
+++ b/app/sessionStoreShutdown.js
@@ -188,13 +188,12 @@ app.on('before-quit', (e) => {
   if (sessionStateSaveInterval !== undefined) {
     clearInterval(sessionStateSaveInterval)
   }
-  initiateSessionStateSave()
+  module.exports.initiateSessionStateSave()
 })
 
 const startSessionSaveInterval = () => {
   // save app state every 5 minutes regardless of update frequency
-  initiateSessionStateSave()
-  sessionStateSaveInterval = setInterval(initiateSessionStateSave, appConfig.sessionSaveInterval)
+  sessionStateSaveInterval = setInterval(module.exports.initiateSessionStateSave, appConfig.sessionSaveInterval)
 }
 
 // User initiated exit using File->Quit

--- a/test/unit/app/sessionStoreShutdownTest.js
+++ b/test/unit/app/sessionStoreShutdownTest.js
@@ -355,4 +355,18 @@ describe('sessionStoreShutdown unit tests', function () {
       })
     })
   })
+  describe('startSessionSaveInterval', function () {
+    before(function () {
+      this.initiateSessionStateSave = sinon.spy(sessionStoreShutdown, 'initiateSessionStateSave')
+    })
+    after(function () {
+      this.initiateSessionStateSave.restore()
+    })
+    // We only care that initiateSessionStateSave is not called sync.
+    // Windows will be initialized for the non sync case.
+    it('does not call initiateSessionStateSave', function () {
+      sessionStoreShutdown.startSessionSaveInterval()
+      assert.equal(this.initiateSessionStateSave.notCalled, true)
+    })
+  })
 })


### PR DESCRIPTION
Fix #10349

Auditors: @bsclifton

This happens because a save would happen on init before the initial window state was present

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


