### PR TITLE
Increase pinned tabs width

### DIFF
--- a/app/renderer/components/styles/global.js
+++ b/app/renderer/components/styles/global.js
@@ -341,8 +341,6 @@ globalStyles.color.loadTimeColor = globalStyles.color.highlightBlue
 globalStyles.color.activeTabDefaultColor = globalStyles.color.chromePrimary
 globalStyles.color.switchBG_on = globalStyles.color.braveOrange
 
-globalStyles.spacing.tabHeight = globalStyles.spacing.tabsToolbarHeight
-
 globalStyles.braveryPanel.stats.colorAds = globalStyles.color.statsRed
 globalStyles.braveryPanel.stats.colorRedirected = globalStyles.color.statsBlue
 globalStyles.braveryPanel.stats.colorFp = globalStyles.color.statsYellow

--- a/app/renderer/components/styles/tab.js
+++ b/app/renderer/components/styles/tab.js
@@ -18,7 +18,6 @@ const styles = StyleSheet.create({
     boxSizing: 'border-box',
     color: '#5a5a5a',
     display: 'flex',
-    height: globalStyles.spacing.tabHeight,
     marginTop: '0',
     transition: `transform 200ms ease, ${globalStyles.transition.tabBackgroundTransition}`,
     left: '0',
@@ -28,6 +27,10 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     padding: globalStyles.spacing.defaultTabPadding,
     position: 'relative',
+
+    // globalStyles.spacing.tabHeight has been set to globalStyles.spacing.tabsToolbarHeight,
+    // which is 1px extra due to the border-top of .tabsToolbar
+    height: '-webkit-fill-available',
 
     ':hover': {
       background: 'linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(250, 250, 250, 0.4))'
@@ -68,12 +71,6 @@ const styles = StyleSheet.create({
     overflow: 'hidden'
   },
 
-  // Add extra space for pages that have no icon
-  // such as about:blank and about:newtab
-  noFavicon: {
-    padding: '0 6px'
-  },
-
   alternativePlayIndicator: {
     borderTop: '2px solid lightskyblue'
   },
@@ -83,24 +80,28 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     display: 'flex',
     flex: '1',
-    minWidth: '0', // @see https://bugzilla.mozilla.org/show_bug.cgi?id=1108514#c5
+
+    // @see https://bugzilla.mozilla.org/show_bug.cgi?id=1108514#c5
+    minWidth: '0',
+
     // prevent the icons wrapper from being the target of mouse events.
     pointerEvents: 'none'
   },
 
   isPinned: {
-    paddingLeft: globalStyles.spacing.defaultIconPadding,
-    paddingRight: globalStyles.spacing.defaultIconPadding
+    padding: 0,
+    width: `calc(${globalStyles.spacing.tabsToolbarHeight} * 1.1)`,
+    justifyContent: 'center'
   },
 
   active: {
     background: `rgba(255, 255, 255, 1.0)`,
-    height: globalStyles.spacing.tabHeight,
     marginTop: '0',
     borderWidth: '0 1px 0 0',
     borderStyle: 'solid',
     borderColor: '#bbb',
     color: '#000',
+
     ':hover': {
       background: `linear-gradient(to bottom, #fff, ${globalStyles.color.chromePrimary})`
     }
@@ -138,13 +139,19 @@ const styles = StyleSheet.create({
     fontSize: globalStyles.fontSize.tabIcon,
     backgroundPosition: 'center',
     backgroundRepeat: 'no-repeat',
-    display: 'flex',
-    alignSelf: 'center',
-    position: 'relative',
-    textAlign: 'center',
-    justifyContent: 'center',
     paddingLeft: globalStyles.spacing.defaultIconPadding,
     paddingRight: globalStyles.spacing.defaultIconPadding
+  },
+
+  icon_audio: {
+    color: globalStyles.color.highlightBlue,
+
+    // 16px
+    fontSize: `calc(${globalStyles.fontSize.tabIcon} + 2px)`,
+
+    // equal spacing around audio icon (favicon and tabTitle)
+    padding: globalStyles.spacing.defaultTabPadding,
+    paddingRight: '0 !important'
   }
 })
 

--- a/app/renderer/components/tabs/content/audioTabIcon.js
+++ b/app/renderer/components/tabs/content/audioTabIcon.js
@@ -3,7 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const React = require('react')
-const {StyleSheet, css} = require('aphrodite/no-important')
+const {css} = require('aphrodite/no-important')
 const Immutable = require('immutable')
 
 // Components
@@ -61,17 +61,11 @@ class AudioTabIcon extends React.Component {
 
   render () {
     return <TabIcon
-      className={css(tabStyles.icon, styles.audioIcon)}
+      className={css(tabStyles.icon, tabStyles.icon_audio)}
       symbol={this.audioIcon}
-      onClick={this.toggleMute} />
+      onClick={this.toggleMute}
+    />
   }
 }
 
 module.exports = ReduxComponent.connect(AudioTabIcon)
-
-const styles = StyleSheet.create({
-  audioIcon: {
-    color: globalStyles.color.highlightBlue,
-    fontSize: '16px'
-  }
-})

--- a/app/renderer/components/tabs/content/tabIcon.js
+++ b/app/renderer/components/tabs/content/tabIcon.js
@@ -17,14 +17,13 @@ const globalStyles = require('../../styles/global')
 class TabIcon extends ImmutableComponent {
   render () {
     const styles = StyleSheet.create({
-      icon: {
+      tabIcon: {
         fontSize: this.props.symbolContent ? '8px' : 'inherit',
         display: 'flex',
-        alignSelf: 'center',
         width: globalStyles.spacing.iconSize,
         height: globalStyles.spacing.iconSize,
         alignItems: 'center',
-        justifyContent: this.props.symbolContent ? 'flex-end' : 'left',
+        justifyContent: this.props.symbolContent ? 'flex-end' : 'center',
         fontWeight: this.props.symbolContent ? 'bold' : 'normal',
         color: this.props.symbolContent ? globalStyles.color.black100 : 'inherit'
       }
@@ -51,7 +50,7 @@ class TabIcon extends ImmutableComponent {
           ? <span
             className={cx({
               [this.props.symbol]: true,
-              [css(styles.icon)]: true
+              [css(styles.tabIcon)]: true
             })}
             data-test-id={this.props['data-test-id']}
             data-test2-id={this.props['data-test2-id']}


### PR DESCRIPTION
Closes #10368

<img width="836" alt="screenshot 2017-08-16 18 48 53" src="https://user-images.githubusercontent.com/3362943/29357758-9e070d24-82b3-11e7-81c2-9789de91421d.png">

Auditors: @cezaraugusto

Test Plan:
1. Open brave.com in a new tab
2. Open github.com in another new tab
3. Pin them
4. Make sure the width of the pinned tabs is enough

Test Plan 2:
1. Open example.com
2. Pin the tab
3. Make sure the default icon appears at the center of the pinned tab

Test Plan 3:
1. Open youtube video
2. Make sure the spacing around the audio icon, favicon and tab's title is equal

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


