### PR TITLE
Return 0% when download totalBytes is 0 or undefined

### DIFF
--- a/js/state/downloadUtil.js
+++ b/js/state/downloadUtil.js
@@ -56,8 +56,15 @@ const getL10nId = (download) => {
   return ''
 }
 
-const getPercentageComplete = (download) =>
-  Math.ceil(download.get('receivedBytes') / download.get('totalBytes') * 100) + '%'
+const getPercentageComplete = (download) => {
+  const totalBytes = download.get('totalBytes')
+  if (!totalBytes) {
+    // Most likely totalBytes has not been calculated yet. Avoid
+    // division by 0.
+    return '0%'
+  }
+  return Math.ceil(download.get('receivedBytes') / totalBytes * 100) + '%'
+}
 
 const shouldAllowCopyLink = (download) => !!download.get('url')
 

--- a/js/state/downloadUtil.js
+++ b/js/state/downloadUtil.js
@@ -10,7 +10,7 @@ const stopStates = [downloadStates.CANCELLED, downloadStates.INTERRUPTED, downlo
 const notErrorStates = [downloadStates.IN_PROGRESS, downloadStates.PAUSED, downloadStates.COMPLETED]
 
 const downloadIsInState = (download, list) =>
- list.includes(download.get('state'))
+ (download && list && list.includes(download.get('state'))) || false
 
 const isPendingState = (download) =>
  downloadIsInState(download, pendingStates)
@@ -57,7 +57,7 @@ const getL10nId = (download) => {
 }
 
 const getPercentageComplete = (download) => {
-  const totalBytes = download.get('totalBytes')
+  const totalBytes = download && download.get('totalBytes')
   if (!totalBytes) {
     // Most likely totalBytes has not been calculated yet. Avoid
     // division by 0.
@@ -66,10 +66,10 @@ const getPercentageComplete = (download) => {
   return Math.ceil(download.get('receivedBytes') / totalBytes * 100) + '%'
 }
 
-const shouldAllowCopyLink = (download) => !!download.get('url')
+const shouldAllowCopyLink = (download) => (download && !!download.get('url')) || false
 
 const getDownloadItems = (state) => {
-  if (!state.get('downloads')) {
+  if (!state || !state.get('downloads')) {
     return Immutable.List()
   }
 

--- a/test/unit/state/downloadUtilTest.js
+++ b/test/unit/state/downloadUtilTest.js
@@ -1,0 +1,37 @@
+/* global describe, it */
+
+const downloadUtil = require('../../../js/state/downloadUtil')
+const assert = require('assert')
+const Immutable = require('immutable')
+
+describe('downloadUtil', function () {
+  describe('getPercentageComplete', function () {
+    it('returns percentage complete for nonzero totalBytes', function () {
+      assert.equal(downloadUtil.getPercentageComplete(new Immutable.Map({
+        totalBytes: 100,
+        receivedBytes: 10
+      })), '10%')
+      assert.equal(downloadUtil.getPercentageComplete(new Immutable.Map({
+        totalBytes: 1,
+        receivedBytes: 1
+      })), '100%')
+      assert.equal(downloadUtil.getPercentageComplete(new Immutable.Map({
+        totalBytes: 0,
+        receivedBytes: 1
+      })), '0%')
+    })
+    it('returns percentage complete for falsey totalBytes', function () {
+      assert.equal(downloadUtil.getPercentageComplete(new Immutable.Map({
+        totalBytes: 0,
+        receivedBytes: 10
+      })), '0%')
+      assert.equal(downloadUtil.getPercentageComplete(new Immutable.Map({
+        totalBytes: 0,
+        receivedBytes: 0
+      })), '0%')
+      assert.equal(downloadUtil.getPercentageComplete(new Immutable.Map({
+        receivedBytes: 0
+      })), '0%')
+    })
+  })
+})

--- a/test/unit/state/downloadUtilTest.js
+++ b/test/unit/state/downloadUtilTest.js
@@ -1,11 +1,26 @@
 /* global describe, it */
 
 const downloadUtil = require('../../../js/state/downloadUtil')
+const downloadStates = require('../../../js/constants/downloadStates')
 const assert = require('assert')
 const Immutable = require('immutable')
 
 describe('downloadUtil', function () {
+  describe('shouldAllowPause', function () {
+    it('handles falsey input', function () {
+      assert.equal(downloadUtil.shouldAllowPause(undefined), false)
+    })
+    it('returns true if state is `downloadStates.IN_PROGRESS`', function () {
+      assert.equal(downloadUtil.shouldAllowPause(new Immutable.Map({
+        state: downloadStates.IN_PROGRESS
+      }), [downloadStates.IN_PROGRESS]), true)
+    })
+  })
+
   describe('getPercentageComplete', function () {
+    it('handles falsey input', function () {
+      assert.equal(downloadUtil.getPercentageComplete(undefined), '0%')
+    })
     it('returns percentage complete for nonzero totalBytes', function () {
       assert.equal(downloadUtil.getPercentageComplete(new Immutable.Map({
         totalBytes: 100,
@@ -32,6 +47,31 @@ describe('downloadUtil', function () {
       assert.equal(downloadUtil.getPercentageComplete(new Immutable.Map({
         receivedBytes: 0
       })), '0%')
+    })
+  })
+
+  describe('shouldAllowCopyLink', function () {
+    it('returns false if input is falsey', function () {
+      assert.equal(downloadUtil.shouldAllowCopyLink(undefined), false)
+    })
+    it('returns false if `download.url` does not have a value', function () {
+      assert.equal(downloadUtil.shouldAllowCopyLink(new Immutable.Map({
+        totalBytes: 0
+      })), false)
+    })
+    it('returns true if `download.url` has a value', function () {
+      assert.equal(downloadUtil.shouldAllowCopyLink(new Immutable.Map({
+        url: 'https://clifton.io/robots.txt'
+      })), true)
+    })
+  })
+
+  describe('getDownloadItems', function () {
+    it('returns an empty Immutable.List if intput is falsey', function () {
+      assert.deepEqual(downloadUtil.getDownloadItems(undefined), Immutable.List())
+    })
+    it('returns an empty Immutable.List if `state.downloads` is falsey', function () {
+      assert.deepEqual(downloadUtil.getDownloadItems(new Immutable.Map({})), Immutable.List())
     })
   })
 })


### PR DESCRIPTION
Fix https://github.com/brave/browser-laptop/issues/10264

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
Download a large file and hit 'pause' immediately. It should not show Infinity% downloaded.

Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


