### PR TITLE
Remove capital B from brave in snap instructions

### DIFF
--- a/docs/linuxInstall.md
+++ b/docs/linuxInstall.md
@@ -16,7 +16,7 @@ automatically and transactionally so your app is always fresh and never broken.
 Installation instructions for `snapd` [can be found here](https://snapcraft.io/docs/core/install).
 Once `snapd` is installed, installing Brave looks like this:
 
-    snap install Brave --beta
+    snap install brave --beta
 
 ## Debian (Jessie) and Ubuntu (Artful, Zesty, Yakkety, Xenial, and Trusty) AMD64:
 


### PR DESCRIPTION
Installing doesn't work using a capital B