### PR TITLE
Normalize action buttons placement

### DIFF
--- a/js/about/history.js
+++ b/js/about/history.js
@@ -12,7 +12,7 @@ const settings = require('../constants/settings')
 const aboutActions = require('./aboutActions')
 const getSetting = require('../settings').getSetting
 const SortableTable = require('../../app/renderer/components/common/sortableTable')
-const Button = require('../../app/renderer/components/common/button')
+const BrowserButton = require('../../app/renderer/components/common/browserButton')
 const {makeImmutable} = require('../../app/common/state/immutableUtil')
 const historyUtil = require('../../app/common/lib/historyUtil')
 
@@ -210,6 +210,11 @@ class AboutHistory extends React.Component {
         <AboutPageSectionTitle data-l10n-id='history' />
         <div className='headerActions'>
           <div className='searchWrapper'>
+            <BrowserButton primaryColor
+              l10nId='clearBrowsingDataNow'
+              testId='clearBrowsingDataButton'
+              onClick={this.clearBrowsingDataNow}
+            />
             <input type='text' className='searchInput' ref='historySearch' id='historySearch' value={this.state.search} onChange={this.onChangeSearch} data-l10n-id='historySearch' />
             {
               this.state.search
@@ -217,11 +222,6 @@ class AboutHistory extends React.Component {
               : <span className='fa fa-search searchInputPlaceholder' />
             }
           </div>
-          <Button className='primaryButton'
-            l10nId='clearBrowsingDataNow'
-            testId='clearBrowsingDataButton'
-            onClick={this.clearBrowsingDataNow}
-          />
         </div>
       </div>
 


### PR DESCRIPTION
Move the button left of the input field.
Also replace Button with BrowserButton.

Fixes #10465

The margin between the buttons and the input field will be adjusted with another PR where I'm going to normalize siteDetails.less, so please ignore it for now.

Auditors:

Test Plan:
1. Open about:history
2. Open about:bookmarks
3. Make sure the action buttons are placed left of the input fields

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


