### PR TITLE
Move the switch wrappers 1rem left

### DIFF
--- a/app/renderer/components/preferences/paymentsTab.js
+++ b/app/renderer/components/preferences/paymentsTab.js
@@ -317,7 +317,11 @@ const styles = StyleSheet.create({
   },
 
   switchWrap: {
-    width: paymentStyles.width.tableCell
+    width: paymentStyles.width.tableCell,
+
+    // TODO: Remove this when #10913 is merged to master
+    position: 'relative',
+    left: '1rem'
   },
   switchWrap__switchControl: {
     // TODO: Refactor switchControls.less
@@ -365,8 +369,10 @@ const styles = StyleSheet.create({
   // History and settings icons
   switchWrap__mainIconsRight: {
     position: 'relative',
-    right: '12px',
-    top: '3.5px'
+    top: '3.5px',
+
+    // See: #11367
+    right: '1rem'
   },
   switchWrap__mainIcons: {
     backgroundColor: globalStyles.color.braveOrange,


### PR DESCRIPTION
This is required for `0.19.x` and `0.20.x` only.


<img width="842" alt="screenshot 2017-10-09 1 00 30" src="https://user-images.githubusercontent.com/3362943/31318431-7b00da5e-ac8d-11e7-90ec-5df5c467683a.png">


Fixes #11367

Auditors:

Test Plan:

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


