### PR TITLE
Add an option to close a pinned tab

### DIFF
--- a/app/browser/reducers/tabsReducer.js
+++ b/app/browser/reducers/tabsReducer.js
@@ -175,12 +175,17 @@ const tabsReducer = (state, action, immutableAction) => {
               break
             }
             const windowId = tabState.getWindowId(state, tabId)
+            const isPinned = tabState.isTabPinned(state, tabId)
             const nonPinnedTabs = tabState.getNonPinnedTabsByWindowId(state, windowId)
             const pinnedTabs = tabState.getPinnedTabsByWindowId(state, windowId)
 
             if (nonPinnedTabs.size > 1 ||
               (nonPinnedTabs.size > 0 && pinnedTabs.size > 0)) {
               setImmediate(() => {
+                if (isPinned) {
+                  // if a tab is pinned, unpin before closing
+                  state = tabs.pin(state, tabId, false)
+                }
                 tabs.closeTab(tabId, action.get('forceClosePinned'))
               })
             } else {

--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -192,12 +192,7 @@ class Tab extends React.Component {
         return
       case 1:
         // Close tab with middle click
-        // This is ignored for pinned tabs
-        // TODO: @cezaraugusto remove conditional
-        // when #4063 is resolved
-        if (!this.props.isPinnedTab) {
-          this.onTabClosedWithMouse(e)
-        }
+        this.onTabClosedWithMouse(e)
         break
       default:
         e.stopPropagation()

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -517,17 +517,20 @@ function tabTemplateInit (frameProps) {
 
   template.push(CommonMenu.separatorMenuItem)
 
-  if (!frameProps.get('pinnedLocation')) {
-    template.push({
-      label: locale.translation('closeTab'),
-      click: (item, focusedWindow) => {
-        if (focusedWindow) {
-          // TODO: Don't switch active tabs when this is called
-          focusedWindow.webContents.send(messages.SHORTCUT_CLOSE_FRAME, tabId)
+  template.push({
+    label: locale.translation('closeTab'),
+    click: (item, focusedWindow) => {
+      if (focusedWindow) {
+        const isPinned = frameProps.get('pinnedLocation')
+        // if a tab is pinned, unpin it first then close
+        if (isPinned) {
+          appActions.tabPinned(tabId, !isPinned)
         }
+        // TODO: Don't switch active tabs when this is called
+        focusedWindow.webContents.send(messages.SHORTCUT_CLOSE_FRAME, tabId)
       }
-    })
-  }
+    }
+  })
 
   template.push({
     label: locale.translation('closeOtherTabs'),

--- a/test/tab-components/pinnedTabTest.js
+++ b/test/tab-components/pinnedTabTest.js
@@ -2,7 +2,6 @@
 
 const Brave = require('../lib/brave')
 
-const messages = require('../../js/constants/messages')
 const {urlInput, tabsTabs, pinnedTabsTabs} = require('../lib/selectors')
 
 describe('pinnedTabs', function () {
@@ -290,11 +289,12 @@ describe('pinnedTabs', function () {
         .click(pinnedTabsTabs)
         .waitForElementCount(pinnedTabsTabs + '[data-test-active-tab]', 1)
     })
-    it('close attempt retains pinned tab and selects next active frame', function * () {
+    it('closes the pinned with middle click', function * () {
       yield this.app.client
-        .waitForExist('[data-test-active-tab][data-frame-key="2"]')
-        .ipcSend(messages.SHORTCUT_CLOSE_FRAME)
-        .waitForExist('[data-test-active-tab][data-frame-key="1"]')
+        .click(pinnedTabsTabs)
+        .waitForExist('[data-test-active-tab]')
+        .middleClick(pinnedTabsTabs)
+        .waitForElementCount(pinnedTabsTabs, 0)
     })
   })
 


### PR DESCRIPTION
closes #4063 

```
npm run test -- --grep="Closing pinned tabs"
```

test plan:

* should be able to close a pinned tab with right-click/close
* should be able to close a pinned tab with middle click