### PR TITLE
Add U2F support via cryptotoken extension

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -467,7 +467,7 @@ module.exports.init = () => {
     }
     if (!extensionInfo.isLoaded(extensionId) && !extensionInfo.isLoading(extensionId)) {
       extensionInfo.setState(extensionId, extensionStates.LOADING)
-      if (extensionId === config.braveExtensionId || extensionId === config.torrentExtensionId || extensionId === config.syncExtensionId) {
+      if (extensionId === config.braveExtensionId || extensionId === config.torrentExtensionId || extensionId === config.cryptoTokenExtensionId || extensionId === config.syncExtensionId) {
         session.defaultSession.extensions.load(extensionPath, manifest, manifestLocation)
         return
       }
@@ -509,6 +509,9 @@ module.exports.init = () => {
   // Manually install the braveExtension and torrentExtension
   extensionInfo.setState(config.braveExtensionId, extensionStates.REGISTERED)
   loadExtension(config.braveExtensionId, getExtensionsPath('brave'), generateBraveManifest(), 'component')
+  // Cryptotoken extension is loaded from electron_resources.pak
+  extensionInfo.setState(config.cryptoTokenExtensionId, extensionStates.REGISTERED)
+  loadExtension(config.cryptoTokenExtensionId, path.join(process.resourcesPath, 'cryptotoken'), {}, 'component')
   extensionInfo.setState(config.syncExtensionId, extensionStates.REGISTERED)
   loadExtension(config.syncExtensionId, getExtensionsPath('brave'), generateSyncManifest(), 'unpacked')
 

--- a/app/renderer/components/preferences/extensionsTab.js
+++ b/app/renderer/components/preferences/extensionsTab.js
@@ -49,7 +49,7 @@ class ExtensionsTab extends ImmutableComponent {
   }
 
   getRow (extension) {
-    if ([config.braveExtensionId, config.syncExtensionId].includes(extension.get('id')) ||
+    if ([config.braveExtensionId, config.syncExtensionId, config.cryptoTokenExtensionId].includes(extension.get('id')) ||
     (!extension.get('dummy') && this.isRemovableExtension(extension))) {
       return []
     }

--- a/js/constants/config.js
+++ b/js/constants/config.js
@@ -86,6 +86,7 @@ module.exports = {
   pinterestExtensionPublicKey: 'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDB95q2hyt49ZDuVnYI91XaZhqQkbXu0X3fzoNxPxhFbfqGKwtts90LJ7lD5DCIfnBg8WGFhp3eW4GxOglAKrnksmJoyAD5PnSAufx8fD3trZvo/ZAqFx1x5Xm3Rm34EgvVXdralgHSYiqcEU/FX3kYnLLhr2TS4lcrsn1KZd/lcQIDAQAB',
   metamaskExtensionId: 'nkbihfbeogaeaoehlefnkodbefgpgknn',
   metamaskPublicKey: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAlcgI4VVL4JUvo6hlSgeCZp9mGltZrzFvc2Asqzb1dDGO9baoYOe+QRoh27/YyVXugxni480Q/R147INhBOyQZVMhZOD5pFMVutia9MHMaZhgRXzrK3BHtNSkKLL1c5mhutQNwiLqLtFkMSGvka91LoMEC8WTI0wi4tACnJ5FyFZQYzvtqy5sXo3VS3gzfOBluLKi7BxYcaUJjNrhOIxl1xL2qgK5lDrDOLKcbaurDiwqofVtAFOL5sM3uJ6D8nOO9tG+T7hoobRFN+nxk43PHgCv4poicOv+NMZQEk3da1m/xfuzXV88NcE/YRbRLwAS82m3gsJZKc6mLqm4wZHzBwIDAQAB',
+  cryptoTokenExtensionId: 'kmendfapggjehodndflmmgagdbamhnfd',
   newtab: {
     fallbackImage: {
       name: 'Bay Bridge',


### PR DESCRIPTION
**Requires: https://github.com/brave/muon/pull/268**

Closes: #518 

This PR adds the cryptotoken extension which is loaded a bit differently then any of our other extensions. Since the cryptotoken extension code is actually in the chromium source tree, at muon build time we use existing build targets to add the cryptotoken extension into `electron_resources.pak`. The muon PR above allows for loading of extensions that are contained within a pak via the existing load api used by `browser-laptop`.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
1. Create muon debug builds for linux, mac and windows
2. Use custom muon builds in combination with this branch to manually test U2F functionality (register token, authenticate with token) both in dev mode and by building a package.

**Note:** I've already run through this test plan however there have been a number of changes with respect to how the extension is loaded so I have kicked off new cross-platform muon builds and will update here after re-testing.

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


