### PR TITLE
SwitchControl text now toggles checked state

### DIFF
--- a/app/renderer/components/common/switchControl.js
+++ b/app/renderer/components/common/switchControl.js
@@ -36,18 +36,19 @@ class SwitchControl extends ImmutableComponent {
     >
       {
         this.props.leftl10nId && this.props.topl10nId
-        ? <div className='switchControlText'><div className='switchControlLeftText'><div className='switchSpacer'>&nbsp;</div><span className='switchControlLeftText' data-l10n-id={this.props.leftl10nId} /></div></div>
+        ? <div className='switchControlText'><div className='switchControlLeftText'><div className='switchSpacer'>&nbsp;</div><label className='switchControlLeftText' onClick={this.onClick} data-l10n-id={this.props.leftl10nId} /></div></div>
         : (this.props.leftl10nId
-          ? <span className='switchControlLeftText' data-l10n-id={this.props.leftl10nId} />
+          ? <label className='switchControlLeftText' onClick={this.onClick} data-l10n-id={this.props.leftl10nId} />
           : null)
       }
       <div className='switchMiddle'>
         {
           this.props.topl10nId
-          ? <span className={cx({
+          ? <label className={cx({
             switchControlTopText: true,
             [this.props.customTopTextClassName]: !!this.props.customTopTextClassName
           })}
+            onClick={this.onClick}
             data-l10n-id={this.props.topl10nId} />
           : null
         }
@@ -67,34 +68,36 @@ class SwitchControl extends ImmutableComponent {
         ? <div className='switchControlText'>
           <div className='switchControlRightText'>
             <div className='switchSpacer'>&nbsp;</div>
-            <span className={cx({
+            <label className={cx({
               switchControlRightText: true,
               [this.props.customRightTextClassName]: !!this.props.customRightTextClassName
             })}
+              onClick={this.onClick}
               data-l10n-id={this.props.rightl10nId}
               data-l10n-args={this.props.rightl10nArgs}
-            >{this.props.rightText || ''}</span>
+            >{this.props.rightText || ''}</label>
           </div>
         </div>
         : <div className='switchControlRight'>
           {
             (this.props.rightl10nId || this.props.rightText) && !this.props.onInfoClick
-            ? <span className={cx({
+            ? <label className={cx({
               switchControlRightText: true,
               [this.props.customRightTextClassName]: !!this.props.customRightTextClassName
             })}
+              onClick={this.onClick}
               data-l10n-id={this.props.rightl10nId}
               data-l10n-args={this.props.rightl10nArgs}
-            >{this.props.rightText || ''}</span>
+            >{this.props.rightText || ''}</label>
           : null
         }
           {
             (this.props.rightl10nId || this.props.rightText) && this.props.onInfoClick
             ? <div className='switchControlRightText'>
-              <span data-l10n-id={this.props.rightl10nId}
+              <label onClick={this.onClick} data-l10n-id={this.props.rightl10nId}
                 data-l10n-args={this.props.rightl10nArgs}>
                 {this.props.rightText}
-              </span>
+              </label>
               <span className={cx({
                 fa: true,
                 'fa-question-circle': true,


### PR DESCRIPTION
The click event will now fire from the label, whether it is to the left, right, or top of the switch element.

This also converts text from `<span />` to `<label />` for accessibility and more appropriate renderer defaults (the cursor) to convey that clicking the label will toggle the checked state.

Usages this affects:
 - all items in the _Brave_ extension panel (compact and full mode)
 - the _Clear Browsing Data_ model
 - the _MessageBox_ component
 - about:adblock

This is a partial resolution only for #8243 since many usages do not use the built-in switchControl label element but render their own text separately. Changing some of those usages to the switchControl label element causes some minor visual regression which may warrant some discussion. A subsequent PR will address converting these usages, which are not covered by this PR:
 - most switches in all sections of about:preferences
 - case-sensitivity switch in the findPage dialog


Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
- Open the _Clear Browsing Data_ model or the _Brave_ extension panel
- Verify clicking a switch label causes the checked state to toggle
- Verify no visual regressions

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


