### PR TITLE
Return about:[name] as origin for about: pages

### DIFF
--- a/js/state/siteUtil.js
+++ b/js/state/siteUtil.js
@@ -845,8 +845,9 @@ module.exports.getBookmarks = function (sites) {
 }
 
 /**
- * Gets a site origin (scheme + hostname + port) from a URL or null if not
- * available.
+ * Gets a site origin (scheme + hostname + port) from a URL or null if not available.
+ * Warning: For unit tests, this currently runs as node without the parsed.origin
+ * branch of code, but in muon this runs through the parsed.origin branch of code.
  * @param {string} location
  * @return {string?}
  */
@@ -861,8 +862,11 @@ module.exports.getOrigin = function (location) {
   }
 
   let parsed = urlParse(location)
-  if (parsed.origin) {
-    // parsed.origin is specific to muon.url.parse
+  // parsed.origin is specific to muon.url.parse
+  if (parsed.origin !== undefined) {
+    if (parsed.protocol === 'about:') {
+      return [parsed.protocol, parsed.path].join('')
+    }
     return parsed.origin.replace(/\/+$/, '')
   }
   if (parsed.host && parsed.protocol) {


### PR DESCRIPTION
This PR is only for merging on 0.18.x only
Sister PR is here: https://github.com/brave/browser-laptop/pull/10412

Fix #10410

Auditors: @diracdeltas

Notes this is in the branch of code which requires muon only so it is already in unit tests but we test it with the wrong url parsing from node.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
  - See comment in commit, also Yan said she will work on a PR to test it via browser test.
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


