### PR TITLE
Remove perWindowState from immutableData if there are no frames in it

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -431,13 +431,12 @@ module.exports.cleanAppData = (immutableData, isShutdown) => {
   }
 
   // Remove windowState from perWindowState if there are no frames
+  // ex: if window only had a single private tab, let's remove it (they aren't saved)
   if (perWindowStateList) {
     perWindowStateList.forEach((immutablePerWindowState, i) => {
-      if (isMap(immutablePerWindowState)) {
-        if (immutablePerWindowState.has('frames')) {
-          if (!immutablePerWindowState.get('frames').size) {
-            immutableData = immutableData.deleteIn(['perWindowState', i])
-          }
+      if (isMap(immutablePerWindowState) && immutablePerWindowState.has('frames')) {
+        if (!immutablePerWindowState.get('frames').size) {
+          immutableData = immutableData.deleteIn(['perWindowState', i])
         }
       }
     })

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -39,7 +39,7 @@ const autofill = require('./autofill')
 const {navigatableTypes} = require('../js/lib/appUrlUtil')
 const Channel = require('./channel')
 const BuildConfig = require('./buildConfig')
-const {isImmutable, makeImmutable, deleteImmutablePaths} = require('./common/state/immutableUtil')
+const {isImmutable, isMap, makeImmutable, deleteImmutablePaths} = require('./common/state/immutableUtil')
 const {getSetting} = require('../js/settings')
 const platformUtil = require('./common/lib/platformUtil')
 const historyUtil = require('./common/lib/historyUtil')
@@ -428,6 +428,19 @@ module.exports.cleanAppData = (immutableData, isShutdown) => {
 
   if (immutableData.hasIn(['ledger', 'locations'])) {
     immutableData = immutableData.deleteIn(['ledger', 'locations'])
+  }
+
+  // Remove windowState from perWindowState if there are no frames
+  if (perWindowStateList) {
+    perWindowStateList.forEach((immutablePerWindowState, i) => {
+      if (isMap(immutablePerWindowState)) {
+        if (immutablePerWindowState.has('frames')) {
+          if (!immutablePerWindowState.get('frames').size) {
+            immutableData = immutableData.deleteIn(['perWindowState', i])
+          }
+        }
+      }
+    })
   }
 
   return immutableData

--- a/test/unit/app/sessionStoreTest.js
+++ b/test/unit/app/sessionStoreTest.js
@@ -378,15 +378,35 @@ describe('sessionStore unit tests', function () {
     })
 
     describe('if perWindowState is present', function () {
+      let cleanPerWindowDataStub
+      before(function () {
+        cleanPerWindowDataStub = sinon.stub(sessionStore, 'cleanPerWindowData', (state) => state)
+      })
+      after(function () {
+        cleanPerWindowDataStub.restore()
+      })
       it('calls cleanPerWindowData for each item', function () {
-        const cleanPerWindowDataStub = sinon.stub(sessionStore, 'cleanPerWindowData')
         const data = Immutable.fromJS({
           perWindowState: ['window1', 'window2']
         })
         sessionStore.cleanAppData(data, 'IS_SHUTDOWN_VALUE')
         assert.equal(cleanPerWindowDataStub.withArgs('window1', 'IS_SHUTDOWN_VALUE').calledOnce, true)
         assert.equal(cleanPerWindowDataStub.withArgs('window2', 'IS_SHUTDOWN_VALUE').calledOnce, true)
-        cleanPerWindowDataStub.restore()
+      })
+
+      it('removes state for windows which have no frames', function () {
+        let data = Immutable.fromJS({
+          perWindowState: [{
+            id: 1,
+            frames: []
+          }, {
+            id: 2,
+            frames: [1, 2, 3]
+          }]
+        })
+        const result = sessionStore.cleanAppData(data)
+        assert.equal(result.get('perWindowState').size, 1)
+        assert.equal(result.getIn(['perWindowState', 0, 'id']), 2)
       })
     })
 


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Test Plan:
- Open Browser
- Create 2 tabs and navigate to websites of your choice
- Create a private tab and navigate to a website of your choice
- Tear off the private tab so it creates a new window
- Quit the browser
- Reopen the browser and only 1 window should show up

Fixes #10768 

## Reviewer Checklist:
@bsclifton 

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


