### PR TITLE
Partial refactoring of switchControl.js

### DIFF
--- a/app/renderer/components/common/settings.js
+++ b/app/renderer/components/common/settings.js
@@ -88,12 +88,6 @@ class SettingCheckbox extends ImmutableComponent {
       props.id = this.props.id
     }
 
-    const labelClass = cx({
-      [css(settingCheckboxStyles.label)]: this.props.small,
-      [this.props.labelClassName]: !!this.props.labelClassName,
-      [css(settingCheckboxStyles.expansiveRightText)]: !this.props.compact
-    })
-
     return <div {...props} data-test-id={this.props.dataTestId}>
       <SwitchControl id={this.props.prefKey}
         small={this.props.small}
@@ -101,23 +95,16 @@ class SettingCheckbox extends ImmutableComponent {
         onClick={this.onClick}
         checkedOn={this.props.checked !== undefined ? this.props.checked : getSetting(this.props.prefKey, this.props.settings)}
         className={this.props.switchClassName}
-        customRightTextClassName={labelClass}
+        customRightTextClassName={this.props.rightLabelClassName}
+        customLeftTextClassName={this.props.leftLabelClassName}
         rightl10nId={this.props.dataL10nId}
         rightl10nArgs={this.props.dataL10nArgs}
+        leftl10nId={this.props.dataL10nIdLeft}
       />
       {this.props.options}
     </div>
   }
 }
-
-const settingCheckboxStyles = StyleSheet.create({
-  label: {
-    fontSize: 'smaller'
-  },
-  expansiveRightText: {
-    paddingLeft: '9px'
-  }
-})
 
 class SiteSettingCheckbox extends ImmutableComponent {
   constructor () {

--- a/app/renderer/components/common/switchControl.js
+++ b/app/renderer/components/common/switchControl.js
@@ -6,6 +6,8 @@ const React = require('react')
 const ImmutableComponent = require('../immutableComponent')
 const cx = require('../../../../js/lib/classSet')
 
+const {StyleSheet, css} = require('aphrodite/no-important')
+
 /**
  * Represents an on/off switch control
  */
@@ -36,9 +38,24 @@ class SwitchControl extends ImmutableComponent {
     >
       {
         this.props.leftl10nId && this.props.topl10nId
-        ? <div className='switchControlText'><div className='switchControlLeftText'><div className='switchSpacer'>&nbsp;</div><label className='switchControlLeftText' onClick={this.onClick} data-l10n-id={this.props.leftl10nId} /></div></div>
+        ? <div className='switchControlText'>
+          <div className='switchControlLeftText'>
+            <div className='switchSpacer'>&nbsp;</div>
+            <label className={cx({
+              [css(styles.switchControlText__label, styles.switchControlText_left__label, this.props.small && styles.switchControlText__label_small)]: true,
+              [this.props.customLeftTextClassName]: !!this.props.customLeftTextClassName
+            })}
+              onClick={this.onClick} data-l10n-id={this.props.leftl10nId}
+            />
+          </div>
+        </div>
         : (this.props.leftl10nId
-          ? <label className='switchControlLeftText' onClick={this.onClick} data-l10n-id={this.props.leftl10nId} />
+          ? <label className={cx({
+            [css(styles.switchControlText__label, styles.switchControlText_left__label, this.props.small && styles.switchControlText__label_small)]: true,
+            [this.props.customLeftTextClassName]: !!this.props.customLeftTextClassName
+          })}
+            onClick={this.onClick} data-l10n-id={this.props.leftl10nId}
+          />
           : null)
       }
       <div className='switchMiddle'>
@@ -46,19 +63,24 @@ class SwitchControl extends ImmutableComponent {
           this.props.topl10nId
           ? <label className={cx({
             switchControlTopText: true,
+            [css(styles.switchControlText__label, this.props.small && styles.switchControlText__label_small)]: true,
             [this.props.customTopTextClassName]: !!this.props.customTopTextClassName
           })}
             onClick={this.onClick}
             data-l10n-id={this.props.topl10nId} />
           : null
         }
-        <div data-test-id='switchBackground' className={cx({
+        <div className={cx({
           switchBackground: true,
           switchedOn: this.props.checkedOn,
           [this.props.backgroundClassName]: !!this.props.backgroundClassName
-        })} onClick={this.onClick}>
+        })}
+          data-test-id='switchBackground'
+          onClick={this.onClick}
+        >
           <div className={cx({
             switchIndicator: true,
+            [css(this.props.small && styles.switchControlText__label_small)]: true,
             [this.props.indicatorClassName]: !!this.props.indicatorClassName
           })} />
         </div>
@@ -69,7 +91,7 @@ class SwitchControl extends ImmutableComponent {
           <div className='switchControlRightText'>
             <div className='switchSpacer'>&nbsp;</div>
             <label className={cx({
-              switchControlRightText: true,
+              [css(styles.switchControlText__label, styles.switchControlText_right__label, this.props.small && styles.switchControlText__label_small)]: true,
               [this.props.customRightTextClassName]: !!this.props.customRightTextClassName
             })}
               onClick={this.onClick}
@@ -82,7 +104,7 @@ class SwitchControl extends ImmutableComponent {
           {
             (this.props.rightl10nId || this.props.rightText) && !this.props.onInfoClick
             ? <label className={cx({
-              switchControlRightText: true,
+              [css(styles.switchControlText__label, styles.switchControlText_right__label, this.props.small && styles.switchControlText__label_small)]: true,
               [this.props.customRightTextClassName]: !!this.props.customRightTextClassName
             })}
               onClick={this.onClick}
@@ -93,9 +115,15 @@ class SwitchControl extends ImmutableComponent {
         }
           {
             (this.props.rightl10nId || this.props.rightText) && this.props.onInfoClick
-            ? <div className='switchControlRightText'>
-              <label onClick={this.onClick} data-l10n-id={this.props.rightl10nId}
-                data-l10n-args={this.props.rightl10nArgs}>
+            ? <div className='switchControlRight'>
+              <label className={cx({
+                [css(styles.switchControlText__label, styles.switchControlText_right__label, this.props.small && styles.switchControlText__label_small)]: true,
+                [this.props.customRightTextClassName]: !!this.props.customRightTextClassName
+              })}
+                onClick={this.onClick}
+                data-l10n-id={this.props.rightl10nId}
+                data-l10n-args={this.props.rightl10nArgs}
+              >
                 {this.props.rightText}
               </label>
               <span className={cx({
@@ -103,6 +131,7 @@ class SwitchControl extends ImmutableComponent {
                 'fa-question-circle': true,
                 info: true,
                 clickable: true,
+                [css(styles.switchControlText__label, this.props.small && styles.switchControlText__label_small)]: true,
                 [this.props.customInfoButtonClassName]: !!this.props.customInfoButtonClassName
               })}
                 onClick={this.props.onInfoClick}
@@ -116,5 +145,25 @@ class SwitchControl extends ImmutableComponent {
     </div>
   }
 }
+
+const styles = StyleSheet.create({
+  switchControlText__label: {
+    userSelect: 'none'
+  },
+
+  switchControlText__label_small: {
+    fontSize: 'smaller'
+  },
+
+  switchControlText_right__label: {
+    paddingLeft: '1ch',
+    marginLeft: 0
+  },
+
+  switchControlText_left__label: {
+    paddingRight: '1ch',
+    marginRight: 0
+  }
+})
 
 module.exports = SwitchControl

--- a/app/renderer/components/preferences/payment/ledgerTable.js
+++ b/app/renderer/components/preferences/payment/ledgerTable.js
@@ -266,7 +266,6 @@ class LedgerTable extends ImmutableComponent {
         <div className={css(gridStyles.row1col2)}>
           <SettingCheckbox
             small
-            compact
             dataL10nId='hideExcluded'
             prefKey={settings.PAYMENTS_SITES_HIDE_EXCLUDED}
             settings={this.props.settings}

--- a/app/renderer/components/preferences/paymentsTab.js
+++ b/app/renderer/components/preferences/paymentsTab.js
@@ -198,21 +198,20 @@ class PaymentsTab extends ImmutableComponent {
             gridStyles.row1col2,
             styles.titleWrapper__switchWrap
           )}>
-            <span className={css(styles.switchWrap__switchSpan)} data-l10n-id='off' />
             <SettingCheckbox
-              compact
               dataL10nId='on'
+              dataL10nIdLeft='off'
               prefKey={settings.PAYMENTS_ENABLED}
               settings={this.props.settings}
               onChangeSetting={this.props.onChangeSetting}
               switchClassName={css(styles.switchWrap__switchControl)}
-              labelClassName={css(styles.switchWrap__label)}
+              leftLabelClassName={css(styles.switchWrap__label, styles.switchWrap__label_left)}
+              rightLabelClassName={css(styles.switchWrap__label, styles.switchWrap__label_right)}
             />
             <a className={cx({
               fa: true,
               'fa-question-circle': true,
-              [css(styles.autoSuggestSwitch__moreInfo)]: true,
-              [css(styles.autoSuggestSwitch__moreInfoBtnSuggest)]: true
+              [css(styles.autoSuggestSwitch__moreInfo, styles.autoSuggestSwitch__moreInfoBtnSuggest)]: true
             })}
               href='https://brave.com/Payments_FAQ.html'
               data-l10n-id='paymentsFAQLink'
@@ -230,7 +229,6 @@ class PaymentsTab extends ImmutableComponent {
                 <div className={css(styles.switchWrap__autoSuggestSwitch)}>
                   <div className={css(styles.flexAlignCenter, styles.autoSuggestSwitch__subtext)}>
                     <SettingCheckbox
-                      compact
                       dataL10nId='autoSuggestSites'
                       prefKey={settings.PAYMENTS_SITES_AUTO_SUGGEST}
                       settings={this.props.settings}
@@ -329,14 +327,21 @@ const styles = StyleSheet.create({
     width: '100%'
   },
 
-  switchWrap__switchSpan: {
+  switchWrap__label: {
     color: '#999',
     fontWeight: 'bold'
   },
-  switchWrap__label: {
-    fontWeight: 'bold',
+
+  switchWrap__label_left: {
+    paddingRight: '.75ch !important'
+  },
+
+  switchWrap__label_right: {
+    // TODO: Add 'position: relative' and 'bottom: 1px' for macOS (en_US) only.
+    paddingLeft: '.75ch !important',
     color: globalStyles.color.braveOrange
   },
+
   switchWrap__right: {
     display: 'flex',
     alignItems: 'center',
@@ -358,11 +363,6 @@ const styles = StyleSheet.create({
     color: globalStyles.color.commonTextColor
   },
   autoSuggestSwitch__moreInfoBtnSuggest: {
-    position: 'relative',
-    left: '3px',
-    cursor: 'pointer',
-    fontSize: globalStyles.payments.fontSize.regular,
-
     // TODO: refactor preferences.less to remove !important
     ':hover': {
       textDecoration: 'none !important'

--- a/less/switchControls.less
+++ b/less/switchControls.less
@@ -36,7 +36,7 @@
       }
     }
   }
-  
+
   &.small {
     .switchBackground {
       height: @smallSwitchHeight;
@@ -52,14 +52,6 @@
 
   .switchControlText {
     margin: auto 0;
-  }
-
-  .switchControlLeftText {
-    margin: auto 5px auto 0;
-  }
-
-  .switchControlRightText {
-    margin: auto 0 auto 5px;
   }
 
   .switchControlTopText {


### PR DESCRIPTION
Addresses #7321

- Add rightLabelClassName and leftLabelClassName props
- Add user-select:none to the labels
- Move 'small' option from settings.js to switchControls.js, removing settingsCheckboxStyles
- Remove 'compact' props as padding-left / padding-right is set by default
- Replace 9px margin with 1ch padding for labels
- Overwrite that padding with 0.75ch for payments switch labels

TODO: Apply 'position: relative' and 'bottom: 1px' for macOS (en_US) only. The placement of the right label has been corrupted on the other environments such as Windows 10 (ja-JP);
  ![clipboard01](https://user-images.githubusercontent.com/3362943/29348631-19f2070a-8290-11e7-9f46-e3724a08be7a.png)

Auditors: @cezaraugusto @petemill

Test Plan 1:
1. Open about:preferences
2. Make sure there is padding space between switches and labels

Test Plan 2:
1. Open about:preferences#payments
2. Make sure the 3 switches are displayed
3. Change the language setting
4. Restart the browser
5. Reopen about:preferences#payments
6. Make sure the labels and the switch are aligned at the center

Test Plan 3:
1. Open braveryPanel.js
2. Replace 'SwitchControl large' to 'SwitchControl small'
3. Run npm run watch && npm start
4. Open brave.com
5. Open the bravery panel
6. Make sure the main switch and the labels around it are small

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


