### PR TITLE
apply brave UA whitelist to first-party subresources

### DIFF
--- a/app/siteHacks.js
+++ b/app/siteHacks.js
@@ -17,19 +17,20 @@ module.exports.init = () => {
   }
 
   Filtering.registerBeforeSendHeadersFilteringCB((details, isPrivate) => {
-    if (details.resourceType !== 'mainFrame') {
+    const mainFrameUrl = Filtering.getMainFrameUrl(details)
+    if (!mainFrameUrl) {
       return {
         resourceName
       }
     }
 
-    // This filter only applies to top-level requests, so details.url == mainFrameUrl
-    let domain = urlParse(details.url).hostname.split('.').slice(-2).join('.')
-    let hack = siteHacks[domain]
+    const domain = urlParse(mainFrameUrl).hostname.split('.').slice(-2).join('.')
+    const hack = siteHacks[domain]
     let customCookie
     let requestHeaders
     let cancel
-    if (hack && hack.onBeforeSendHeaders) {
+    if (hack && hack.onBeforeSendHeaders &&
+      domain === urlParse(details.url).hostname.split('.').slice(-2).join('.')) {
       const result = hack.onBeforeSendHeaders.call(this, details)
       if (result) {
         customCookie = result.customCookie

--- a/test/unit/app/siteHacksTest.js
+++ b/test/unit/app/siteHacksTest.js
@@ -1,0 +1,123 @@
+/* global describe, before, after, it */
+const mockery = require('mockery')
+const assert = require('assert')
+const sinon = require('sinon')
+
+require('../braveUnit')
+
+describe('siteHacks unit tests', function () {
+  let siteHacks
+  let siteHacksData
+  let beforeSendCB
+  // let beforeRequestCB
+  let urlParse
+  let filtering
+  const fakeElectron = require('../lib/fakeElectron')
+  const fakeAdBlock = require('../lib/fakeAdBlock')
+  const fakeFiltering = {
+    getMainFrameUrl: (details) => {
+      return filtering.getMainFrameUrl(details)
+    },
+    isResourceEnabled: (resourceName, url, isPrivate) => {
+      return true
+    },
+    registerBeforeSendHeadersFilteringCB: (cb) => {
+      beforeSendCB = cb
+    },
+    registerBeforeRequestFilteringCB: (cb) => {
+      // beforeRequestCB = cb
+    }
+  }
+
+  before(function () {
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    })
+
+    mockery.registerMock('electron', fakeElectron)
+    mockery.registerMock('ad-block', fakeAdBlock)
+    urlParse = require('../../../app/common/urlParse')
+    mockery.registerMock('./common/urlParse', urlParse)
+    filtering = require('../../../app/filtering')
+    mockery.registerMock('./filtering', fakeFiltering)
+    siteHacksData = require('../../../js/data/siteHacks')
+    mockery.registerMock('../js/data/siteHacks', siteHacksData)
+
+    siteHacks = require('../../../app/siteHacks')
+  })
+
+  after(function () {
+    mockery.disable()
+  })
+
+  describe('init', function () {
+    let beforeSendSpy
+    let beforeRequestSpy
+
+    before(function () {
+      beforeSendSpy = sinon.spy(fakeFiltering, 'registerBeforeSendHeadersFilteringCB')
+      beforeRequestSpy = sinon.spy(fakeFiltering, 'registerBeforeRequestFilteringCB')
+      siteHacks.init()
+    })
+    after(function () {
+      beforeSendSpy.restore()
+      beforeRequestSpy.restore()
+    })
+
+    it('calls Filtering.registerBeforeSendHeadersFilteringCB', function () {
+      assert.equal(beforeSendSpy.calledOnce, true)
+    })
+
+    describe('in the callback passed into registerBeforeSendHeadersFilteringCB', function () {
+      let getMainFrameUrlSpy
+      let onBeforeSendHeadersSpy
+      // let result
+      const details = {
+        resourceType: 'mainFrame',
+        requestHeaders: {
+          'User-Agent': 'Brave Chrome/60.0.3112.101'
+        },
+        url: 'https://subdomain.adobe.com',
+        tabId: 1
+      }
+      before(function () {
+        getMainFrameUrlSpy = sinon.spy(fakeFiltering, 'getMainFrameUrl')
+        onBeforeSendHeadersSpy = sinon.spy(siteHacksData.siteHacks['adobe.com'], 'onBeforeSendHeaders')
+
+        if (typeof beforeSendCB === 'function') {
+          // result = beforeSendCB(details)
+          beforeSendCB(details)
+        }
+      })
+      after(function () {
+        getMainFrameUrlSpy.restore()
+        onBeforeSendHeadersSpy.restore()
+      })
+
+      it('calls Filtering.getMainFrameUrl', function () {
+        assert.equal(getMainFrameUrlSpy.calledOnce, true)
+      })
+
+      describe('when site hack is found for domain', function () {
+        it('calls hack.onBeforeSendHeaders', function () {
+          assert.equal(onBeforeSendHeadersSpy.calledOnce, true)
+        })
+      })
+    })
+
+    it('calls Filtering.registerBeforeRequestFilteringCB', function () {
+      assert.equal(beforeRequestSpy.calledOnce, true)
+    })
+
+    // describe('in the callback passed into registerBeforeRequestFilteringCB', function () {
+    //   let result
+    //   before(function () {
+    //     if (typeof beforeRequestCB === 'function') {
+    //       result = beforeRequestCB()
+    //     }
+    //   })
+    // })
+  })
+})


### PR DESCRIPTION
fix #10800

Test Plan:
load adobe.com within Brave
open the developer tools via "option + command + I"
select the "Network" tab and reload adobe.com via "command + r"
select on the first resource and you'll notice the correct Brave Chrome/60.0.3112.101 UA
select another resource that's underneath the first one and is from Host:www.adobe.com
the Brave UA should be there

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


