### PR TITLE
Polish about:brave

### DIFF
--- a/js/about/brave.js
+++ b/js/about/brave.js
@@ -13,6 +13,7 @@ const ipc = window.chrome.ipcRenderer
 
 const cx = require('../lib/classSet')
 const {StyleSheet, css} = require('aphrodite/no-important')
+const globalStyles = require('../../app/renderer/components/styles/global')
 const commonStyles = require('../../app/renderer/components/styles/commonStyles')
 
 const {
@@ -20,7 +21,7 @@ const {
   AboutPageSectionSubTitle
 } = require('../../app/renderer/components/common/sectionTitle')
 
-require('../../less/about/history.less')
+require('../../less/about/siteDetails.less')
 require('../../node_modules/font-awesome/css/font-awesome.css')
 
 const tranformVersionInfoToString = (versionInformation) =>
@@ -44,7 +45,10 @@ class AboutBrave extends React.Component {
   }
 
   render () {
-    return <div className='siteDetailsPage'>
+    return <div className={cx({
+      siteDetailsPage: true,
+      [css(styles.aboutBrave)]: true
+    })}>
       <div className='siteDetailsPageHeader'>
         <AboutPageSectionTitle data-l10n-id='aboutBrave' />
         <div data-l10n-id='braveInfo' />
@@ -52,8 +56,7 @@ class AboutBrave extends React.Component {
 
       <div className={cx({
         siteDetailsPageContent: true,
-        aboutBrave: true,
-        [css(commonStyles.siteDetailsPageContent)]: true
+        [css(styles.aboutBrave__content)]: true
       })}>
         <AboutPageSectionSubTitle data-l10n-id='releaseNotes' />
 
@@ -65,7 +68,7 @@ class AboutBrave extends React.Component {
           <span data-l10n-id='relNotesInfo3' />
         </div>
 
-        <div className={css(styles.versionInformationWrapper)}>
+        <div className={css(styles.aboutBrave__content__versionInformation)}>
           <AboutPageSectionSubTitle data-l10n-id='versionInformation' />
           <ClipboardButton
             dataL10nId='copyToClipboard'
@@ -75,6 +78,7 @@ class AboutBrave extends React.Component {
         </div>
 
         <SortableTable
+          fillAvailable
           headings={['Name', 'Version']}
           rows={this.state.versionInformation.map((version, name) => [
             {
@@ -95,11 +99,22 @@ class AboutBrave extends React.Component {
 }
 
 const styles = StyleSheet.create({
-  versionInformationWrapper: {
+  aboutBrave: {
+    width: '400px',
+    marginTop: globalStyles.spacing.aboutPageSectionPadding,
+
+    // See issue #10711
+    padding: '0 !important'
+  },
+
+  aboutBrave__content: {
+    marginLeft: globalStyles.spacing.aboutPageSectionPadding
+  },
+
+  aboutBrave__content__versionInformation: {
     display: 'flex',
     justifyContent: 'space-between',
-    alignItems: 'baseline',
-    width: '400px'
+    alignItems: 'baseline'
   }
 })
 

--- a/less/about/history.less
+++ b/less/about/history.less
@@ -4,16 +4,6 @@
   min-width: 704px;
 
   .siteDetailsPageContent {
-    &.aboutBrave {
-      .sortableTable {
-        user-select: text;
-        width: 400px;
-        td {
-          cursor: auto;
-          padding-left: 8px;
-        }
-      }
-    }
 
     .sortableTable {
       user-select: none;


### PR DESCRIPTION
Closes #10712
Possible fix for #10711

Replace history.less requirement with siteDetails.less, which is more straightforward

Auditors: @cezaraugusto @jonathansampson

Test Plan:
1. Open about:brave
2. Make sure the layout is not broken

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


