### PR TITLE
Display brave icon on CheckDefaultBrowserDialog

### DIFF
--- a/app/renderer/components/main/checkDefaultBrowserDialog.js
+++ b/app/renderer/components/main/checkDefaultBrowserDialog.js
@@ -119,7 +119,7 @@ const styles = StyleSheet.create({
   },
 
   section__braveIcon: {
-    backgroundImage: `image-set(url(${braveAbout}) 2x)`,
+    backgroundImage: `-webkit-image-set(url(${braveAbout}) 2x)`,
     backgroundRepeat: 'no-repeat',
     height: '64px',
     width: '64px',


### PR DESCRIPTION
Fixes #11041

Auditors:

Test Plan:
1. Change the default browser from Brave
2. Open Brave
3. Make sure the lion image is displayed on the dialog

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


