### PR TITLE
extension icons should appear

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -3,7 +3,7 @@ const contextMenus = require('./browser/extensions/contextMenus')
 const extensionActions = require('./common/actions/extensionActions')
 const config = require('../js/constants/config')
 const appConfig = require('../js/constants/appConfig')
-const {fileUrl} = require('../js/lib/appUrlUtil')
+const {chromeUrl} = require('../js/lib/appUrlUtil')
 const {getExtensionsPath, getBraveExtUrl, getBraveExtIndexHTML} = require('../js/lib/appUrlUtil')
 const {getSetting} = require('../js/settings')
 const settings = require('../js/constants/settings')
@@ -407,7 +407,9 @@ module.exports.init = () => {
     extensionInfo.setState(installInfo.id, extensionStates.ENABLED)
     extensionInfo.setInstallInfo(installInfo.id, installInfo)
     installInfo.filePath = installInfo.base_path
-    installInfo.base_path = fileUrl(installInfo.base_path)
+
+    installInfo.base_path = chromeUrl(installInfo.base_path)
+
     extensionActions.extensionInstalled(installInfo.id, installInfo)
     extensionActions.extensionEnabled(installInfo.id)
   })

--- a/js/lib/appUrlUtil.js
+++ b/js/lib/appUrlUtil.js
@@ -24,6 +24,13 @@ module.exports.fileUrl = (filePath) => {
   return encodeURI('file://' + fileUrlPath)
 }
 
+module.exports.chromeUrl = (filePath = '') => {
+  filePath = module.exports.fileUrl(filePath)
+  filePath = filePath.replace('file://', 'chrome://brave')
+
+  return filePath
+}
+
 /**
  * Gets the URL of a page hosted by the braveExtension or torrentExtension
  * Returns 'chrome-extension://<...>'

--- a/test/unit/lib/appUrlUtilTest.js
+++ b/test/unit/lib/appUrlUtilTest.js
@@ -79,6 +79,14 @@ describe('appUrlUtil test', function () {
       assert.equal(fileUrl, expected)
     })
   })
+  describe('chromeUrl', function () {
+    it('can convert file paths', function () {
+      const filePath = '/users/bbondy/space here/tesT.html'
+      const chromeUrl = appUrlUtil.chromeUrl(filePath)
+      const expected = 'chrome://brave/users/bbondy/space%20here/tesT.html'
+      assert.equal(chromeUrl, expected)
+    })
+  })
   describe('newFrameUrl', function () {
     describe('when NEWTAB_MODE = HOMEPAGE', function () {
       it('returns the configured home page', function () {


### PR DESCRIPTION
changes `file://` to `chrome://brave` for extension icon loading

Issue brave/browser-laptop#11142

Auditors:
@bridiver @diracdeltas @darkdh @jonathansampson