### PR TITLE
Set the same opacity to the counter box as the disabled BrowserButton

### DIFF
--- a/app/renderer/components/styles/theme.js
+++ b/app/renderer/components/styles/theme.js
@@ -11,6 +11,15 @@
   * Note: If an element is not color-related, it should go into global.js
   */
   module.exports.theme = {
+    navigator: {
+      braveMenu: {
+        counter: {
+          backgroundColor: '#555',
+          color: '#fff'
+        }
+      }
+    },
+
     tab: {
       transition: `
       background-color 150ms cubic-bezier(0.26, 0.63, 0.39, 0.65),

--- a/test/lib/selectors.js
+++ b/test/lib/selectors.js
@@ -28,6 +28,10 @@ module.exports = {
   errorContent: '.errorContent',
   errorUrl: '.errorUrl',
   errorText: '.errorText',
+  braveMenu: '[data-test-id="braveMenu"]',
+  braveMenuDisabled: '[data-test-id="braveMenuDisabled"]',
+
+  // findBar
   findBar: '[data-test-id="findBar"]',
   findBarInput: '[data-test-id="findBarInput"]',
   findBarMatches: '[data-test-id="foundResults"]',
@@ -35,8 +39,6 @@ module.exports = {
   findBarNextButton: '[data-test-id="findBarNextButton"]',
   findBarPrevButton: '[data-test-id="findBarPrevButton"]',
   findBarClearButton: '[data-test-id="findBarClearButton"]',
-  braveMenu: '.braveMenu:not(.braveShieldsDisabled)',
-  braveMenuDisabled: '.braveMenu.braveShieldsDisabled',
 
   // braveryPanelTest.js
   braveryPanel: '[data-test-id="braveryPanel"]',

--- a/test/unit/app/renderer/components/navigation/navigatorTest.js
+++ b/test/unit/app/renderer/components/navigation/navigatorTest.js
@@ -159,7 +159,7 @@ describe('Navigator component unit tests', function () {
     })
 
     it('disables the lion icon', function () {
-      const node = wrapper.find('[data-test-id="braveShieldButton"]').getDOMNode()
+      const node = wrapper.find('[data-test-id="braveMenu"]').getDOMNode()
       assert.equal(node.disabled, true)
     })
   })
@@ -172,7 +172,7 @@ describe('Navigator component unit tests', function () {
 
     it('lion icon is shown by default', function () {
       const wrapper = mount(<Navigator />)
-      const node = wrapper.find('[data-test-id="braveShieldButton"]').getDOMNode()
+      const node = wrapper.find('[data-test-id="braveMenu"]').getDOMNode()
       assert.equal(node.disabled, false)
     })
 


### PR DESCRIPTION
Fixes #9696 

Also:
- Update to the modified BEM style

Auditors: @cezaraugusto

Test Plan:
1. Open https://jsfiddle.net/6zj4sjxr/
2. Make sure both brave lion icon and the counter box has the same opacity

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


