### PR TITLE
Remove obsolete styles introduced with #2460

### DIFF
--- a/less/sortableTable.less
+++ b/less/sortableTable.less
@@ -57,30 +57,6 @@ table.sortableTable {
       -webkit-font-smoothing: antialiased;
       position: relative;
       width: auto;
-
-      input[type='range'] {
-        background: transparent;
-        -webkit-appearance: none;
-        width: 90%;
-        margin: 0 0 0 20%;
-        outline: none;
-
-        &::-webkit-slider-runnable-track {
-          -webkit-appearance: none;
-          background: @gray25;
-          border-radius: 1000px;
-          height: 1em;
-        }
-
-        &::-webkit-slider-thumb {
-          -webkit-appearance: none;
-          background: linear-gradient(to bottom, @braveOrange, @braveDarkOrange);
-          width: 1em;
-          height: 1em;
-          border-radius: 50%;
-          box-shadow: 0 0 6px @black25;
-        }
-      }
     }
   }
   tr.rowHover:hover {


### PR DESCRIPTION
Addresses #10263

These styles were introduced on https://github.com/brave/browser-laptop/commit/ac2e6d116de7045eb248e6ed1590afb1dc3ffcba#diff-b6afd5ab48e47aa71ccacf98b2e44c42R49 without direction of usage. It is not possible to detect where they are / have been used. Let's revert it if we'll use those.

Auditors: @cezaraugusto

Test Plan:
1. Search your repo for `type="range"`
2. Make sure nothing is found

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


