### PR TITLE
Reorganize rel='noopener'

### DIFF
--- a/app/renderer/components/preferences/helpfulHints.js
+++ b/app/renderer/components/preferences/helpfulHints.js
@@ -22,8 +22,9 @@ class HelpfulHints extends ImmutableComponent {
       <div className={css(styles.hints, styles.white)} data-l10n-id={`hint${this.props.hintNumber}`} />
       <div className={css(styles.helpfulHintsBottom)}>
         <a className={css(styles.white)}
-          target='_blank' href='https://community.brave.com/'
-          data-l10n-id='submitFeedback' />
+          href='https://community.brave.com/'
+          data-l10n-id='submitFeedback'
+          rel='noopener' target='_blank' />
       </div>
     </div>
   }

--- a/app/renderer/components/preferences/payment/bitcoinDashboard.js
+++ b/app/renderer/components/preferences/payment/bitcoinDashboard.js
@@ -140,7 +140,7 @@ class BitcoinDashboard extends ImmutableComponent {
             <div data-l10n-id='fundingDisabled1' />
             <div>
               <span data-l10n-id='fundingDisabled2' />&nbsp;
-              <a href='https://community.brave.com/c/payments' target='_blank' data-l10n-id='fundingDisabled3' />
+              <a href='https://community.brave.com/c/payments' data-l10n-id='fundingDisabled3' rel='noopener' target='_blank' />
             </div>
           </div>
           : <div className={css(
@@ -194,7 +194,7 @@ class BitcoinDashboard extends ImmutableComponent {
           </div>
         </div>
         <div className={css(styles.panel__divider, styles.panel__divider_right)}>
-          <a target='_blank' rel='noopener' href={url}>
+          <a href={url} rel='noopener' target='_blank'>
             <BrowserButton
               primaryColor
               panelItem
@@ -219,7 +219,7 @@ class BitcoinDashboard extends ImmutableComponent {
         </div>
       </div>
       <div className={css(styles.panel__divider, styles.panel__divider_right)}>
-        <a target='_blank' rel='noopener' href='https://www.buybitcoinworldwide.com/'>
+        <a href='https://www.buybitcoinworldwide.com/' rel='noopener' target='_blank'>
           <BrowserButton
             primaryColor
             panelItem
@@ -325,19 +325,19 @@ class BitcoinDashboard extends ImmutableComponent {
     if (coinbaseCountries.indexOf(this.props.ledgerData.get('countryCode')) > -1) {
       return <section className={css(styles.modalOverlay__qrcodeOverlay__footerWrapper__footer)}>
         <div className={css(styles.coinbaseLogo)} />
-        <a rel='noopener' target='_blank'
-          className={css(
-            styles.modalOverlay__qrcodeOverlay__footerWrapper__footer__qrcodeLogo,
-            styles.modalOverlay__qrcodeOverlay__footerWrapper__footer__appstoreLogo
-          )}
+        <a className={css(
+          styles.modalOverlay__qrcodeOverlay__footerWrapper__footer__qrcodeLogo,
+          styles.modalOverlay__qrcodeOverlay__footerWrapper__footer__appstoreLogo
+        )}
           href='https://itunes.apple.com/us/app/coinbase-bitcoin-wallet/id886427730?mt=8'
+          rel='noopener' target='_blank'
         />
-        <a rel='noopener' target='_blank'
-          className={css(
-            styles.modalOverlay__qrcodeOverlay__footerWrapper__footer__qrcodeLogo,
-            styles.modalOverlay__qrcodeOverlay__footerWrapper__footer__playstoreLogo
-          )}
+        <a className={css(
+          styles.modalOverlay__qrcodeOverlay__footerWrapper__footer__qrcodeLogo,
+          styles.modalOverlay__qrcodeOverlay__footerWrapper__footer__playstoreLogo
+        )}
           href='https://play.google.com/store/apps/details?id=com.coinbase.android'
+          rel='noopener' target='_blank'
         />
       </section>
     }

--- a/app/renderer/components/preferences/payment/enabledContent.js
+++ b/app/renderer/components/preferences/payment/enabledContent.js
@@ -84,7 +84,7 @@ class EnabledContent extends ImmutableComponent {
 
     return <section className={css(styles.balance)}>
       <FormTextbox data-test-id='fundsAmount' readOnly value={btcToCurrencyString(value, ledgerData)} />
-      <a className={css(styles.iconLink)} href='https://brave.com/Payments_FAQ.html' target='_blank'>
+      <a className={css(styles.iconLink)} href='https://brave.com/Payments_FAQ.html' rel='noopener' target='_blank'>
         <span className={cx({
           fa: true,
           'fa-question-circle': true,

--- a/app/renderer/components/preferences/paymentsTab.js
+++ b/app/renderer/components/preferences/paymentsTab.js
@@ -214,8 +214,8 @@ class PaymentsTab extends ImmutableComponent {
               [css(styles.autoSuggestSwitch__moreInfoBtnSuggest)]: true
             })}
               href='https://brave.com/Payments_FAQ.html'
-              target='_blank'
               data-l10n-id='paymentsFAQLink'
+              rel='noopener' target='_blank'
             />
           </div>
           {

--- a/js/about/about.js
+++ b/js/about/about.js
@@ -36,7 +36,7 @@ class AboutAbout extends ImmutableComponent {
           {
             aboutUrls.keySeq().sort().filter((aboutSourceUrl) => isNavigatableAboutPage(aboutSourceUrl)).map((aboutSourceUrl) =>
               <li>
-                <a href={aboutUrls.get(aboutSourceUrl)} target='_blank'>
+                <a href={aboutUrls.get(aboutSourceUrl)} rel='noopener' target='_blank'>
                   {aboutSourceUrl}
                 </a>
               </li>)

--- a/js/about/brave.js
+++ b/js/about/brave.js
@@ -60,7 +60,11 @@ class AboutBrave extends React.Component {
         <div>
           <span data-l10n-id='relNotesInfo1' />
           &nbsp;
-          <a className={css(commonStyles.linkText)} href={`https://github.com/brave/browser-laptop/releases/tag/v${this.state.versionInformation.get('Brave')}dev`} rel='noopener' target='_blank' data-l10n-id='relNotesInfo2' />
+          <a className={css(commonStyles.linkText)}
+            href={`https://github.com/brave/browser-laptop/releases/tag/v${this.state.versionInformation.get('Brave')}dev`}
+            data-l10n-id='relNotesInfo2'
+            rel='noopener' target='_blank'
+          />
           &nbsp;
           <span data-l10n-id='relNotesInfo3' />
         </div>
@@ -83,7 +87,7 @@ class AboutBrave extends React.Component {
             },
             {
               html: name === 'rev'
-                ? <a rel='noopener' target='_blank' className={css(commonStyles.linkText)} href={`https://github.com/brave/browser-laptop/commit/${version}`}>{(version && version.substring(0, 7)) || ''}</a>
+                ? <a className={css(commonStyles.linkText)} href={`https://github.com/brave/browser-laptop/commit/${version}`} rel='noopener' target='_blank'>{(version && version.substring(0, 7)) || ''}</a>
                 : version,
               value: version
             }

--- a/js/about/contributionStatement.js
+++ b/js/about/contributionStatement.js
@@ -451,7 +451,7 @@ class ContributionStatement extends React.Component {
                 transactions.map(function (tx) {
                   return (
                     <li>
-                      <a className={css(styles.list__anchor)} href={aboutContributionsUrl + '#' + tx.get('viewingId')} target='_blank'>
+                      <a className={css(styles.list__anchor)} href={aboutContributionsUrl + '#' + tx.get('viewingId')} rel='noopener' target='_blank'>
                         {this.receiptFileName(tx)}
                       </a>
                     </li>

--- a/js/about/newTabComponents/footerInfo.js
+++ b/js/about/newTabComponents/footerInfo.js
@@ -15,7 +15,7 @@ class FooterInfo extends ImmutableComponent {
           this.props.backgroundImage && this.props.backgroundImage.name
           ? <div>
             <div className='copyrightCredits'>
-              <span className='photoBy' data-l10n-id='photoBy' /> <a className='copyrightOwner' href={this.props.backgroundImage.link} rel='noopner' target='_blank'>{this.props.backgroundImage.author}</a>
+              <span className='photoBy' data-l10n-id='photoBy' /> <a className='copyrightOwner' href={this.props.backgroundImage.link} rel='noopener' target='_blank'>{this.props.backgroundImage.author}</a>
             </div>
             <span className='photoName'>{this.props.backgroundImage.name}</span>
           </div>

--- a/js/webtorrent/components/torrentViewer.js
+++ b/js/webtorrent/components/torrentViewer.js
@@ -54,8 +54,7 @@ class TorrentViewer extends React.Component {
         })}
           data-l10n-id='poweredByWebTorrent'
           href='https://webtorrent.io'
-          rel='noopener'
-          target='_blank'
+          rel='noopener' target='_blank'
         />
       )
     } else {


### PR DESCRIPTION
Follow-up to #10290

Also:
- Add `rel='noopener'` to `brave.com` (as the site also may be hacked, which of course should not happen)
- Fix a typo on https://github.com/brave/browser-laptop/pull/10290/files#diff-53c54a977fb4fffd2f7da96ec29f0c71R18
- Always `rel='noopener'` first, `target='_blank'` second on the same line (to make it easy to search it with regex)

Auditors:

Test Plan:
1. Search your repo for `target='_blank'`
2. Make sure external anchor links with `target='_blank'` have `rel='noopener'`

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


