### PR TITLE
Fix the issue that the title of unloaded tabs shift down

### DIFF
--- a/app/renderer/components/styles/tab.js
+++ b/app/renderer/components/styles/tab.js
@@ -30,7 +30,7 @@ const styles = StyleSheet.create({
 
     // globalStyles.spacing.tabHeight has been set to globalStyles.spacing.tabsToolbarHeight,
     // which is 1px extra due to the border-top of .tabsToolbar
-    height: '-webkit-fill-available',
+    height: `calc(${globalStyles.spacing.tabsToolbarHeight} - 1px)`,
 
     ':hover': {
       background: 'linear-gradient(to bottom, rgba(255, 255, 255, 0.8), rgba(250, 250, 250, 0.4))'


### PR DESCRIPTION
by specifying the height in pixel

Follow-up to #10533. The issue is a regression introduced with that PR.

Auditors:

Test Plan:
1. Open the browser
2. Load several tabs
3. Close the browser
4. Re-open it
5. Make sure the unloaded tab titles are not shifted down

I cannot find the exact STR but I have seen the issue several times already.

<img width="272" alt="screenshot 2017-09-10 11 43 44" src="https://user-images.githubusercontent.com/3362943/30245707-a1c57db0-961d-11e7-9005-c944c00e721c.png">

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


