### PR TITLE
avoid empty node when closing a tab with right click

### DIFF
--- a/app/renderer/lib/tabUtil.js
+++ b/app/renderer/lib/tabUtil.js
@@ -44,9 +44,15 @@ module.exports.hasBreakpoint = (breakpoint, arr) => {
  * @returns {Boolean} Whether or not the related target is a tab
  */
 module.exports.hasTabAsRelatedTarget = (event) => {
-  const relatedTarget = event.relatedTarget
-  const hasDataset = relatedTarget.parentNode && relatedTarget.parentNode.dataset
-  const tabAsRelatedTarget = hasDataset.tab || hasDataset.tabArea
+  let tabAsRelatedTarget = false
+  const relatedTarget = event && event.relatedTarget
 
-  return hasDataset && tabAsRelatedTarget
+  if (relatedTarget != null) {
+    const hasDataset = relatedTarget.parentNode && relatedTarget.parentNode.dataset
+    if (hasDataset != null) {
+      tabAsRelatedTarget = (hasDataset.tab || hasDataset.tabArea) || false
+    }
+  }
+
+  return tabAsRelatedTarget
 }

--- a/test/unit/app/renderer/lib/tabUtilTest.js
+++ b/test/unit/app/renderer/lib/tabUtilTest.js
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 /* global describe, it */
 const tabUtil = require('../../../../../app/renderer/lib/tabUtil')
 const assert = require('assert')
@@ -13,17 +17,33 @@ describe('tabUtil', function () {
         }
       }
     })
+
+    it('null case', function () {
+      assert.equal(tabUtil.hasTabAsRelatedTarget(null), false)
+    })
+
+    it('dataset is not provided', function () {
+      const param = {
+        relatedTarget: {
+          parentNode: { }
+        }
+      }
+      assert.equal(tabUtil.hasTabAsRelatedTarget(param), false)
+    })
+
     it('returns true if dataset is tab', function () {
       const fakeDataset = fakeEvent('tab')
       assert.equal(tabUtil.hasTabAsRelatedTarget(fakeDataset), true)
     })
+
     it('returns true if dataset is tabArea', function () {
       const fakeDataset = fakeEvent('tabArea')
       assert.equal(tabUtil.hasTabAsRelatedTarget(fakeDataset), true)
     })
+
     it('returns false if dataset is neither tab nor tabArea', function () {
       const fakeDataset = fakeEvent('badCoffee')
-      assert.notEqual(tabUtil.hasTabAsRelatedTarget(fakeDataset), true)
+      assert.equal(tabUtil.hasTabAsRelatedTarget(fakeDataset), false)
     })
   })
 })


### PR DESCRIPTION
fix #10590
Auditors: @bsclifton

happened after #9887 so moving to the same milestone.
error happens because dataset check is made after declaration. Given context-menu exposes no nodes, error is thrown.

STR:
* right-click to close a tab
* should show no console error