### PR TITLE
Fix getOrigin to work with muon.url.parse

### DIFF
--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -429,11 +429,14 @@ const UrlUtil = {
     }
 
     let parsed = urlParse(location)
+    if (parsed.origin) {
+      // parsed.origin is specific to muon.url.parse
+      return parsed.origin.replace(/\/+$/, '')
+    }
     if (parsed.host && parsed.protocol) {
       return parsed.slashes ? [parsed.protocol, parsed.host].join('//') : [parsed.protocol, parsed.host].join('')
-    } else {
-      return null
     }
+    return null
   }
 }
 


### PR DESCRIPTION
Fix https://github.com/brave/browser-laptop/issues/10391
Fix https://github.com/brave/browser-laptop/issues/10408

Test Plan:
1. go to google.com
2. click 'remember this decision' and 'deny' when it asks for your location
3. close tab, open google.com again. it should not ask to see your location.
4. also try the test plan from https://github.com/brave/browser-laptop/issues/10408

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


