### PR TITLE
Fixes auto unpinning for payment publishers

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -717,8 +717,8 @@ const synopsisNormalizer = (state, changedPublisher, returnState) => {
     const publisherKey = item.site
     const weight = item.weight
     const pinPercentage = item.pinPercentage
-    savePublisherOption(publisherKey, 'weight', weight)
-    savePublisherOption(publisherKey, 'pinPercentage', pinPercentage)
+    savePublisherData(publisherKey, 'weight', weight)
+    savePublisherData(publisherKey, 'pinPercentage', pinPercentage)
     state = ledgerState.setPublishersProp(state, publisherKey, 'weight', weight)
     state = ledgerState.setPublishersProp(state, publisherKey, 'pinPercentage', pinPercentage)
   })
@@ -2224,6 +2224,12 @@ const saveOptionSynopsis = (prop, value) => {
 const savePublisherOption = (publisherKey, prop, value) => {
   if (synopsis.publishers && synopsis.publishers[publisherKey]) {
     synopsis.publishers[publisherKey].options[prop] = value
+  }
+}
+
+const savePublisherData = (publisherKey, prop, value) => {
+  if (synopsis.publishers && synopsis.publishers[publisherKey]) {
+    synopsis.publishers[publisherKey][prop] = value
   }
 }
 


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Resolves #11369

Auditors:

Test Plan:

1. Upgrade to 0.19.35
2. Have three publishers pinned
3. One at 90%, second at 4%, third at 4%
4. Have one publisher enabled, set at 2% completing 100%
5. Use browser normally for a while
6. Open payments
7. One of the pinned publisher with 4% is unpinned but still enabled

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


