### PR TITLE
Fix 'blocks custom adblock resources' tests

### DIFF
--- a/test/bravery-components/braveryPanelTest.js
+++ b/test/bravery-components/braveryPanelTest.js
@@ -334,7 +334,8 @@ describe('Bravery Panel', function () {
         .tabByIndex(0)
         .loadUrl(aboutAdblockURL)
         .waitForVisible(customFiltersInput)
-        .click(customFiltersInput)
+        .setValue(customFiltersInput, '')
+        .waitForInputText(customFiltersInput, '')
         .typeText(customFiltersInput, 'testblock.brave.com')
         .windowByUrl(Brave.browserWindowUrl)
         .waitUntil(function () {
@@ -385,7 +386,8 @@ describe('Bravery Panel', function () {
         .loadUrl(aboutAdblockURL)
         .url(aboutAdblockURL)
         .waitForVisible(customFiltersInput)
-        .click(customFiltersInput)
+        .setValue(customFiltersInput, '')
+        .waitForInputText(customFiltersInput, '')
         .typeText(customFiltersInput, 'testblock.brave.com')
         .windowByUrl(Brave.browserWindowUrl)
         .waitUntil(function () {


### PR DESCRIPTION
Fixes #11184

Auditors:

Test Plan:
1. Run `npm run test -- --grep='Bravery Panel Adblock stats without iframe tests blocks custom adblock resources'`
2. Make sure it passes

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


