### PR TITLE
Update MDN name on Search Settings

### DIFF
--- a/js/data/searchProviders.js
+++ b/js/data/searchProviders.js
@@ -51,7 +51,7 @@ module.exports = { "providers" :
       "shortcut" : ":s"
     },
     {
-      "name" : "Mozilla Developer Network (MDN)",
+      "name" : "MDN Web Docs",
       "base": "https://developer.mozilla.org/search",
       "image" : "https://developer.cdn.mozilla.net/static/img/favicon32.png",
       "search" : "https://developer.mozilla.org/search?q={searchTerms}",


### PR DESCRIPTION
Fix: #10511 
Change MDN name on Search Settings. From Mozilla Developer Network (MDN) to MDN Web Docs.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
1. Open about:preferences#search
2. See the name is now MDN Web Docs

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


