### PR TITLE
Show 'Brave Browser' as the origin if origin is null

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -481,7 +481,9 @@ function registerPermissionHandler (session, partition) {
       return
     }
 
-    const message = locale.translation('permissionMessage').replace(/{{\s*host\s*}}/, origin).replace(/{{\s*permission\s*}}/, permissions[permission].action)
+    // Display 'Brave Browser' if the origin is null; ex: when a mailto: link
+    // is opened in a new tab via right-click
+    const message = locale.translation('permissionMessage').replace(/{{\s*host\s*}}/, origin || 'Brave Browser').replace(/{{\s*permission\s*}}/, permissions[permission].action)
 
     // If this is a duplicate, clear the previous callback and use the new one
     if (permissionCallbacks[message]) {
@@ -495,7 +497,7 @@ function registerPermissionHandler (session, partition) {
       ],
       frameOrigin: getOrigin(mainFrameUrl),
       options: {
-        persist: true
+        persist: !!origin
       },
       message
     })


### PR DESCRIPTION
in the permission notification bar

fix #4198

Test Plan:
1. go to brave.com
2. scroll down to the contact section
4. right click on one of the email addresses to open in a new tab
5. the notification bar should say, 'Allow Brave Browser to open an external application?'

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


