### PR TITLE
Fix phantom tab crashes

### DIFF
--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -118,11 +118,15 @@ class Tab extends React.Component {
   }
 
   onDragStart (e) {
-    dnd.onDragStart(dragTypes.TAB, this.frame, e)
+    if (this.frame) {
+      dnd.onDragStart(dragTypes.TAB, this.frame, e)
+    }
   }
 
   onDragEnd (e) {
-    dnd.onDragEnd(dragTypes.TAB, this.frame, e)
+    if (this.frame) {
+      dnd.onDragEnd(dragTypes.TAB, this.frame, e)
+    }
   }
 
   onDragOver (e) {

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -378,6 +378,10 @@ function autofillTemplateInit (suggestions, frame) {
 }
 
 function tabTemplateInit (frameProps) {
+  if (!frameProps) {
+    return null
+  }
+
   const frameKey = frameProps.get('key')
   const tabId = frameProps.get('tabId')
   const template = [CommonMenu.newTabMenuItem(frameProps.get('tabId'))]
@@ -1211,8 +1215,11 @@ function onMainContextMenu (nodeProps, frame, tab, contextMenuType) {
 
 function onTabContextMenu (frameProps, e) {
   e.stopPropagation()
-  const tabMenu = Menu.buildFromTemplate(tabTemplateInit(frameProps))
-  tabMenu.popup(getCurrentWindow())
+  const template = tabTemplateInit(frameProps)
+  if (template) {
+    const tabMenu = Menu.buildFromTemplate(template)
+    tabMenu.popup(getCurrentWindow())
+  }
 }
 
 function onNewTabContextMenu (target) {


### PR DESCRIPTION
Add extra checks to ensure that a crash doesn't happen in an edge case with "phantom tab" (which has null frame)

Related to https://github.com/brave/browser-laptop/issues/11070

Fixes https://github.com/brave/browser-laptop/issues/11183

Auditors: @darkdh

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Test Plan:
See https://github.com/brave/browser-laptop/issues/11183

## Reviewer Checklist:

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

## Merge Checklist:
- [ ] Merge to 0.19.x
- [ ] Merge to 0.20.x
- [ ] Merge to master