### PR TITLE
Update path for widevine sig file on macOS

### DIFF
--- a/tools/buildInstaller.js
+++ b/tools/buildInstaller.js
@@ -52,10 +52,15 @@ if (isDarwin) {
   }
 
   const wvBundle = buildDir + '/Brave.app/Contents/Frameworks/Brave Framework.framework/Brave Framework'
+  const wvBundleSig = buildDir + '/Brave.app/Contents/Frameworks/Widevine Resources.bundle/Contents/Resources/Brave Framework.sig'
   const wvPlugin = buildDir + '/Brave.app/Contents/Frameworks/Brave Framework.framework/Libraries/WidevineCdm/_platform_specific/mac_x64/widevinecdmadapter.plugin'
   cmds = [
     // Remove old
     'rm -f ' + outDir + '/Brave.dmg',
+
+    // sign for widevine
+    'python tools/signature_generator.py --input_file "' + wvBundle + '" --output_file "' + wvBundleSig + '" --flag 1',
+    'python tools/signature_generator.py --input_file "' + wvPlugin + '"',
 
     // Sign it
     'cd ' + buildDir + '/Brave.app/Contents/Frameworks',
@@ -63,12 +68,8 @@ if (isDarwin) {
     'cd ../../..',
     'codesign --deep --force --strict --verbose --sign $IDENTIFIER Brave.app/',
 
-    // sign for widevine
-    'cd ..',
-    'python tools/signature_generator.py --input_file "' + wvBundle + '" --flag 1',
-    'python tools/signature_generator.py --input_file "' + wvPlugin + '"',
-
     // Package it into a dmg
+    'cd ..',
     'build ' +
       '--prepackaged="' + buildDir + '/Brave.app" ' +
       '--mac=dmg ' +

--- a/tools/buildInstaller.js
+++ b/tools/buildInstaller.js
@@ -54,13 +54,11 @@ if (isDarwin) {
   const wvBundle = buildDir + '/Brave.app/Contents/Frameworks/Brave Framework.framework/Brave Framework'
   const wvBundleSig = buildDir + '/Brave.app/Contents/Frameworks/Widevine Resources.bundle/Contents/Resources/Brave Framework.sig'
   const wvPlugin = buildDir + '/Brave.app/Contents/Frameworks/Brave Framework.framework/Libraries/WidevineCdm/_platform_specific/mac_x64/widevinecdmadapter.plugin'
+  // Do not codesign verification because it will fail duto widevine signature
+  process.env['CSC_IDENTITY_AUTO_DISCOVERY'] = false
   cmds = [
     // Remove old
     'rm -f ' + outDir + '/Brave.dmg',
-
-    // sign for widevine
-    'python tools/signature_generator.py --input_file "' + wvBundle + '" --output_file "' + wvBundleSig + '" --flag 1',
-    'python tools/signature_generator.py --input_file "' + wvPlugin + '"',
 
     // Sign it
     'cd ' + buildDir + '/Brave.app/Contents/Frameworks',
@@ -68,8 +66,12 @@ if (isDarwin) {
     'cd ../../..',
     'codesign --deep --force --strict --verbose --sign $IDENTIFIER Brave.app/',
 
-    // Package it into a dmg
+    // sign for widevine
     'cd ..',
+    'python tools/signature_generator.py --input_file "' + wvBundle + '" --output_file "' + wvBundleSig + '" --flag 1',
+    'python tools/signature_generator.py --input_file "' + wvPlugin + '"',
+
+    // Package it into a dmg
     'build ' +
       '--prepackaged="' + buildDir + '/Brave.app" ' +
       '--mac=dmg ' +


### PR DESCRIPTION
Please don't merge until the new Muon build is available which creates the empty `Widevine Resources.bundle`

_____

Auditors: @darkdh

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


