### PR TITLE
Using souceFrameIndex because new frame hasn't showed up in frames

### DIFF
--- a/app/renderer/reducers/frameReducer.js
+++ b/app/renderer/reducers/frameReducer.js
@@ -120,30 +120,30 @@ const frameReducer = (state, action, immutableAction) => {
       const pinned = immutableAction.getIn(['changeInfo', 'pinned'])
       if (pinned != null) {
         if (pinned) {
-          state = state.setIn(['frames', index, 'pinnedLocation'], tab.get('url'))
+          state = state.setIn(['frames', sourceFrameIndex, 'pinnedLocation'], tab.get('url'))
         } else {
-          state = state.deleteIn(['frames', index, 'pinnedLocation'])
+          state = state.deleteIn(['frames', sourceFrameIndex, 'pinnedLocation'])
         }
       }
       // handle pinned tabs that are created as pinned
       const url = immutableAction.getIn(['changeInfo', 'url'])
       if (url != null && tab.get('pinned') === true) {
-        const pinnedLocation = state.getIn(['frames', index, 'pinnedLocation'])
+        const pinnedLocation = state.getIn(['frames', sourceFrameIndex, 'pinnedLocation'])
         if (!pinnedLocation || pinnedLocation === 'about:blank' || pinnedLocation === '') {
-          state = state.setIn(['frames', index, 'pinnedLocation'], tab.get('url'))
+          state = state.setIn(['frames', sourceFrameIndex, 'pinnedLocation'], tab.get('url'))
         }
       }
 
       const title = tab.get('title')
       if (title != null) {
-        state = state.setIn(['frames', index, 'title'], title)
+        state = state.setIn(['frames', sourceFrameIndex, 'title'], title)
       }
 
       const active = tab.get('active')
       if (active != null) {
         if (active) {
           state = frameStateUtil.setActiveFrameKey(state, frame.get('key'))
-          state = frameStateUtil.setFrameLastAccessedTime(state, index)
+          state = frameStateUtil.setFrameLastAccessedTime(state, sourceFrameIndex)
 
           // Handle tabPage updates and preview cancelation based on tab updated
           // otherwise tabValue will fire those events each time a tab finish loading

--- a/test/unit/app/renderer/reducers/frameReducerTest.js
+++ b/test/unit/app/renderer/reducers/frameReducerTest.js
@@ -291,6 +291,18 @@ describe('frameReducer', function () {
         // Old index 2 moves 1 to the left
         assert.equal(this.newState.toJS().frames[1].tabId, windowState.toJS().frames[2].tabId)
       })
+      it('new frame has not showed up in frames', function () {
+        const action = {
+          actionType: appConstants.APP_TAB_UPDATED,
+          tabValue: {
+            tabId: 13,
+            index: 3,
+            title: 'Bondy Power!'
+          }
+        }
+        this.newState = frameReducer(windowState, action, Immutable.fromJS(action))
+        assert.equal(this.newState.toJS().frames.length, windowState.toJS().frames.length)
+      })
     })
     describe('when pinned status changes', function () {
       // TODO(bbondy): Noticed this is missing while in the context of fixing an unrelated thing.


### PR DESCRIPTION
fix #11070

Auditors: @bbondy, @bsclifton

Test Plan: Covered by unittest

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


