### PR TITLE
Ignore package-lock.json temporarily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ app/extensions/brave/content/scripts/sync.js
 
 # script used for signing for widevine
 signature_generator.py
+
+# Issue 8283
+package-lock.json


### PR DESCRIPTION
Let's revert it after https://github.com/travis-ci/travis-ci/issues/7936 is fixed. See: https://github.com/brave/browser-laptop/pull/9691#issuecomment-310793112

Addresses #8283

Test Plan:
1. rm -rf node_modules
2. npm install
3. git status
3. make sure package-lock.json is no longer listed

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


