### PR TITLE
re-enable option to Recover Wallet

### DIFF
--- a/app/ledger.js
+++ b/app/ledger.js
@@ -56,7 +56,6 @@ const uuid = require('uuid')
 const appActions = require('../js/actions/appActions')
 const appConfig = require('../js/constants/appConfig')
 const appConstants = require('../js/constants/appConstants')
-const appDispatcher = require('../js/dispatcher/appDispatcher')
 const messages = require('../js/constants/messages')
 const settings = require('../js/constants/settings')
 const request = require('../js/lib/request')
@@ -145,7 +144,7 @@ let notificationTryPaymentsMessage
 let notificationTimeout = null
 
 // TODO(bridiver) - create a better way to get setting changes
-const doAction = (action) => {
+const doAction = (state, action) => {
   var i, publisher
 
 /* TBD: handle
@@ -163,12 +162,26 @@ const doAction = (action) => {
   }
 
   switch (action.actionType) {
+    case appConstants.APP_SET_STATE:
+      init()
+      break
+
+    case appConstants.APP_BACKUP_KEYS:
+      state = backupKeys(state, action)
+      break
+
+    case appConstants.APP_RECOVER_WALLET:
+      state = recoverKeys(state, action)
+      break
+
     case appConstants.APP_SHUTTING_DOWN:
       quit()
       break
 
     case appConstants.APP_ON_CLEAR_BROWSING_DATA:
-      if (action.clearDataDetail.get('browserHistory') && !getSetting(settings.PAYMENTS_ENABLED)) reset(true)
+      if (state.getIn(['clearBrowsingDataDefaults', 'browserHistory']) && !getSetting(settings.PAYMENTS_ENABLED)) {
+        reset(true)
+      }
       break
 
     case appConstants.APP_IDLE_STATE_CHANGED:
@@ -264,6 +277,8 @@ const doAction = (action) => {
     default:
       break
   }
+
+  return state
 }
 
 /*
@@ -272,7 +287,6 @@ const doAction = (action) => {
 
 var init = () => {
   try {
-    appDispatcher.register(doAction)
     initialize(getSetting(settings.PAYMENTS_ENABLED))
   } catch (ex) { console.log('ledger.js initialization failed: ' + ex.toString() + '\n' + ex.stack) }
 }
@@ -2269,5 +2283,6 @@ module.exports = {
   backupKeys: backupKeys,
   quit: quit,
   boot: boot,
-  reset: reset
+  reset: reset,
+  doAction
 }

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -376,7 +376,6 @@ function handleChangeSettingAction (settingKey, settingValue) {
 }
 
 let reducers = []
-let ledger = null
 
 const applyReducers = (state, action, immutableAction) => reducers.reduce(
     (appState, reducer) => {
@@ -388,7 +387,6 @@ const applyReducers = (state, action, immutableAction) => reducers.reduce(
 
 const handleAppAction = (action) => {
   if (action.actionType === appConstants.APP_SET_STATE) {
-    ledger = require('../../app/ledger')
     reducers = [
       require('../../app/browser/reducers/downloadsReducer'),
       require('../../app/browser/reducers/flashReducer'),
@@ -409,7 +407,7 @@ const handleAppAction = (action) => {
       require('../../app/browser/reducers/extensionsReducer'),
       require('../../app/browser/reducers/shareReducer'),
       require('../../app/browser/reducers/updatesReducer'),
-      require('../../app/browser/reducers/topSitesReducer')
+      require('../../app/ledger').doAction
     ]
     initialized = true
     appState = action.appState
@@ -435,7 +433,6 @@ const handleAppAction = (action) => {
       appState = profiles.init(appState, action, appStore)
       appState = require('../../app/browser/menu').init(appState, action, appStore)
       appState = require('../../app/sync').init(appState, action, appStore)
-      ledger.init()
       break
     case appConstants.APP_SHUTTING_DOWN:
       AppDispatcher.shutdown()


### PR DESCRIPTION
### Dear reviewers read this first:
* This PR is against 0.18.x only. No other action should be taken since 17057bdb59e3bdff82b382d413502b3bb83deee5 is included for 0.19.x and beyond.
* This is a cherry-pick from 17057bdb59e3bdff82b382d413502b3bb83deee5
<hr>

Fix #10442

Test Plan (same as https://github.com/brave/browser-laptop/pull/9457#issue-235903786):

* check if you can clear history
* check if toggles are preserved as you click clear
* toggle one switch, click cancel and check that toggle was not preserved when you open it next time
* check if ledger is still working correctly: ledger initi, ledger backup, ledger recovery

Test plan 2:

* Recover wallet in both ways (manual and file import) should work