### PR TITLE
Allow creating directories for downloads path

### DIFF
--- a/app/browser/reducers/downloadsReducer.js
+++ b/app/browser/reducers/downloadsReducer.js
@@ -95,7 +95,7 @@ const downloadsReducer = (state, action) => {
 
       dialog.showOpenDialog(focusedWindow, {
         defaultPath: app.getPath('downloads'),
-        properties: ['openDirectory']
+        properties: ['openDirectory', 'createDirectory']
       }, (folder) => {
         if (Array.isArray(folder) && fs.lstatSync(folder[0]).isDirectory()) {
           appActions.changeSetting(settings.DOWNLOAD_DEFAULT_PATH, folder[0])


### PR DESCRIPTION
Fixes #10479

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:

**Note: macOS-only**
1. Open about:preferences > General tab.
2. Under "Save my downloads here:", click the path field or the pencil icon.
3. Make sure there is a "New Folder" button at the bottom left (see screenshot).

![image](https://user-images.githubusercontent.com/19424103/29295513-6772452a-811a-11e7-8e82-084221637bea.png)

Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


