### PR TITLE
Enable border on sortableTable by default

### DIFF
--- a/app/renderer/components/common/sortableTable.js
+++ b/app/renderer/components/common/sortableTable.js
@@ -481,7 +481,10 @@ const styles = StyleSheet.create({
   table: {
     boxSizing: 'border-box',
     cursor: 'default',
-    borderSpacing: 0
+    borderSpacing: 0,
+
+    // #10434: Enable border on the table by default
+    borderCollapse: 'collapse'
   },
 
   // Setting 'fillAvailable' maximizes the width of the table.


### PR DESCRIPTION
Fixes #10434
Follow-up to #10265

Auditors: @cezaraugusto

Test Plan:
1. Run `npm run add-simulated-synopsis-visits 100`
2. Open about:preferences#payments
3. Pin some sites
4. Make sure the orange border appears on the table

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


