### PR TITLE
Wait 10 seconds to make sure browser instances are closed

### DIFF
--- a/test/about/ledgerPanelTest.js
+++ b/test/about/ledgerPanelTest.js
@@ -174,7 +174,8 @@ describe('Regular payment panel tests', function () {
         .waitForElementCount('[data-tbody-index="1"] tr', 2)
         .click(walletSwitch)
         .waitForElementCount(addFundsButton, 0)
-      yield Brave.stopApp(false)
+      // See: #10490
+      yield Brave.stopApp(false, 10000)
 
       yield Brave.startApp()
       yield setupBrave(Brave.app.client)
@@ -218,7 +219,7 @@ describe('Regular payment panel tests', function () {
         .click(securityTab)
         .waitForVisible('[data-test-id="clearBrowsingHistory"]')
         .click('[data-test-id="clearBrowsingHistory"] .switchBackground')
-      yield Brave.stopApp(false)
+      yield Brave.stopApp(false, 10000)
 
       yield Brave.startApp()
       yield setupBrave(Brave.app.client)
@@ -263,7 +264,7 @@ describe('Regular payment panel tests', function () {
         .click(securityTab)
         .waitForVisible('[data-test-id="clearBrowsingHistory"]')
         .click('[data-test-id="clearBrowsingHistory"] .switchBackground')
-      yield Brave.stopApp(false)
+      yield Brave.stopApp(false, 10000)
 
       yield Brave.startApp()
       yield setupBrave(Brave.app.client)

--- a/test/app/sessionStoreTest.js
+++ b/test/app/sessionStoreTest.js
@@ -60,7 +60,8 @@ describe('sessionStore test', function () {
         .waitForExist(navigatorNotBookmarked)
         .addBookmark(site)
         .waitForExist(navigatorBookmarked)
-      yield Brave.stopApp(false)
+      // See: #10490
+      yield Brave.stopApp(false, 10000)
       yield Brave.startApp()
       yield setupBrave(Brave.app.client)
     })
@@ -107,8 +108,8 @@ describe('sessionStore test', function () {
         .waitForExist(navigatorNotBookmarked)
         .addBookmark(site)
         .waitForExist(navigatorBookmarked)
-
-      yield Brave.stopApp(false)
+      // See: #10490
+      yield Brave.stopApp(false, 10000)
       yield Brave.startApp()
       yield setupBrave(Brave.app.client)
 
@@ -121,7 +122,7 @@ describe('sessionStore test', function () {
         .newTab({active: false})
         .waitForTabCount(2)
         .waitForBrowserWindow()
-
+      // See: #10490
       yield Brave.stopApp(false, 10000)
       yield Brave.startApp()
       yield setupBrave(Brave.app.client)
@@ -180,7 +181,8 @@ describe('sessionStore test', function () {
           .waitForElementCount(tabsTabs, 2)
           .activateTabByIndex(1)
           .waitForExist(this.activeTabSelector, 30000)
-        yield Brave.stopApp(false)
+        // See: #10490
+        yield Brave.stopApp(false, 10000)
         yield Brave.startApp()
         yield setupBrave(Brave.app.client)
       })
@@ -219,7 +221,8 @@ describe('sessionStore test', function () {
           .waitForElementCount(pinnedTabsTabs, 1)
           .waitForElementCount(tabsTabs, 1)
           .waitForExist(this.activeTabSelector)
-        yield Brave.stopApp(false)
+        // See: #10490
+        yield Brave.stopApp(false, 10000)
         yield Brave.startApp()
         yield setupBrave(Brave.app.client)
       })
@@ -265,7 +268,8 @@ describe('sessionStore test', function () {
           })
         })
 
-      yield Brave.stopApp(false)
+      // See: #10490
+      yield Brave.stopApp(false, 10000)
       yield Brave.startApp()
       yield setupBrave(Brave.app.client)
       yield Brave.app.client
@@ -309,7 +313,8 @@ describe('sessionStore test', function () {
         .waitForBrowserWindow()
         .changeSetting(settings.STARTUP_MODE, startsWithOption.WINDOWS_TABS_FROM_LAST_TIME)
 
-      yield Brave.stopApp(false)
+      // See: #10490
+      yield Brave.stopApp(false, 10000)
       yield Brave.startApp()
       yield setupBrave(Brave.app.client)
       yield setup(Brave.app.client)
@@ -323,7 +328,8 @@ describe('sessionStore test', function () {
         .waitForBrowserWindow()
         .changeSetting(settings.STARTUP_MODE, startsWithOption.HOMEPAGE)
 
-      yield Brave.stopApp(false)
+      // See: #10490
+      yield Brave.stopApp(false, 10000)
       yield Brave.startApp()
       yield setupBrave(Brave.app.client)
       yield setup(Brave.app.client)
@@ -337,7 +343,8 @@ describe('sessionStore test', function () {
         .waitForBrowserWindow()
         .changeSetting(settings.STARTUP_MODE, startsWithOption.NEW_TAB_PAGE)
 
-      yield Brave.stopApp(false)
+      // See: #10490
+      yield Brave.stopApp(false, 10000)
       yield Brave.startApp()
       yield setupBrave(Brave.app.client)
       yield setup(Brave.app.client)

--- a/test/misc-components/syncTest.js
+++ b/test/misc-components/syncTest.js
@@ -569,7 +569,7 @@ describe('Syncing bookmarks from an existing profile', function () {
     yield Brave.app.client.pause(1000)
 
     // Finally start a fresh profile and setup sync
-    yield Brave.stopApp()
+    yield Brave.stopApp(false, 10000)
     yield Brave.startApp()
     yield setupBrave(Brave.app.client)
     yield setupSync(Brave.app.client, this.seed)


### PR DESCRIPTION
There are several cases where a new browser instance starts with .startApp() before the existing instance is completely closed with .stopApp(). Adding 10 seconds delay should almost assure that the existing instance is closed before new one starts on a slow machine.

Closes #10490

Auditors:

Test Plan:
1. Run `npm run test -- --grep='sessionStore test'`
1. Run `npm run test -- --grep='ledger history'`
2. Check the Travis result as well

    https://travis-ci.org/brave/browser-laptop/jobs/286708254#L3528

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


