### PR TITLE
Fix Travis errors related with data-l10n-id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5154,61 +5154,6 @@
         }
       }
     },
-    "electron-download": {
-      "version": "github:brave/electron-download#409b65caff14edeef1daa36a7445ba6334658d7c",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "home-path": "1.0.5",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "mv": "2.1.1",
-        "nugget": "1.6.2",
-        "path-exists": "1.0.0",
-        "rc": "1.2.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "nugget": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/nugget/-/nugget-1.6.2.tgz",
-          "integrity": "sha1-iMpuA7pXBqmRc/XaCQJZPWvK4Qc=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "minimist": "1.2.0",
-            "pretty-bytes": "1.0.4",
-            "progress-stream": "1.2.0",
-            "request": "2.82.0",
-            "single-line-log": "0.4.1",
-            "throttleit": "0.0.2"
-          }
-        },
-        "path-exists": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
-          "dev": true
-        },
-        "single-line-log": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz",
-          "integrity": "sha1-h6VWSfdJ14PsDc2AToFA2Yc8fO4=",
-          "dev": true
-        },
-        "throttleit": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-          "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
-          "dev": true
-        }
-      }
-    },
     "electron-download-tf": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/electron-download-tf/-/electron-download-tf-4.3.1.tgz",
@@ -5394,6 +5339,20 @@
           "integrity": "sha1-HUixB9ghJqLz4hHC6iX4A7pVGyE=",
           "dev": true
         },
+        "electron-download": {
+          "version": "github:brave/electron-download#409b65caff14edeef1daa36a7445ba6334658d7c",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "home-path": "1.0.5",
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "mv": "2.1.1",
+            "nugget": "1.6.2",
+            "path-exists": "1.0.0",
+            "rc": "1.2.1"
+          }
+        },
         "electron-osx-sign": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.3.2.tgz",
@@ -5443,6 +5402,27 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
+        "nugget": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/nugget/-/nugget-1.6.2.tgz",
+          "integrity": "sha1-iMpuA7pXBqmRc/XaCQJZPWvK4Qc=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "minimist": "1.2.0",
+            "pretty-bytes": "1.0.4",
+            "progress-stream": "1.2.0",
+            "request": "2.82.0",
+            "single-line-log": "0.4.1",
+            "throttleit": "0.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
+          "dev": true
+        },
         "plist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
@@ -5454,6 +5434,18 @@
             "xmlbuilder": "4.0.0",
             "xmldom": "0.1.27"
           }
+        },
+        "single-line-log": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz",
+          "integrity": "sha1-h6VWSfdJ14PsDc2AToFA2Yc8fO4=",
+          "dev": true
+        },
+        "throttleit": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+          "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
+          "dev": true
         },
         "xmlbuilder": {
           "version": "4.0.0",
@@ -5472,6 +5464,61 @@
       "requires": {
         "electron-download": "github:brave/electron-download#409b65caff14edeef1daa36a7445ba6334658d7c",
         "extract-zip": "1.6.5"
+      },
+      "dependencies": {
+        "electron-download": {
+          "version": "github:brave/electron-download#409b65caff14edeef1daa36a7445ba6334658d7c",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "home-path": "1.0.5",
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "mv": "2.1.1",
+            "nugget": "1.6.2",
+            "path-exists": "1.0.0",
+            "rc": "1.2.1"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "nugget": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/nugget/-/nugget-1.6.2.tgz",
+          "integrity": "sha1-iMpuA7pXBqmRc/XaCQJZPWvK4Qc=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "minimist": "1.2.0",
+            "pretty-bytes": "1.0.4",
+            "progress-stream": "1.2.0",
+            "request": "2.82.0",
+            "single-line-log": "0.4.1",
+            "throttleit": "0.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
+          "dev": true
+        },
+        "single-line-log": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz",
+          "integrity": "sha1-h6VWSfdJ14PsDc2AToFA2Yc8fO4=",
+          "dev": true
+        },
+        "throttleit": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+          "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
+          "dev": true
+        }
       }
     },
     "electron-publish": {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "immutablepatch": "brave/immutable-js-patch",
     "l20n": "^3.5.1",
     "lru-cache": "^1.0.0",
-    "moment": "^2.15.1",
+    "moment": "~2.18.1",
     "niceware": "^1.0.4",
     "parse-torrent": "^5.8.1",
     "prettier-bytes": "^1.0.3",


### PR DESCRIPTION
Closes #11454

Fix failures on Travis related with data-l10n-id. See https://travis-ci.org/brave/browser-laptop/jobs/286524924#L3411 for examples

[`moment`](https://www.npmjs.com/package/moment) was updated from `2.18.1` to `2.19.0` yesterday.
See https://gist.github.com/ichernev/5f3f4eb02761b4f765a0cccf02cec603 for the full changelog. 

diff: https://github.com/moment/moment/compare/2.18.1...2.19.0

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


