### PR TITLE
Polish bravery panel

### DIFF
--- a/app/renderer/components/common/dropdown.js
+++ b/app/renderer/components/common/dropdown.js
@@ -55,7 +55,7 @@ const styles = StyleSheet.create({
     height: '2rem',
     outline: 'none',
     // right padding is larger, to account for the down arrow SVG
-    padding: `${selectPadding} 1.5em ${selectPadding} ${selectPadding}`,
+    padding: `${selectPadding} 2em ${selectPadding} ${selectPadding}`,
     '-webkit-appearance': 'none',
     width: 'auto'
   },

--- a/app/renderer/components/main/braveryPanel.js
+++ b/app/renderer/components/main/braveryPanel.js
@@ -528,6 +528,7 @@ class BraveryPanel extends React.Component {
                 <SwitchControl className={css(
                   !this.props.isCompactBraveryPanel && gridStyles.row6col1,
                   this.props.isCompactBraveryPanel && gridStyles.row8col1,
+                  !this.props.isCompactBraveryPanel && styles.braveryPanel__body__advanced__control__switchControl_noScript,
                   this.props.isCompactBraveryPanel && styles.braveryPanel_compact__body__advanced__control__switchControl
                 )}
                   onClick={this.onToggleNoScript}
@@ -727,13 +728,13 @@ const buttonSize = '13px'
 const styles = StyleSheet.create({
   braveryPanel: {
     padding: 0,
-    width: '500px',
     right: '20px',
     userSelect: 'none',
     cursor: 'default',
     color: globalStyles.braveryPanel.color,
     overflowY: 'auto',
-    maxHeight: `calc(100% - ${globalStyles.spacing.dialogTopOffset})`
+    maxHeight: `calc(100% - ${globalStyles.spacing.dialogTopOffset})`,
+    maxWidth: 'calc(100% - 40px)'
   },
   braveryPanel_compact: {
     width: 'auto',
@@ -993,6 +994,7 @@ const styles = StyleSheet.create({
   braveryPanel__body__advanced__control: {
     display: 'grid',
     gridColumnGap: '1rem',
+    gridTemplateColumns: 'max-content max-content',
     margin: '15px 10px'
   },
   braveryPanel__body__advanced__control__forms__title: {
@@ -1009,6 +1011,9 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between'
   },
+  braveryPanel__body__advanced__control__switchControl_noScript: {
+    marginTop: '2.5px'
+  },
   braveryPanel__body__advanced__control__switchControl__infoButton: {
     display: 'inline',
     cursor: 'pointer',
@@ -1018,12 +1023,13 @@ const styles = StyleSheet.create({
 
   // controlWrapper - Normal Panel
   braveryPanel__body__advanced__control__forms__dropdown: {
-    marginBottom: '25px'
+    marginBottom: '1rem'
   },
 
   // controlWrapper - Compact Panel
   braveryPanel_compact__body__advanced__control: {
     gridColumnGap: 0,
+    gridTemplateColumns: 'initial',
     margin: 0,
 
     // Align the advanced control wrapper with the counters


### PR DESCRIPTION
Closes #5726
Follow-up to #10181

- Remove fixed width; now that we have the compact bravery panel, we would not have to take the possibility into consideration that the panel would cover the UI.
- Increase padding-right from 1.5em to 2em on the dropdown to add 1em space between the option and the down arrow (See `Block 3rd Party Fingerprinting` option below).
- Decrease the margin-bottom of the dropdown and Increase margin between switches

From:

<img width="236" alt="screenshot 2017-08-15 16 29 57" src="https://user-images.githubusercontent.com/3362943/29306431-9c28ca28-81d8-11e7-80cf-4f1ee781bc1e.png">

To:

<img width="234" alt="screenshot 2017-08-15 16 30 47" src="https://user-images.githubusercontent.com/3362943/29306430-9c0805ea-81d8-11e7-9d7a-7299d9d63f66.png">

Here is an extreme example (which would not happen in reality, unless the font rendering is quite poor + screen resolution is very low).

<img width="1195" alt="screenshot 2017-08-15 16 43 10" src="https://user-images.githubusercontent.com/3362943/29306486-ddf8799e-81d8-11e7-912e-bb3559a6c6ed.png">

That panel can be scrolled horizontally.

Auditors:

Test Plan:
1. Change lang setting
2. Restart the browser
3. Open Bravery panel on an external site
4. Make sure the strings are not wrapped

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


