### PR TITLE
Fixes cache problem with private tabs for siteSettings

### DIFF
--- a/app/common/cache/braverySettingsCache.js
+++ b/app/common/cache/braverySettingsCache.js
@@ -12,12 +12,18 @@ const clearBraverySettingsCache = () => {
   currentBraverySettingsCache.clear()
 }
 
-const getBraverySettingsCache = (url) => {
-  return currentBraverySettingsCache.get(url)
+const getBraverySettingsCache = (url, isPrivate) => {
+  const key = generateKey(url, isPrivate)
+  return currentBraverySettingsCache.get(key)
 }
 
-const updateBraverySettingsCache = (url, braverySettings) => {
-  currentBraverySettingsCache.set(url, braverySettings)
+const updateBraverySettingsCache = (url, isPrivate, braverySettings) => {
+  const key = generateKey(url, isPrivate)
+  currentBraverySettingsCache.set(key, braverySettings)
+}
+
+const generateKey = (url, isPrivate) => {
+  return `${url}|${isPrivate}`
 }
 
 module.exports = {

--- a/app/filtering.js
+++ b/app/filtering.js
@@ -60,7 +60,7 @@ const registeredSessions = {}
 const permissionCallbacks = {}
 
 const getBraverySettingsForUrl = (url, appState, isPrivate) => {
-  const cachedBraverySettings = getBraverySettingsCache(url)
+  const cachedBraverySettings = getBraverySettingsCache(url, isPrivate)
   if (cachedBraverySettings) {
     return cachedBraverySettings
   }
@@ -71,7 +71,8 @@ const getBraverySettingsForUrl = (url, appState, isPrivate) => {
   if (isPrivate && tempSettings) {
     braverySettings = siteSettings.activeSettings(tempSettings, appState, appConfig)
   }
-  updateBraverySettingsCache(url, braverySettings)
+  updateBraverySettingsCache(url, isPrivate, braverySettings)
+
   return braverySettings
 }
 


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Resolves #10829

Auditors:

Test Plan:
- visit one site with ads
- visit the same site in a private tab
- `Allow Ads and Tracking` in this private tab
- check that ads are loaded in the private tab
- visit the regular tab and reload it
- make sure that ads are still blocked in the regular tab



Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


