### PR TITLE
Fix margin around buttons on certerror.js

### DIFF
--- a/js/about/certerror.js
+++ b/js/about/certerror.js
@@ -139,10 +139,10 @@ class CertErrorPage extends React.Component {
       <div className='buttons'>
         <BrowserButton actionItem l10nId='certErrorSafety' onClick={this.onSafety.bind(this)} />
         {this.state.url ? (this.state.advanced
-          ? (<BrowserButton subtleItem l10nId='certErrorButtonText' onClick={this.onAccept.bind(this)} />) : null) : null}
+          ? (<BrowserButton subtleItem groupedItem l10nId='certErrorButtonText' onClick={this.onAccept.bind(this)} />) : null) : null}
         {this.state.url ? (this.state.advanced
-          ? (<BrowserButton subtleItem l10nId='certErrorShowCertificate' onClick={this.onDetail.bind(this)} />)
-          : <BrowserButton subtleItem l10nId='certErrorAdvanced' onClick={this.onAdvanced.bind(this)} />) : null}
+          ? (<BrowserButton subtleItem groupedItem l10nId='certErrorShowCertificate' onClick={this.onDetail.bind(this)} />)
+          : <BrowserButton subtleItem groupedItem l10nId='certErrorAdvanced' onClick={this.onAdvanced.bind(this)} />) : null}
       </div>
     </div>
   }


### PR DESCRIPTION
Fixes #10677

Auditors: @cezaraugusto

Test Plan:
1. Open https://expired.badssl.com/
2. Make sure there is a gap between the buttons

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


