### PR TITLE
Add FlyoutDialog and polish CommonForm

### DIFF
--- a/app/renderer/components/autofill/autofillAddressPanel.js
+++ b/app/renderer/components/autofill/autofillAddressPanel.js
@@ -11,11 +11,9 @@ const ReduxComponent = require('../reduxComponent')
 const Dialog = require('../common/dialog')
 const Button = require('../common/button')
 const {
-  CommonFormLarge,
+  CommonForm,
   CommonFormSection,
-  CommonFormTitle,
   CommonFormDropdown,
-  CommonFormButtonWrapper,
   commonFormStyles
 } = require('../common/commonForm')
 
@@ -160,8 +158,8 @@ class AutofillAddressPanel extends React.Component {
 
   render () {
     return <Dialog onHide={this.onHide} testId='autofillAddressPanel' isClickDismiss>
-      <CommonFormLarge onClick={this.onClick}>
-        <CommonFormTitle data-l10n-id='editAddress' />
+      <CommonForm large onClick={this.onClick}>
+        <CommonFormSection title l10nId='editAddress' />
         <CommonFormSection>
           <div className={css(commonFormStyles.sectionWrapper)}>
             <div className={css(commonFormStyles.inputWrapper, commonFormStyles.inputWrapper__label)}>
@@ -273,7 +271,7 @@ class AutofillAddressPanel extends React.Component {
             </div>
           </div>
         </CommonFormSection>
-        <CommonFormButtonWrapper>
+        <CommonFormSection buttons>
           <Button className='whiteButton'
             l10nId='cancel'
             testId='cancelAddressButton'
@@ -285,8 +283,8 @@ class AutofillAddressPanel extends React.Component {
             testId='saveAddressButton'
             onClick={this.onSave}
           />
-        </CommonFormButtonWrapper>
-      </CommonFormLarge>
+        </CommonFormSection>
+      </CommonForm>
     </Dialog>
   }
 }

--- a/app/renderer/components/autofill/autofillCreditCardPanel.js
+++ b/app/renderer/components/autofill/autofillCreditCardPanel.js
@@ -13,10 +13,8 @@ const Button = require('../common/button')
 const {
   CommonForm,
   CommonFormSection,
-  CommonFormTitle,
   CommonFormDropdown,
   CommonFormTextbox,
-  CommonFormButtonWrapper,
   commonFormStyles
 } = require('../common/commonForm')
 
@@ -128,9 +126,9 @@ class AutofillCreditCardPanel extends React.Component {
   render () {
     return <Dialog onHide={this.onHide} testId='autofillCreditCardPanel' isClickDismiss>
       <CommonForm onClick={this.onClick}>
-        <CommonFormTitle
-          data-test-id='manageAutofillDataTitle'
-          data-l10n-id='editCreditCard'
+        <CommonFormSection title
+          l10nId='editCreditCard'
+          testId='manageAutofillDataTitle'
         />
         <CommonFormSection>
           <div className={css(commonFormStyles.sectionWrapper)}>
@@ -202,7 +200,7 @@ class AutofillCreditCardPanel extends React.Component {
             </div>
           </div>
         </CommonFormSection>
-        <CommonFormButtonWrapper>
+        <CommonFormSection buttons>
           <Button className='whiteButton'
             l10nId='cancel'
             testId='cancelCreditCardButton'
@@ -214,13 +212,11 @@ class AutofillCreditCardPanel extends React.Component {
             testId='saveCreditCardButton'
             onClick={this.onSave}
           />
-        </CommonFormButtonWrapper>
+        </CommonFormSection>
       </CommonForm>
     </Dialog>
   }
 }
-
-module.exports = ReduxComponent.connect(AutofillCreditCardPanel)
 
 const styles = StyleSheet.create({
   // Copied from textbox.js
@@ -239,3 +235,5 @@ const styles = StyleSheet.create({
     marginLeft: `calc(${globalStyles.spacing.dialogInsideMargin} / 3)`
   }
 })
+
+module.exports = ReduxComponent.connect(AutofillCreditCardPanel)

--- a/app/renderer/components/bookmarks/addEditBookmarkFolder.js
+++ b/app/renderer/components/bookmarks/addEditBookmarkFolder.js
@@ -4,13 +4,15 @@
 
 const React = require('react')
 const Immutable = require('immutable')
-const {StyleSheet, css} = require('aphrodite/no-important')
 
 // Components
 const ReduxComponent = require('../reduxComponent')
 const Dialog = require('../common/dialog')
 const AddEditBookmarkFolderForm = require('./addEditBookmarkFolderForm')
-const {CommonFormBookmarkHanger} = require('../common/commonForm')
+const {
+  CommonFormHanger,
+  CommonFormSection
+} = require('../common/commonForm')
 
 // State
 const bookmarkFoldersState = require('../../../common/state/bookmarkFoldersState')
@@ -22,9 +24,6 @@ const windowActions = require('../../../../js/actions/windowActions')
 // Utils
 const cx = require('../../../../js/lib/classSet')
 const bookmarkFoldersUtil = require('../../../common/lib/bookmarkFoldersUtil')
-
-// Styles
-const globalStyles = require('../styles/global')
 
 class AddEditBookmarkFolder extends React.Component {
   constructor (props) {
@@ -68,11 +67,8 @@ class AddEditBookmarkFolder extends React.Component {
     return <Dialog className={cx({
       bookmarkDialog: true
     })} onHide={this.onClose} isClickDismiss>
-      <CommonFormBookmarkHanger onClick={this.onClick}>
-        <div className={cx({
-          [css(styles.commonFormSection)]: true,
-          [css(styles.commonFormTitle)]: true
-        })} data-l10n-id={this.props.heading} />
+      <CommonFormHanger bookmark onClick={this.onClick}>
+        <CommonFormSection title l10nId={this.props.heading} />
         <AddEditBookmarkFolderForm
           folderName={this.props.folderName}
           editKey={this.props.editKey}
@@ -83,21 +79,9 @@ class AddEditBookmarkFolder extends React.Component {
           isDisabled={!this.props.isFolderNameValid}
           hasBookmarks={this.props.hasBookmarks}
         />
-      </CommonFormBookmarkHanger>
+      </CommonFormHanger>
     </Dialog>
   }
 }
-
-const styles = StyleSheet.create({
-  // Copied from commonForm.js
-  commonFormSection: {
-    // PR #7985
-    margin: `${globalStyles.spacing.dialogInsideMargin} 30px`
-  },
-  commonFormTitle: {
-    color: globalStyles.color.braveOrange,
-    fontSize: '1.2em'
-  }
-})
 
 module.exports = ReduxComponent.connect(AddEditBookmarkFolder)

--- a/app/renderer/components/bookmarks/addEditBookmarkFolderForm.js
+++ b/app/renderer/components/bookmarks/addEditBookmarkFolderForm.js
@@ -11,7 +11,6 @@ const BrowserButton = require('../common/browserButton')
 const {
   CommonFormSection,
   CommonFormDropdown,
-  CommonFormButtonWrapper,
   commonFormStyles
 } = require('../common/commonForm')
 
@@ -193,7 +192,7 @@ class AddEditBookmarkFolderForm extends React.Component {
           </div>
         </div>
       </CommonFormSection>
-      <CommonFormButtonWrapper>
+      <CommonFormSection buttons>
         {
           this.props.editKey != null
             ? <BrowserButton groupedItem secondaryColor
@@ -213,7 +212,7 @@ class AddEditBookmarkFolderForm extends React.Component {
           disabled={this.state.isDisabled}
           onClick={this.onSave}
         />
-      </CommonFormButtonWrapper>
+      </CommonFormSection>
     </div>
   }
 }

--- a/app/renderer/components/bookmarks/addEditBookmarkForm.js
+++ b/app/renderer/components/bookmarks/addEditBookmarkForm.js
@@ -12,7 +12,6 @@ const {
   CommonFormSection,
   CommonFormDropdown,
   CommonFormTextbox,
-  CommonFormButtonWrapper,
   commonFormStyles
 } = require('../common/commonForm')
 
@@ -229,7 +228,7 @@ class AddEditBookmarkForm extends React.Component {
           </div>
         </div>
       </CommonFormSection>
-      <CommonFormButtonWrapper>
+      <CommonFormSection buttons>
         {
           this.props.editKey != null
             ? <BrowserButton groupedItem secondaryColor
@@ -249,7 +248,7 @@ class AddEditBookmarkForm extends React.Component {
           disabled={this.state.isDisabled}
           onClick={this.onSave}
         />
-      </CommonFormButtonWrapper>
+      </CommonFormSection>
     </div>
   }
 }

--- a/app/renderer/components/bookmarks/addEditBookmarkHanger.js
+++ b/app/renderer/components/bookmarks/addEditBookmarkHanger.js
@@ -11,8 +11,8 @@ const ReduxComponent = require('../reduxComponent')
 const Dialog = require('../common/dialog')
 const AddEditBookmarkForm = require('./addEditBookmarkForm')
 const {
-  CommonFormBookmarkHanger,
-  CommonFormBottomWrapper
+  CommonFormHanger,
+  CommonFormSection
 } = require('../common/commonForm')
 
 // States
@@ -108,8 +108,8 @@ class AddEditBookmarkHanger extends React.Component {
       bookmarkDialog: this.props.isModal,
       bookmarkHanger: !this.props.isModal,
       [css(styles.bookmarkHanger)]: !this.props.isModal
-    })} onHide={this.onClose} isClickDismiss>
-      <CommonFormBookmarkHanger onClick={this.onClick}>
+    })} isClickDismiss>
+      <CommonFormHanger bookmark onClick={this.onClick}>
         {
           !this.props.isModal
           ? <div className={cx({
@@ -118,10 +118,7 @@ class AddEditBookmarkHanger extends React.Component {
           })} />
           : null
         }
-        <div className={cx({
-          [css(styles.commonFormSection)]: true,
-          [css(styles.commonFormTitle)]: true
-        })} data-l10n-id={this.props.heading} />
+        <CommonFormSection title l10nId={this.props.heading} />
         <AddEditBookmarkForm
           title={this.props.title}
           editKey={this.props.editKey}
@@ -136,30 +133,20 @@ class AddEditBookmarkHanger extends React.Component {
         />
         {
           !this.props.isModal
-            ? <CommonFormBottomWrapper>
+            ? <CommonFormSection bottom>
               <div className={css(styles.bookmark__bottomWrapper, styles.bottomWrapper__cursor)}
                 data-test-id='viewBookmarks'
                 data-l10n-id='viewBookmarks'
                 onClick={this.onViewBookmarks} />
-            </CommonFormBottomWrapper>
+            </CommonFormSection>
             : null
         }
-      </CommonFormBookmarkHanger>
+      </CommonFormHanger>
     </Dialog>
   }
 }
 
 const styles = StyleSheet.create({
-  // Copied from commonForm.js
-  commonFormSection: {
-    // PR #7985
-    margin: `${globalStyles.spacing.dialogInsideMargin} 30px`
-  },
-  commonFormTitle: {
-    color: globalStyles.color.braveOrange,
-    fontSize: '1.2em'
-  },
-
   bookmarkHanger: {
     // See: #9040
     justifyContent: 'flex-start !important',

--- a/app/renderer/components/common/commonForm.js
+++ b/app/renderer/components/common/commonForm.js
@@ -16,53 +16,30 @@ const {FormTextbox} = require('./textbox')
 
 class CommonForm extends ImmutableComponent {
   render () {
-    return <FlyoutDialog custom={styles.commonForm}>
+    return <FlyoutDialog custom={[
+      styles.commonForm,
+      this.props.small && styles.commonForm_small,
+      this.props.medium && styles.commonForm_medium,
+      this.props.large && styles.commonForm_large,
+      this.props.custom
+    ]}
+      onClick={this.props.onClick}
+      testId={this.props.testId}
+    >
       {this.props.children}
     </FlyoutDialog>
   }
 }
 
-class CommonFormSmall extends ImmutableComponent {
+class CommonFormHanger extends ImmutableComponent {
   render () {
-    return <FlyoutDialog custom={[
-      styles.commonForm,
-      styles.commonFormSmall
+    return <CommonForm custom={[
+      styles.commonForm_hanger,
+      this.props.bookmark && styles.commonForm_hanger_bookmark,
+      this.props.custom
     ]}>
       {this.props.children}
-    </FlyoutDialog>
-  }
-}
-
-class CommonFormMedium extends ImmutableComponent {
-  render () {
-    return <FlyoutDialog custom={[
-      styles.commonForm,
-      styles.commonFormMedium
-    ]}>
-      {this.props.children}
-    </FlyoutDialog>
-  }
-}
-
-class CommonFormLarge extends ImmutableComponent {
-  render () {
-    return <FlyoutDialog custom={[
-      styles.commonForm,
-      styles.commonFormLarge
-    ]}>
-      {this.props.children}
-    </FlyoutDialog>
-  }
-}
-
-class CommonFormBookmarkHanger extends ImmutableComponent {
-  render () {
-    return <FlyoutDialog custom={[
-      styles.commonForm,
-      styles.commonFormBookmarkHanger
-    ]}>
-      {this.props.children}
-    </FlyoutDialog>
+    </CommonForm>
   }
 }
 
@@ -78,60 +55,39 @@ class CommonFormTextbox extends ImmutableComponent {
   }
 }
 
-class CommonFormClickable extends ImmutableComponent {
-  render () {
-    return <div className={css(styles.commonFormClickable)} {...this.props} />
-  }
-}
-
 class CommonFormSection extends ImmutableComponent {
   render () {
-    return <div className={css(styles.commonFormSection)} {...this.props} />
+    return <div className={css(
+      styles.commonForm__section,
+      this.props.subSection && styles.commonForm__section_sub,
+      this.props.title && styles.commonForm__section_title,
+      this.props.buttons && styles.commonForm__section_buttons,
+      this.props.bottom && styles.commonForm__section_bottom,
+      this.props.custom
+    )}
+      data-l10n-id={this.props.l10nId}
+      data-test-id={this.props.testId}
+    >
+      {this.props.children}
+    </div>
   }
 }
 
-class CommonFormTitle extends ImmutableComponent {
+class CommonFormClickable extends ImmutableComponent {
   render () {
     return <div className={css(
-      styles.commonFormSection,
-      styles.commonFormTitle
-    )} {...this.props} />
-  }
-}
-
-class CommonFormSubSection extends ImmutableComponent {
-  render () {
-    return <div className={css(
-      styles.commonFormSection,
-      styles.commonFormSubSection
-    )} {...this.props} />
-  }
-}
-
-class CommonFormButtonWrapper extends ImmutableComponent {
-  render () {
-    return <div className={css(
-      styles.commonFormSection,
-      styles.flexJustifyEnd
-    )} {...this.props} />
-  }
-}
-
-class CommonFormBottomWrapper extends ImmutableComponent {
-  render () {
-    return <div className={css(
-      styles.commonFormSection,
-      styles.commonFormBottomWrapper
-    )} {...this.props} />
+      styles.commonForm__clickable,
+      this.props.custom
+    )}
+      data-l10n-id={this.props.l10nId}
+      onClick={this.props.onClick}
+    >
+      {this.props.children}
+    </div>
   }
 }
 
 const styles = StyleSheet.create({
-  flexJustifyEnd: {
-    display: 'flex',
-    justifyContent: 'flex-end'
-  },
-
   commonForm: {
     background: globalStyles.color.commonFormBackgroundColor,
     color: globalStyles.color.commonTextColor,
@@ -153,53 +109,62 @@ const styles = StyleSheet.create({
     // maxHeight: '100%'
   },
 
-  commonFormSmall: {
+  commonForm_small: {
     maxWidth: globalStyles.spacing.dialogSmallWidth
   },
 
-  commonFormMedium: {
+  commonForm_medium: {
     maxWidth: globalStyles.spacing.dialogMediumWidth
   },
 
-  commonFormLarge: {
+  commonForm_large: {
     maxWidth: globalStyles.spacing.dialogLargeWidth
   },
 
-  commonFormBookmarkHanger: {
-    maxWidth: globalStyles.spacing.bookmarkHangerMaxWidth,
-    height: 'initial', // #8634
-
+  commonForm_hanger: {
     // Cancel the inherited value from .navbarMenubarFlexContainer, which is 'nowrap'.
-    whiteSpace: 'normal'
+    whiteSpace: 'normal',
+
+    // #8634
+    height: 'initial'
   },
 
-  commonFormClickable: {
+  commonForm_hanger_bookmark: {
+    maxWidth: globalStyles.spacing.bookmarkHangerMaxWidth
+  },
+
+  commonForm__section: {
+    // PR #7985
+    margin: `${globalStyles.spacing.dialogInsideMargin} 30px`
+  },
+
+  commonForm__section_sub: {
+    margin: `0 0 ${globalStyles.spacing.dialogInsideMargin} ${globalStyles.spacing.dialogInsideMargin}`
+  },
+
+  commonForm__section_title: {
+    color: globalStyles.color.braveOrange,
+    fontSize: '1.2em'
+  },
+
+  commonForm__section_buttons: {
+    display: 'flex',
+    justifyContent: 'flex-end'
+  },
+
+  commonForm__section_bottom: {
+    margin: 0,
+    padding: `${globalStyles.spacing.dialogInsideMargin} 30px`,
+    background: globalStyles.color.commonFormBottomWrapperBackground,
+    borderRadius: `0 0 ${globalStyles.radius.borderRadius} ${globalStyles.radius.borderRadius}`
+  },
+
+  commonForm__clickable: {
     color: '#5b5b5b',
 
     ':hover': {
       color: '#000'
     }
-  },
-
-  commonFormTitle: {
-    color: globalStyles.color.braveOrange,
-    fontSize: '1.2em'
-  },
-
-  commonFormSection: {
-    // PR #7985
-    margin: `${globalStyles.spacing.dialogInsideMargin} 30px`
-  },
-
-  commonFormSubSection: {
-    margin: `0 0 ${globalStyles.spacing.dialogInsideMargin} ${globalStyles.spacing.dialogInsideMargin}`
-  },
-
-  commonFormBottomWrapper: {
-    margin: 0,
-    padding: `${globalStyles.spacing.dialogInsideMargin} 30px`,
-    background: globalStyles.color.commonFormBottomWrapperBackground,
-    borderRadius: `0 0 ${globalStyles.radius.borderRadius} ${globalStyles.radius.borderRadius}`
   }
 })
 
@@ -234,17 +199,10 @@ const commonFormStyles = StyleSheet.create({
 
 module.exports = {
   CommonForm,
-  CommonFormSmall,
-  CommonFormMedium,
-  CommonFormLarge,
-  CommonFormBookmarkHanger,
+  CommonFormHanger,
   CommonFormDropdown,
   CommonFormTextbox,
-  CommonFormClickable,
   CommonFormSection,
-  CommonFormTitle,
-  CommonFormSubSection,
-  CommonFormButtonWrapper,
-  CommonFormBottomWrapper,
+  CommonFormClickable,
   commonFormStyles
 }

--- a/app/renderer/components/common/commonForm.js
+++ b/app/renderer/components/common/commonForm.js
@@ -7,8 +7,8 @@ const ImmutableComponent = require('../immutableComponent')
 
 const {StyleSheet, css} = require('aphrodite/no-important')
 const globalStyles = require('../styles/global')
-const commonStyles = require('../styles/commonStyles')
 
+const FlyoutDialog = require('./flyoutDialog')
 const {FormDropdown} = require('./dropdown')
 const {FormTextbox} = require('./textbox')
 
@@ -16,50 +16,53 @@ const {FormTextbox} = require('./textbox')
 
 class CommonForm extends ImmutableComponent {
   render () {
-    return <div className={css(
-      commonStyles.flyoutDialog,
-      styles.commonForm
-    )} {...this.props} />
+    return <FlyoutDialog custom={styles.commonForm}>
+      {this.props.children}
+    </FlyoutDialog>
   }
 }
 
 class CommonFormSmall extends ImmutableComponent {
   render () {
-    return <div className={css(
-      commonStyles.flyoutDialog,
+    return <FlyoutDialog custom={[
       styles.commonForm,
       styles.commonFormSmall
-    )} {...this.props} />
+    ]}>
+      {this.props.children}
+    </FlyoutDialog>
   }
 }
 
 class CommonFormMedium extends ImmutableComponent {
   render () {
-    return <div className={css(
-      commonStyles.flyoutDialog,
+    return <FlyoutDialog custom={[
       styles.commonForm,
       styles.commonFormMedium
-    )} {...this.props} />
+    ]}>
+      {this.props.children}
+    </FlyoutDialog>
   }
 }
 
 class CommonFormLarge extends ImmutableComponent {
   render () {
-    return <div className={css(
-      commonStyles.flyoutDialog,
+    return <FlyoutDialog custom={[
       styles.commonForm,
       styles.commonFormLarge
-    )} {...this.props} />
+    ]}>
+      {this.props.children}
+    </FlyoutDialog>
   }
 }
 
 class CommonFormBookmarkHanger extends ImmutableComponent {
   render () {
-    return <div className={css(
-      commonStyles.flyoutDialog,
+    return <FlyoutDialog custom={[
       styles.commonForm,
       styles.commonFormBookmarkHanger
-    )} {...this.props} />
+    ]}>
+      {this.props.children}
+    </FlyoutDialog>
   }
 }
 
@@ -139,8 +142,10 @@ const styles = StyleSheet.create({
     maxWidth: globalStyles.spacing.dialogWidth,
     minWidth: '310px',
     height: 'auto',
-    maxHeight: '100vh', // #8634: commonStyles.flyoutDialog,
-    userSelect: 'none'
+    userSelect: 'none',
+
+    // #8634: commonStyles.flyoutDialog,
+    maxHeight: '100vh'
 
     // Need a general solution
     // See: #7930

--- a/app/renderer/components/common/flyoutDialog.js
+++ b/app/renderer/components/common/flyoutDialog.js
@@ -1,0 +1,45 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const React = require('react')
+const ImmutableComponent = require('../immutableComponent')
+
+const {StyleSheet, css} = require('aphrodite/no-important')
+const globalStyles = require('../styles/global')
+
+class FlyoutDialog extends ImmutableComponent {
+  render () {
+    return <div
+      data-l10n-id={this.props.l10nId}
+      data-test-id={this.props.testId}
+      onKeyDown={this.props.onKeyDown}
+      onClick={this.props.onClick}
+      className={css(styles.flyoutDialog, this.props.custom)}
+    >
+      {this.props.children}
+    </div>
+  }
+}
+
+const styles = StyleSheet.create({
+  flyoutDialog: {
+    background: globalStyles.color.toolbarBackground,
+    borderRadius: globalStyles.radius.borderRadius,
+    boxShadow: globalStyles.shadow.flyoutDialogBoxShadow,
+    color: '#000',
+    fontSize: '13px',
+
+    // Issue #7949
+    padding: `${globalStyles.spacing.dialogInsideMargin} 30px`,
+    position: 'absolute',
+    top: globalStyles.spacing.dialogTopOffset,
+
+    // Issue #7930
+    boxSizing: 'border-box',
+    maxWidth: '600px',
+    maxHeight: `calc(80vh - ${globalStyles.spacing.downloadsBarHeight})`
+  }
+})
+
+module.exports = FlyoutDialog

--- a/app/renderer/components/common/messageBox.js
+++ b/app/renderer/components/common/messageBox.js
@@ -9,6 +9,7 @@ const {StyleSheet, css} = require('aphrodite/no-important')
 // Components
 const ReduxComponent = require('../reduxComponent')
 const Dialog = require('./dialog')
+const FlyoutDialog = require('./flyoutDialog')
 const BrowserButton = require('../common/browserButton')
 const SwitchControl = require('./switchControl')
 
@@ -125,8 +126,8 @@ class MessageBox extends React.Component {
 
   render () {
     return <Dialog testId='messageBoxDialog'>
-      <div className={css(commonStyles.flyoutDialog)}
-        data-test-id={'msgBoxTab_' + this.props.tabId}
+      <FlyoutDialog
+        testId={'msgBoxTab_' + this.props.tabId}
         onKeyDown={this.onKeyDown}
       >
         <div className={css(styles.title)} data-test-id='msgBoxTitle'>
@@ -155,7 +156,7 @@ class MessageBox extends React.Component {
             {this.messageBoxButtons}
           </div>
         </div>
-      </div>
+      </FlyoutDialog>
     </Dialog>
   }
 }

--- a/app/renderer/components/main/braveryPanel.js
+++ b/app/renderer/components/main/braveryPanel.js
@@ -9,6 +9,7 @@ const {StyleSheet, css} = require('aphrodite/no-important')
 // Components
 const ReduxComponent = require('../reduxComponent')
 const Dialog = require('../common/dialog')
+const FlyoutDialog = require('../common/flyoutDialog')
 const BrowserButton = require('../common/browserButton')
 const SwitchControl = require('../common/switchControl')
 const {FormDropdown} = require('../common/dropdown')
@@ -37,7 +38,6 @@ const urlUtil = require('../../../../js/lib/urlutil')
 
 // Styles
 const globalStyles = require('../styles/global')
-const commonStyles = require('../styles/commonStyles')
 const closeButton = require('../../../../img/toolbar/braveryPanel_btn.svg')
 
 class BraveryPanel extends React.Component {
@@ -249,13 +249,13 @@ class BraveryPanel extends React.Component {
     })
 
     return <Dialog onHide={this.onHide} testId='braveryPanelContainer' isClickDismiss>
-      <div className={css(
-        commonStyles.flyoutDialog,
+      <FlyoutDialog custom={[
         styles.braveryPanel,
         this.props.isCompactBraveryPanel && styles.braveryPanel_compact
-      )}
+      ]}
         onClick={(e) => e.stopPropagation()}
-        data-test-id={this.props.isCompactBraveryPanel ? 'braveryPanelCompact' : 'braveryPanel'}>
+        testId={this.props.isCompactBraveryPanel ? 'braveryPanelCompact' : 'braveryPanel'}
+      >
         {
           this.props.isCompactBraveryPanel
           ? this.compactBraveryPanelHeader
@@ -649,7 +649,7 @@ class BraveryPanel extends React.Component {
             </div>
           </div>
         </section>
-      </div>
+      </FlyoutDialog>
     </Dialog>
   }
 }

--- a/app/renderer/components/main/checkDefaultBrowserDialog.js
+++ b/app/renderer/components/main/checkDefaultBrowserDialog.js
@@ -11,9 +11,8 @@ const Dialog = require('../common/dialog')
 const BrowserButton = require('../common/browserButton')
 const SwitchControl = require('../common/switchControl')
 const {
-  CommonFormMedium,
-  CommonFormSection,
-  CommonFormButtonWrapper
+  CommonForm,
+  CommonFormSection
 } = require('../common/commonForm')
 
 // Actions
@@ -78,7 +77,7 @@ class CheckDefaultBrowserDialog extends React.Component {
 
   render () {
     return <Dialog className='checkDefaultBrowserDialog'>
-      <CommonFormMedium onClick={this.onClick}>
+      <CommonForm medium onClick={this.onClick}>
         <CommonFormSection>
           <div className={css(styles.flexAlignCenter)}>
             <div className={css(styles.section__braveIcon)} />
@@ -93,7 +92,7 @@ class CheckDefaultBrowserDialog extends React.Component {
             </div>
           </div>
         </CommonFormSection>
-        <CommonFormButtonWrapper>
+        <CommonFormSection buttons>
           <BrowserButton groupedItem secondaryColor
             l10nId='notNow'
             testId='notNowButton'
@@ -104,13 +103,11 @@ class CheckDefaultBrowserDialog extends React.Component {
             testId='useBraveButton'
             onClick={this.onUseBrave}
           />
-        </CommonFormButtonWrapper>
-      </CommonFormMedium>
+        </CommonFormSection>
+      </CommonForm>
     </Dialog>
   }
 }
-
-module.exports = ReduxComponent.connect(CheckDefaultBrowserDialog)
 
 const styles = StyleSheet.create({
   flexAlignCenter: {
@@ -134,3 +131,5 @@ const styles = StyleSheet.create({
     marginTop: `calc(${globalStyles.spacing.dialogInsideMargin} / 2)`
   }
 })
+
+module.exports = ReduxComponent.connect(CheckDefaultBrowserDialog)

--- a/app/renderer/components/main/clearBrowsingDataPanel.js
+++ b/app/renderer/components/main/clearBrowsingDataPanel.js
@@ -12,11 +12,8 @@ const Dialog = require('../common/dialog')
 const Button = require('../common/button')
 const SwitchControl = require('../common/switchControl')
 const {
-  CommonFormSmall,
-  CommonFormSection,
-  CommonFormTitle,
-  CommonFormButtonWrapper,
-  CommonFormBottomWrapper
+  CommonForm,
+  CommonFormSection
 } = require('../common/commonForm')
 
 // Actions
@@ -87,8 +84,8 @@ class ClearBrowsingDataPanel extends React.Component {
 
   render () {
     return <Dialog onHide={this.onHide} testId='clearBrowsingDataPanel' isClickDismiss>
-      <CommonFormSmall onClick={(e) => e.stopPropagation()}>
-        <CommonFormTitle data-l10n-id='clearBrowsingData' />
+      <CommonForm small onClick={(e) => e.stopPropagation()}>
+        <CommonFormSection title l10nId='clearBrowsingData' />
         <CommonFormSection>
           <SwitchControl
             rightl10nId='browserHistory'
@@ -127,7 +124,7 @@ class ClearBrowsingDataPanel extends React.Component {
             checkedOn={this.props.savedSiteSettings}
             onClick={this.onToggleSavedSiteSettings} />
         </CommonFormSection>
-        <CommonFormButtonWrapper>
+        <CommonFormSection buttons>
           <Button className='whiteButton'
             l10nId='cancel'
             testId='cancelButton'
@@ -138,11 +135,11 @@ class ClearBrowsingDataPanel extends React.Component {
             testId='clearDataButton'
             onClick={this.onClear}
           />
-        </CommonFormButtonWrapper>
-        <CommonFormBottomWrapper>
+        </CommonFormSection>
+        <CommonFormSection bottom>
           <div data-l10n-id='clearDataWarning' />
-        </CommonFormBottomWrapper>
-      </CommonFormSmall>
+        </CommonFormSection>
+      </CommonForm>
     </Dialog>
   }
 }

--- a/app/renderer/components/main/importBrowserDataPanel.js
+++ b/app/renderer/components/main/importBrowserDataPanel.js
@@ -14,10 +14,7 @@ const SwitchControl = require('../common/switchControl')
 const {
   CommonForm,
   CommonFormDropdown,
-  CommonFormSection,
-  CommonFormTitle,
-  CommonFormButtonWrapper,
-  CommonFormBottomWrapper
+  CommonFormSection
 } = require('../common/commonForm')
 
 // Actions
@@ -101,12 +98,12 @@ class ImportBrowserDataPanel extends React.Component {
 
   render () {
     return <Dialog onHide={this.onHide} testId='importBrowserDataPanel' isClickDismiss>
-      <CommonForm data-test-id='importBrowserData' onClick={(e) => e.stopPropagation()}>
-        <CommonFormTitle
-          data-test-id='importBrowserDataTitle'
-          data-l10n-id='importBrowserData'
+      <CommonForm testId='importBrowserData' onClick={(e) => e.stopPropagation()}>
+        <CommonFormSection title
+          l10nId='importBrowserData'
+          testId='importBrowserDataTitle'
         />
-        <CommonFormSection data-test-id='importBrowserDataOptions'>
+        <CommonFormSection testId='importBrowserDataOptions'>
           <div className={css(styles.dropdownWrapper)}>
             <CommonFormDropdown
               value={this.props.currentIndex}
@@ -147,22 +144,22 @@ class ImportBrowserDataPanel extends React.Component {
         <CommonFormSection>
           <div data-l10n-id='importDataCloseBrowserWarning' />
         </CommonFormSection>
-        <CommonFormButtonWrapper data-test-id='importBrowserDataButtons'>
+        <CommonFormSection buttons testId='importBrowserDataButtons'>
           <Button l10nId='cancel' className='whiteButton' onClick={this.onHide} />
           <Button l10nId='import' className='primaryButton' onClick={this.onImport} />
-        </CommonFormButtonWrapper>
-        <CommonFormBottomWrapper data-test-id='importBrowserDataWarning'>
+        </CommonFormSection>
+        <CommonFormSection bottom testId='importBrowserDataWarning'>
           <div data-l10n-id='importDataWarning' />
-        </CommonFormBottomWrapper>
+        </CommonFormSection>
       </CommonForm>
     </Dialog>
   }
 }
-
-module.exports = ReduxComponent.connect(ImportBrowserDataPanel)
 
 const styles = StyleSheet.create({
   dropdownWrapper: {
     marginBottom: `calc(${globalStyles.spacing.dialogInsideMargin} / 2)`
   }
 })
+
+module.exports = ReduxComponent.connect(ImportBrowserDataPanel)

--- a/app/renderer/components/main/loginRequired.js
+++ b/app/renderer/components/main/loginRequired.js
@@ -11,9 +11,7 @@ const Button = require('../common/button')
 const {
   CommonForm,
   CommonFormSection,
-  CommonFormTitle,
   CommonFormTextbox,
-  CommonFormButtonWrapper,
   commonFormStyles
 } = require('../common/commonForm')
 
@@ -95,8 +93,10 @@ class LoginRequired extends React.Component {
     }
     return <Dialog onHide={this.onClose} isClickDismiss>
       <CommonForm onClick={this.onClick.bind(this)}>
-        <CommonFormTitle data-l10n-id='basicAuthRequired' />
-        <CommonFormSection data-l10n-id='basicAuthMessage' data-l10n-args={JSON.stringify(l10nArgs)} />
+        <CommonFormSection title l10nId='basicAuthRequired' />
+        <CommonFormSection>
+          <span data-l10n-id='basicAuthMessage' data-l10n-args={JSON.stringify(l10nArgs)} />
+        </CommonFormSection>
         <CommonFormSection>
           <div className={css(styles.sectionWrapper)}>
             <div className={css(
@@ -108,9 +108,9 @@ class LoginRequired extends React.Component {
             </div>
             {
               <div id='loginInput' className={css(
-                  commonFormStyles.inputWrapper,
-                  commonFormStyles.inputWrapper__input
-                )}>
+                commonFormStyles.inputWrapper,
+                commonFormStyles.inputWrapper__input
+              )}>
                 <input className={css(
                   commonStyles.formControl,
                   commonStyles.textbox,
@@ -136,16 +136,14 @@ class LoginRequired extends React.Component {
             }
           </div>
         </CommonFormSection>
-        <CommonFormButtonWrapper>
+        <CommonFormSection buttons>
           <Button l10nId='cancel' className='whiteButton' onClick={this.onClose} />
           <Button l10nId='ok' className='primaryButton' onClick={this.onSave} />
-        </CommonFormButtonWrapper>
+        </CommonFormSection>
       </CommonForm>
     </Dialog>
   }
 }
-
-module.exports = LoginRequired
 
 const styles = StyleSheet.create({
   sectionWrapper: {
@@ -153,3 +151,5 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between'
   }
 })
+
+module.exports = LoginRequired

--- a/app/renderer/components/main/releaseNotes.js
+++ b/app/renderer/components/main/releaseNotes.js
@@ -9,12 +9,10 @@ const Immutable = require('immutable')
 // Components
 const ReduxComponent = require('../reduxComponent')
 const Dialog = require('../common/dialog')
+const FlyoutDialog = require('../common/flyoutDialog')
 
 // Actions
 const windowActions = require('../../../../js/actions/windowActions')
-
-// Styles
-const commonStyles = require('../styles/commonStyles')
 
 class ReleaseNotes extends React.Component {
   constructor (props) {
@@ -41,21 +39,14 @@ class ReleaseNotes extends React.Component {
   }
 
   render () {
-    const className = css(
-      commonStyles.flyoutDialog,
-      styles.releaseNotes
-    )
-
     return <Dialog onHide={this.onHide} isClickDismiss>
-      <div className={className} onClick={this.onClick}>
+      <FlyoutDialog className={styles.releaseNotes} onClick={this.onClick}>
         <h1 className={css(styles.header)}>{this.props.name}</h1>
         <div>{this.props.notes}</div>
-      </div>
+      </FlyoutDialog>
     </Dialog>
   }
 }
-
-module.exports = ReduxComponent.connect(ReleaseNotes)
 
 const styles = StyleSheet.create({
   releaseNotes: {
@@ -69,3 +60,5 @@ const styles = StyleSheet.create({
     marginBottom: '10px'
   }
 })
+
+module.exports = ReduxComponent.connect(ReleaseNotes)

--- a/app/renderer/components/main/siteInfo.js
+++ b/app/renderer/components/main/siteInfo.js
@@ -9,6 +9,7 @@ const {StyleSheet, css} = require('aphrodite/no-important')
 // Components
 const ReduxComponent = require('../reduxComponent')
 const Dialog = require('../common/dialog')
+const FlyoutDialog = require('../common/flyoutDialog')
 const Button = require('../common/button')
 
 // Actions
@@ -28,7 +29,6 @@ const urlUtil = require('../../../../js/lib/urlutil')
 
 // Styles
 const globalStyles = require('../styles/global')
-const commonStyles = require('../styles/commonStyles')
 
 class SiteInfo extends React.Component {
   constructor (props) {
@@ -242,12 +242,11 @@ class SiteInfo extends React.Component {
 
   render () {
     return <Dialog testId='siteInfoDialog' onHide={this.onHide} className='siteInfo' isClickDismiss>
-      <div onClick={(e) => e.stopPropagation()}
-        className={css(
-          commonStyles.flyoutDialog,
+      <FlyoutDialog onClick={(e) => e.stopPropagation()}
+        custom={[
           styles.siteInfo,
           (this.props.isBlockedRunInsecureContent || this.props.runInsecureContent) && styles.siteInfo_large
-      )}>
+        ]}>
         {
           this.secureIcon
         }
@@ -257,7 +256,7 @@ class SiteInfo extends React.Component {
         {
           this.connectionInfo
         }
-      </div>
+      </FlyoutDialog>
     </Dialog>
   }
 }

--- a/app/renderer/components/main/widevinePanel.js
+++ b/app/renderer/components/main/widevinePanel.js
@@ -13,11 +13,8 @@ const Button = require('../common/button')
 const WidevineInfo = require('./widevineInfo')
 const SwitchControl = require('../common/switchControl')
 const {
-  CommonFormLarge,
-  CommonFormTitle,
-  CommonFormSection,
-  CommonFormButtonWrapper,
-  CommonFormBottomWrapper
+  CommonForm,
+  CommonFormSection
 } = require('../common/commonForm')
 
 // Constants
@@ -79,12 +76,12 @@ class WidevinePanel extends React.Component {
        to be installed on the computer.
     */
     return <Dialog onHide={this.onHide} testId='widevinePanelDialog'>
-      <CommonFormLarge onClick={(e) => e.stopPropagation()}>
-        <CommonFormTitle data-l10n-id='widevinePanelTitle' />
+      <CommonForm large onClick={(e) => e.stopPropagation()}>
+        <CommonFormSection title l10nId='widevinePanelTitle' />
         <CommonFormSection>
           <WidevineInfo createTabRequestedAction={appActions.createTabRequested} />
         </CommonFormSection>
-        <CommonFormButtonWrapper>
+        <CommonFormSection buttons>
           <Button className='whiteButton'
             l10nId='cancel'
             testId='cancelButton'
@@ -94,8 +91,8 @@ class WidevinePanel extends React.Component {
             l10nId='installAndAllow'
             testId='installAndAllowButton'
             onClick={this.onInstallAndAllow} />
-        </CommonFormButtonWrapper>
-        <CommonFormBottomWrapper>
+        </CommonFormSection>
+        <CommonFormSection bottom>
           <div className={css(styles.flexJustifyCenter)}>
             {/* TODO: refactor switchControl.js to remove commonStyles.noPadding */}
             <SwitchControl
@@ -105,13 +102,11 @@ class WidevinePanel extends React.Component {
               onClick={this.onClickRememberForNetflix}
               checkedOn={this.props.alsoAddRememberSiteSetting} />
           </div>
-        </CommonFormBottomWrapper>
-      </CommonFormLarge>
+        </CommonFormSection>
+      </CommonForm>
     </Dialog>
   }
 }
-
-module.exports = ReduxComponent.connect(WidevinePanel)
 
 const styles = StyleSheet.create({
   flexJustifyCenter: {
@@ -119,3 +114,5 @@ const styles = StyleSheet.create({
     justifyContent: 'center'
   }
 })
+
+module.exports = ReduxComponent.connect(WidevinePanel)

--- a/app/renderer/components/styles/commonStyles.js
+++ b/app/renderer/components/styles/commonStyles.js
@@ -47,23 +47,6 @@ const styles = StyleSheet.create({
     fontSize: globalStyles.spacing.textAreaFontSize
   },
 
-  // Dialogs
-  flyoutDialog: {
-    background: globalStyles.color.toolbarBackground,
-    borderRadius: globalStyles.radius.borderRadius,
-    boxShadow: globalStyles.shadow.flyoutDialogBoxShadow,
-    color: '#000',
-    fontSize: '13px',
-    // Issue #7949
-    padding: `${globalStyles.spacing.dialogInsideMargin} 30px`,
-    position: 'absolute',
-    top: globalStyles.spacing.dialogTopOffset,
-    // Issue #7930
-    boxSizing: 'border-box',
-    maxWidth: '600px',
-    maxHeight: `calc(80vh - ${globalStyles.spacing.downloadsBarHeight})`
-  },
-
   // itemList.less
   listItem: {
     cursor: 'default',

--- a/js/about/styles.js
+++ b/js/about/styles.js
@@ -31,13 +31,9 @@ const {
 
 const {
   CommonForm,
-  CommonFormTitle,
   CommonFormSection,
   CommonFormDropdown,
-  CommonFormClickable,
-  CommonFormSubSection,
-  CommonFormButtonWrapper,
-  CommonFormBottomWrapper
+  CommonFormClickable
 } = require('../../app/renderer/components/common/commonForm')
 
 class Container extends ImmutableComponent {
@@ -394,7 +390,7 @@ class AboutStyle extends ImmutableComponent {
             bottom: '40px'
           }}>
             <CommonForm>
-              <CommonFormTitle>CommonFormTitle</CommonFormTitle>
+              <CommonFormSection title>Title</CommonFormSection>
               <CommonFormSection>
                 CommonFormSection - Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
                 labore et dolore magna aliqua.
@@ -405,41 +401,37 @@ class AboutStyle extends ImmutableComponent {
                 </CommonFormDropdown>
               </CommonFormSection>
               <CommonFormSection>
-                <CommonFormSubSection>CommonFormSubSection</CommonFormSubSection>
-                <CommonFormSubSection>
+                <CommonFormSection subSection>Sub Section</CommonFormSection>
+                <CommonFormSection subSection>
                   <CommonFormDropdown>
                     <option value='CommonFormDropdown'>CommonFormDropdown</option>
                   </CommonFormDropdown>
-                </CommonFormSubSection>
+                </CommonFormSection>
               </CommonFormSection>
               <CommonFormSection>
                 CommonFormSection - Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut
                 labore et dolore magna aliqua.
               </CommonFormSection>
-              <CommonFormButtonWrapper>
+              <CommonFormSection buttons>
                 <BrowserButton groupedItem secondaryColor l10nId='Cancel' />
                 <BrowserButton groupedItem primaryColor l10nId='Done' />
-              </CommonFormButtonWrapper>
-              <CommonFormBottomWrapper>
+              </CommonFormSection>
+              <CommonFormSection bottom>
                 <CommonFormClickable>CommonFormClickable</CommonFormClickable>
-              </CommonFormBottomWrapper>
+              </CommonFormSection>
             </CommonForm>
           </div>
 
           <Pre><Code>
             const &#123;{'\n'}
             <Tab>CommonForm,{'\n'}</Tab>
-            <Tab>CommonFormTitle,{'\n'}</Tab>
             <Tab>CommonFormSection,{'\n'}</Tab>
             <Tab>CommonFormDropdown,{'\n'}</Tab>
-            <Tab>CommonFormClickable,{'\n'}</Tab>
-            <Tab>CommonFormSubSection,{'\n'}</Tab>
-            <Tab>CommonFormButtonWrapper,{'\n'}</Tab>
-            <Tab>CommonFormBottomWrapper{'\n'}</Tab>
+            <Tab>CommonFormClickable{'\n'}</Tab>
             &#125; = require('../../app/renderer/components/common/commonForm'){'\n'}
             {'\n'}
             &lt;CommonForm&gt;{'\n'}
-            <Tab>&lt;CommonFormTitle&gt;CommonFormTitle&lt;/CommonFormTitle&gt;{'\n'}</Tab>
+            <Tab>&lt;CommonFormSection title&gt;Title&lt;/CommonFormSection&gt;{'\n'}</Tab>
             <Tab>&lt;CommonFormSection&gt;{'\n'}</Tab>
             <Tab2>CommonFormSection - Lorem ipsum dolor sit amet, consectetur adipisicing elit,{'\n'}</Tab2>
             <Tab2>sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.{'\n'}</Tab2>
@@ -450,24 +442,24 @@ class AboutStyle extends ImmutableComponent {
             <Tab2>&lt;/CommonFormDropdown&gt;{'\n'}</Tab2>
             <Tab>&lt;/CommonFormSection&gt;{'\n'}</Tab>
             <Tab>&lt;CommonFormSection&gt;{'\n'}</Tab>
-            <Tab2>&lt;CommonFormSubSection&gt;CommonFormSubSection&lt;/CommonFormSubSection&gt;{'\n'}</Tab2>
-            <Tab2>&lt;CommonFormSubSection&gt;{'\n'}</Tab2>
+            <Tab2>&lt;CommonFormSection subSection&gt;Sub Section&lt;/CommonFormSection&gt;{'\n'}</Tab2>
+            <Tab2>&lt;CommonFormSection subSection&gt;{'\n'}</Tab2>
             <Tab3>&lt;CommonFormDropdown&gt;{'\n'}</Tab3>
             <Tab4>&lt;option value='CommonFormDropdown'&gt;CommonFormDropdown&lt;/option&gt;{'\n'}</Tab4>
             <Tab3>&lt;/CommonFormDropdown&gt;{'\n'}</Tab3>
-            <Tab2>&lt;/CommonFormSubSection&gt;{'\n'}</Tab2>
+            <Tab2>&lt;/CommonFormSection&gt;{'\n'}</Tab2>
             <Tab>&lt;/CommonFormSection&gt;{'\n'}</Tab>
             <Tab>&lt;CommonFormSection&gt;{'\n'}</Tab>
             <Tab2>CommonFormSection - Lorem ipsum dolor sit amet, consectetur adipisicing elit,{'\n'}</Tab2>
             <Tab2>sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.{'\n'}</Tab2>
             <Tab>&lt;/CommonFormSection&gt;{'\n'}</Tab>
-            <Tab>&lt;CommonFormButtonWrapper&gt;{'\n'}</Tab>
+            <Tab>&lt;CommonFormSection buttons&gt;{'\n'}</Tab>
             <Tab2>&lt;BrowserButton groupedItem secondaryColor l10nId='Cancel' /&gt;{'\n'}</Tab2>
             <Tab2>&lt;BrowserButton groupedItem primaryColor l10nId='Done' /&gt;{'\n'}</Tab2>
-            <Tab>&lt;/CommonFormButtonWrapper&gt;{'\n'}</Tab>
-            <Tab>&lt;CommonFormBottomWrapper&gt;{'\n'}</Tab>
+            <Tab>&lt;/CommonFormSection&gt;{'\n'}</Tab>
+            <Tab>&lt;CommonFormSection bottom&gt;{'\n'}</Tab>
             <Tab2>&lt;CommonFormClickable&gt;CommonFormClickable&lt;/CommonFormClickable&gt;{'\n'}</Tab2>
-            <Tab>&lt;/CommonFormBottomWrapper&gt;{'\n'}</Tab>
+            <Tab>&lt;/CommonFormSection&gt;{'\n'}</Tab>
             &lt;/CommonForm&gt;{'\n'}
           </Code></Pre>
 
@@ -490,18 +482,18 @@ class AboutStyle extends ImmutableComponent {
             bottom: '40px'
           }}>
             <CommonForm>
-              <CommonFormTitle>CommonFormTitle</CommonFormTitle>
+              <CommonFormSection title>Title</CommonFormSection>
             </CommonForm>
           </div>
 
           <Pre><Code>
             const &#123;{'\n'}
             <Tab>CommonForm,{'\n'}</Tab>
-            <Tab>CommonFormTitle{'\n'}</Tab>
+            <Tab>CommonFormSection{'\n'}</Tab>
             &#125; = require('../../app/renderer/components/common/commonForm'){'\n'}
             {'\n'}
             &lt;CommonForm&gt;{'\n'}
-            <Tab>&lt;CommonFormTitle&gt;CommonFormTitle&lt;/CommonFormTitle&gt;{'\n'}</Tab>
+            <Tab>&lt;CommonFormSection title&gt;Title&lt;/CommonFormSection&gt;{'\n'}</Tab>
             &lt;/CommonForm&gt;{'\n'}
           </Code></Pre>
         </Container>
@@ -578,12 +570,12 @@ class AboutStyle extends ImmutableComponent {
           }}>
             <CommonForm>
               <CommonFormSection>
-                <CommonFormSubSection>CommonFormSubSection</CommonFormSubSection>
-                <CommonFormSubSection>
+                <CommonFormSection subSection>Sub Section</CommonFormSection>
+                <CommonFormSection subSection>
                   <CommonFormDropdown>
                     <option value='CommonFormDropdown'>CommonFormDropdown</option>
                   </CommonFormDropdown>
-                </CommonFormSubSection>
+                </CommonFormSection>
               </CommonFormSection>
             </CommonForm>
           </div>
@@ -592,18 +584,17 @@ class AboutStyle extends ImmutableComponent {
             const &#123;{'\n'}
             <Tab>CommonForm,{'\n'}</Tab>
             <Tab>CommonFormSection,{'\n'}</Tab>
-            <Tab>CommonFormSubSection,{'\n'}</Tab>
             <Tab>CommonFormDropdown{'\n'}</Tab>
             &#125; = require('../../app/renderer/components/common/commonForm'){'\n'}
             {'\n'}
             &lt;CommonForm&gt;{'\n'}
             <Tab>&lt;CommonFormSection&gt;{'\n'}</Tab>
-            <Tab2>&lt;CommonFormSubSection&gt;CommonFormSubSection&lt;/CommonFormSubSection&gt;{'\n'}</Tab2>
-            <Tab2>&lt;CommonFormSubSection&gt;{'\n'}</Tab2>
+            <Tab2>&lt;CommonFormSection subSection&gt;Sub Section&lt;/CommonFormSection&gt;{'\n'}</Tab2>
+            <Tab2>&lt;CommonFormSection subSection&gt;{'\n'}</Tab2>
             <Tab3>&lt;CommonFormDropdown&gt;{'\n'}</Tab3>
             <Tab4>&lt;option value='CommonFormDropdown'&gt;CommonFormDropdown&lt;/option&gt;{'\n'}</Tab4>
             <Tab3>&lt;/CommonFormDropdown&gt;{'\n'}</Tab3>
-            <Tab2>&lt;/CommonFormSubSection&gt;{'\n'}</Tab2>
+            <Tab2>&lt;/CommonFormSection&gt;{'\n'}</Tab2>
             <Tab>&lt;/CommonFormSection&gt;{'\n'}</Tab>
             &lt;/CommonForm&gt;{'\n'}
           </Code></Pre>
@@ -617,24 +608,24 @@ class AboutStyle extends ImmutableComponent {
             bottom: '40px'
           }}>
             <CommonForm>
-              <CommonFormButtonWrapper>
+              <CommonFormSection buttons>
                 <BrowserButton groupedItem secondaryColor l10nId='Cancel' />
                 <BrowserButton groupedItem primaryColor l10nId='Done' />
-              </CommonFormButtonWrapper>
+              </CommonFormSection>
             </CommonForm>
           </div>
 
           <Pre><Code>
             const &#123;{'\n'}
             <Tab>CommonForm,{'\n'}</Tab>
-            <Tab>CommonFormButtonWrapper{'\n'}</Tab>
+            <Tab>CommonFormSection{'\n'}</Tab>
             &#125; = require('../../app/renderer/components/common/commonForm'){'\n'}
             {'\n'}
             &lt;CommonForm&gt;{'\n'}
-            <Tab>&lt;CommonFormButtonWrapper&gt;{'\n'}</Tab>
+            <Tab>&lt;CommonFormSection buttons&gt;{'\n'}</Tab>
             <Tab2>&lt;BrowserButton groupedItem secondaryColor l10nId='Cancel' /&gt;{'\n'}</Tab2>
             <Tab2>&lt;BrowserButton groupedItem primaryColor l10nId='Done' /&gt;{'\n'}</Tab2>
-            <Tab>&lt;/CommonFormButtonWrapper&gt;{'\n'}</Tab>
+            <Tab>&lt;/CommonFormSection&gt;{'\n'}</Tab>
             &lt;/CommonForm&gt;{'\n'}
           </Code></Pre>
         </Container>
@@ -647,23 +638,23 @@ class AboutStyle extends ImmutableComponent {
             bottom: '40px'
           }}>
             <CommonForm>
-              <CommonFormBottomWrapper>
+              <CommonFormSection bottom>
                 <CommonFormClickable>CommonFormClickable</CommonFormClickable>
-              </CommonFormBottomWrapper>
+              </CommonFormSection>
             </CommonForm>
           </div>
 
           <Pre><Code>
             const &#123;{'\n'}
             <Tab>CommonForm,{'\n'}</Tab>
-            <Tab>CommonFormBottomWrapper,{'\n'}</Tab>
+            <Tab>CommonFormSection,{'\n'}</Tab>
             <Tab>CommonFormClickable{'\n'}</Tab>
             &#125; = require('../../app/renderer/components/common/commonForm'){'\n'}
             {'\n'}
             &lt;CommonForm&gt;{'\n'}
-            <Tab>&lt;CommonFormBottomWrapper&gt;{'\n'}</Tab>
+            <Tab>&lt;CommonFormSection bottom&gt;{'\n'}</Tab>
             <Tab2>&lt;CommonFormClickable&gt;CommonFormClickable&lt;/CommonFormClickable&gt;{'\n'}</Tab2>
-            <Tab>&lt;/CommonFormBottomWrapper&gt;{'\n'}</Tab>
+            <Tab>&lt;/CommonFormSection&gt;{'\n'}</Tab>
             &lt;/CommonForm&gt;{'\n'}
           </Code></Pre>
         </Container>


### PR DESCRIPTION
- Update commonForm components based on FlyoutDialog
- Replace FlyoutDialog with CommonForm to reduce the possibility of visual regression
- Update to the modified BEM style

Addresses #7114
Closes #10977

Auditors: @cezaraugusto @bsclifton

Test Plan
1. Open about:styles
2. Click `commonForms`
3. Make sure the common form dialog is properly styled
4. Disable Widevine
5. Open https://netflix.com
6. Make sure the title is displayed on the dialog

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


