### PR TITLE
Add transition animation to tab width when returning to normal after mouse close

### DIFF
--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -240,7 +240,7 @@ class Tab extends React.Component {
       return 0
     }
 
-    const rect = this.tabNode.parentNode.getBoundingClientRect()
+    const rect = this.elementRef.getBoundingClientRect()
     return rect && rect.width
   }
 
@@ -280,6 +280,29 @@ class Tab extends React.Component {
     return props
   }
 
+  componentWillReceiveProps (nextProps) {
+    if (this.props.tabWidth && !nextProps.tabWidth) {
+      // remember the width so we can transition from it
+      this.originalWidth = this.elementRef.getBoundingClientRect().width
+    }
+  }
+
+  componentDidUpdate (prevProps) {
+    if (prevProps.tabWidth && !this.props.tabWidth) {
+      window.requestAnimationFrame(() => {
+        const newWidth = this.elementRef.getBoundingClientRect().width
+        this.elementRef.animate([
+          { flexBasis: `${this.originalWidth}px`, flexGrow: 0, flexShrink: 0 },
+          { flexBasis: `${newWidth}px`, flexGrow: 0, flexShrink: 0 }
+        ], {
+          duration: 250,
+          iterations: 1,
+          easing: 'ease-in-out'
+        })
+      })
+    }
+  }
+
   render () {
     // we don't want themeColor if tab is private
     const perPageStyles = !this.props.isPrivateTab && StyleSheet.create({
@@ -307,7 +330,9 @@ class Tab extends React.Component {
       onMouseEnter={this.onMouseEnter}
       onMouseLeave={this.onMouseLeave}
       data-test-id='tab-area'
-      data-frame-key={this.props.frameKey}>
+      data-frame-key={this.props.frameKey}
+      ref={elementRef => { this.elementRef = elementRef }}
+      >
       {
         this.props.isActive && this.props.notificationBarActive
           ? <NotificationBarCaret />


### PR DESCRIPTION
Fix #7001

*note* that this functionality will appear broken, as it does without the animation in master currently, due to a bug which is fixed by #11436.

![59ddd21894f7a209624579](https://user-images.githubusercontent.com/741836/31428875-3109e284-ae21-11e7-9577-5d6035b1cf90.gif)


Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).


## Test Plan (manual):

### flex tabs
- Make the window narrow
- Open ~7 tabs (enough for the tabs to fill the width of the container and get smaller)
- Mouse over the first tab's close button and click it
- Close another couple tabs (optional)
- Mouse away from the tabs bar
- Observe animation of tabs back to normal size

### Max-width tabs
- Make the window wider
- Open ~3 tabs (not enough for the tabs to fill the width of the container and get smaller)
- Mouse over the first tab's close button and click it
- mouse away from the tabs bar
- Observe there is *no* animation of tabs back to normal size, since they did not change size

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


