### PR TITLE
Add conditional to download and apply RELEASES file on Windows

### DIFF
--- a/app/updater.js
+++ b/app/updater.js
@@ -187,6 +187,9 @@ var downloadHandler = (err, metadata) => {
   if (process.platform === 'win32') {
     // check versions to see if an update is required
     if (metadata) {
+      if (metadata.braveURL) {
+        autoUpdater.setFeedURL(metadata.braveURL)
+      }
       autoUpdater.checkForUpdates()
     } else {
       autoUpdater.emit(messages.UPDATE_NOT_AVAILABLE)


### PR DESCRIPTION
Add conditional to download and apply RELEASES file on Windows
if the braveURL attribute is set in the metadata response. This will
download the version specified, not the latest version as is happening
before this commit.

Auditors: @bbondy, @clifton

fixes: #11152

## Test plan:

  * Change version in package.json to something lower than current
  * Build browser on Windows
  * Install and check for updates
  * Ensure the following line is shown in SquirrelSetup.log
    It must contain a version number (0.19.16 in example below)

2017-09-25 18:04:13> CheckForUpdateImpl: Downloading RELEASES file from
https://brave-download.global.ssl.fastly.net/multi-channel/releases/beta/0.19.16/winx64

## Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Ran `git rebase -i` to squash commits (if needed).
- [X] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
