### PR TITLE
Fix automated security tests

### DIFF
--- a/test/fixtures/tabnapping.html
+++ b/test/fixtures/tabnapping.html
@@ -3,7 +3,7 @@
 <script>
 
 var target_html =
-  '<title>Tabnapping Target</title>'
+  '<title>tabnapped</title>'
 
 var w = null
 function open_target() {

--- a/test/fixtures/websockets.html
+++ b/test/fixtures/websockets.html
@@ -7,7 +7,7 @@
     document.getElementById('error').innerText = 'error'
   }
   // This should be a valid connection
-  var ws = new WebSocket("wss://wss.websocketstest.com:443/service")
+  var ws = new WebSocket("wss://echo.websocket.org")
   ws.onopen = function() {
     document.getElementById('result').innerText = 'success'
   }

--- a/test/navbar-components/navigationBarTest.js
+++ b/test/navbar-components/navigationBarTest.js
@@ -118,11 +118,12 @@ describe('navigationBar tests', function () {
           .leftClick('#open_target')
       })
 
-      it('updates the location in the navbar when changed by the opener', function * () {
+      it('does not navigate to the tabnapped location', function * () {
         yield this.app.client
           .windowByUrl(Brave.browserWindowUrl)
-          .ipcSend('shortcut-focus-url')
-          .waitForInputText(urlInput, 'data:text/html;,<title>Tabnapping Target</title>')
+          .pause(500)
+          .getText(activeTabTitle)
+          .then((title) => assert(title !== 'tabnapped'))
       })
     })
 


### PR DESCRIPTION
fix tabnapping test; the old test failed because we now block top-level opener-initiated navigation to data: urls
fix websocket test by updating to a working test URL

fixes #10825

Test Plan:
npm run test -- --grep='tabnapping'
npm run test -- --grep='blocks websocket'

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


