### PR TITLE
fix data URL phishing warning appear on the wrong tab

### DIFF
--- a/docs/state.md
+++ b/docs/state.md
@@ -490,6 +490,7 @@ WindowStore
       internalFindStatePresent: boolean // true if a find-first (ie findNext: false) call has been made
     }
     guestInstanceId: string, // not persisted
+    hasBeenActivated: boolean, // whether this frame has ever been the active frame
     history: array, // navigation history
     hrefPreview: string, // show hovered link preview
     httpsEverywhere: Object<string, Array<string>>, // map of XML rulesets name to redirected resources

--- a/test/navbar-components/siteInfoTest.js
+++ b/test/navbar-components/siteInfoTest.js
@@ -69,5 +69,26 @@ describe('siteInfo component tests', function () {
         .waitForElementCount(siteInfoDialog, 1)
         .waitForElementCount(siteInfoDialog, 0)
     })
+
+    it('shows siteInfo once when switching to a new tab', function * () {
+      const page1 = 'data:,Hello%2C%20World!'
+      yield this.app.client
+        .tabByIndex(0)
+        .url('https://example.com')
+        .windowByUrl(Brave.browserWindowUrl)
+        .newTab({
+          active: false,
+          url: page1
+        })
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForElementCount(siteInfoDialog, 0)
+        .activateTabByIndex(1)
+        .waitForElementCount(siteInfoDialog, 1)
+        .activateTabByIndex(0)
+        .waitForElementCount(siteInfoDialog, 0)
+        .activateTabByIndex(1)
+        .waitForExist('[data-test-active-tab][data-frame-key="2"]')
+        .waitForElementCount(siteInfoDialog, 0)
+    })
   })
 })


### PR DESCRIPTION
fix #10754

test plan
1. go to https://jsfiddle.net/y3uw6q1w/
2. right click the link and open in new tab
3. no siteInfo popup should appear
4. switch to the new tab
5. siteInfo popup should appear
6. switch to tab 1 and back to tab 2. the siteInfo popup should not appear.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


