### PR TITLE
Align the first button on error pages

### DIFF
--- a/less/about/error.less
+++ b/less/about/error.less
@@ -23,11 +23,8 @@
       .buttons {
         display: flex;
         flex-flow: row wrap;
-        position: relative;
-        right: .2em; // cancel margin: .2em to align .buttons and .certErrorText
 
         > .browserButton {
-          margin: .2em;
           font-size: 14px;
         }
       }


### PR DESCRIPTION
Fix #10679

Auditors: @cezaraugusto

Test Plan:
1. Open https://expired.badssl.com/
2. Make sure the first button is aligned to the left

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


Setting the milestone to 0.19 as the regression has been introduced with 3dfc598#diff-0ff973318abdc5c07f55cefe86bd5ed7R109.