### PR TITLE
make tabTitle work for gradient calc instead of tab

### DIFF
--- a/app/renderer/components/styles/theme.js
+++ b/app/renderer/components/styles/theme.js
@@ -10,11 +10,10 @@
   */
   module.exports.theme = {
     tab: {
-      // mimics chrome hover effect
       transition: `
-        background-color 200ms cubic-bezier(0.26, 0.63, 0.39, 0.65),
-        color 200ms cubic-bezier(0.26, 0.63, 0.39, 0.65)
-      `,
+      background-color 150ms cubic-bezier(0.26, 0.63, 0.39, 0.65),
+      color 150ms cubic-bezier(0.26, 0.63, 0.39, 0.65)
+    `,
       background: '#ddd',
       borderColor: '#bbb',
       color: '#5a5a5a',

--- a/app/renderer/components/tabs/content/newSessionIcon.js
+++ b/app/renderer/components/tabs/content/newSessionIcon.js
@@ -76,7 +76,7 @@ const styles = StyleSheet.create({
     animationDuration: '200ms',
     animationFillMode: 'forwards',
 
-    zIndex: globalStyles.zindex.zindexWindow,
+    zIndex: globalStyles.zindex.zindexTabsThumbnail,
     boxSizing: 'border-box',
     display: 'flex',
     alignItems: 'center',

--- a/app/renderer/components/tabs/content/privateIcon.js
+++ b/app/renderer/components/tabs/content/privateIcon.js
@@ -67,7 +67,7 @@ const styles = StyleSheet.create({
     animationDuration: '200ms',
     animationFillMode: 'forwards',
 
-    zIndex: globalStyles.zindex.zindexWindow,
+    zIndex: globalStyles.zindex.zindexTabsThumbnail,
     boxSizing: 'border-box',
     WebkitMaskRepeat: 'no-repeat',
     WebkitMaskPosition: 'center',

--- a/app/renderer/components/tabs/content/tabTitle.js
+++ b/app/renderer/components/tabs/content/tabTitle.js
@@ -36,6 +36,7 @@ class TabTitle extends React.Component {
     props.displayTitle = titleState.getDisplayTitle(currentWindow, frameKey)
     props.addExtraGutter = tabUIState.addExtraGutterToTitle(currentWindow, frameKey)
     props.isTextWhite = tabUIState.checkIfTextColor(currentWindow, frameKey, 'white')
+    props.gradientColor = tabUIState.getTabEndIconBackgroundColor(currentWindow, frameKey)
     props.tabId = tabId
 
     return props
@@ -45,10 +46,18 @@ class TabTitle extends React.Component {
     if (this.props.isPinned || !this.props.showTabTitle) {
       return null
     }
+    const perPageGradient = StyleSheet.create({
+      tab__title_gradient: {
+        '::after': {
+          background: this.props.gradientColor
+        }
+      }
+    })
 
     return <div data-test-id='tabTitle'
       className={css(
         styles.tab__title,
+        !this.props.isPinned && perPageGradient.tab__title_gradient,
         this.props.addExtraGutter && styles.tab__title_extraGutter,
         (this.props.isDarwin && this.props.isTextWhite) && styles.tab__title_isDarwin,
         // Windows specific style
@@ -72,7 +81,21 @@ const styles = StyleSheet.create({
     lineHeight: '1.6',
     minWidth: 0, // see https://stackoverflow.com/a/36247448/4902448
     marginLeft: '4px',
-    overflow: 'hidden'
+    overflow: 'hidden',
+
+    // this enable us to have gradient text
+    '::after': {
+      zIndex: globalStyles.zindex.zindexTabs,
+      content: '""',
+      position: 'absolute',
+      bottom: 0,
+      right: 0,
+      width: '-webkit-fill-available',
+      height: '-webkit-fill-available',
+      // add a pixel margin so the box-shadow of the
+      // webview is not covered by the gradient
+      marginBottom: '1px'
+    }
   },
 
   tab__title_isDarwin: {

--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -266,7 +266,6 @@ class Tab extends React.Component {
     props.partOfFullPageSet = partOfFullPageSet
     props.showAudioTopBorder = audioState.showAudioTopBorder(currentWindow, frameKey, isPinned)
     props.centralizeTabIcons = tabUIState.centralizeTabIcons(currentWindow, frameKey, isPinned)
-    props.gradientColor = tabUIState.getTabEndIconBackgroundColor(currentWindow, frameKey)
 
     // used in other functions
     props.dragData = state.getIn(['dragData', 'type']) === dragTypes.TAB && state.get('dragData')
@@ -285,13 +284,6 @@ class Tab extends React.Component {
         ':hover': {
           color: this.props.themeColor ? getTextColorForBackground(this.props.themeColor) : 'inherit',
           background: this.props.themeColor ? this.props.themeColor : 'inherit'
-        }
-      }
-    })
-    const perPageGradient = StyleSheet.create({
-      tab_gradient: {
-        '::after': {
-          background: this.props.gradientColor
         }
       }
     })
@@ -321,7 +313,6 @@ class Tab extends React.Component {
         ref={(node) => { this.tabNode = node }}
         className={css(
           styles.tab,
-          !this.props.isPinnedTab && perPageGradient.tab_gradient,
           // Windows specific style
           isWindows && styles.tab_forWindows,
           this.props.isPinnedTab && styles.tab_pinned,
@@ -381,17 +372,6 @@ const styles = StyleSheet.create({
 
     ':hover': {
       background: theme.tab.hover.background
-    },
-
-    // this enable us to have gradient text
-    '::before': {
-      zIndex: globalStyles.zindex.zindexTabs,
-      content: '""',
-      position: 'absolute',
-      bottom: 0,
-      right: 0,
-      width: '-webkit-fill-available',
-      height: '-webkit-fill-available'
     }
   },
 


### PR DESCRIPTION
Auditors: @luixxiul
Address #10691
Follow-up of sha 33c5d10c16624eade868e2150ee43b96384ed82c

In some rebase the gradient for titles got lost in #10691. 
It was made by a pseudo-class in tab but turns out moving that to tabTitle made transition seems faster.

Test plan:
1. Open some tabs, let some have background color (i.e. about:preferences, facebook, etc), some private/partition are good too.
2. They should have a gradient at the end of the text

(note the gradient at text's end)

<img width="187" alt="screen shot 2017-09-22 at 1 41 03 am" src="https://user-images.githubusercontent.com/4672033/30729593-2519528c-9f37-11e7-8000-701bf68fdd65.png">
<img width="187" alt="screen shot 2017-09-22 at 1 40 54 am" src="https://user-images.githubusercontent.com/4672033/30729594-251a1078-9f37-11e7-90ff-c1a25472d974.png">
