### PR TITLE
[wip] Tab sorting with drag and drop moves tabs with animation and creates space

### DIFF
--- a/js/dnd.js
+++ b/js/dnd.js
@@ -49,7 +49,7 @@ module.exports.onDragEnd = () => {
   }, 100)
 }
 
-module.exports.onDragOver = (dragType, sourceBoundingRect, draggingOverKey, draggingOverDetail, e) => {
+module.exports.onDragOver = (dragType, sourceBoundingRect, draggingOverKey, draggingOverDetail, e, draggingOverIndex = null) => {
   if (module.exports.getInterBraveDragType() !== dragType) {
     return
   }
@@ -63,6 +63,7 @@ module.exports.onDragOver = (dragType, sourceBoundingRect, draggingOverKey, drag
       draggingOverType: dragType,
       draggingOverLeftHalf: false,
       draggingOverRightHalf: false,
+      draggingOverIndex,
       draggingOverWindowId: getCurrentWindowId()
     })
     return
@@ -71,24 +72,23 @@ module.exports.onDragOver = (dragType, sourceBoundingRect, draggingOverKey, drag
   if (!sourceBoundingRect) {
     return
   }
-
-  if (e.clientX > sourceBoundingRect.left && e.clientX < sourceBoundingRect.left + (sourceBoundingRect.width / 5) &&
-    (!draggingOverDetail || !draggingOverDetail.get('draggingOverLeftHalf'))) {
+  if (e.clientX > sourceBoundingRect.left && e.clientX < sourceBoundingRect.left + (sourceBoundingRect.width / 5)) {
     appActions.draggedOver({
       draggingOverKey,
       draggingOverType: dragType,
       draggingOverLeftHalf: true,
       draggingOverRightHalf: false,
+      draggingOverIndex,
       draggingOverWindowId: getCurrentWindowId()
     })
     windowActions.setContextMenuDetail()
-  } else if (e.clientX < sourceBoundingRect.right && e.clientX >= sourceBoundingRect.left + (sourceBoundingRect.width / 5) &&
-    (!draggingOverDetail || !draggingOverDetail.get('draggingOverRightHalf'))) {
+  } else if (e.clientX < sourceBoundingRect.right && e.clientX >= sourceBoundingRect.left + (sourceBoundingRect.width / 5)) {
     appActions.draggedOver({
       draggingOverKey,
       draggingOverType: dragType,
       draggingOverLeftHalf: false,
       draggingOverRightHalf: true,
+      draggingOverIndex,
       draggingOverWindowId: getCurrentWindowId()
     })
     windowActions.setContextMenuDetail()

--- a/less/tabs.less
+++ b/less/tabs.less
@@ -53,12 +53,10 @@
   }
 }
 
-.tabArea {
-  box-sizing: border-box;
-  display: inline-block;
+.tabDragArea {
+  overflow: visible;
   position: relative;
-  vertical-align: top;
-  overflow: hidden;
+
   height: -webkit-fill-available;
   // There's a special case that tabs should span the full width
   // if there are a full set of them.
@@ -68,10 +66,20 @@
 
   &:not(.isPinned) {
     flex: 1;
-    &:first-child {
-      //padding-left: 6px;
-    }
   }
+
+}
+
+.tabArea {
+  box-sizing: border-box;
+  width: 100%;
+  display: inline-block;
+  position: absolute;
+  top: 0;right: 0;
+  left: 0; bottom: 0;
+  vertical-align: top;
+  overflow: hidden;
+  transition: transform .1s;
 
   &.isPinned {
     .tabIcon {
@@ -80,20 +88,19 @@
     }
   }
 
-  &.draggingOverLeft {
-    &:not(.isDragging) {
-      padding-left: @dragSpacing;
-    }
+  &.insertingPrevious {
+    transform: translateX(100%);
+    pointer-events: none;
   }
 
-  &.draggingOverRight {
-    &:not(.isDragging) {
-      padding-right: @dragSpacing;
-    }
+  &.insertingNext {
+    transform: translateX(-100%);
+    pointer-events: none;
   }
 
   &.isDragging {
     opacity: 0.2;
+    visibility: hidden;
   }
 
   hr.dragIndicator {


### PR DESCRIPTION
**This is a work in progress!**

Addresses #6242 (Improve Drag and Drop for Tabs)

requires: https://github.com/brave/browser-laptop/pull/11530

State so far:
![brave-tab-sort-smooth](https://user-images.githubusercontent.com/741836/29765045-6ec09dda-8b8e-11e7-89a2-9d937f9f9a67.gif)


I put some time investigating a more physical experience for dragging tabs around. Some of the aims:
1. Immediate physical movement during tab sorting in a tab-page of a window
2. Immediate space-making when dragging a tab to a new window
3. nicer detach-to-new-window experience:
   - higher threshold
   - more visual preview

What I have so far, achieves 1. and, almost perfectly, 2. I can certainly polish it up and make the inter-window experience quite nice, and increase the threshold before detaching a tab to a new window for 3., but first wanted some feedback before progressing both on the direction of the UX and the implementation.

The main difficulty that doesn't seem possible within the current architecture is being able to have *both* of the following:
- Dragging the tabs to re-sort constrained to an axis (x-axis currently)
- After dragging in the opposite axis past a threshold (e.g. 50px), some kind of preview image is attached to the mouse cursor and able to be dragged *outside of* the window

This is because:
- The only way to get a drag-image attached to the mouse cursor that will work outside of the renderer window is to use html `draggable` (as is currently done)
- An html `draggable` cannot be constrained to an axis
- An html `draggable` cannot have its drag-image changed after the `dragstart` event has fired (it can have *no* image, but has to stay that way)

Furhtermore, an html `draggable` drag cannot be fired from javascript (e.g. whilst the mouse is already dragging), so we cannot start with our own tab-sorting `mousedown` and `mousemove` handler and then start a proper cross-window drag event when the mouse moves past a certain threshold outside the tab area.

Since we have to use html `draggable` in order to get the drag data being sent outside the window, or to a new window, we are constrained by the above.

Some brief thoughts on ways this could be solved if we do want the perfect constrained-axis dragging:

 1. Do it from the muon / chromium side - provide an API to attach a tab's dragdata and a window preview to the mouse, that the renderer javascript could call whilst a mousedown and mousemove are in progress, or perhaps even more specific APIs.
 2. See if we can do it through IPC purely in this layer of the app - as the mouse is dragged away, actually create a new window with the new tab before the mouse is released, and update the position of the window as the mouse moves. When a tab bar in another window receives the mouse whilst the other window is still reporting that the mouse is down and the tab selected, start showing the tab being inserted, whilst the main process closes the new window. If the process is interrupted, the tab goes back to the original position.




Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


