### PR TITLE
Pass desktop name to muon and set/check `xdg-settings default-web-browser`

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -207,8 +207,7 @@ app.on('ready', () => {
         isDefaultBrowser = true
       } else if (process.platform === 'linux') {
         const desktopName = 'brave.desktop'
-        isDefaultBrowser = defaultProtocols.every(p => app.isDefaultProtocolClient(p, desktopName)) &&
-          app.isDefaultProtocolClient('', desktopName)
+        isDefaultBrowser = app.isDefaultProtocolClient('', desktopName)
       } else {
         isDefaultBrowser = defaultProtocols.every(p => app.isDefaultProtocolClient(p))
       }

--- a/app/index.js
+++ b/app/index.js
@@ -202,8 +202,16 @@ app.on('ready', () => {
       }
     } else {
       // Default browser checking
-      let isDefaultBrowser = ['development', 'test'].includes(process.env.NODE_ENV)
-        ? true : defaultProtocols.every(p => app.isDefaultProtocolClient(p))
+      let isDefaultBrowser
+      if (['development', 'test'].includes(process.env.NODE_ENV)) {
+        isDefaultBrowser = true
+      } else if (process.platform === 'linux') {
+        const desktopName = 'brave.desktop'
+        isDefaultBrowser = defaultProtocols.every(p => app.isDefaultProtocolClient(p, desktopName)) &&
+          app.isDefaultProtocolClient('', desktopName)
+      } else {
+        isDefaultBrowser = defaultProtocols.every(p => app.isDefaultProtocolClient(p))
+      }
       appActions.changeSetting(settings.IS_DEFAULT_BROWSER, isDefaultBrowser)
     }
 

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -560,8 +560,7 @@ const handleAppAction = (action) => {
             app.setAsDefaultProtocolClient(p, desktopName)
             app.setAsDefaultProtocolClient('', desktopName)
           }
-          isDefaultBrowser = defaultProtocols.every(p => app.isDefaultProtocolClient(p, desktopName)) &&
-            app.isDefaultProtocolClient('', desktopName)
+          isDefaultBrowser = app.isDefaultProtocolClient('', desktopName)
         } else {
           for (const p of defaultProtocols) {
             app.setAsDefaultProtocolClient(p)

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -33,6 +33,7 @@ const assert = require('assert')
 const profiles = require('../../app/browser/profiles')
 const {zoomLevel} = require('../../app/common/constants/toolbarUserInterfaceScale')
 const {HrtimeLogger} = require('../../app/common/lib/logUtil')
+const platformUtil = require('../../app/common/lib/platformUtil')
 
 // state helpers
 const {makeImmutable} = require('../../app/common/state/immutableUtil')
@@ -552,12 +553,23 @@ const handleAppAction = (action) => {
     }
     case appConstants.APP_DEFAULT_BROWSER_UPDATED:
       if (action.useBrave) {
-        for (const p of defaultProtocols) {
-          app.setAsDefaultProtocolClient(p)
+        let isDefaultBrowser
+        if (platformUtil.isLinux()) {
+          const desktopName = 'brave.desktop'
+          for (const p of defaultProtocols) {
+            app.setAsDefaultProtocolClient(p, desktopName)
+            app.setAsDefaultProtocolClient('', desktopName)
+          }
+          isDefaultBrowser = defaultProtocols.every(p => app.isDefaultProtocolClient(p, desktopName)) &&
+            app.isDefaultProtocolClient('', desktopName)
+        } else {
+          for (const p of defaultProtocols) {
+            app.setAsDefaultProtocolClient(p)
+          }
+          isDefaultBrowser = defaultProtocols.every(p => app.isDefaultProtocolClient(p))
         }
+        appState = appState.setIn(['settings', settings.IS_DEFAULT_BROWSER], isDefaultBrowser)
       }
-      let isDefaultBrowser = defaultProtocols.every(p => app.isDefaultProtocolClient(p))
-      appState = appState.setIn(['settings', settings.IS_DEFAULT_BROWSER], isDefaultBrowser)
       break
     case appConstants.APP_DEFAULT_BROWSER_CHECK_COMPLETE:
       appState = appState.set('defaultBrowserCheckComplete', {})


### PR DESCRIPTION
**THIS PR MAKES https://github.com/brave/muon/pull/309 REQUIRED BY #10552 LANDED SMOOTHLY**

It is basically the subset of 5ec53ab8cb1df4a852ca0b492b8270cc4c7275ab


required by https://github.com/brave/muon/pull/309
fix #1336

Auditors: @bsclifton, @bbondy

Test Plan:
1. Set default browser to non Brave browser
2. Open Brave from fresh profile
3. You should see Brave ask to set as default
4. Click Yes, in about:preferences#general, you should see Brave is your
default browser
5. Check system setting, default browser should be Brave

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


