### PR TITLE
Improve install instructions for Linux Mint

### DIFF
--- a/docs/linuxInstall.md
+++ b/docs/linuxInstall.md
@@ -8,15 +8,19 @@ to [enable userns in your kernel](https://superuser.com/questions/1094597/enable
 
 ## Snapcraft
 
-According to [snapcraft.io](https://snapcraft.io/)
-> Snaps are quick to install, easy to create, safe to run, and they update automatically and transactionally so your app is always fresh and never broken.
+According to [snapcraft.io](https://snapcraft.io/):
 
-Installation instructions for `snapd` [can be found here](https://snapcraft.io/docs/core/install). Once `snapd` is installed, installing Brave looks like this:
+> Snaps are quick to install, easy to create, safe to run, and they update
+automatically and transactionally so your app is always fresh and never broken.
 
-    snap install brave --beta
+Installation instructions for `snapd` [can be found here](https://snapcraft.io/docs/core/install).
+Once `snapd` is installed, installing Brave looks like this:
 
-## Debian (jessie) and Ubuntu (Artful, Zesty, Yakkety, Xenial, and Trusty) AMD64:
-To install brave using apt and lsb\_release :
+    snap install Brave --beta
+
+## Debian (Jessie) and Ubuntu (Artful, Zesty, Yakkety, Xenial, and Trusty) AMD64:
+
+To install Brave using apt and lsb\_release :
 
 ```
 curl https://s3-us-west-2.amazonaws.com/brave-apt/keys.asc | sudo apt-key add -
@@ -31,29 +35,81 @@ sudo apt install brave
 ```
 
 To install the latest which also often has early staging builds:
+
 ```
 curl https://s3-us-west-2.amazonaws.com/brave-apt-staging/keys.asc | sudo apt-key add -
 echo "deb [arch=amd64] https://s3-us-west-2.amazonaws.com/brave-apt-staging `lsb_release -sc` main" | sudo tee -a /etc/apt/sources.list.d/brave-`lsb_release -sc`.list
 ```
 
 Upgrades can be done via:
+
 ```
 apt-get update && apt-get upgrade -y
 ```
 
-Alternatively you can install the deb directly but then you won't get automatic upgrades:
+Alternatively you can install the deb directly but then you won't get automatic
+upgrades:
 
 ```
 wget -O brave.deb https://laptop-updates.brave.com/latest/dev/debian64
 sudo apt-get install -y gdebi && sudo gdebi brave.deb
 ```
-or for Ubuntu
+
+Or for Ubuntu
+
 ```
 wget -O brave.deb https://laptop-updates.brave.com/latest/dev/ubuntu64
 sudo dpkg -i brave.deb
 ```
 
-or for Mint
+If there are dependency errors during `dpkg -i`, the following command will
+install the dependency for you:
+
+```
+sudo apt-get -f install
+```
+
+## Linux Mint
+
+Brave does not currently support an apt repository for Linux Mint directly, but
+you can use the corresponding Ubuntu package. Using the lsb\_release method
+above will return an error during `apt update`.
+
+For Sarah, Serena and Sonya:
+
+```
+curl https://s3-us-west-2.amazonaws.com/brave-apt/keys.asc | sudo apt-key add -
+echo "deb [arch=amd64] https://s3-us-west-2.amazonaws.com/brave-apt xenial main" | sudo tee -a /etc/apt/sources.list.d/brave-xenial.list
+```
+
+Or for Qiana, Rebecca, Rafaela and Rosa:
+
+```
+curl https://s3-us-west-2.amazonaws.com/brave-apt/keys.asc | sudo apt-key add -
+echo "deb [arch=amd64] https://s3-us-west-2.amazonaws.com/brave-apt trusty main" | sudo tee -a /etc/apt/sources.list.d/brave-trusty.list
+```
+
+Or for LMDE Betsy:
+
+```
+curl https://s3-us-west-2.amazonaws.com/brave-apt/keys.asc | sudo apt-key add -
+echo "deb [arch=amd64] https://s3-us-west-2.amazonaws.com/brave-apt jessie main" | sudo tee -a /etc/apt/sources.list.d/brave-jessie.list
+```
+
+Then install Brave with:
+
+```
+sudo apt update
+sudo apt install brave
+```
+
+Upgrades can be done via:
+
+```
+apt-get update && apt-get upgrade -y
+```
+
+Alternatively you can install the deb directly but then you won't get automatic upgrades:
 
 ```
 wget -O brave.deb https://laptop-updates.brave.com/latest/mint64
@@ -62,13 +118,14 @@ sudo dpkg -i ./brave.deb
 
 If there are dependency errors during `dpkg -i`, the following command will
 install the dependency for you:
+
 ```
 sudo apt-get -f install
 ```
 
 ## Fedora x86_64:
 
-To install brave using dnf:
+To install Brave using dnf:
 
 ```
 sudo dnf config-manager --add-repo https://s3-us-west-2.amazonaws.com/brave-rpm-release/x86_64/
@@ -76,12 +133,11 @@ sudo rpm --import https://s3-us-west-2.amazonaws.com/brave-rpm-release/keys.asc
 sudo dnf install brave
 ```
 
-To update brave using dnf:
+To update Brave using dnf:
 
 ```
 dnf upgrade brave
 ```
-
 
 Alternatively you can install the rpm directly, but then you won't get automatic upgrades:
 
@@ -93,7 +149,7 @@ sudo dnf install ./brave.rpm
 
 ## OpenSUSE AMD64:
 
-To install brave using zypper:
+To install Brave using zypper:
 
 ```
 sudo rpmkeys --import https://s3-us-west-2.amazonaws.com/brave-rpm-release/keys.asc
@@ -103,7 +159,7 @@ sudo zypper ref
 sudo zypper install brave
 ```
 
-To update brave using zypper:
+To update Brave using zypper:
 
 ```
 sudo zypper ref


### PR DESCRIPTION
The `lsb_release` method doesn't work for Mint since it's not
explicitly supported. This adds instructions for using the upstream
Ubuntu name instead.

Also a couple of formatting changes (no content change), and the word Brave was capitalized.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
  - #6446
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
  - see below
- [x] Ran `git rebase -i` to squash commits (if needed).
  - not needed
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:

Since this is a text documentation file only, I didn't run any tests. If there are some to run, please let me know, I'd be happy run them.

Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


