### PR TITLE
Use 'PDF Viewer' instead of 'chrome-extension://...' for notifications

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -422,12 +422,13 @@ function registerPermissionHandler (session, partition) {
     // TODO(bridiver) - the permission handling should be converted to an action because we should never call `appStore.getState()`
     // Check whether there is a persistent site setting for this host
     const appState = appStore.getState()
+    const isBraveOrigin = origin.startsWith(`chrome-extension://${config.braveExtensionId}/`)
+    const isPDFOrigin = origin.startsWith(`${pdfjsOrigin}/`)
     let settings
     let tempSettings
-    if (mainFrameUrl === appUrlUtil.getBraveExtIndexHTML() ||
-      origin.startsWith('chrome-extension://' + config.braveExtensionId)) {
-      // lookup, display and store site settings by "Brave Browser"
-      origin = 'Brave Browser'
+    if (mainFrameUrl === appUrlUtil.getBraveExtIndexHTML() || isPDFOrigin || isBraveOrigin) {
+      // lookup, display and store site settings by the origin alias
+      origin = isPDFOrigin ? 'PDF Viewer' : 'Brave Browser'
       // display on all tabs
       mainFrameUrl = null
       // Lookup by exact host pattern match since 'Brave Browser' is not
@@ -464,8 +465,7 @@ function registerPermissionHandler (session, partition) {
         response.push(true)
       } else if (permission === 'openExternal' && (
         // The Brave extension and PDFJS are always allowed to open files in an external app
-        origin.startsWith('chrome-extension://' + config.PDFJSExtensionId) ||
-        origin.startsWith('chrome-extension://' + config.braveExtensionId))) {
+        isPDFOrigin || isBraveOrigin)) {
         response.push(true)
       } else {
         const permissionName = permission + 'Permission'


### PR DESCRIPTION
fix #11020

Test Plan:
1. open any PDF in Brave
2. click the fullscreen button
3. the notification should say 'Allow PDF Viewer to use fullscreen?'

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


