### PR TITLE
replace momentjs with date-fns

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -5,7 +5,7 @@
 'use strict'
 
 const acorn = require('acorn')
-const moment = require('moment')
+const format = require('date-fns/format')
 const Immutable = require('immutable')
 const electron = require('electron')
 const ipc = electron.ipcMain
@@ -995,7 +995,7 @@ const pageDataChanged = (state, viewData = {}, keepInfo = false) => {
 }
 
 const backupKeys = (state, backupAction) => {
-  const date = moment().format('L')
+  const date = format(new Date(), 'MM/DD/YYYY')
   const passphrase = ledgerState.getInfoProp(state, 'passphrase')
 
   const messageLines = [

--- a/app/browser/bookmarksExporter.js
+++ b/app/browser/bookmarksExporter.js
@@ -5,7 +5,7 @@
 'use strict'
 
 const path = require('path')
-const moment = require('moment')
+const format = require('date-fns/format')
 const fs = require('fs')
 const electron = require('electron')
 const dialog = electron.dialog
@@ -29,7 +29,7 @@ const indentType = ' '
 
 const showDialog = (state) => {
   const focusedWindow = BrowserWindow.getFocusedWindow()
-  const fileName = moment().format('DD_MM_YYYY') + '.html'
+  const fileName = format(new Date(), 'DD_MM_YYYY') + '.html'
   const defaultPath = path.join(getSetting(settings.DOWNLOAD_DEFAULT_PATH) || app.getPath('downloads'), fileName)
   let personal = []
   let other = []

--- a/app/common/lib/ledgerExportUtil.js
+++ b/app/common/lib/ledgerExportUtil.js
@@ -3,7 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const underscore = require('underscore')
-const moment = require('moment')
+const format = require('date-fns/format')
 
 /**
  * Filter an array of transactions by an array of viewingIds
@@ -284,7 +284,7 @@ const addExportFilenamePrefixToTransactions = (transactions) => {
   return transactions.map(function (transaction) {
     const timestamp = transaction.submissionStamp
 
-    let numericDateStr = moment(new Date(timestamp)).format('YYYY-MM-DD')
+    let numericDateStr = format(new Date(timestamp), 'YYYY-MM-DD')
 
     let dateCount = (dateCountMap[numericDateStr] ? dateCountMap[numericDateStr] : 1)
     dateCountMap[numericDateStr] = dateCount + 1

--- a/app/common/lib/ledgerUtil.js
+++ b/app/common/lib/ledgerUtil.js
@@ -5,7 +5,8 @@
 'use strict'
 
 const Immutable = require('immutable')
-const moment = require('moment')
+const format = require('date-fns/format')
+const distanceInWordsToNow = require('date-fns/distance_in_words_to_now')
 const BigNumber = require('bignumber.js')
 const queryString = require('querystring')
 
@@ -77,13 +78,11 @@ const formatCurrentBalance = (ledgerData) => {
 }
 
 const formattedTimeFromNow = (timestamp) => {
-  moment.locale(navigator.language)
-  return moment(new Date(timestamp)).fromNow()
+  return distanceInWordsToNow(new Date(timestamp), {locale: navigator.language})
 }
 
-const formattedDateFromTimestamp = (timestamp, format) => {
-  moment.locale(navigator.language)
-  return moment(new Date(timestamp)).format(format)
+const formattedDateFromTimestamp = (timestamp, dateFormat) => {
+  return format(new Date(timestamp), dateFormat, {locale: navigator.language})
 }
 
 const walletStatus = (ledgerData) => {

--- a/app/renderer/components/preferences/payment/enabledContent.js
+++ b/app/renderer/components/preferences/payment/enabledContent.js
@@ -4,7 +4,7 @@
 
 const React = require('react')
 const {StyleSheet, css} = require('aphrodite/no-important')
-const moment = require('moment')
+const addMonths = require('date-fns/add_months')
 const Immutable = require('immutable')
 
 // util
@@ -179,7 +179,7 @@ class EnabledContent extends ImmutableComponent {
     let l10nDataId = 'statusNextReconcileDate'
 
     if (!nextReconcileDateRelative) {
-      nextReconcileDateRelative = formattedDateFromTimestamp(moment().add(1, 'months'), 'MMMM Do')
+      nextReconcileDateRelative = formattedDateFromTimestamp(addMonths(Date.now(), 1), 'MMMM Do')
     } else {
       const timestamp = ledgerData.get('reconcileStamp')
       const now = new Date().getTime()

--- a/app/renderer/components/preferences/payment/history.js
+++ b/app/renderer/components/preferences/payment/history.js
@@ -22,8 +22,6 @@ const {paymentStylesVariables} = require('../../styles/payment')
 // other
 const aboutUrls = appUrlUtil.aboutUrls
 const aboutContributionsUrl = aboutUrls.get('about:contributions')
-const moment = require('moment')
-moment.locale(navigator.language)
 
 class HistoryContent extends ImmutableComponent {
   render () {

--- a/js/about/contributionStatement.js
+++ b/js/about/contributionStatement.js
@@ -11,7 +11,7 @@ const ledgerExportUtil = require('../../app/common/lib/ledgerExportUtil')
 const getTransactionCSVRows = ledgerExportUtil.getTransactionCSVRows
 const addExportFilenamePrefixToTransactions = ledgerExportUtil.addExportFilenamePrefixToTransactions
 
-const moment = require('moment')
+const format = require('date-fns/format')
 
 const messages = require('../constants/messages')
 
@@ -463,19 +463,17 @@ class ContributionStatement extends React.Component {
 
 function formattedDateFromTimestamp (timestamp) {
   // e.g. 2016-11-15
-  return moment(new Date(timestamp)).format('YYYY-MM-DD')
+  return format(new Date(timestamp), 'YYYY-MM-DD')
 }
 
 function formattedTimeFromTimestamp (timestamp) {
   // e.g. 4:00pm
-  return moment(new Date(timestamp)).format('h:mma')
+  return format(new Date(timestamp), 'h:mma')
 }
 
 function longFormattedDateFromTimestamp (timestamp) {
-  let momentDate = moment(new Date(timestamp))
-
   // e.g. June 15th at 4:00pm
-  return `${momentDate.format('MMMM Do')} at ${momentDate.format('h:mma')}`
+  return `${format(new Date(timestamp), 'MMMM Do')} at ${format(new Date(timestamp), 'h:mma')}`
 }
 
 const containerMargin = '25px'

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,15 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "7zip-bin": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-2.2.4.tgz",
+      "integrity": "sha512-vs1IkxmbdYv0K8rPBXLl/qicRRF7CDjpOWHY1m+CUVByMkepJtWVlxtnszyY1rAWWL71IGc2JWRzJgUbHpzGDw==",
+      "dev": true,
+      "requires": {
+        "7zip-bin-mac": "1.0.1"
+      }
+    },
     "7zip-bin-mac": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/7zip-bin-mac/-/7zip-bin-mac-1.0.1.tgz",
@@ -4422,6 +4431,11 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-1.2.0.tgz",
       "integrity": "sha512-vKQ9DTQPN1FLYiiEEOQ6IBGFqvjCa5rSK3cWMy/Nespm5d/x3dGFT9UBZnkLxCwua/IXBi2TYnwTEpsOvhC4UQ=="
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw=="
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -6249,6 +6263,28 @@
       "version": "github:brave/electron-squirrel-startup#88d78fee0079d7bfce7e5238658e54e2e75550ef",
       "requires": {
         "debug": "2.6.9"
+      }
+    },
+    "electron-publish": {
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-17.9.0.tgz",
+      "integrity": "sha1-WCbOIqBv+V6dHNb07jZ3A4EKJLs=",
+      "dev": true,
+      "requires": {
+        "bluebird-lst": "1.0.3",
+        "chalk": "1.1.3",
+        "electron-builder-http": "17.9.0",
+        "electron-builder-util": "17.9.0",
+        "fs-extra-p": "4.4.2",
+        "mime": "1.4.1"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "dev": true
+        }
       }
     },
     "electron-to-chromium": {

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "bloodhound-js": "brave/bloodhound",
     "clipboard-copy": "^1.0.0",
     "compare-versions": "^3.0.1",
+    "date-fns": "^1.29.0",
     "deepmerge": "^2.0.1",
     "electron-localshortcut": "^0.6.0",
     "electron-squirrel-startup": "brave/electron-squirrel-startup",

--- a/test/about/ledgerPanelAdvancedPanelTest.js
+++ b/test/about/ledgerPanelAdvancedPanelTest.js
@@ -17,7 +17,7 @@ const urlParse = require('url').parse
 const WALLET_RECOVERY_FILE_BASENAME = 'brave_wallet_recovery.txt'
 const PASSPHRASE_TRANSLATION_KEY = 'ledgerBackupText4'
 
-const moment = require('moment')
+const format = require('date-fns/format')
 
 let translationsCache = null
 
@@ -91,7 +91,7 @@ let generateAndSaveRecoveryFile = function (recoveryFilePath, passphrase) {
   let recoveryFileContents = ''
 
   if (typeof passphrase === 'string') {
-    const date = moment().format('L')
+    const date = format(new Date(), 'MM/DD/YYYY')
 
     const messageLines = [
       translationsCache['ledgerBackupText1'],

--- a/test/unit/app/common/lib/ledgerExportUtilTest.js
+++ b/test/unit/app/common/lib/ledgerExportUtilTest.js
@@ -2,7 +2,7 @@
 const assert = require('assert')
 const underscore = require('underscore')
 const uuid = require('uuid')
-const moment = require('moment')
+const format = require('date-fns/format')
 
 require('../../../braveUnit')
 
@@ -322,7 +322,7 @@ describe('ledger export utilities test', function () {
 
       let tx = txs[0]
       let timestamp = tx.submissionStamp
-      let dateStr = moment(new Date(timestamp)).format('YYYY-MM-DD')
+      let dateStr = format(new Date(timestamp), 'YYYY-MM-DD')
       let expectedExportFilenamePrefix = `${EXPORT_FILENAME_CONST_PREFIX_PART}${dateStr}`
 
       assert.equal(typeof tx.exportFilenamePrefix, 'string', 'transaction should have "exportFilenamePrefix" field with type "string"')


### PR DESCRIPTION
Initially, the plan was to reduce bundle cost given `moment` is enormous and we only use 2-3 methods from there:

<img width="436" alt="screen shot 2017-09-21 at 3 24 56 am" src="https://user-images.githubusercontent.com/4672033/30684568-14335f4e-9e88-11e7-9b11-2f99b89360de.png">
<img width="473" alt="screen shot 2017-09-21 at 3 24 49 am" src="https://user-images.githubusercontent.com/4672033/30684567-1431ac9e-9e88-11e7-9be3-8d6eda475e92.png">


What came to my attention regarding security was [an issue](https://github.com/moment/moment/issues/4163) created in `moment`'s repo explaining that a given regular expression could be used to parse dates specified as strings being vulnerable to ReDoS. I first saw this in a [Medium post](https://medium.com/node-security/pull-requests-welcome-we-need-your-help-to-fix-some-redos-vulnerabilities-da9fc74b4fd5) from Node Security

This, in fact, didn't remove `moment` entirely as we still require `Joi` which has it as a dependency but may be a good starting point.

Fix #11061

## Test plan:

This affected bookmarks exporter and ledger.

The general test plan is that you can still export a bookmark (with the same file name as before) and ledger/contribution statement should have their times as usual.

Ledger panel and ledger export util tests should pass too. `npm run unittest` should cover.

/cc @evq @darkdh