### PR TITLE
Bypass cookie mismatch error on google login

### DIFF
--- a/app/importer.js
+++ b/app/importer.js
@@ -222,6 +222,16 @@ importer.on('add-keywords', (e, templateUrls, uniqueOnHostAndPath) => {
 importer.on('add-autofill-form-data-entries', (e, detail) => {
 })
 
+const shouldSkipCookie = (cookie) => {
+  // Bypassing cookie mismatch error in
+  // https://github.com/brave/browser-laptop/issues/11401
+  if (cookie.domain === '.google.com' &&
+      ['https://notifications.google.com', 'https://accounts.google.com'].includes(cookie.url)) {
+    return true
+  }
+  return false
+}
+
 importer.on('add-cookies', (e, cookies) => {
   for (let i = 0; i < cookies.length; ++i) {
     const cookie = {
@@ -234,9 +244,13 @@ importer.on('add-cookies', (e, cookies) => {
       httpOnly: cookies[i].httponly,
       expirationDate: cookies[i].expiry_date
     }
+    if (shouldSkipCookie(cookie)) {
+      continue
+    }
     session.defaultSession.cookies.set(cookie, (error) => {
       if (error) {
         console.error(error)
+        console.error(cookie)
       }
     })
   }

--- a/app/importer.js
+++ b/app/importer.js
@@ -231,6 +231,7 @@ const shouldSkipCookie = (cookie) => {
   }
   return false
 }
+module.exports.shouldSkipCookie = shouldSkipCookie
 
 importer.on('add-cookies', (e, cookies) => {
   for (let i = 0; i < cookies.length; ++i) {

--- a/test/unit/app/importerTest.js
+++ b/test/unit/app/importerTest.js
@@ -1,0 +1,35 @@
+/* global describe, before, after, it */
+const mockery = require('mockery')
+const assert = require('assert')
+
+require('../braveUnit')
+
+describe('importer unit tests', function () {
+  let importer
+  const fakeElectron = require('../lib/fakeElectron')
+
+  before(function () {
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    })
+    mockery.registerMock('electron', fakeElectron)
+    mockery.registerMock('./adBlock', {adBlockResourceName: 'adblock'})
+    importer = require('../../../app/importer')
+  })
+
+  after(function () {
+    mockery.disable()
+  })
+
+  describe('shouldSkipCookie', function () {
+    it('returns true if domain is google and URL is one which has a mismatch', function () {
+      assert.equal(importer.shouldSkipCookie({domain: '.google.com', url: 'https://notifications.google.com'}), true)
+    })
+
+    it('returns false for other cases', function () {
+      assert.equal(importer.shouldSkipCookie({domain: '.brave.com', url: 'https://brave.com'}), false)
+    })
+  })
+})

--- a/test/unit/lib/fakeElectron.js
+++ b/test/unit/lib/fakeElectron.js
@@ -93,7 +93,10 @@ const fakeElectron = {
   extensions: {
     createTab: function () {}
   },
-  autoUpdater: new EventEmitter()
+  autoUpdater: new EventEmitter(),
+  importer: {
+    on: () => {}
+  }
 }
 
 module.exports = fakeElectron


### PR DESCRIPTION
Auditors: @bbondy, @bsclifton

fix #11401

Test Plan:
1. Clean cookies on Chrome/Firefox and login in google account
2. Import cookies from Chrome/Firefox to Brave
3. Login google account on Brave
4. Import cookies from Chrome/Firefox to Brave and refresh
5. Logout google account on Brave
6. There shouldn't be any cookie mismatch error pages displayed within these steps

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


