### PR TITLE
put private tabs in different sessions

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -12,7 +12,7 @@ const {app, BrowserWindow, extensions, session, ipcMain} = require('electron')
 const {makeImmutable, makeJS} = require('../common/state/immutableUtil')
 const {getTargetAboutUrl, getSourceAboutUrl, isSourceAboutUrl, newFrameUrl, isTargetAboutUrl, isIntermediateAboutPage, isTargetMagnetUrl, getSourceMagnetUrl} = require('../../js/lib/appUrlUtil')
 const {isURL, getUrlFromInput, toPDFJSLocation, getDefaultFaviconUrl, isHttpOrHttps, getLocationIfPDF} = require('../../js/lib/urlutil')
-const {isSessionPartition} = require('../../js/state/frameStateUtil')
+const {isSessionPartition, getPartitionNumber, getPartitionFromNumber} = require('../../js/state/frameStateUtil')
 const {getOrigin} = require('../../js/lib/urlutil')
 const settingsStore = require('../../js/settings')
 const settings = require('../../js/constants/settings')
@@ -41,7 +41,10 @@ const activeTabHistory = require('./activeTabHistory')
 
 let adBlockRegions
 let currentPartitionNumber = 0
-const incrementPartitionNumber = () => ++currentPartitionNumber
+let currentPrivatePartitionNumber = 0
+const incrementPartitionNumber = (isPrivate) => isPrivate
+  ? ++currentPrivatePartitionNumber
+  : ++currentPartitionNumber
 
 const normalizeUrl = function (url) {
   if (isSourceAboutUrl(url)) {
@@ -76,28 +79,26 @@ const updateTab = (tabId, changeInfo = {}) => {
   }
 }
 
-const getPartitionNumber = (partition) => {
-  return Number(partition.split('persist:partition-')[1] || 0)
-}
-
 /**
  * Obtains the current partition.
  * Warning: This function has global side effects in that it increments the
  * global next partition number if isPartitioned is passed into the create options.
  */
 const getPartition = (createProperties) => {
-  let partition = session.defaultSession.partition
   if (createProperties.partition) {
-    partition = createProperties.partition
-  } else if (createProperties.isPrivate) {
-    partition = 'default'
-  } else if (createProperties.isPartitioned) {
-    partition = `persist:partition-${incrementPartitionNumber()}`
-  } else if (createProperties.partitionNumber) {
-    partition = `persist:partition-${createProperties.partitionNumber}`
+    return createProperties.partition
   }
-
-  return partition
+  if (createProperties.partitionNumber) {
+    return getPartitionFromNumber(createProperties.partitionNumber,
+      createProperties.isPrivate)
+  }
+  if (createProperties.isPrivate) {
+    return getPartitionFromNumber(incrementPartitionNumber(true), true)
+  }
+  if (createProperties.isPartitioned) {
+    return getPartitionFromNumber(incrementPartitionNumber(false), false)
+  }
+  return session.defaultSession.partition
 }
 
 const needsPartitionAssigned = (createProperties) => {

--- a/app/common/state/tabContentState/partitionState.js
+++ b/app/common/state/tabContentState/partitionState.js
@@ -10,13 +10,7 @@ const frameStateUtil = require('../../../../js/state/frameStateUtil')
 const {tabs} = require('../../../../js/constants/config')
 
 module.exports.isPartitionTab = (state, frameKey) => {
-  const frame = frameStateUtil.getFrameByKey(state, frameKey)
-
-  if (frame == null) {
-    return false
-  }
-
-  return !!frame.get('partitionNumber')
+  return module.exports.getPartitionNumber(state, frameKey) > 0
 }
 
 module.exports.getPartitionNumber = (state, frameKey) => {
@@ -28,9 +22,9 @@ module.exports.getPartitionNumber = (state, frameKey) => {
 
   const partitionNumber = frame.get('partitionNumber')
   if (typeof partitionNumber === 'string') {
-    return partitionNumber.replace(/^partition-/i, '')
+    return Number(partitionNumber.replace(/^partition-/i, ''))
   }
-  return partitionNumber
+  return Number(partitionNumber)
 }
 
 module.exports.getMaxAllowedPartitionNumber = (state, frameKey) => {

--- a/app/renderer/components/frame/frame.js
+++ b/app/renderer/components/frame/frame.js
@@ -39,7 +39,6 @@ const domUtil = require('../../lib/domUtil')
 const {
   aboutUrls,
   isSourceMagnetUrl,
-  isTargetAboutUrl,
   getTargetAboutUrl,
   getBaseUrl,
   isIntermediateAboutPage
@@ -639,26 +638,6 @@ class Frame extends React.Component {
         return
       }
       if (isFrameError(e.errorCode)) {
-        // temporary workaround for https://github.com/brave/browser-laptop/issues/1817
-        if (e.validatedURL === aboutUrls.get('about:newtab') ||
-            e.validatedURL === aboutUrls.get('about:blank') ||
-            e.validatedURL === aboutUrls.get('about:certerror') ||
-            e.validatedURL === aboutUrls.get('about:error') ||
-            e.validatedURL === aboutUrls.get('about:safebrowsing')) {
-          // this will just display a blank page for errors
-          // but we don't want to take the user out of the private tab
-          return
-        } else if (isTargetAboutUrl(e.validatedURL)) {
-          // open a new tab for other about urls
-          // and send this tab back to wherever it came from
-          appActions.onGoBack(this.props.tabId)
-          appActions.createTabRequested({
-            url: e.validatedURL,
-            active: true
-          })
-          return
-        }
-
         windowActions.setFrameError(this.frame, {
           event_type: 'did-fail-load',
           errorCode: e.errorCode,

--- a/app/renderer/components/main/siteInfo.js
+++ b/app/renderer/components/main/siteInfo.js
@@ -105,7 +105,7 @@ class SiteInfo extends React.Component {
   }
 
   get partitionInfo () {
-    if (this.props.partitionNumber) {
+    if (this.props.partitionNumber > 0) {
       // Figure out the partition info display
       let l10nArgs = {
         partitionNumber: this.props.partitionNumber

--- a/test/unit/app/common/state/tabContentStateTest/partitionStateTest.js
+++ b/test/unit/app/common/state/tabContentStateTest/partitionStateTest.js
@@ -52,7 +52,7 @@ describe('partitionState unit tests', function () {
       assert.equal(partitionState.isPartitionTab(), false)
     })
 
-    it('returns true if partition number is defined', function * () {
+    it('returns true if partition number is positive', function * () {
       const partitionNumber = 1337
       const state = defaultState
         .setIn(['frames', index, 'partitionNumber'], partitionNumber)
@@ -65,6 +65,22 @@ describe('partitionState unit tests', function () {
       const result = partitionState.isPartitionTab(state, frameKey)
       assert.equal(result, false)
     })
+
+    it('returns false if partition number is 0', function * () {
+      const partitionNumber = 0
+      const state = defaultState
+        .setIn(['frames', index, 'partitionNumber'], partitionNumber)
+      const result = partitionState.isPartitionTab(state, frameKey)
+      assert.equal(result, false)
+    })
+
+    it('returns false if partition number is negative', function * () {
+      const partitionNumber = -10
+      const state = defaultState
+        .setIn(['frames', index, 'partitionNumber'], partitionNumber)
+      const result = partitionState.isPartitionTab(state, frameKey)
+      assert.equal(result, false)
+    })
   })
 
   describe('getPartitionNumber', function () {
@@ -72,8 +88,10 @@ describe('partitionState unit tests', function () {
       assert.equal(partitionState.getPartitionNumber(), 0)
     })
 
-    it('returns zero if frame is null/undefined', function * () {
-      assert.equal(partitionState.getPartitionNumber(), 0)
+    it('returns zero if partition number is null/undefined', function * () {
+      const state = defaultState
+        .setIn(['frames', index, 'partitionNumber'], null)
+      assert.equal(partitionState.getPartitionNumber(state, frameKey), 0)
     })
 
     it('can remove _partition_ string and keep the partition number', function * () {
@@ -95,8 +113,14 @@ describe('partitionState unit tests', function () {
   })
 
   describe('getMaxAllowedPartitionNumber', function () {
-    it('returns false if frame is null/undefined', function () {
-      assert.equal(partitionState.getMaxAllowedPartitionNumber(), false)
+    it('returns zero if frame is null/undefined', function () {
+      assert.equal(partitionState.getMaxAllowedPartitionNumber(), 0)
+    })
+
+    it('returns zero if partition number is null/undefined', function * () {
+      const state = defaultState
+        .setIn(['frames', index, 'partitionNumber'], null)
+      assert.equal(partitionState.getMaxAllowedPartitionNumber(state, frameKey), 0)
     })
 
     it('returns partition number', function * () {

--- a/test/unit/state/frameStateUtilTest.js
+++ b/test/unit/state/frameStateUtilTest.js
@@ -492,4 +492,40 @@ describe('frameStateUtil', function () {
       assert.equal(result, true)
     })
   })
+
+  describe('partition utils', function () {
+    it('getPartitionNumber', function () {
+      const getPartitionNumber = frameStateUtil.getPartitionNumber
+      assert.equal(getPartitionNumber(''), 0)
+      assert.equal(getPartitionNumber('1'), 0)
+      assert.equal(getPartitionNumber('partition-1'), -1)
+      assert.equal(getPartitionNumber('partition-222'), -222)
+      assert.equal(getPartitionNumber('partition-222.1'), 0)
+      assert.equal(getPartitionNumber('persist:partition-1'), 1)
+      assert.equal(getPartitionNumber('unpersist:partition-1'), 0)
+      assert.equal(getPartitionNumber('persist:partition-10'), 10)
+      assert.equal(getPartitionNumber('persist:partition'), 0)
+    })
+    it('isPrivatePartition', function () {
+      const isPrivatePartition = frameStateUtil.isPrivatePartition
+      assert.equal(isPrivatePartition(''), true)
+      assert.equal(isPrivatePartition('partition-1'), true)
+      assert.equal(isPrivatePartition('persist:partition-1'), false)
+    })
+    it('isSessionPartition', function () {
+      const isSessionPartition = frameStateUtil.isSessionPartition
+      assert.equal(isSessionPartition(''), false)
+      assert.equal(isSessionPartition('default'), false)
+      assert.equal(isSessionPartition('partition-1'), true)
+      assert.equal(isSessionPartition('persist:partition-1'), true)
+    })
+    it('getPartitionFromNumber', function () {
+      const getPartitionFromNumber = frameStateUtil.getPartitionFromNumber
+      assert.equal(getPartitionFromNumber(0, true), 'default')
+      assert.equal(getPartitionFromNumber(0, false), 'persist:default')
+      assert.equal(getPartitionFromNumber(1, true), 'partition-1')
+      assert.equal(getPartitionFromNumber(-10, true), 'partition-10')
+      assert.equal(getPartitionFromNumber(1, false), 'persist:partition-1')
+    })
+  })
 })


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/6684
partial fix for https://github.com/brave/browser-laptop/issues/8963
required https://github.com/brave/muon/pull/472

TODO: Either the private tab sessions should be cleared and revert back to private session 1 when the last private tab is closed, or we need a private tab session manager menu. Currently the session will keep incrementing until the browser restarts.

Test Plan:
1. open private tab
2. in the private tab, go to a site that requires login
3. login, then open a link from that site in a new private tab via cmd+click or ctrl+click on the link
4. you should also be logged in in the second private tab
5. open a new private tab. the tab should show the newtab page, not blank.
6. go to the same site. you should not be logged in.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


