### PR TITLE
Fix button alignment on error page

### DIFF
--- a/less/about/error.less
+++ b/less/about/error.less
@@ -12,7 +12,7 @@ body {
 
     .errorContent {
       display: flex;
-      width: 40vw;
+      width: 60vw;
       max-width: 600px;
       margin: 20vh auto;
       line-height: 1.6em;


### PR DESCRIPTION
Submitter Checklist:
Fixes:#11007

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
Visit  https://expired.badssl.com/
Reduce the browser width to 478px
Ensure buttons are aligned properly as shown
![image](https://user-images.githubusercontent.com/17010094/30578702-ec62c8d4-9d32-11e7-8dad-7db40eca2f6e.png)


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


