### PR TITLE
Replace span with BrowserButton on urlbar.js, etc.

### DIFF
--- a/app/renderer/components/common/browserButton.js
+++ b/app/renderer/components/common/browserButton.js
@@ -113,6 +113,9 @@ const styles = StyleSheet.create({
     // cf: https://github.com/brave/browser-laptop/blob/548e11b1c889332fadb379237555625ad2a3c845/less/button.less#L49
     color: globalStyles.button.color,
 
+    // See #11111
+    WebkitAppRegion: 'no-drag',
+
     ':hover': {
       color: globalStyles.button.default.hoverColor
     }
@@ -181,7 +184,6 @@ const styles = StyleSheet.create({
   },
 
   browserButton_extensionItem: {
-    WebkitAppRegion: 'no-drag',
     backgroundSize: 'contain',
     height: '17px',
     margin: '4px 0 0 0',

--- a/app/renderer/components/navigation/publisherToggle.js
+++ b/app/renderer/components/navigation/publisherToggle.js
@@ -98,7 +98,6 @@ const styles = StyleSheet.create({
     width: globalStyles.spacing.buttonWidth,
     minHeight: globalStyles.spacing.buttonHeight,
     minWidth: globalStyles.spacing.buttonWidth,
-    WebkitAppRegion: 'no-drag',
     borderWidth: '1px 1px 1px 0px',
     borderStyle: 'solid',
     borderColor: globalStyles.color.urlBarOutline,

--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -11,6 +11,7 @@ const ipc = require('electron').ipcRenderer
 const ReduxComponent = require('../reduxComponent')
 const UrlBarSuggestions = require('./urlBarSuggestions')
 const UrlBarIcon = require('./urlBarIcon')
+const BrowserButton = require('../common/browserButton')
 
 // Actions
 const windowActions = require('../../../../js/actions/windowActions')
@@ -478,14 +479,14 @@ class UrlBar extends React.Component {
   }
 
   render () {
-    return <form
+    return <div
       className={cx({
         urlbarForm: true,
         [css(styles.urlbarForm_wide)]: this.props.isWideURLbarEnabled,
         noBorderRadius: this.props.publisherButtonVisible
       })}
-      action='#'
-      id='urlbar'>
+      id='urlbar'
+    >
       <div className='urlbarIconContainer'>
         <UrlBarIcon
           titleMode={this.props.titleMode}
@@ -531,10 +532,13 @@ class UrlBar extends React.Component {
         ? null
         : <span className={css(styles.noScriptContainer)}
           onClick={this.onNoScript}>
-          <span
-            data-l10n-id='noScriptButton'
-            data-test-id='noScriptButton'
-            className={css(styles.noScriptButton)} />
+          <BrowserButton
+            iconOnly
+            size='14px'
+            l10nId='noScriptButton'
+            testId='noScriptButton'
+            custom={styles.noScriptContainer__button}
+          />
         </span>
       }
       {
@@ -542,7 +546,7 @@ class UrlBar extends React.Component {
           ? <UrlBarSuggestions />
           : null
         }
-    </form>
+    </div>
   }
 }
 
@@ -553,12 +557,13 @@ const styles = StyleSheet.create({
     marginRight: '-8px',
     WebkitAppRegion: 'drag'
   },
-  noScriptButton: {
+
+  noScriptContainer__button: {
     WebkitAppRegion: 'no-drag',
     backgroundImage: `url(${iconNoScript})`,
-    width: '14px',
-    height: '14px',
-    border: '0px'
+
+    // Override the default value defined by browserButton on browserButton.js
+    backgroundSize: '14px'
   },
 
   urlbarForm_wide: {

--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -559,7 +559,6 @@ const styles = StyleSheet.create({
   },
 
   noScriptContainer__button: {
-    WebkitAppRegion: 'no-drag',
     backgroundImage: `url(${iconNoScript})`,
 
     // Override the default value defined by browserButton on browserButton.js


### PR DESCRIPTION
by replacing form with div. Input element does not have to have form as a parent.

Closes #8457
Closes #11111
Follow-up to #8410

Auditors: @cezaraugusto

Test Plan for #8457:
1. Run `npm run test -- --grep='can selectively allow scripts'`
2. disable scripts on twitter.com. the lock icon should not disappear
3. click noscript icon
4. open browser console. you should not see any CSP errors.

Test Plan for #11111 
1. Open brave.com
2. Enable NoScript
3. Enable an extension
4. Make sure NoScript button, the extension button, and publisher button is not draggable

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


