### PR TITLE
Remove button.less requirement from about pages

### DIFF
--- a/js/about/certerror.js
+++ b/js/about/certerror.js
@@ -9,7 +9,6 @@ const messages = require('../constants/messages')
 const ipc = window.chrome.ipcRenderer
 const {isSourceAboutUrl, getTargetAboutUrl} = require('../lib/appUrlUtil')
 
-require('../../less/button.less')
 require('../../less/window.less')
 require('../../less/about/error.less')
 

--- a/js/about/errorPage.js
+++ b/js/about/errorPage.js
@@ -8,7 +8,6 @@ const BrowserButton = require('../../app/renderer/components/common/browserButto
 const appActions = require('../../js/actions/appActions')
 const tabActions = require('../../app/common/actions/tabActions')
 
-require('../../less/button.less')
 require('../../less/window.less')
 require('../../less/about/error.less')
 

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -66,7 +66,6 @@ const hintCount = 3
 require('../../less/switchControls.less')
 require('../../less/about/preferences.less')
 require('../../less/forms.less')
-require('../../less/button.less')
 require('../../node_modules/font-awesome/css/font-awesome.css')
 
 const permissionNames = {

--- a/js/about/safebrowsing.js
+++ b/js/about/safebrowsing.js
@@ -7,7 +7,6 @@ const BrowserButton = require('../../app/renderer/components/common/browserButto
 
 const {StyleSheet, css} = require('aphrodite/no-important')
 
-require('../../less/button.less')
 require('../../less/window.less')
 require('../../less/about/error.less')
 


### PR DESCRIPTION
Closes #10700

Auditors: @cezaraugusto

Test Plan:
1. Open `https://expired.badssl.com` (for certerror.js)
2. Open `https://brave.rules` (for errorPage.js)
3. Open `about:preferences` (for preferences.js)
4. Open `http://downloadme.org` (for safebrowsing.js)
5. Make sure the all error pages are rendered

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


