### PR TITLE
Add `netflix.com` to Brave's UA inclusion list

### DIFF
--- a/js/data/siteHacks.js
+++ b/js/data/siteHacks.js
@@ -14,7 +14,7 @@ const googleTagServicesRedirect = 'data:application/javascript;base64,' + base64
 const emptyDataURI = {
   enableForAdblock: true,
   enableForTrackingProtection: true,
-  onBeforeRequest: function(details) {
+  onBeforeRequest: function (details) {
     return {
       redirectURL: 'data:application/javascript;base64,MA=='
     }
@@ -43,7 +43,7 @@ module.exports.localStorageExceptions = [
   ['https://mail.google.com', 'https://hangouts.google.com']
 ]
 
-const braveUAWhitelist = ['adobe.com', 'duckduckgo.com', 'brave.com']
+const braveUAWhitelist = ['adobe.com', 'duckduckgo.com', 'brave.com', 'netflix.com']
 
 module.exports.siteHacks = {
   'sp1.nypost.com': emptyDataURI,
@@ -101,7 +101,7 @@ module.exports.siteHacks = {
       }
       return {
         redirectURL: googleTagServicesRedirect
-       }
+      }
     }
   },
   'twitter.com': {
@@ -128,7 +128,7 @@ module.exports.siteHacks = {
   'www.youtube.com': {
     allowFirstPartyAdblockChecks: true
   },
-   'www.theatlantic.com': {
+  'www.theatlantic.com': {
     allowFirstPartyAdblockChecks: true
   }
 }
@@ -145,4 +145,3 @@ braveUAWhitelist.forEach((domain) => {
     }
   }
 })
-


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/10614

Auditors: @bbondy, @darkdh

Test Plan:
1. Launch Brave and visit https://netflix.com
2. Open the developer tools (F12 or shift + option + i)
3. Force reload the page (shift + cmd + R or shift + ctrl + R)
4. Inspect the network tab for the `netflix.com` resource
5. Under request headers, you should see the user agent (`Brave` being the important part) which should be like:
"user-agent:Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) **Brave** Chrome/60.0.3112.90 Safari/537.36"

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


