### PR TITLE
Disable the url bar on activeTabShowingMessageBox

### DIFF
--- a/app/renderer/components/navigation/navigationBar.js
+++ b/app/renderer/components/navigation/navigationBar.js
@@ -50,7 +50,7 @@ class NavigationBar extends React.Component {
     const locationCache = bookmarkLocationCache.getCacheKey(state, location)
 
     const hasTitle = title && location && title !== location.replace(/^https?:\/\//, '')
-    const titleMode = activeTabShowingMessageBox ||
+    const titleMode =
       (
         mouseInTitlebar === false &&
         bookmarkDetail.isEmpty() &&
@@ -65,6 +65,7 @@ class NavigationBar extends React.Component {
     const props = {}
     // used in renderer
     props.activeFrameKey = activeFrameKey
+    props.activeTabShowingMessageBox = activeTabShowingMessageBox
     props.titleMode = titleMode
     props.isWideUrlBarEnabled = getSetting(settings.WIDE_URL_BAR)
     props.showBookmarkHanger = bookmarkDetail.get('isBookmarkHanger', false)
@@ -85,7 +86,7 @@ class NavigationBar extends React.Component {
       data-frame-key={this.props.activeFrameKey}
       className={cx({
         titleMode: this.props.titleMode,
-        [css(styles.navigator_wide)]: this.props.isWideUrlBarEnabled
+        [css(this.props.activeTabShowingMessageBox && styles.navigator_isActiveTabShowingMessageBox, this.props.isWideUrlBarEnabled && styles.navigator_wide)]: true
       })}>
       {
         this.props.showBookmarkHanger
@@ -118,8 +119,13 @@ class NavigationBar extends React.Component {
 }
 
 const styles = StyleSheet.create({
-  navigator_wide: {
+  navigator_isActiveTabShowingMessageBox: {
+    // See browserButton_disabled and braveMenu_disabled
+    opacity: 0.25,
+    pointerEvents: 'none'
+  },
 
+  navigator_wide: {
     // TODO: Refactor navigationBar.js to remove !important
     maxWidth: '100% !important',
     marginRight: '0 !important',

--- a/app/renderer/components/navigation/navigator.js
+++ b/app/renderer/components/navigation/navigator.js
@@ -151,7 +151,8 @@ class Navigator extends React.Component {
   render () {
     return <div className={cx({
       navbarCaptionButtonContainer: true,
-      allowDragging: this.props.shouldAllowWindowDrag
+      allowDragging: this.props.shouldAllowWindowDrag,
+      [css(this.props.activeTabShowingMessageBox && styles.navigatorWrapper_activeTabShowingMessageBox)]: true
     })}>
       <div className='navbarMenubarFlexContainer'>
         {
@@ -251,6 +252,9 @@ class Navigator extends React.Component {
 module.exports = ReduxComponent.connect(Navigator)
 
 const styles = StyleSheet.create({
+  navigatorWrapper_activeTabShowingMessageBox: {
+    pointerEvents: 'none'
+  },
   lionBadge: {
     left: 'calc(50% - 1px)',
     top: '14px',


### PR DESCRIPTION
Fix #8298

Auditors:

Test Plan:
1. Open about:preferences#advanced
2. Disable `Always show the URL bar`
1. Open https://jsfiddle.net/6zj4sjxr/
2. Make sure the whole URL bar is grayed out
3. Make sure you can switch tabs

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


