### PR TITLE
Add outline:none to .dialog

### DIFF
--- a/app/renderer/components/common/dialog.js
+++ b/app/renderer/components/common/dialog.js
@@ -44,8 +44,7 @@ class Dialog extends ImmutableComponent {
     return <div
       data-bookmark-hanger={this.props.bookmarkHanger}
       className={cx({
-        [css(styles.dialog)]: true,
-        [css(styles.dialog_isNotClickDismiss)]: !this.props.isClickDismiss,
+        [css(styles.dialog, !this.props.isClickDismiss && styles.dialog_isNotClickDismiss)]: true,
         [this.props.className]: !!this.props.className
       })}
       data-test-id={this.props.testId}
@@ -80,8 +79,13 @@ const styles = StyleSheet.create({
     zIndex: globalStyles.zindex.zindexDialogs,
     display: 'flex',
     justifyContent: 'center',
-    alignItems: 'center'
+    alignItems: 'center',
+
+    ':focus': {
+      outline: 'none'
+    }
   },
+
   dialog_isNotClickDismiss: {
     background: 'rgba(0, 0, 0, 0.15)'
   }


### PR DESCRIPTION
Closes #10536

Auditors:

Test Plan:
1. Open brave.com
2. Click the lion icon
3. Make sure the focus ring around the browser's window does not appear

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


