### PR TITLE
Specify a command line flag (--store-devtool) that allows visualizing store state and actions

### DIFF
--- a/app/cmdLine.js
+++ b/app/cmdLine.js
@@ -136,3 +136,39 @@ module.exports.newWindowURL = () => {
   }
   return newWindowURL
 }
+
+const storeDevtoolFlagName = '--store-devtool'
+
+const shouldConnectToReduxDevtools = (
+  process.env.NODE_ENV === 'development' &&
+  process.argv.includes(storeDevtoolFlagName)
+)
+
+let reduxDevtoolsPort
+if (shouldConnectToReduxDevtools) {
+  // default port to connect
+  reduxDevtoolsPort = 8181
+  // allow port override from cli args
+  const argIdx = process.argv.indexOf(storeDevtoolFlagName)
+  if (argIdx !== -1) {
+    const argValRaw = process.argv[argIdx + 1]
+    if (argValRaw) {
+      const argVal = Number(argValRaw)
+      if (!Number.isNaN(argVal)) {
+        reduxDevtoolsPort = argVal
+      }
+    }
+  }
+}
+
+/**
+ * Visualize dispatched actions, their data, and the state after all reducers have run for each action.
+ * Enable this by running with the flag '--store-devtool',
+ *  and then monitoring with a tool from https://github.com/zalmoxisus/remotedev#monitoring
+ */
+module.exports.shouldConnectToReduxDevtools = shouldConnectToReduxDevtools
+
+/**
+ * If enabled, http port number to connect to remote redux tools on
+ */
+module.exports.reduxDevtoolsPort = reduxDevtoolsPort

--- a/package.json
+++ b/package.json
@@ -176,6 +176,8 @@
     "react-addons-perf": "^15.2.1",
     "react-addons-test-utils": "^15.4.1",
     "react-test-renderer": "^15.5.4",
+    "remotedev": "^0.2.7",
+    "remotedev-server": "^0.2.3",
     "request": "^2.81.0",
     "sinon": "^1.17.6",
     "spectron": "brave/spectron#chromium60",

--- a/tools/reduxRemoteDevtoolsServer.js
+++ b/tools/reduxRemoteDevtoolsServer.js
@@ -1,0 +1,20 @@
+module.exports = function startReduxDevtoolsServer (flagName) {
+  // default port to accept connections
+  let port = 8181
+  // allow port override from cli args
+  const argIdx = process.argv.indexOf(flagName)
+  if (argIdx !== -1) {
+    const argValRaw = process.argv[argIdx + 1]
+    if (argValRaw) {
+      const argVal = Number(argValRaw)
+      if (!Number.isNaN(argVal)) {
+        port = argVal
+      }
+    }
+  }
+  // start listening
+  require('remotedev-server')({
+    hostname: 'localhost',
+    port
+  })
+}

--- a/tools/start.js
+++ b/tools/start.js
@@ -1,7 +1,14 @@
 const path = require('path')
 const spawn = require('child_process').spawn
+const startReduxDevtoolsServer = require('./reduxRemoteDevtoolsServer')
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'development'
+
+const storeDevtoolFlagName = '--store-devtool'
+if (process.env.NODE_ENV === 'development' && process.argv.includes(storeDevtoolFlagName)) {
+  startReduxDevtoolsServer(storeDevtoolFlagName)
+}
+
 const options = {
   env: process.env,
   stdio: 'inherit',


### PR DESCRIPTION
Data sent can be visualized in a tool on localhost that this flag enables being served (default port 8181)

Just an idea to solve #10654. This is just one way that I solved being able to use the redux-tools browser extension tools. It's not the cleanest way as it has to start an http server, and I'm not sure if it will be useful to anyone else, but it's helped me visualize the store's state and actions in realtime.

![image](https://user-images.githubusercontent.com/741836/29703764-db3be25e-892b-11e7-9faa-9254ebc179d3.png)

![image](https://user-images.githubusercontent.com/741836/29703777-f49d6f88-892b-11e7-9831-5f4f1e6cd9ca.png)


Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
**Disabled**
- `npm start` should behave as normal - no log entries about 'Remote store logging'
- Visiting http://localhost:8181 in a (separate) browser should render nothing

**Enabled, default**
- `npm start -- --store-devtool`
- Should print log `Remote store logging enabled. View store actions along with changes in state at http://localhost:8181`
- Visit http://localhost:8181 in a (separate) browser
  - Confirm redux devtool is rendered
- Interact with browser / window
 - Confirm actions and state is logged in devtool

**Enabled, custom port**
- `npm start -- --store-devtool 8282`
- Should print log `Remote store logging enabled. View store actions along with changes in state at http://localhost:8282`
- Visit http://localhost:8282 in a (separate) browser
  - Confirm redux devtool is rendered
- Interact with browser / window
 - Confirm actions and state is logged in devtool

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


