### PR TITLE
Showing better names for channels in about:brave page 

### DIFF
--- a/app/channel.js
+++ b/app/channel.js
@@ -17,9 +17,15 @@ if (!channels.has(channel)) {
 }
 
 exports.channel = () => {
-  let channelMapping = {
-    'dev': 'Release',
-    'beta': 'Beta'
+  return channel
+}
+
+exports.formattedChannel = () => {
+  const locale = require('./locale')
+
+  const channelMapping = {
+    'dev': locale.translation('channelDev'),
+    'beta': locale.translation('channelBeta')
   }
   return Object.keys(channelMapping).includes(channel) ? channelMapping[channel] : channel
 }

--- a/app/channel.js
+++ b/app/channel.js
@@ -17,7 +17,11 @@ if (!channels.has(channel)) {
 }
 
 exports.channel = () => {
-  return channel
+  let channelMapping = {
+    'dev': 'Release',
+    'beta': 'Beta'
+  }
+  return Object.keys(channelMapping).includes(channel) ? channelMapping[channel] : channel
 }
 
 exports.browserLaptopRev = () => process.env.NODE_ENV === 'development'

--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -264,3 +264,5 @@ connectionError=Server connection failed. Please make sure you are connected to 
 unknownError=Oops, something went wrong.
 browserActionButton.title={{name}}
 allowAutoplay=Allow {{origin}} to autoplay media?
+channelDev=Release
+channelBeta=Beta

--- a/app/locale.js
+++ b/app/locale.js
@@ -255,7 +255,10 @@ var rendererIdentifiers = function () {
     'connectionError',
     'unknownError',
     'allowAutoplay',
-    'autoplayMedia'
+    'autoplayMedia',
+    // Release channels
+    'channelDev',
+    'channelBeta'
   ]
 }
 

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -443,7 +443,7 @@ const setVersionInformation = (immutableData) => {
     ['libchromiumcontent', () => { return process.versions['chrome'] }],
     ['V8', () => { return process.versions.v8 }],
     ['Node.js', () => { return process.versions.node }],
-    ['Update Channel', Channel.channel],
+    ['Update Channel', Channel.formattedChannel],
     ['OS Platform', () => platformUtil.formatOsPlatform(os.platform())],
     ['OS Release', os.release],
     ['OS Architecture', os.arch]
@@ -784,8 +784,9 @@ module.exports.loadAppState = () => {
 
       immutableData = module.exports.runPostMigrations(immutableData)
     }
-    immutableData = setVersionInformation(immutableData)
+
     locale.init(immutableData.getIn(['settings', settings.LANGUAGE])).then((locale) => {
+      immutableData = setVersionInformation(immutableData)
       app.setLocale(locale)
       resolve(immutableData)
     })


### PR DESCRIPTION
I have modified the function that returns the channel name. I have included a map which has the mapping of the channel names as asked in the [issue](https://github.com/brave/browser-laptop/issues/10239)

Fix brave/browser-laptop#10239

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


