### PR TITLE
Force min-width for browserButton

### DIFF
--- a/app/renderer/components/common/browserButton.js
+++ b/app/renderer/components/common/browserButton.js
@@ -123,7 +123,6 @@ const styles = StyleSheet.create({
     position: 'relative',
     boxShadow: globalStyles.button.default.boxShadow,
     cursor: 'pointer',
-    width: 'auto',
 
     // TODO: #9223
     height: '32px', // 32px == 1rem * 2
@@ -141,8 +140,9 @@ const styles = StyleSheet.create({
     paddingRight: '16px',
     paddingLeft: '16px',
 
-    // cf: https://github.com/brave/browser-laptop/blob/548e11b1c889332fadb379237555625ad2a3c845/less/button.less#L98
-    minWidth: `calc(${globalStyles.spacing.defaultFontSize} * 6)`, // issue #6384
+    // Ensure that the button label does not overflow
+    width: `calc(${globalStyles.spacing.defaultFontSize} * 6)`, // issue #6384
+    minWidth: 'fit-content',
 
     ':active': {
       // push the button down when active


### PR DESCRIPTION
Partial fix for #6779

TODO: Add spacing around buttons *without* re-adding margin, by applying flex/grid

<img width="322" alt="screenshot 2017-09-14 1 11 08" src="https://user-images.githubusercontent.com/3362943/30388105-9d08aefe-98e9-11e7-9322-f3ad8195cf40.png">

Auditors:

Test Plan 1:
1. Open about:styles
2. Click `buttons`
3. Make sure the buttons are rendered properly

Test Plan 2:
1. Open https://expired.badssl.com/
2. Click `Advanced`
3. Make sure the button labels do not overflow

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


