### PR TITLE
Add 'fillAvailable' to SortableTable on bookmarksList.js and history.js

### DIFF
--- a/app/renderer/about/bookmarks/bookmarksList.js
+++ b/app/renderer/about/bookmarks/bookmarksList.js
@@ -103,6 +103,7 @@ class BookmarksList extends ImmutableComponent {
     }
     return <div>
       <SortableTable
+        fillAvailable
         ref='bookmarkTable'
         headings={[
           <BookmarkTitleHeader heading='title' selectedFolderId={this.props.selectedFolderId} />

--- a/js/about/history.js
+++ b/js/about/history.js
@@ -78,7 +78,9 @@ class HistoryDay extends ImmutableComponent {
       <div className={css(styles.subTitleMargin)}>
         <AboutPageSectionSubTitle>{this.props.date}</AboutPageSectionSubTitle>
       </div>
-      <SortableTable headings={['time', 'title', 'domain']}
+      <SortableTable
+        fillAvailable
+        headings={['time', 'title', 'domain']}
         defaultHeading='time'
         defaultHeadingSortOrder='desc'
         rows={this.props.entries.map((entry) => [


### PR DESCRIPTION
Fixes #10450
Addresses #10263

It is not added to SortableTable on brave.js and torrentFileList.js

Auditors: @cezaraugusto

Test Plan:
1. Open about:bookmarks
2. Open about:history
3. Make sure the layout is not broken

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


