### PR TITLE
Specify the same background color to error.less as siteDetails.less

### DIFF
--- a/less/about/error.less
+++ b/less/about/error.less
@@ -1,5 +1,10 @@
 @import "./common.less";
 
+// See siteDetails.less
+body {
+  background: @veryLightGray;
+}
+
 #appContainer {
   &.errorPageContainer {
     overflow: auto;
@@ -12,7 +17,6 @@
       margin: 20vh auto;
       line-height: 1.6em;
       flex-direction: column;
-      background-color: #FFF;
       padding: 40px;
       height: auto;
 
@@ -64,6 +68,11 @@
 
     &.safeBrowsing {
       background-color: red;
+
+      .errorContent {
+        // See the body property above
+        background: @veryLightGray;
+      }
     }
   }
 }

--- a/less/window.less
+++ b/less/window.less
@@ -169,7 +169,7 @@ a {
 }
 
 // TODO: Investigate if these are required
-// See PR #10861
+// See PR #10861, Issue #10877
 body {
   background-color: #000;
 }


### PR DESCRIPTION
to overwrite the inherited global black background-color.

Follow-up to #10861
Fixes #10877

Auditors: @bsclifton

Test Plan:
1. Open https://expired.badssl.com/
2. Open http://downloadme.org/
3. Open http://brave.rules/
4. Make sure all error pages do not have the black background color

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


