### PR TITLE
Unskip 'bitwarden installs when enabled' automated test

### DIFF
--- a/test/about/extensionsTest.js
+++ b/test/about/extensionsTest.js
@@ -137,7 +137,7 @@ describe('about:extensions', function () {
         .waitForVisible(`[data-extension-id="${extensionIds[passwordManagers.ENPASS]}"]`, extensionDownloadWaitTime)
     })
   })
-  describe.skip('bitwarden installs when enabled', function () {
+  describe('bitwarden installs when enabled', function () {
     Brave.beforeAll(this)
     before(function * () {
       yield setup(this.app.client)


### PR DESCRIPTION
Closes #11357
Follow-up to #4776

It should not be skipped since 0.19 as the extension is re-enabled on that version.

Auditors: @bsclifton

Test Plan:
1. Run `npm run test -- --grep='bitwarden installs when enabled'`

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


