### PR TITLE
Hide unsupported extensions

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -500,17 +500,17 @@ module.exports.init = () => {
       disableExtension(extensionIds[passwordManagers.LAST_PASS])
     }
 
-    if (activePasswordManager === passwordManagers.ENPASS) {
-      registerComponent(extensionIds[passwordManagers.ENPASS], publicKeys[passwordManagers.ENPASS])
-    } else {
-      disableExtension(extensionIds[passwordManagers.ENPASS])
-    }
+    // if (activePasswordManager === passwordManagers.ENPASS) {
+    //   registerComponent(extensionIds[passwordManagers.ENPASS], publicKeys[passwordManagers.ENPASS])
+    // } else {
+    //   disableExtension(extensionIds[passwordManagers.ENPASS])
+    // }
 
-    if (activePasswordManager === passwordManagers.BITWARDEN) {
-      registerComponent(extensionIds[passwordManagers.BITWARDEN], publicKeys[passwordManagers.BITWARDEN])
-    } else {
-      disableExtension(extensionIds[passwordManagers.BITWARDEN])
-    }
+    // if (activePasswordManager === passwordManagers.BITWARDEN) {
+    //   registerComponent(extensionIds[passwordManagers.BITWARDEN], publicKeys[passwordManagers.BITWARDEN])
+    // } else {
+    //   disableExtension(extensionIds[passwordManagers.BITWARDEN])
+    // }
 
     if (getSetting(settings.POCKET_ENABLED)) {
       registerComponent(config.PocketExtensionId, config.PocketExtensionPublicKey)
@@ -518,11 +518,11 @@ module.exports.init = () => {
       disableExtension(config.PocketExtensionId)
     }
 
-    if (getSetting(settings.VIMIUM_ENABLED)) {
-      registerComponent(config.vimiumExtensionId, config.vimiumExtensionPublicKey)
-    } else {
-      disableExtension(config.vimiumExtensionId)
-    }
+    // if (getSetting(settings.VIMIUM_ENABLED)) {
+    //   registerComponent(config.vimiumExtensionId, config.vimiumExtensionPublicKey)
+    // } else {
+    //   disableExtension(config.vimiumExtensionId)
+    // }
 
     if (getSetting(settings.HONEY_ENABLED)) {
       registerComponent(config.honeyExtensionId, config.honeyExtensionPublicKey)
@@ -530,11 +530,11 @@ module.exports.init = () => {
       disableExtension(config.honeyExtensionId)
     }
 
-    if (getSetting(settings.PINTEREST_ENABLED)) {
-      registerComponent(config.pinterestExtensionId, config.pinterestExtensionPublicKey)
-    } else {
-      disableExtension(config.pinterestExtensionId)
-    }
+    // if (getSetting(settings.PINTEREST_ENABLED)) {
+    //   registerComponent(config.pinterestExtensionId, config.pinterestExtensionPublicKey)
+    // } else {
+    //   disableExtension(config.pinterestExtensionId)
+    // }
 
     if (getSetting(settings.METAMASK_ENABLED)) {
       registerComponent(config.metamaskExtensionId, config.metamaskPublicKey)


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/10343

Specifically fixes the case where extension was enabled with an older version but then we want to force it to be disabled.

Auditors: @bbondy, @jonathansampson

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
See https://github.com/brave/browser-laptop/issues/10343

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


