### PR TITLE
Reorganize dropdown.js

### DIFF
--- a/app/extensions/brave/locales/en-US/styles.properties
+++ b/app/extensions/brave/locales/en-US/styles.properties
@@ -1,4 +1,7 @@
 actionButton=Action Button
+adsAllow=Allow Ads and Tracking
+adsBlock=Block Ads
+adsShowBrave=Show Brave Ads
 browserButton=Browser Button
 buttons=Buttons
 extensionItem=Extension Item

--- a/app/renderer/components/autofill/autofillAddressPanel.js
+++ b/app/renderer/components/autofill/autofillAddressPanel.js
@@ -14,7 +14,7 @@ const {
   CommonFormLarge,
   CommonFormSection,
   CommonFormTitle,
-  CommonFormFullWidthDropdown,
+  CommonFormDropdown,
   CommonFormButtonWrapper,
   commonFormStyles
 } = require('../common/commonForm')
@@ -241,13 +241,14 @@ class AutofillAddressPanel extends React.Component {
                 />
               </div>
               <div className={css(commonFormStyles.input__marginRow)}>
-                <CommonFormFullWidthDropdown
+                <CommonFormDropdown
+                  data-isFullWidth
+                  data-test-id='country'
                   value={this.props.country}
                   onChange={this.onCountryChange}
-                  data-test-id='country'
                 >
                   {this.countryList}
-                </CommonFormFullWidthDropdown>
+                </CommonFormDropdown>
               </div>
               <div className={css(commonFormStyles.input__marginRow)}>
                 <input

--- a/app/renderer/components/common/commonForm.js
+++ b/app/renderer/components/common/commonForm.js
@@ -69,12 +69,6 @@ class CommonFormDropdown extends ImmutableComponent {
   }
 }
 
-class CommonFormFullWidthDropdown extends ImmutableComponent {
-  render () {
-    return <FormDropdown data-isCommonForm='true' data-isFullWidth='true' {...this.props} />
-  }
-}
-
 class CommonFormTextbox extends ImmutableComponent {
   render () {
     return <FormTextbox data-isCommonForm='true' {...this.props} />
@@ -240,7 +234,6 @@ module.exports = {
   CommonFormLarge,
   CommonFormBookmarkHanger,
   CommonFormDropdown,
-  CommonFormFullWidthDropdown,
   CommonFormTextbox,
   CommonFormClickable,
   CommonFormSection,

--- a/app/renderer/components/common/dropdown.js
+++ b/app/renderer/components/common/dropdown.js
@@ -40,18 +40,6 @@ class SettingDropdown extends ImmutableComponent {
   }
 }
 
-class PanelDropdown extends ImmutableComponent {
-  render () {
-    return <FormDropdown data-isPanel {...this.props} />
-  }
-}
-
-class BraveryPanelDropdown extends ImmutableComponent {
-  render () {
-    return <FormDropdown data-isBraveryPanel {...this.props} />
-  }
-}
-
 const selectPadding = '0.4em'
 
 const styles = StyleSheet.create({
@@ -95,15 +83,12 @@ const styles = StyleSheet.create({
   },
 
   braveryPanel: {
-    fontSize: '13px',
-    width: '100%'
+    fontSize: '13px'
   }
 })
 
 module.exports = {
   Dropdown,
   FormDropdown,
-  SettingDropdown,
-  PanelDropdown,
-  BraveryPanelDropdown
+  SettingDropdown
 }

--- a/app/renderer/components/main/braveryPanel.js
+++ b/app/renderer/components/main/braveryPanel.js
@@ -11,7 +11,7 @@ const ReduxComponent = require('../reduxComponent')
 const Dialog = require('../common/dialog')
 const BrowserButton = require('../common/browserButton')
 const SwitchControl = require('../common/switchControl')
-const {BraveryPanelDropdown} = require('../common/dropdown')
+const {FormDropdown} = require('../common/dropdown')
 
 // Constants
 const config = require('../../../../js/constants/config')
@@ -506,11 +506,18 @@ class BraveryPanel extends React.Component {
                   !this.props.isCompactBraveryPanel && styles.braveryPanel__body__advanced__control__forms__dropdown,
                   this.props.isCompactBraveryPanel && styles.braveryPanel_compact__body__advanced__control__forms__dropdown
                 )}>
-                  <BraveryPanelDropdown data-test-id='adsBlockedControl' value={this.props.adControl} onChange={this.onToggleAdControl} disabled={!this.props.shieldsUp}>
+                  <FormDropdown
+                    data-isFullWidth
+                    data-isBraveryPanel
+                    data-test-id='adsBlockedControl'
+                    value={this.props.adControl}
+                    onChange={this.onToggleAdControl}
+                    disabled={!this.props.shieldsUp}
+                  >
                     <option data-l10n-id='showBraveAds' data-test-id='showBraveAds' value='showBraveAds' />
                     <option data-l10n-id='blockAds' data-test-id='blockAdsOption' value='blockAds' />
                     <option data-l10n-id='allowAdsAndTracking' data-test-id='showAdsOption' value='allowAdsAndTracking' />
-                  </BraveryPanelDropdown>
+                  </FormDropdown>
                 </div>
 
                 <SwitchControl className={css(
@@ -552,11 +559,18 @@ class BraveryPanel extends React.Component {
                   this.props.isCompactBraveryPanel && gridStyles.row4col1,
                   this.props.isCompactBraveryPanel && styles.braveryPanel_compact__body__advanced__control__forms__dropdown
                 )}>
-                  <BraveryPanelDropdown data-test-id='cookieControl' value={this.props.cookieControl} onChange={this.onToggleCookieControl} disabled={!this.props.shieldsUp}>
+                  <FormDropdown
+                    data-isFullWidth
+                    data-isBraveryPanel
+                    data-test-id='cookieControl'
+                    value={this.props.cookieControl}
+                    onChange={this.onToggleCookieControl}
+                    disabled={!this.props.shieldsUp}
+                  >
                     <option data-l10n-id='block3rdPartyCookie' value='block3rdPartyCookie' />
                     <option data-l10n-id='allowAllCookies' data-test-id='allowAllCookies' value='allowAllCookies' />
                     <option data-l10n-id='blockAllCookies' data-test-id='blockAllCookies' value='blockAllCookies' />
-                  </BraveryPanelDropdown>
+                  </FormDropdown>
                 </div>
 
                 <div className={css(
@@ -580,15 +594,18 @@ class BraveryPanel extends React.Component {
                   this.props.isCompactBraveryPanel && gridStyles.row6col1,
                   this.props.isCompactBraveryPanel && styles.braveryPanel_compact__body__advanced__control__forms__dropdown
                 )}>
-                  <BraveryPanelDropdown
+                  <FormDropdown
+                    data-isFullWidth
+                    data-isBraveryPanel
                     data-test-id='fpControl'
                     value={this.props.fingerprintingProtection}
                     onChange={this.onToggleFp}
-                    disabled={!this.props.shieldsUp}>
+                    disabled={!this.props.shieldsUp}
+                  >
                     <option data-l10n-id='block3rdPartyFingerprinting' data-test-id='block3rdPartyFingerprinting' value='block3rdPartyFingerprinting' />
                     <option data-l10n-id='allowAllFingerprinting' data-test-id='allowAllFingerprinting' value='allowAllFingerprinting' />
                     <option data-l10n-id='blockAllFingerprinting' data-test-id='blockAllFingerprinting' value='blockAllFingerprinting' />
-                  </BraveryPanelDropdown>
+                  </FormDropdown>
                 </div>
 
                 <SwitchControl className={css(

--- a/app/renderer/components/preferences/payment/enabledContent.js
+++ b/app/renderer/components/preferences/payment/enabledContent.js
@@ -15,7 +15,7 @@ const {changeSetting} = require('../../../lib/settingsUtil')
 const ImmutableComponent = require('../../immutableComponent')
 const BrowserButton = require('../../common/browserButton')
 const {FormTextbox} = require('../../common/textbox')
-const {PanelDropdown} = require('../../common/dropdown')
+const {FormDropdown} = require('../../common/dropdown')
 const LedgerTable = require('./ledgerTable')
 
 // style
@@ -172,7 +172,8 @@ class EnabledContent extends ImmutableComponent {
         <div className={css(gridStyles.row1col2, styles.walletBar__title)} data-l10n-id='accountBalance' />
         <div className={css(gridStyles.row1col3)} />
         <div className={css(gridStyles.row2col1)}>
-          <PanelDropdown
+          <FormDropdown
+            data-isPanel
             data-test-id='fundsSelectBox'
             value={getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT, this.props.settings)}
             onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.PAYMENTS_CONTRIBUTION_AMOUNT)}>
@@ -181,7 +182,7 @@ class EnabledContent extends ImmutableComponent {
                 <option value={amount}>{amount} {ledgerData.get('currency') || 'USD'}</option>
               )
             }
-          </PanelDropdown>
+          </FormDropdown>
         </div>
         <div className={css(gridStyles.row2col2)}>
           {

--- a/js/about/styles.js
+++ b/js/about/styles.js
@@ -15,9 +15,7 @@ const {TextArea, DefaultTextArea} = require('../../app/renderer/components/commo
 const {
   Dropdown,
   FormDropdown,
-  SettingDropdown,
-  PanelDropdown,
-  BraveryPanelDropdown
+  SettingDropdown
 } = require('../../app/renderer/components/common/dropdown')
 
 const BrowserButton = require('../../app/renderer/components/common/browserButton')
@@ -191,6 +189,7 @@ class AboutStyle extends ImmutableComponent {
           </Dropdown>
           <Pre><Code>
             const { '{Dropdown}' } = require('../../app/renderer/components/common/dropdown'){'\n'}
+            {'\n'}
             &lt;Dropdown>{'\n'}
             &nbsp;&nbsp;&lt;option>Select Box&lt;/option>{'\n'}
             &nbsp;&nbsp;&lt;option>Second Choice&lt;/option>{'\n'}
@@ -208,10 +207,47 @@ class AboutStyle extends ImmutableComponent {
           </FormDropdown>
           <Pre><Code>
             const { '{FormDropdown}' } = require('../../app/renderer/components/common/dropdown'){'\n'}
+            {'\n'}
             &lt;FormDropdown>{'\n'}
             &nbsp;&nbsp;&lt;option>Select Box&lt;/option>{'\n'}
             &nbsp;&nbsp;&lt;option>Second Choice&lt;/option>{'\n'}
             &nbsp;&nbsp;&lt;option>Third Choice&lt;/option>{'\n'}
+            &lt;/FormDropdown>
+          </Code></Pre>
+        </Container>
+
+        <Container>
+          <h2>Dropdown used on Brave Payments; has 180px width (same as Panel Item button below)</h2>
+          <FormDropdown data-isPanel>
+            <option>5 USD</option>
+            <option>10 USD</option>
+            <option>15 USD</option>
+          </FormDropdown>
+          <Pre><Code>
+            const { '{FormDropdown}' } = require('../../app/renderer/components/common/dropdown'){'\n'}
+            {'\n'}
+            &lt;FormDropdown data-isPanel>{'\n'}
+            &nbsp;&nbsp;&lt;option>5 USD&lt;/option>{'\n'}
+            &nbsp;&nbsp;&lt;option>10 USD&lt;/option>{'\n'}
+            &nbsp;&nbsp;&lt;option>15 USD&lt;/option>{'\n'}
+            &lt;/FormDropdown>
+          </Code></Pre>
+        </Container>
+
+        <Container>
+          <h2>Dropdown used on Bravery Panel; has 100% width and 13px font size</h2>
+          <FormDropdown data-isFullWidth data-isBraveryPanel>
+            <option data-l10n-id='adsShowBrave' data-test-id='showBraveAds' value='showBraveAds' />
+            <option data-l10n-id='adsBlock' data-test-id='blockAdsOption' value='blockAds' />
+            <option data-l10n-id='adsAllow' data-test-id='showAdsOption' value='allowAdsAndTracking' />
+          </FormDropdown>
+          <Pre><Code>
+            const { '{FormDropdown}' } = require('../../app/renderer/components/common/dropdown'){'\n'}
+            {'\n'}
+            &lt;FormDropdown data-isFullWidth data-isBraveryPanel>{'\n'}
+            &nbsp;&nbsp;&lt;option data-l10n-id='showBraveAds' data-test-id='showBraveAds' value='showBraveAds' />{'\n'}
+            &nbsp;&nbsp;&lt;option data-l10n-id='blockAds' data-test-id='blockAdsOption' value='blockAds' />{'\n'}
+            &nbsp;&nbsp;&lt;option data-l10n-id='allowAdsAndTracking' data-test-id='showAdsOption' value='allowAdsAndTracking' />{'\n'}
             &lt;/FormDropdown>
           </Code></Pre>
         </Container>
@@ -225,6 +261,7 @@ class AboutStyle extends ImmutableComponent {
           </SettingDropdown>
           <Pre><Code>
             const { '{SettingDropdown}' } = require('../../app/renderer/components/common/dropdown'){'\n'}
+            {'\n'}
             &lt;SettingDropdown>{'\n'}
             &nbsp;&nbsp;&lt;option>Select Box&lt;/option>{'\n'}
             &nbsp;&nbsp;&lt;option>Second Choice&lt;/option>{'\n'}
@@ -234,36 +271,20 @@ class AboutStyle extends ImmutableComponent {
         </Container>
 
         <Container>
-          <h2>Dropdown used on Brave Payments; has 180px width (same as Panel Item button below)</h2>
-          <PanelDropdown>
-            <option>5 USD</option>
-            <option>10 USD</option>
-            <option>15 USD</option>
-          </PanelDropdown>
-          <Pre><Code>
-            const { '{PanelDropdown}' } = require('../../app/renderer/components/common/dropdown'){'\n'}
-            &lt;PanelDropdown>{'\n'}
-            &nbsp;&nbsp;&lt;option>5 USD&lt;/option>{'\n'}
-            &nbsp;&nbsp;&lt;option>10 USD&lt;/option>{'\n'}
-            &nbsp;&nbsp;&lt;option>15 USD&lt;/option>{'\n'}
-            &lt;/PanelDropdown>
-          </Code></Pre>
-        </Container>
-
-        <Container>
-          <h2>Dropdown used mostly on Bravery Panel; has 100% width and 13px font size</h2>
-          <BraveryPanelDropdown>
+          <h2>Dropdown used on CommonForm</h2>
+          <CommonFormDropdown>
             <option>Select Box</option>
             <option>Second Choice</option>
             <option>Third Choice</option>
-          </BraveryPanelDropdown>
+          </CommonFormDropdown>
           <Pre><Code>
-            const { '{BraveryPanelDropdown}' } = require('../../app/renderer/components/common/dropdown'){'\n'}
-            &lt;BraveryPanelDropdown>{'\n'}
+            const { '{CommonFormDropdown}' } = require('../../app/renderer/components/common/commonForm'){'\n'}
+            {'\n'}
+            &lt;CommonFormDropdown>{'\n'}
             &nbsp;&nbsp;&lt;option>Select Box&lt;/option>{'\n'}
             &nbsp;&nbsp;&lt;option>Second Choice&lt;/option>{'\n'}
             &nbsp;&nbsp;&lt;option>Third Choice&lt;/option>{'\n'}
-            &lt;/BraveryPanelDropdown>
+            &lt;/CommonFormDropdown>
           </Code></Pre>
         </Container>
 


### PR DESCRIPTION
Closes #11063

- Replace specific components with ones styled with data attirbutions

Auditors:

Test Plan:
1. Open about:styles
2. Click `dropdowns`
3. Make sure they are properly styled
4. Open about:autofill
5. Click `Add Address`
6. Make sure the country dropdown has 100% width

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


