### PR TITLE
Don't remove url suffix when suggestion is selected

### DIFF
--- a/app/renderer/reducers/urlBarReducer.js
+++ b/app/renderer/reducers/urlBarReducer.js
@@ -269,9 +269,11 @@ const urlBarReducer = (state, action) => {
     case windowConstants.WINDOW_SET_RENDER_URL_BAR_SUGGESTIONS:
       state = setRenderUrlBarSuggestions(state, action.enabled)
       break
-    case windowConstants.WINDOW_ACTIVE_URL_BAR_SUGGESTION_CLICKED:
-      const selectedIndex = state.getIn(activeFrameStatePath(state).concat(['navbar', 'urlbar', 'suggestions', 'selectedIndex'])) || 0
-      const suggestionList = state.getIn(activeFrameStatePath(state).concat(['navbar', 'urlbar', 'suggestions', 'suggestionList']))
+    case windowConstants.WINDOW_ACTIVE_URL_BAR_SUGGESTION_CLICKED: {
+      const activeFramePath = activeFrameStatePath(state)
+      const selectedIndex = state.getIn(activeFramePath.concat(['navbar', 'urlbar', 'suggestions', 'selectedIndex'])) || 0
+      const suggestionList = state.getIn(activeFramePath.concat(['navbar', 'urlbar', 'suggestions', 'suggestionList']))
+      state = state.setIn(activeFramePath.concat(['navbar', 'urlbar', 'suggestions', 'autocompleteEnabled']), false)
       if (suggestionList.size > 0) {
         // It's important this doesn't run sync or else the returned state below will overwrite anything done in the click handler
         setImmediate(() => {
@@ -280,6 +282,7 @@ const urlBarReducer = (state, action) => {
         })
       }
       break
+    }
     case windowConstants.WINDOW_ON_STOP:
       if (action.isFocused) {
         state = setActive(state, false)

--- a/test/unit/app/renderer/reducers/urlBarReducerTest.js
+++ b/test/unit/app/renderer/reducers/urlBarReducerTest.js
@@ -319,6 +319,11 @@ describe('urlBarReducer', function () {
         urlBarReducer(inputState, {actionType: windowConstants.WINDOW_ACTIVE_URL_BAR_SUGGESTION_CLICKED})
         assert.equal(this.suggestionClickHandlers.navigateSiteClickHandler.callCount, 0)
       })
+      it('sets the urlbar to disabled', function () {
+        const inputState = windowState.setIn(['frames', 1, 'navbar', 'urlbar', 'suggestions', 'suggestionList', Immutable.fromJS([{location: 'https://www.brave.com'}])])
+        const newState = urlBarReducer(inputState, {actionType: windowConstants.WINDOW_ACTIVE_URL_BAR_SUGGESTION_CLICKED})
+        assert.equal(newState.getIn(['frames', 1, 'navbar', 'urlbar', 'suggestions', 'autocompleteEnabled']), false)
+      })
     })
   })
 })


### PR DESCRIPTION
The bug is because of this section in urlBar component's `componentDidUpdate`:

```
    } else if (this.props.autocompleteEnabled &&
        this.props.normalizedSuggestion !== prevProps.normalizedSuggestion) {
      this.updateAutocomplete(this.lastVal)
    // This case handles when entering urlmode from tilemode
    }
```

In this case there is no suggestion because we emptied it out so we shouldn't clear what the user typed in yet.

Fix #11060

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


