### PR TITLE
Integrate with the `signature_generator.py` script (for widevine).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ httpse.leveldb
 
 # sync bundle file should be built and copied from the brave/sync repo for now
 app/extensions/brave/content/scripts/sync.js
+
+# script used for signing for widevine
+signature_generator.py

--- a/tools/buildInstaller.js
+++ b/tools/buildInstaller.js
@@ -8,24 +8,51 @@ const isDarwin = process.platform === 'darwin'
 const isLinux = process.platform === 'linux'
 var outDir = 'dist'
 var arch = 'x64'
+var widevineCdmArch = 'win_x64'
 var cmds
 
 if (isWindows) {
   if (process.env.TARGET_ARCH === 'ia32') {
     arch = 'ia32'
+    widevineCdmArch = 'win_x86'
   }
 }
 const buildDir = 'Brave-' + process.platform + '-' + arch
 
 console.log('Building install and update for version ' + VersionInfo.braveVersion + ' in ' + buildDir + ' with Electron ' + VersionInfo.electronVersion)
 
+const raiseError = (errorMessage) => {
+  console.error(errorMessage)
+  process.exit(1)
+}
+
+if (isDarwin || isWindows) {
+  const requiredText = 'is required for widevine signing'
+  if (!process.env.SIGN_WIDEVINE_PASSPHRASE) {
+    raiseError('SIGN_WIDEVINE_PASSPHRASE ' + requiredText)
+  }
+  if (!process.env.SIGN_WIDEVINE_CERT) {
+    raiseError('SIGN_WIDEVINE_CERT ' + requiredText)
+  }
+  if (!process.env.SIGN_WIDEVINE_KEY) {
+    raiseError('SIGN_WIDEVINE_KEY ' + requiredText)
+  }
+
+  // check if widevine script exists
+  const fs = require('fs')
+  if (!fs.existsSync('tools/signature_generator.py')) {
+    raiseError('`tools/signature_generator.py` ' + requiredText)
+  }
+}
+
 if (isDarwin) {
   const identifier = process.env.IDENTIFIER
   if (!identifier) {
-    console.error('IDENTIFIER needs to be set to the certificate organization')
-    process.exit(1)
+    raiseError('IDENTIFIER needs to be set to the certificate organization')
   }
 
+  const wvBundle = buildDir + '/Brave.app/Contents/Frameworks/Brave Framework.framework/Brave Framework'
+  const wvPlugin = buildDir + '/Brave.app/Contents/Frameworks/Brave Framework.framework/Libraries/WidevineCdm/_platform_specific/mac_x64/widevinecdmadapter.plugin'
   cmds = [
     // Remove old
     'rm -f ' + outDir + '/Brave.dmg',
@@ -36,8 +63,12 @@ if (isDarwin) {
     'cd ../../..',
     'codesign --deep --force --strict --verbose --sign $IDENTIFIER Brave.app/',
 
-    // Package it into a dmg
+    // sign for widevine
     'cd ..',
+    'python tools/signature_generator.py --input_file "' + wvBundle + '" --flag 1',
+    'python tools/signature_generator.py --input_file "' + wvPlugin + '"',
+
+    // Package it into a dmg
     'build ' +
       '--prepackaged="' + buildDir + '/Brave.app" ' +
       '--mac=dmg ' +
@@ -53,32 +84,46 @@ if (isDarwin) {
   var cert = process.env.CERT || '../brave-authenticode.pfx'
   var certPassword = process.env.CERT_PASSWORD
   if (!certPassword) {
-    throw new Error('Certificate password required. Set environment variable CERT_PASSWORD.')
+    raiseError('Certificate password required. Set environment variable CERT_PASSWORD.')
   }
 
-  // Because both x64 and ia32 creates a RELEASES and a .nupkg file we
-  // need to store the output files in separate directories
-  outDir = path.join(outDir, arch)
+  // sign for widevine
+  const wvExe = buildDir + '/Brave.exe'
+  const wvPlugin = buildDir + '/WidevineCdm/_platform_specific/' + widevineCdmArch + '/widevinecdmadapter.dll'
+  cmds = [
+    'python tools/signature_generator.py --input_file "' + wvExe + '" --flag 1',
+    'python tools/signature_generator.py --input_file "' + wvPlugin + '"'
+  ]
+  execute(cmds, {}, (err) => {
+    if (err) {
+      raiseError('signing for widevine failed' + JSON.stringify(err))
+      return
+    }
 
-  var muonInstaller = require('muon-winstaller')
-  var resultPromise = muonInstaller.createWindowsInstaller({
-    appDirectory: buildDir,
-    outputDirectory: outDir,
-    title: 'Brave',
-    authors: 'Brave Software',
-    loadingGif: 'res/brave_splash_installing.gif',
-    setupIcon: 'res/brave_installer.ico',
-    iconUrl: 'https://brave.com/favicon.ico',
-    signWithParams: format('-a -fd sha256 -f "%s" -p "%s" -t http://timestamp.verisign.com/scripts/timstamp.dll', path.resolve(cert), certPassword),
-    noMsi: true,
-    exe: 'Brave.exe'
+    // Because both x64 and ia32 creates a RELEASES and a .nupkg file we
+    // need to store the output files in separate directories
+    outDir = path.join(outDir, arch)
+
+    var muonInstaller = require('muon-winstaller')
+    var resultPromise = muonInstaller.createWindowsInstaller({
+      appDirectory: buildDir,
+      outputDirectory: outDir,
+      title: 'Brave',
+      authors: 'Brave Software',
+      loadingGif: 'res/brave_splash_installing.gif',
+      setupIcon: 'res/brave_installer.ico',
+      iconUrl: 'https://brave.com/favicon.ico',
+      signWithParams: format('-a -fd sha256 -f "%s" -p "%s" -t http://timestamp.verisign.com/scripts/timstamp.dll', path.resolve(cert), certPassword),
+      noMsi: true,
+      exe: 'Brave.exe'
+    })
+    resultPromise.then(() => {
+      cmds = [
+        `mv ${outDir}/Setup.exe ${outDir}/BraveSetup-${arch}.exe`
+      ]
+      execute(cmds, {}, console.log.bind(null, 'done'))
+    }, (e) => console.log(`No dice: ${e.message}`))
   })
-  resultPromise.then(() => {
-    cmds = [
-      `mv ${outDir}/Setup.exe ${outDir}/BraveSetup-${arch}.exe`
-    ]
-    execute(cmds, {}, console.log.bind(null, 'done'))
-  }, (e) => console.log(`No dice: ${e.message}`))
 } else if (isLinux) {
   console.log('Install with sudo dpkg -i dist/brave_' + VersionInfo.braveVersion + '_amd64.deb')
   console.log('Or install with sudo dnf install dist/brave_' + VersionInfo.braveVersion + '.x86_64.rpm')
@@ -100,13 +145,11 @@ if (isDarwin) {
   ]
   execute(cmds, {}, (err) => {
     if (err) {
-      console.error('buildInstaller failed', err)
-      process.exit(1)
+      raiseError('buildInstaller failed' + JSON.stringify(err))
       return
     }
     console.log('done')
   })
 } else {
-  console.log('Installer not supported for platform: ' + process.platform)
-  process.exit(1)
+  raiseError('Installer not supported for platform: ' + process.platform)
 }


### PR DESCRIPTION
This is a 3rd party file and will not be checked into source control
CI (such as Jenkins) can copy the file into place before building.

Auditors: @darkdh, @bbondy

Depends on https://github.com/brave/muon/pull/283
Helping to fix https://github.com/brave/browser-laptop/issues/10449

**NOTE: once accepted, we need to update the Jenkins job to copy this file into place before starting a CI build.**

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


