### PR TITLE
Fixes removal of bookmarkLocation cache when removing bookmark folder

### DIFF
--- a/app/common/state/bookmarksState.js
+++ b/app/common/state/bookmarksState.js
@@ -216,6 +216,8 @@ const bookmarksState = {
         if (syncEnabled) {
           removedBookmarks.push(bookmark.toJS())
         }
+
+        state = bookmarkLocationCache.removeCacheKey(state, bookmark.get('location'), bookmark.get('key'))
         return false
       })
 


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Resolves #10908

Auditors:

Test Plan:
- import bookmark file 300 from qa repo
- delete folder 100-199
- check that state was cleaned correctly (`state->cache->bookmarkLocation` should only have 99 items inside)


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


