### PR TITLE
add CanvasRenderingContext2D.prototype.isPointInPath and 4 other meth…

### DIFF
--- a/app/extensions/brave/content/scripts/blockCanvasFingerprinting.js
+++ b/app/extensions/brave/content/scripts/blockCanvasFingerprinting.js
@@ -174,7 +174,7 @@ if (chrome.contentSettings.canvasFingerprinting == 'block') {
   }
 
   var methods = []
-  var canvasMethods = ['getImageData', 'getLineDash', 'measureText']
+  var canvasMethods = ['getImageData', 'getLineDash', 'measureText', 'isPointInPath']
   canvasMethods.forEach(function (method) {
     var item = {
       type: 'Canvas',
@@ -196,7 +196,8 @@ if (chrome.contentSettings.canvasFingerprinting == 'block') {
   })
 
   var webglMethods = ['getSupportedExtensions', 'getParameter', 'getContextAttributes',
-    'getShaderPrecisionFormat', 'getExtension', 'readPixels']
+    'getShaderPrecisionFormat', 'getExtension', 'readPixels', 'getUniformLocation',
+    'getAttribLocation']
   webglMethods.forEach(function (method) {
     var item = {
       type: 'WebGL',
@@ -223,6 +224,26 @@ if (chrome.contentSettings.canvasFingerprinting == 'block') {
     var item = {
       type: 'AudioContext',
       objName: 'AnalyserNode',
+      propName: method
+    }
+    methods.push(item)
+  })
+
+  var svgPathMethods = ['getTotalLength']
+  svgPathMethods.forEach(function (method) {
+    var item = {
+      type: 'SVG',
+      objName: 'SVGPathElement',
+      propName: method
+    }
+    methods.push(item)
+  })
+
+  var svgTextContentMethods = ['getComputedTextLength']
+  svgTextContentMethods.forEach(function (method) {
+    var item = {
+      type: 'SVG',
+      objName: 'SVGTextContentElement',
       propName: method
     }
     methods.push(item)


### PR DESCRIPTION
Fixes brave/browser-laptop#10288

This change would block the following 5 methods (presented below, with brief motivation for each).  Numbers for feature use / tracking use are taken from https://www.cs.uic.edu/%7Epsnyder/static/papers/Browser_Feature_Usage_on_the_Modern_Web.pdf

I've added a link to this paper in the [FP part of the wiki](https://github.com/brave/browser-laptop/wiki/Fingerprinting-Protection-Mode), along with a description of the SVG related methods.  I did not further discuss the canvas and WebGL related methods, since they're already mentioned.

`CanvasRenderingContext2D.prototype.isPointInPath`
- Is used in popular [live, popular fingerprinting code](https://github.com/Valve/fingerprintjs2/blob/master/fingerprint2.js#L673)
- Is infrequently used on the web (was observed on only 166 sites in the Alexa 10k)
- Is frequently blocked by anti-tracking tools (in the presence of Ghostery, it is only seen on 28 sites in the Alexa 10k, suggesting its used for tracking 83% of the time) 

`WebGLRenderingContext.prototype.getUniformLocation` and `WebGLRenderingContext.prototype.getAttribLocation`
- Are used in popular live, popular fingerprinting code, ([here](https://github.com/Valve/fingerprintjs2/blob/master/fingerprint2.js#L760) and [here](https://github.com/Valve/fingerprintjs2/blob/master/fingerprint2.js#L759), for example)
- Are infrequently used on the web (was observed on only 255 and 250 sites in the Alexa 10k, respectivly)
- Are frequently blocked by anti-tracking tools (in the presence of Ghostery, it is only seen on 44 and sites in the Alexa 10k, suggesting its used for tracking 82.75% and 82.4% of the time)
- Non-obvious use case (e.x.: its not obvious to see why you'd need to query these parameters out of the context, if you'd already set them)

`SVGPathElement.prototype.getTotalLength`
- Anecdotally Used in ways similar to canvas finger printing (font enumeration, getting subtle differences in rendering between platforms)
- Very infrequently used on the web (observed on 140 of the Alexa 10k)
- Very frequently associated with tracking (use goes down to only 2 sites, or a 98.57% reduction, in the presence of Ghostery)

`SVGTextContentElement.prototype.getComputedTextLength`
- Anecdotally Used in ways similar to canvas finger printing (font enumeration, getting subtle differences in rendering between platforms)
- Extremely associated with tracking (use goes from 1003 sites in the Alexa 10k, to 1, or a 99.9% reduction, in the presence of Ghostery)