### PR TITLE
Fix alignment of the buttons and keys on Brave wallet backup dialog

### DIFF
--- a/app/renderer/components/preferences/payment/ledgerBackup.js
+++ b/app/renderer/components/preferences/payment/ledgerBackup.js
@@ -26,26 +26,31 @@ class LedgerBackupContent extends ImmutableComponent {
 
     return <section>
       <span data-l10n-id='ledgerBackupContent' />
-      <div className={css(styles.copyKeyContainer)}>
-        <BrowserButton secondaryColor
-          l10nId='copy'
-          testId='copyButtonFirst'
-          onClick={this.copyToClipboard.bind(this, paymentId)}
-        />
-        <div className={css(styles.keyContainer)}>
-          <h3 className={css(styles.keyContainer__h3)} data-l10n-id='firstKey' />
-          <span className={css(styles.keyContainer__span)}>{paymentId}</span>
+      <div className={css(styles.ledgerBackupContent)}>
+        <div className={css(styles.ledgerBackupContent__copyKey)}>
+          <BrowserButton secondaryColor
+            l10nId='copy'
+            testId='copyButtonFirst'
+            onClick={this.copyToClipboard.bind(this, paymentId)}
+          />
+          <div className={css(styles.ledgerBackupContent__copyKey__key)}>
+            <h3 className={css(styles.ledgerBackupContent__copyKey__key__header)} data-l10n-id='firstKey' />
+            <span className={css(styles.ledgerBackupContent__copyKey__key__phrase)}>{paymentId}</span>
+          </div>
         </div>
-      </div>
-      <div className={css(styles.copyKeyContainer)}>
-        <BrowserButton secondaryColor
-          l10nId='copy'
-          testId='copyButtonSecond'
-          onClick={this.copyToClipboard.bind(this, passphrase)}
-        />
-        <div className={css(styles.keyContainer)}>
-          <h3 className={css(styles.keyContainer__h3)} data-l10n-id='secondKey' />
-          <span className={css(styles.keyContainer__span)}>{passphrase}</span>
+        <div className={css(
+          styles.ledgerBackupContent__copyKey,
+          styles.ledgerBackupContent__copyKey_second
+        )}>
+          <BrowserButton secondaryColor
+            l10nId='copy'
+            testId='copyButtonSecond'
+            onClick={this.copyToClipboard.bind(this, passphrase)}
+          />
+          <div className={css(styles.ledgerBackupContent__copyKey__key)}>
+            <h3 className={css(styles.ledgerBackupContent__copyKey__key__header)} data-l10n-id='secondKey' />
+            <span className={css(styles.ledgerBackupContent__copyKey__key__phrase)}>{passphrase}</span>
+          </div>
         </div>
       </div>
     </section>
@@ -93,21 +98,31 @@ class LedgerBackupFooter extends ImmutableComponent {
 }
 
 const styles = StyleSheet.create({
-  copyKeyContainer: {
+  ledgerBackupContent: {
+    // Align the buttons and keys even when the width of the strings is not equal
+    width: 'max-content',
+    margin: 'auto'
+  },
+
+  ledgerBackupContent__copyKey: {
     display: 'flex',
-    alignItems: 'flex-end',
-    justifyContent: 'center',
+    alignItems: 'center',
     margin: `${globalStyles.spacing.dialogInsideMargin} auto`
   },
 
-  keyContainer: {
-    marginLeft: '2em'
+  ledgerBackupContent__copyKey_second: {
+    marginBottom: 0
   },
-  keyContainer__h3: {
+
+  ledgerBackupContent__copyKey__key: {
+    marginLeft: `calc(${globalStyles.spacing.dialogInsideMargin} * 2)`
+  },
+
+  ledgerBackupContent__copyKey__key__header: {
     marginBottom: globalStyles.spacing.modalPanelHeaderMarginBottom
   },
-  keyContainer__span: {
-    whiteSpace: 'nowrap',
+
+  ledgerBackupContent__copyKey__key__phrase: {
     userSelect: 'initial',
     cursor: 'initial'
   }


### PR DESCRIPTION
Fixes #10389

Auditors: @cezaraugusto

Test Plan:
1. Open about:preferences#payments
2. Open Brave wallet backup dialog
3. Make sure the buttons and keys are aligned

<img width="516" alt="screenshot 2017-08-10 18 26 18" src="https://user-images.githubusercontent.com/3362943/29164117-745c3346-7df9-11e7-88e4-d630176f6b41.png">

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


