### PR TITLE
Convert helpfulText with Aphrodite

### DIFF
--- a/app/renderer/components/preferences/extensionsTab.js
+++ b/app/renderer/components/preferences/extensionsTab.js
@@ -121,7 +121,8 @@ class ExtensionsTab extends ImmutableComponent {
             className={css(styles.moreInfo__link)}
             onClick={aboutActions.createTabRequested.bind(null, {
               url: 'https://community.brave.com/c/feature-requests/extension-requests'
-            }, true)} />.
+            }, true)}
+          />.
         </HelpfulText>
       </footer>
     </section>

--- a/app/renderer/components/preferences/helpfulText.js
+++ b/app/renderer/components/preferences/helpfulText.js
@@ -3,21 +3,36 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const ImmutableComponent = require('../immutableComponent')
+
+const cx = require('../../../../js/lib/classSet')
+
+const {StyleSheet, css} = require('aphrodite/no-important')
 const globalStyles = require('../styles/global')
 
 class HelpfulText extends ImmutableComponent {
   render () {
-    return <div className={this.props.wrapperClassName}>
-      <span className={globalStyles.appIcons.moreInfo}
-        style={{
-          color: globalStyles.color.mediumGray,
-          fontSize: '20px',
-          marginRight: '5px'
-        }} />
-      <span className={this.props.textClassName} data-l10n-id={this.props.l10nId} />
+    return <div className={css(styles.helpfulText)}>
+      <span className={cx({
+        [globalStyles.appIcons.moreInfo]: true,
+        [css(styles.helpfulText__icon)]: true
+      })} />
+      <span data-l10n-id={this.props.l10nId} />
       {this.props.children}
     </div>
   }
 }
+
+const styles = StyleSheet.create({
+  helpfulText: {
+    display: 'flex',
+    alignItems: 'center'
+  },
+
+  helpfulText__icon: {
+    color: globalStyles.color.mediumGray,
+    fontSize: '1.25rem',
+    marginRight: '.5ch'
+  }
+})
 
 module.exports = HelpfulText


### PR DESCRIPTION
Closes #10608

Auditors:

Test Plan:
1. Open `about:preferences#extensions`
2. Make sure the help text is rendered

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


