### PR TITLE
Spoof referer header on cross-origin navigations

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -241,12 +241,12 @@ module.exports.applyCookieSetting = (requestHeaders, url, firstPartyUrl, isPriva
   if (cookieSetting) {
     const parsedTargetUrl = urlParse(url || '')
     const parsedFirstPartyUrl = urlParse(firstPartyUrl)
+    const targetOrigin = getOrigin(url)
 
     if (cookieSetting === 'blockAllCookies' ||
       isThirdPartyHost(parsedFirstPartyUrl.hostname, parsedTargetUrl.hostname)) {
       let hasCookieException = false
       const firstPartyOrigin = getOrigin(firstPartyUrl)
-      const targetOrigin = getOrigin(url)
       if (cookieExceptions.hasOwnProperty(firstPartyOrigin)) {
         const subResources = cookieExceptions[firstPartyOrigin]
         for (let i = 0; i < subResources.length; ++i) {
@@ -267,10 +267,16 @@ module.exports.applyCookieSetting = (requestHeaders, url, firstPartyUrl, isPriva
           firstPartyOrigin !== pdfjsOrigin && !hasCookieException) {
         requestHeaders['Cookie'] = undefined
       }
-      if (requestHeaders['Referer'] &&
-          !refererExceptions.includes(parsedTargetUrl.hostname)) {
-        requestHeaders['Referer'] = targetOrigin
-      }
+    }
+
+    const referer = requestHeaders['Referer']
+    if (referer &&
+        cookieSetting !== 'allowAllCookies' &&
+        !refererExceptions.includes(parsedTargetUrl.hostname) &&
+        targetOrigin !== getOrigin(referer)) {
+      // Unless the setting is 'allow all cookies', spoof the referer if it
+      // is a cross-origin referer
+      requestHeaders['Referer'] = targetOrigin
     }
   }
 


### PR DESCRIPTION
Previously we were only spoofing it on cross-origin subresource requests, not
navigations. Fix https://github.com/brave/browser-laptop/issues/10721

Test Plan:
1. go to https://community.brave.com/t/tracking-not-blocked/6787 and click on the two links in the post
2. the sites should report the referer as the origin of the site itself, not community.brave.com
3. now turn off shields on one of the sites
4. repeat steps 1 and 2. the site should now report the referer as community.brave.com

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


