### PR TITLE
use muon's IP address check instead of node's

### DIFF
--- a/js/state/contentSettings.js
+++ b/js/state/contentSettings.js
@@ -19,7 +19,6 @@ const {registerUserPrefs} = require('./userPrefs')
 const {getSetting} = require('../settings')
 const {autoplayOption} = require('../../app/common/constants/settingsEnums')
 const {getFlashResourceId} = require('../flash')
-const net = require('net')
 
 // backward compatibility with appState siteSettings
 const parseSiteSettingsPattern = (pattern) => {
@@ -28,7 +27,7 @@ const parseSiteSettingsPattern = (pattern) => {
   }
   let normalizedPattern = pattern.replace('https?', 'https')
   let parsed = urlParse(normalizedPattern)
-  if (net.isIP(parsed.hostname)) {
+  if (muon.url.new(normalizedPattern).hostIsIPAddress()) {
     return parsed.host
   } else if (parsed.host) {
     return '[*.]' + parsed.host


### PR DESCRIPTION
partial fix for https://github.com/brave/browser-laptop/issues/10825 (noscript allowing scripts when host is an ipv6 address)

Test Plan:
1. npm run test -- --grep='can allow scripts when the url host is an ipv6 address' (the test is skipped on travis due to lack of ipv6 support)

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


