### PR TITLE
Fix vertical spacing for all navbar item combinations

### DIFF
--- a/app/renderer/components/bookmarks/bookmarksToolbar.js
+++ b/app/renderer/components/bookmarks/bookmarksToolbar.js
@@ -211,13 +211,14 @@ const styles = StyleSheet.create({
     boxSizing: 'border-box',
     display: 'flex',
     flex: 1,
-    padding: `${globalStyles.spacing.navbarMenubarMargin} ${globalStyles.spacing.bookmarksToolbarPadding}`
+    padding: `0 ${globalStyles.spacing.bookmarksToolbarPadding}`,
+    margin: `${globalStyles.spacing.navbarMenubarMargin} 0`
   },
   bookmarksToolbar__allowDragging: {
     WebkitAppRegion: 'drag'
   },
   bookmarksToolbar__showOnlyFavicon: {
-    padding: `${globalStyles.spacing.navbarMenubarMargin} 0 ${globalStyles.spacing.tabPagesHeight} ${globalStyles.spacing.bookmarksToolbarPadding}`
+    padding: `0 0 0 ${globalStyles.spacing.bookmarksToolbarPadding}`
   },
   bookmarksToolbar__bookmarkButton: {
     boxSizing: 'border-box',

--- a/app/renderer/components/main/main.js
+++ b/app/renderer/components/main/main.js
@@ -607,7 +607,11 @@ class Main extends React.Component {
         ? <PopupWindow />
         : null
       }
-      <div className='top'
+      <div className={cx({
+            top: true,
+            allowDragging: this.props.shouldAllowWindowDrag,
+          })
+        }
         onMouseEnter={windowActions.setMouseInTitlebar.bind(null, true)}
         onMouseLeave={windowActions.setMouseInTitlebar.bind(null, false)}
         >
@@ -690,18 +694,22 @@ class Main extends React.Component {
           ? <BookmarksToolbar />
           : null
         }
-        <div className={cx({
-          tabPages: true,
-          allowDragging: this.props.shouldAllowWindowDrag,
-          singlePage: this.props.isSinglePage
-        })}
-          onContextMenu={this.onTabContextMenu}>
-          {
-            this.props.showTabPages
-            ? <TabPages />
-            : null
-          }
-        </div>
+        {
+          this.props.isSinglePage
+          ? null
+          : <div className={cx({
+            tabPages: true,
+            allowDragging: this.props.shouldAllowWindowDrag,
+            singlePage: this.props.isSinglePage
+          })}
+            onContextMenu={this.onTabContextMenu}>
+            {
+              this.props.showTabPages
+              ? <TabPages />
+              : null
+            }
+          </div>
+        }
         <TabsToolbar key='tab-bar' />
         {
           this.props.showNotificationBar

--- a/app/renderer/components/styles/commonStyles.js
+++ b/app/renderer/components/styles/commonStyles.js
@@ -142,6 +142,7 @@ const styles = StyleSheet.create({
 
   // notificationBar
   notificationBar: {
+    '-webkit-app-region': 'no-drag',
     display: 'inline-block',
     boxSizing: 'border-box',
     width: '100%',

--- a/less/findbar.less
+++ b/less/findbar.less
@@ -5,6 +5,7 @@
 @import "variables.less";
 
 .findBar {
+  -webkit-app-region: no-drag;
   background: @findbarBackground;
   border-bottom: 1px solid @lightGray;
   color: @highlightBlue;

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -359,7 +359,7 @@
 // Styles had to be reworked to properly position the new caption buttons for Windows
 .navbarCaptionButtonContainer {
   display: flex;
-  //border-bottom: 1px solid #bbb;
+  margin-bottom: @navbarMenubarMargin;
 
   &.allowDragging {
     -webkit-app-region: drag;

--- a/less/tabs.less
+++ b/less/tabs.less
@@ -119,6 +119,7 @@
 }
 
 .tabsToolbar {
+  -webkit-app-region: no-drag;
   box-sizing: border-box;
   background: @tabsBackground;
   display: flex;
@@ -143,7 +144,7 @@
   display: flex;
   justify-content: center;
   height: @tabPagesHeight;
-  padding: @tabPagesHeight 0 @navbarMenubarMargin 0;
+  margin: @navbarMenubarMargin 0 @navbarMenubarMargin 0;
   position: relative;
   z-index: @zindexTabs;
 
@@ -152,11 +153,6 @@
     >* {
       -webkit-app-region: no-drag;
     }
-  }
-
-  &.singlePage {
-    margin: 0;
-    padding: 0;
   }
 
   >div {

--- a/less/window.less
+++ b/less/window.less
@@ -41,6 +41,9 @@ html,
 
 .top {
   background: linear-gradient(to bottom, #eaeaea, #f2f2f4);
+  &.allowDragging {
+    -webkit-app-region: drag;
+  }
 }
 
 .mainContainer {


### PR DESCRIPTION
Fix #9370 by using collapsible margin so that items without border+padding can be evenly spaced (caption buttons, bookmark, tab pages), and those with border+padding (notifications, tabs) can be touching. Removes empty element for tab pages when there is only a single page, as it had no functional purpose. Instead, margin is used.

### Buttons, Notification, Bookmarks, Tab Pages, Tabs, Find
<img width="981" alt="screenshot 2017-08-15 13 06 42" src="https://user-images.githubusercontent.com/741836/29335072-570f9e86-81be-11e7-9e29-eed0260e2b16.png">

### Buttons, Notification, Bookmarks, Tab Pages, Tabs
<img width="983" alt="screenshot 2017-08-15 13 07 00" src="https://user-images.githubusercontent.com/741836/29335107-6c7b1174-81be-11e7-96e2-b25f80e93dfb.png">

### Buttons, Notification, Tab Pages, Tabs
<img width="981" alt="screenshot 2017-08-15 13 07 19" src="https://user-images.githubusercontent.com/741836/29335132-82e688b2-81be-11e7-984a-21846d81cf19.png">

### Buttons, Notification, Bookmarks, Tabs
<img width="847" alt="screenshot 2017-08-15 13 09 54" src="https://user-images.githubusercontent.com/741836/29335219-cc80d112-81be-11e7-8c96-273e48e74a07.png">


### Buttons, Bookmarks, Tab Pages, Tabs
<img width="979" alt="screenshot 2017-08-15 13 07 50" src="https://user-images.githubusercontent.com/741836/29335160-9799fe60-81be-11e7-8966-03e13552d821.png">

### Buttons, Tab Pages, Tabs
<img width="981" alt="screenshot 2017-08-15 13 08 06" src="https://user-images.githubusercontent.com/741836/29335170-a04eadbc-81be-11e7-9a00-2a9aa942860e.png">

### Buttons, Tabs
<img width="846" alt="screenshot 2017-08-15 13 09 02" src="https://user-images.githubusercontent.com/741836/29335183-a82f80f6-81be-11e7-83d8-8a39de2fd706.png">

### Buttons, Bookmarks, Tabs
<img width="845" alt="screenshot 2017-08-15 13 09 17" src="https://user-images.githubusercontent.com/741836/29335189-afb2e2b4-81be-11e7-825a-2c4c3517c913.png">

### Buttons, Tabs, Find
<img width="846" alt="screenshot 2017-08-15 13 18 45" src="https://user-images.githubusercontent.com/741836/29335226-d4d44b00-81be-11e7-97d6-a73e3393e85b.png">


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Test Plan:
- Enable above combinations and check visual regressions compared to screenshots.

### Draggable area regression checks (inspired by #7740)
**Test case 1 - default status**
1. Clear your profile
1. Start the browser
1. Make sure that the area between the URL bar and the tabs bar is draggable

**Test case 2 - text only**
1. Open https://github.com/ in a new tab
1. Open https://github.com/features in a new tab
1. Open https://github.com/explore in a new tab
1. Open https://github.com/pricing in a new tab
1. Display the bookmark toolbar
1. Bookmark them by dragging the lock icon on the URL bar to the bookmark toolbar
1. (Not on Windows) Make sure that the area between the bookmarked items and the URL bar is draggable
1. (Not on Windows) Make sure that the area between the bookmarked items and the tabs bar is draggable

**Test case 3 - text only with tab sets**
1. Open about:preferences#tabs
1. Set the number of tabs per tab set to 6
1. Open several new tabs to create another tab page
1. Narrow the window size to place the tab page indicators under the bookmarked items
1. (Not on Windows) Make sure that the area between the tab page indicators and the bookmark bar is draggable (the tiny area between the indicators is NOT draggable)
1. Make sure that the area between the tab page indicators and the tabs bar is draggable

**Test case 4 - text and favicons with tab sets**
1. Open about:preferences
1. Change "Text only" to "Text and Favicons"
1. Repeat the step 3:5 and 3:6
1. Close several tabs to clear the 2nd tab set
1. (Not on Windows) Make sure that the area around the bookmarks is draggable

**Test case 5 - only tab sets**
1. Hide the bookmark toolbar
1. Make sure that the area around the tab page indicators is draggable

**Test case 6 - favicon only with and without tab sets**
1. Bookmark several other GitHub pages
1. Open about:preferences
1. Change "Text and Favicons" to "Favicon only"
1. Change window size to place the tab page indicators under the bookmark favicons
1. Repeat the step 3:5 and 3:6
1. Close tabs to clear the 2nd tab set
1. (Not on Windows) Make sure that the area around favicons is draggable

**Test case 7 - main menu button (especially *Windows*)**
1. Open a small amount of tabs so there is space between tabs and main menu button
1. Ensure dragging the space between tabs and main menu button *does* drag the window
1. Ensure clicking the main menu button opens the main menu

**Test case 8 - notification bar**
1. Click *'check for updates...'* menu item
1. Make sure that nowhere on the notification bar is draggable

**Test case 9 - find page bar**
1. Visit github.com
1. Open 'find in page' bar using cmd-f / ctrl-f or the menu item
1. Make sure no area of 'find in page' bar is draggable

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


