### PR TITLE
Add volatility text to BAT screen

### DIFF
--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -12,6 +12,7 @@ balance=Balance:
 helloBat=Hello, and thank you for using Brave Payments!
 helloBatText1=Brave Payments allows you to make anonymous, monthly<br>contributions to the publishers you visit on the internet. 
 helloBatText2=Please note that <strong>your Brave Payments Wallet is unidirectional</strong>, and the money you transfer from outside accounts <strong>can not be retrieved or refunded</strong>. The wallet’s primary purpose is to send your contributions to publishers each month, based on your control and advisement.
+helloBatText3=Note: Due to the inherent volatility of cryptocurrency markets, your balance will typically fluctuate on a daily basis.
 batContributionTitle=Introducing BAT Contribution Matching!
 batContributionText1=To say thanks to our early adopters, Brave is matching the next 5.00 USD of BATs that you add to your wallet.
 batContributionText2=Just transfer any amount from your crypto-currency wallet and we’ll match the next 5.00 USD.

--- a/app/renderer/components/preferences/payment/addFundsDialog/steps/addFundsBatScreen.js
+++ b/app/renderer/components/preferences/payment/addFundsDialog/steps/addFundsBatScreen.js
@@ -24,6 +24,9 @@ class BatWelcomeScreen extends React.Component {
         <p data-l10n-id='helloBatText2'
           className={css(styles.batScreen__text)}
         />
+        <p data-l10n-id='helloBatText3'
+          className={css(styles.batScreen__text)}
+        />
       </div>
     )
   }


### PR DESCRIPTION
Submitter Checklist:
Fixes:#11332

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
Ensure wizard shows volatility text when add funds is clicked
![image](https://user-images.githubusercontent.com/17010094/31306518-ebf1e3f6-ab49-11e7-9001-0ca031468cff.png)


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


