### PR TITLE
fix setting for minimum visits for publisher relevancy

### DIFF
--- a/app/renderer/components/preferences/payment/advancedSettings.js
+++ b/app/renderer/components/preferences/payment/advancedSettings.js
@@ -48,7 +48,7 @@ class AdvancedSettingsContent extends ImmutableComponent {
             <SettingDropdown
               data-test-id='visitSelector'
               defaultValue={minPublisherVisits || 1}
-              onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.MINIMUM_VISITS)}>
+              onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.PAYMENTS_MINIMUM_VISITS)}>
               <option data-l10n-id='minimumVisitsLow' value='1' />
               <option data-l10n-id='minimumVisitsMedium' value='5' />
               <option data-l10n-id='minimumVisitsHigh' value='10' />


### PR DESCRIPTION
close #10439
Auditors: @bsclifton, @luixxiul 

after #10164, only in 0.21.x

str:
1. enable payments
2. click the wheel
3. set `minimum visits for publisher relevancy` to other value
4. close modal
5. re-open
6. value is saved