### PR TITLE
Normalize SortableTable's th, tr, and td

### DIFF
--- a/app/renderer/components/common/sortableTable.js
+++ b/app/renderer/components/common/sortableTable.js
@@ -7,6 +7,7 @@ const Immutable = require('immutable')
 const tableSort = require('tablesort')
 
 const {StyleSheet, css} = require('aphrodite/no-important')
+const globalStyles = require('../styles/global')
 
 // Utils
 const cx = require('../../../../js/lib/classSet')
@@ -370,7 +371,8 @@ class SortableTable extends React.Component {
 
         return <td className={cx({
           [hasColumnClassNames]: true,
-          [customCellClassesStr]: true
+          [customCellClassesStr]: true,
+          [css(styles.table__tbody__tr__td, this.props.smallRow && styles.table__tbody__tr_smallRow__td)]: true
         })}
           data-sort={value} data-td-index={`${j}`}>
           {
@@ -400,7 +402,10 @@ class SortableTable extends React.Component {
           data-context-menu-disable={rowAttributes && rowAttributes.onContextMenu ? true : undefined}
           data-table-id={this.tableID}
           data-row-index={`${currentIndex}`}
-          className={classes.join(' ')}>{entry}</tr>
+          className={cx({
+            [css(styles.table__tbody__tr, this.props.largeRow && styles.table__tbody__tr_largeRow)]: true,
+            [classes.join(' ')]: classes
+          })}>{entry}</tr>
         : null
     })
   }
@@ -448,7 +453,8 @@ class SortableTable extends React.Component {
             }
             const headerClasses = {
               'sort-header': true,
-              'sort-default': this.sortingDisabled || heading === this.props.defaultHeading
+              'sort-default': this.sortingDisabled || heading === this.props.defaultHeading,
+              [css(styles.table__th)]: true
             }
             const isString = typeof heading === 'string'
             const sortMethod = this.sortingDisabled ? 'none' : (dataType === 'number' ? 'number' : undefined)
@@ -461,6 +467,7 @@ class SortableTable extends React.Component {
                 isString
                   ? <div className={cx({
                     'th-inner': true,
+                    [css(styles.table__th__inner, this.props.smallRow && styles.table__th__inner_smallRow)]: true,
                     [this.props.headerClassNames]: !!this.props.headerClassNames
                   })} data-l10n-id={heading} />
                   : heading
@@ -487,6 +494,58 @@ const styles = StyleSheet.create({
   // Setting 'fillAvailable' maximizes the width of the table.
   table_fillAvailable: {
     width: '-webkit-fill-available'
+  },
+
+  table__th: {
+    background: `linear-gradient(to bottom, ${globalStyles.color.lightGray}, ${globalStyles.color.veryLightGray})`,
+    borderTop: `1px solid ${globalStyles.color.gray}`,
+    borderLeft: `1px solid ${globalStyles.color.braveOrange}`,
+    textAlign: 'left',
+    fontWeight: 300,
+    padding: '1ch',
+    whiteSpace: 'nowrap',
+
+    // Up/down arrow
+    ':after': {
+      fontFamily: 'FontAwesome',
+      fontSize: '8pt',
+      marginLeft: '4px',
+      position: 'relative',
+      bottom: '2px'
+    },
+
+    ':first-child': {
+      borderLeft: 'none'
+    }
+  },
+
+  table__th__inner: {
+    display: 'inline-block',
+    userSelect: 'none'
+  },
+
+  // See ledgerTable.js for an example
+  table__th__inner_smallRow: {
+    fontSize: '14px'
+  },
+
+  table__tbody__tr: {
+    height: '1rem'
+  },
+
+  // Add 'largeRow' to SortableTable to increase the height of tr.
+  table__tbody__tr_largeRow: {
+    height: '4rem'
+  },
+
+  table__tbody__tr__td: {
+    padding: '.5ch 1ch'
+  },
+
+  // Add 'smallRow' to SortableTable to decrease padding-top and padding-bottom of td.
+  table__tbody__tr_smallRow__td: {
+    paddingTop: '.3ch',
+    paddingBottom: '.3ch'
   }
 })
 

--- a/app/renderer/components/preferences/extensionsTab.js
+++ b/app/renderer/components/preferences/extensionsTab.js
@@ -77,15 +77,6 @@ class ExtensionsTab extends ImmutableComponent {
           checked={this.getCheckedExtension(extension.get('id'))}
           onChangeSetting={this.props.onChangeSetting} />
       }
-      // { // Exclude option
-      //  /* TODO @cezaraugusto reenable it once we can be able
-      //   * to recover from an excluded->re-enabled extension state
-      //  html: !extension.get('isDummy') && !isBuiltInExtension(extension.get('id'))
-      //  ? <div className={globalStyles.appIcons.trash}
-      //    onClick={this.onRemoveExtension.bind(this, extension.get('id'))} />
-      //  : <span data-l10n-id={isBuiltInExtension(extension.get('id')) ? 'integrated' : 'notInstalled'} />
-      //  */
-      // }
     ]
   }
 

--- a/app/renderer/components/preferences/extensionsTab.js
+++ b/app/renderer/components/preferences/extensionsTab.js
@@ -56,7 +56,7 @@ class ExtensionsTab extends ImmutableComponent {
 
     return [
       { // Icon
-        html: <img className={css(styles.tableRow__column__icon)} src={this.getIcon(extension)} />
+        html: <img className={css(styles.icon)} src={this.getIcon(extension)} />
       },
       { // Name
         html: <span data-extension-id={extension.get('id')}
@@ -76,27 +76,16 @@ class ExtensionsTab extends ImmutableComponent {
           settings={this.props.settings}
           checked={this.getCheckedExtension(extension.get('id'))}
           onChangeSetting={this.props.onChangeSetting} />
-      },
-      { // Exclude option
-        /* TODO @cezaraugusto reenable it once we can be able
-         * to recover from an excluded->re-enabled extension state
-        html: !extension.get('isDummy') && !isBuiltInExtension(extension.get('id'))
-        ? <div className={globalStyles.appIcons.trash}
-          onClick={this.onRemoveExtension.bind(this, extension.get('id'))} />
-        : <span data-l10n-id={isBuiltInExtension(extension.get('id')) ? 'integrated' : 'notInstalled'} />
-        */
       }
-    ]
-  }
-
-  get columnClassNames () {
-    return [
-      css(styles.tableRow__column, styles.tableRow__column_center),
-      css(styles.tableRow__column),
-      css(styles.tableRow__column),
-      css(styles.tableRow__column),
-      css(styles.tableRow__column, styles.tableRow__column_center)
-      // css(styles.tableRow__column, styles.tableRow__column_center)
+      // { // Exclude option
+      //  /* TODO @cezaraugusto reenable it once we can be able
+      //   * to recover from an excluded->re-enabled extension state
+      //  html: !extension.get('isDummy') && !isBuiltInExtension(extension.get('id'))
+      //  ? <div className={globalStyles.appIcons.trash}
+      //    onClick={this.onRemoveExtension.bind(this, extension.get('id'))} />
+      //  : <span data-l10n-id={isBuiltInExtension(extension.get('id')) ? 'integrated' : 'notInstalled'} />
+      //  */
+      // }
     ]
   }
 
@@ -108,13 +97,14 @@ class ExtensionsTab extends ImmutableComponent {
       <DefaultSectionTitle data-l10n-id='extensions' />
       <SortableTable
         fillAvailable
+        largeRow
         sortingDisabled
         headings={['icon', 'name', 'description', 'version', 'enabled'] /* 'exclude' */}
-        columnClassNames={this.columnClassNames}
         rowClassNames={
           this.props.extensions.map(entry => css(styles.tableRow)).toJS()
         }
-        rows={this.props.extensions.map(entry => this.getRow(entry))} />
+        rows={this.props.extensions.map(entry => this.getRow(entry))}
+      />
       <footer className={css(styles.moreInfo)}>
         <HelpfulText l10nId='extensionsTabFooterInfo'>&nbsp;
           <span data-l10n-id='community'
@@ -133,9 +123,6 @@ const styles = StyleSheet.create({
     fontSize: '15px',
     background: '#fff',
 
-    // TODO (Suguru): refactor sortableTable.js to remove !important
-    height: '56px !important',
-
     ':nth-child(even)': {
       background: globalStyles.color.veryLightGray
     },
@@ -145,15 +132,7 @@ const styles = StyleSheet.create({
     }
   },
 
-  tableRow__column: {
-    padding: '0 8px'
-  },
-
-  tableRow__column_center: {
-    textAlign: 'center'
-  },
-
-  tableRow__column__icon: {
+  icon: {
     display: 'flex',
     margin: 'auto',
     width: '32px',

--- a/app/renderer/components/preferences/payment/ledgerTable.js
+++ b/app/renderer/components/preferences/payment/ledgerTable.js
@@ -112,13 +112,13 @@ class LedgerTable extends ImmutableComponent {
 
   get columnClassNames () {
     return [
-      css(styles.tableTd, styles.alignRight, styles.verifiedTd), // verified
-      css(styles.tableTd, styles.alignRight), // sites
-      css(styles.tableTd),                    // include
-      css(styles.tableTd, styles.alignRight), // views
-      css(styles.tableTd, styles.alignRight), // time spent
-      css(styles.tableTd, styles.alignRight, styles.percTd), // percentage
-      css(styles.tableTd, styles.alignLeft)   // actions
+      css(styles.alignRight, styles.verifiedTd), // verified
+      css(styles.alignRight), // sites
+      css(styles.alignLeft),  // include
+      css(styles.alignRight), // views
+      css(styles.alignRight), // time spent
+      css(styles.alignRight, styles.percTd), // percentage
+      css(styles.alignLeft)   // actions
     ]
   }
 
@@ -129,14 +129,14 @@ class LedgerTable extends ImmutableComponent {
       pinnedRows.map(item => {
         j++
         return this.enabledForSite(item)
-          ? css(styles.tableTr, j % 2 && styles.tableTdBg)
-          : css(styles.tableTr, styles.paymentsDisabled, j % 2 && styles.tableTdBg)
+          ? css(j % 2 && styles.tableTdBg)
+          : css(styles.paymentsDisabled, j % 2 && styles.tableTdBg)
       }).toJS(),
       unPinnedRows.map(item => {
         j++
         return this.enabledForSite(item)
-          ? css(styles.tableTr, j % 2 && styles.tableTdBg)
-          : css(styles.tableTr, styles.paymentsDisabled, j % 2 && styles.tableTdBg)
+          ? css(j % 2 && styles.tableTdBg)
+          : css(styles.paymentsDisabled, j % 2 && styles.tableTdBg)
       }).toJS()
     ]
   }
@@ -274,6 +274,7 @@ class LedgerTable extends ImmutableComponent {
       </div>
       <SortableTable
         fillAvailable
+        smallRow
         headings={['', 'publisher', 'include', 'views', 'timeSpent', 'percentage', 'actions']}
         defaultHeading='percentage'
         defaultHeadingSortOrder='desc'
@@ -341,17 +342,7 @@ const styles = StyleSheet.create({
 
   tableTh: {
     color: paymentStylesVariables.tableHeader.fontColor,
-    fontSize: '14px',
     fontWeight: paymentStylesVariables.tableHeader.fontWeight
-  },
-
-  tableTr: {
-    height: '26px'
-  },
-
-  tableTd: {
-    position: 'relative',
-    padding: '0 15px'
   },
 
   tableTdBg: {
@@ -363,8 +354,7 @@ const styles = StyleSheet.create({
   },
 
   percTd: {
-    width: '45px',
-    paddingLeft: '5px'
+    width: '45px'
   },
 
   hideTd: {

--- a/app/renderer/components/preferences/syncTab.js
+++ b/app/renderer/components/preferences/syncTab.js
@@ -160,7 +160,6 @@ class SyncTab extends ImmutableComponent {
         defaultHeadingSortOrder='desc'
         rows={this.devicesTableRows}
         tableClassNames={css(styles.devices__devicesList)}
-        customCellClasses={css(styles.devices__devicesListCell)}
       />
     </section>
   }
@@ -592,9 +591,6 @@ const styles = StyleSheet.create({
   devices__devicesList: {
     marginBottom: globalStyles.spacing.dialogInsideMargin,
     width: '600px'
-  },
-  devices__devicesListCell: {
-    padding: '4px 8px'
   },
 
   textArea__passphrase: {

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -254,7 +254,7 @@ table.sortableTable {
   }
 
   .default {
-    width: 95x;
+    width: 95px;
   }
   .searchEngine {
     width: 304px !important;

--- a/less/sortableTable.less
+++ b/less/sortableTable.less
@@ -6,8 +6,6 @@
 
 table.sort {
   th {
-    color: @buttonColor;
-
     &:hover {
       color: #000;
     }
@@ -16,30 +14,7 @@ table.sort {
 
 table.sortableTable {
   tr {
-    height: 1.7em;
-    padding: 5px 20px;
-
     th {
-      background: linear-gradient(to bottom, @lightGray, @veryLightGray);
-      border-top: 1px solid @gray;
-      text-align: left;
-      font-weight: 300;
-      padding: 8px;
-      box-sizing: border-box;
-
-      .th-inner {
-        display: inline-block;
-        user-select: none;
-      }
-
-      &:after {
-        font-family: FontAwesome;
-        font-size: 8pt;
-        margin-top: 3px;
-        margin-right: 3px;
-        float: right;
-      }
-
       &[aria-sort="ascending"]:after {
         content: "\f077";
       }
@@ -47,9 +22,6 @@ table.sortableTable {
       &[aria-sort="descending"]:after {
         content: "\f078";
       }
-    }
-    th + th {
-      border-left: 1px solid @braveOrange;
     }
 
     td {
@@ -83,23 +55,30 @@ table.sortableTable {
       }
     }
   }
+
   tr.rowHover:hover {
     background: @lightGray;
+
     &.selected {
       background: @braveOrange;
+
       td {
         color: white;
       }
+
       div {
         color: white;
       }
     }
   }
+
   tr.selected {
     background-color: lighten(@gray, 20%);
+
     td {
       color: @buttonColor;
     }
+
     div {
       color: @buttonColor;
     }


### PR DESCRIPTION
Addresses #10263

Add options 'smallRow' and 'LargeRow'
- smallRow for ledgerTable.js
- largeRow for extensionsTab.js

TODO: Add mockups on `styles.js`.

Also:
- Comment out Exclude option to hide the most right column on about:preferences#extensions

Auditors: @cezaraugusto

Test Plan 1:
1. Open about:preferences#search
2. Make sure that the height of the table row is '1rem' and the padding of the cell is '.5ch 1ch'

Test Plan 2 (Small Row):
1. Run `npm run add-simulated-synopsis-visits 100`
2. Open about:preferences#payments
3. Make ure that the height of the table row is '1rem' and the padding-top and padding-bottom is '0.3ch'

Test Plan 3 (Large Row):
1. Open about:preferences#extensions
2. Make sure that the height of the table row is '4rem' and the padding of the cell is '.5ch 1ch'

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


