### PR TITLE
always return copy of parse url and remove option for query as object

### DIFF
--- a/app/common/urlParse.js
+++ b/app/common/urlParse.js
@@ -16,14 +16,13 @@ try {
 
 let cachedUrlParse = new LRUCache(config.cache.urlParse)
 
-module.exports = (url, ...args) => {
+module.exports = (url) => {
   let parsedUrl = cachedUrlParse.get(url)
-  if (parsedUrl) {
-    // make a copy so we don't alter the cached object with any changes
-    return Object.assign({}, parsedUrl)
+  if (parsedUrl == null) {
+    parsedUrl = urlParse(url)
+    cachedUrlParse.set(url, parsedUrl)
   }
 
-  parsedUrl = urlParse(url, ...args)
-  cachedUrlParse.set(url, parsedUrl)
-  return parsedUrl
+  // make a copy so we don't alter the cached object with any changes
+  return Object.assign({}, parsedUrl)
 }

--- a/js/webtorrent/entry.js
+++ b/js/webtorrent/entry.js
@@ -6,7 +6,6 @@ const path = require('path')
 const querystring = require('querystring')
 const React = require('react')
 const ReactDOM = require('react-dom')
-const urlFormat = require('url').format
 const WebTorrentRemoteClient = require('webtorrent-remote/client')
 
 const App = require('./components/app')
@@ -183,10 +182,12 @@ function stop () {
 }
 
 function saveTorrentFile () {
-  const parsedUrl = urlParse(store.torrentId, true)
-  parsedUrl.query.download = true
+  const parsedUrl = new window.URL(store.torrentId)
+  const search = parsedUrl.search ? parsedUrl.search.split('&') : []
+  parsedUrl.search = search.concat(['download=true']).join('&')
+
   const name = path.basename(parsedUrl.pathname) || 'untitled.torrent'
-  const href = urlFormat(parsedUrl)
+  const href = parsedUrl.href
 
   const a = document.createElement('a')
   a.rel = 'noopener'


### PR DESCRIPTION
fix #11101

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
As mentioned in the ticket there really isn't a good way to QA this

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


