### PR TITLE
fix ghost tab after tab page close

### DIFF
--- a/app/renderer/reducers/frameReducer.js
+++ b/app/renderer/reducers/frameReducer.js
@@ -113,6 +113,9 @@ const frameReducer = (state, action, immutableAction) => {
         if (activeFrame) {
           // Update tab page index to the active tab in case the active tab changed
           state = frameStateUtil.updateTabPageIndex(state, activeFrame.get('tabId'))
+          // after tabPageIndex is updated we need to update framesInternalIndex too
+          state = frameStateUtil
+            .updateFramesInternalIndex(state, Math.min(sourceFrameIndex, index))
         }
         state = frameStateUtil.setPreviewFrameKey(state, null)
       }

--- a/js/state/frameStateUtil.js
+++ b/js/state/frameStateUtil.js
@@ -63,7 +63,7 @@ function getPinnedFrames (state) {
 }
 
 function getNonPinnedFrames (state) {
-  return state.get('frames').filter((frame) => !frame.get('pinnedLocation'))
+  return state.get('frames').filter((frame) => !frame.get('pinnedLocation')) || Immutable.List()
 }
 
 function getFrameIndex (state, frameKey) {

--- a/test/tab-components/tabPagesTest.js
+++ b/test/tab-components/tabPagesTest.js
@@ -14,6 +14,7 @@ const {
   tabPage2,
   activeWebview,
   activeTab,
+  activeTabTitle,
   tabsTab,
   closeTab
 } = require('../lib/selectors')
@@ -45,6 +46,24 @@ describe('tab pages', function () {
     it('shows 2 tab pages when there are more than 1 page worth of tabs', function * () {
       yield this.app.client.click(newFrameButton)
         .waitForElementCount(tabPage, 2)
+    })
+
+    it('sets a new active tab when closed tab page includes the last active tab', function * () {
+      yield this.app.client
+      .newTab({ url: 'about:blank', active: false })
+      .waitForElementCount(tabPage, 2)
+      .waitForExist(tabPage1 + '.active')
+      .waitForExist(tabPage2)
+      .moveToObject(tabPage2, 5, 5)
+      .click(tabPage2)
+      .waitForExist(tabPage2 + '.active')
+      .moveToObject(tabPage1, 5, 5)
+      // close first tab page
+      .middleClick(tabPage1)
+      .waitForElementCount(tabPage, 0)
+      .waitForExist(activeTab)
+      .moveToObject(activeTab)
+      .waitForTextValue(activeTabTitle, 'Untitled')
     })
 
     it('shows no tab pages when you have only 1 page', function * () {


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

fix #11028
address #11091

Auditors: @bsclifton 

> Heads-up this needs #11228 for tests to pass. There's no way ATM to test a closed tab page, which that PR addresses. Functionality is not dependent so you're free to manually test and it should work.

Test Plan:

```
npm run test -- --grep="sets a new active tab when closed tab page includes the last active tab"
```

Manual Test Plan (cc @luixxiul, @srirambv):

1. set max tabs to 6
2. open a new tab so you have 2 tab pages
3. go to a known website (like brave.com)
4. go back to first tab page, set any tab in there as active
5. switch back to tab page 2. This tab page should have no active tab
6. close the first tab page by right click->close
7. You should see the site you defined in step 3 and not a blank dead page

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


