### PR TITLE
Fix error when codesign --verify

### DIFF
--- a/tools/buildInstaller.js
+++ b/tools/buildInstaller.js
@@ -54,11 +54,15 @@ if (isDarwin) {
   const wvBundle = buildDir + '/Brave.app/Contents/Frameworks/Brave Framework.framework/Brave Framework'
   const wvBundleSig = buildDir + '/Brave.app/Contents/Frameworks/Widevine Resources.bundle/Contents/Resources/Brave Framework.sig'
   const wvPlugin = buildDir + '/Brave.app/Contents/Frameworks/Brave Framework.framework/Libraries/WidevineCdm/_platform_specific/mac_x64/widevinecdmadapter.plugin'
-  // Do not codesign verification because it will fail duto widevine signature
-  process.env['CSC_IDENTITY_AUTO_DISCOVERY'] = false
   cmds = [
     // Remove old
     'rm -f ' + outDir + '/Brave.dmg',
+
+    // sign for widevine
+    'codesign --deep --force --strict --verbose --sign $IDENTIFIER "' + wvBundle + '"',
+    'codesign --deep --force --strict --verbose --sign $IDENTIFIER "' + wvPlugin + '"',
+    'python tools/signature_generator.py --input_file "' + wvBundle + '" --output_file "' + wvBundleSig + '" --flag 1',
+    'python tools/signature_generator.py --input_file "' + wvPlugin + '"',
 
     // Sign it
     'cd ' + buildDir + '/Brave.app/Contents/Frameworks',
@@ -66,12 +70,8 @@ if (isDarwin) {
     'cd ../../..',
     'codesign --deep --force --strict --verbose --sign $IDENTIFIER Brave.app/',
 
-    // sign for widevine
-    'cd ..',
-    'python tools/signature_generator.py --input_file "' + wvBundle + '" --output_file "' + wvBundleSig + '" --flag 1',
-    'python tools/signature_generator.py --input_file "' + wvPlugin + '"',
-
     // Package it into a dmg
+    'cd ..',
     'build ' +
       '--prepackaged="' + buildDir + '/Brave.app" ' +
       '--mac=dmg ' +


### PR DESCRIPTION
fix #10798

```
Error details: "-67054: a sealed resource is missing or invalid" {
      Resources added:
                Contents/Frameworks/Brave
                Framework.framework/Libraries/WidevineCdm/_platform_specific/mac_x64/widevinecdmadapter.plugin.sig
                    Error in subcomponent: Contents/Frameworks/Brave
                    Framework.framework
}
```

Auditors: @bsclifton

Test Plan:

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


