### PR TITLE
immutableData.getIn first arg should be an array

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -97,7 +97,7 @@ let loadAppStatePromise = SessionStore.loadAppState()
 loadAppStatePromise.then((initialImmutableState) => {
   telemetry.setCheckpointAndReport('state-loaded')
   const {HARDWARE_ACCELERATION_ENABLED, SMOOTH_SCROLL_ENABLED, SEND_CRASH_REPORTS} = require('../js/constants/settings')
-  if (initialImmutableState.getIn('settings', HARDWARE_ACCELERATION_ENABLED) === false) {
+  if (initialImmutableState.getIn(['settings', HARDWARE_ACCELERATION_ENABLED]) === false) {
     app.disableHardwareAcceleration()
   }
   if (initialImmutableState.getIn(['settings', SEND_CRASH_REPORTS]) !== false) {
@@ -308,7 +308,7 @@ app.on('ready', () => {
         process.platform,
         process.arch,
         process.env.BRAVE_UPDATE_VERSION || app.getVersion(),
-        initialImmutableState.getIn('settings', settings.UPDATE_TO_PREVIEW_RELEASES)
+        initialImmutableState.getIn(['settings', settings.UPDATE_TO_PREVIEW_RELEASES])
       )
 
       // This is fired by a menu entry


### PR DESCRIPTION
Fix #10415

Auditors: @bsclifton

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
No but it's kind of a lame introduced bug that is not likely to happen again now that we're on immutable.
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


