### PR TITLE
fix bad tab page preview for the first tab set

### DIFF
--- a/js/state/frameStateUtil.js
+++ b/js/state/frameStateUtil.js
@@ -487,7 +487,7 @@ const getTabPageIndex = (state) => {
   const tabPageIndex = state.getIn(['ui', 'tabs', 'tabPageIndex'], 0)
   const previewTabPageIndex = state.getIn(['ui', 'tabs', 'previewTabPageIndex'])
 
-  return previewTabPageIndex || tabPageIndex
+  return previewTabPageIndex != null ? previewTabPageIndex : tabPageIndex
 }
 
 /**


### PR DESCRIPTION
fix bad tab page preview for the first tab set

fix #11269
Auditors: @luixxiul

This is in fact a port from the working version of 0.19.x: 
https://github.com/brave/browser-laptop/blob/0.19.x/app/common/state/tabContentState.js#L90

given this broke in 0.20.x I'm setting the same milestone.

Test Plan:

```
npm run test -- --grep="tab pages tab page previews hovering over a tab page changes it"
```