### PR TITLE
Workaround for the codesign issue seen when building DMG for macOS on…

### DIFF
--- a/res/builderConfig.json
+++ b/res/builderConfig.json
@@ -3,7 +3,8 @@
   "productName": "Brave",
   "npmRebuild": false,
   "mac": {
-    "target": "dmg"
+    "target": "dmg",
+    "identity": null
   },
   "dmg": {
     "title": "Brave",


### PR DESCRIPTION
… Jenkins server.

If identity is set (which it is when running Jenkins but not when interactive), the `CSC_IDENTITY_AUTO_DISCOVERY` option is never considered.
See https://github.com/electron-userland/electron-builder/blob/351b0b44a04e6eeadcbcd003745d6c2aab1cfe67/packages/electron-builder/src/targets/dmg.ts#L171 for more info.

**NOTE: this only needs to be merged back to 0.19.x.  The code already exists in 0.18.x from the tests I did, which were done with https://github.com/brave/browser-laptop/commit/d98e492d4a9c3df165dfd5e3022dda97e32a4f74 and https://github.com/brave/browser-laptop/commit/78c4d57ee743f81096efe259721f54c4d2813198**

Auditors: @darkdh

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


