### PR TITLE
fix homepage punycode display bypass

### DIFF
--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -354,7 +354,7 @@ const UrlUtil = {
       parsed.hostname = punycode.toASCII(parsed.hostname)
       return urlFormat(parsed)
     } catch (e) {
-      return url
+      return punycode.toASCII(url)
     }
   },
 

--- a/test/about/preferencesTest.js
+++ b/test/about/preferencesTest.js
@@ -35,6 +35,17 @@ describe('General Panel', function () {
         .waitForInputText(homepageInput, 'https://www.brave.xn--com-8cd/')
     })
 
+    it('homepage displays punycode without HTTP prefix', function * () {
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(prefsUrl)
+        .waitForVisible(homepageInput)
+        .click(homepageInput)
+        .keys(Array.apply(null, Array(50)).map(() => Brave.keys.BACKSPACE))
+        .keys('а')
+        .waitForInputText(homepageInput, 'xn--80a')
+    })
+
     it('homepage can be backspaced', function * () {
       yield this.app.client
         .tabByIndex(0)

--- a/test/unit/lib/urlutilTest.js
+++ b/test/unit/lib/urlutilTest.js
@@ -280,8 +280,11 @@ describe('urlutil', function () {
   })
 
   describe('getPunycodeUrl', function () {
-    it('returns empty string if input is not a URL', function () {
+    it('returns original string if input is ASCII', function () {
       assert.equal(urlUtil.getPunycodeUrl('invalid-url-goes-here'), 'invalid-url-goes-here')
+    })
+    it('returns punycode ASCII string if input is non-ASCII', function () {
+      assert.equal(urlUtil.getPunycodeUrl('ebаy.com'), 'xn--eby-7cd.com')
     })
     it('returns the punycode URL when given a valid URL', function () {
       assert.equal(urlUtil.getPunycodeUrl('http://brave:brave@ebаy.com:1234/brave#brave'), 'http://brave:brave@xn--eby-7cd.com:1234/brave#brave')


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/11001

Test Plan:
1. automated tests for homepage should pass
2. try setting your homepage to `ebаy.com/`
3. it should display the punycode

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


