### PR TITLE
Force upgrade WidevineCdm ext when last app version <= 0.18.23

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -739,11 +739,11 @@ module.exports.runPreMigrations = (data) => {
   }
 
   if (data.lastAppVersion) {
-    // Force WidevineCdm to be upgraded when last app version <= 0.18.23
+    // Force WidevineCdm to be upgraded when last app version <= 0.18.25
     let runWidevineCleanup = false
     const compareVersions = require('compare-versions')
 
-    try { runWidevineCleanup = compareVersions(data.lastAppVersion, '0.18.23') < 1 } catch (e) {}
+    try { runWidevineCleanup = compareVersions(data.lastAppVersion, '0.18.25') < 1 } catch (e) {}
 
     if (runWidevineCleanup) {
       const fs = require('fs-extra')

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -738,6 +738,20 @@ module.exports.runPreMigrations = (data) => {
     delete data.sites
   }
 
+  if (data.lastAppVersion) {
+    // Force WidevineCdm to be upgraded when last app version <= 0.18.23
+    const compareVersions = require('compare-versions')
+    if (compareVersions(data.lastAppVersion, '0.18.23') < 1) {
+      const fs = require('fs-extra')
+      const wvExtPath = path.join(app.getPath('userData'), 'Extensions', 'WidevineCdm')
+      fs.remove(wvExtPath, (err) => {
+        if (err) {
+          console.error(`Could not remove ${wvExtPath}`)
+        }
+      })
+    }
+  }
+
   return data
 }
 

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -740,8 +740,12 @@ module.exports.runPreMigrations = (data) => {
 
   if (data.lastAppVersion) {
     // Force WidevineCdm to be upgraded when last app version <= 0.18.23
+    let runWidevineCleanup = false
     const compareVersions = require('compare-versions')
-    if (compareVersions(data.lastAppVersion, '0.18.23') < 1) {
+
+    try { runWidevineCleanup = compareVersions(data.lastAppVersion, '0.18.23') < 1 } catch (e) {}
+
+    if (runWidevineCleanup) {
       const fs = require('fs-extra')
       const wvExtPath = path.join(app.getPath('userData'), 'Extensions', 'WidevineCdm')
       fs.remove(wvExtPath, (err) => {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "async": "^2.0.1",
     "bloodhound-js": "^1.2.1",
     "clipboard-copy": "^1.0.0",
+    "compare-versions": "^3.0.1",
     "electron-localshortcut": "^0.6.0",
     "electron-squirrel-startup": "brave/electron-squirrel-startup",
     "emoji-regex": "^6.5.1",

--- a/test/unit/app/sessionStoreTest.js
+++ b/test/unit/app/sessionStoreTest.js
@@ -6,6 +6,7 @@ const Immutable = require('immutable')
 const settings = require('../../../js/constants/settings')
 const {makeImmutable} = require('../../../app/common/state/immutableUtil')
 const downloadStates = require('../../../js/constants/downloadStates')
+const compareVersions = require('compare-versions')
 
 require('../braveUnit')
 
@@ -62,6 +63,10 @@ describe('sessionStore unit tests', function () {
     existsSync: (path) => {
       console.log('calling mocked fs.existsSync')
       return true
+    },
+    remove: (path, callback) => {
+      console.log('calling mocked fs.remove')
+      if (callback) callback()
     }
   }
   const fakeLocale = {
@@ -83,6 +88,7 @@ describe('sessionStore unit tests', function () {
     })
     mockery.registerMock('fs-extra', fakeFileSystem)
     mockery.registerMock('fs', fakeFileSystem)
+    mockery.registerMock('compare-versions', compareVersions)
     mockery.registerMock('electron', fakeElectron)
     mockery.registerMock('./locale', fakeLocale)
     mockery.registerMock('./autofill', fakeAutofill)


### PR DESCRIPTION
Auditors: @bsclifton, @bbondy

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


