### PR TITLE
Do not re-create stylesheet rules every time tabs are rendered

### DIFF
--- a/app/renderer/components/tabs/content/favIcon.js
+++ b/app/renderer/components/tabs/content/favIcon.js
@@ -52,45 +52,40 @@ class Favicon extends React.Component {
       return null
     }
 
-    const iconStyles = StyleSheet.create({
-      icon__loading_color: {
-        filter: this.props.tabIconColor === 'white'
-          ? filter.makeWhite
-          : 'none'
-      },
-      icon__favicon: {
-        backgroundImage: `url(${this.props.favicon})`,
-        filter: this.props.tabIconColor === 'white'
-          ? filter.whiteShadow
-          : 'none'
-      },
-      icon__default_sizeAndColor: {
-        WebkitMaskSize: this.props.showIconAtReducedSize ? '10px' : '12px',
-        backgroundColor: this.props.tabIconColor === 'white'
-          ? color.white100
-          : color.mediumGray
-      }
-    })
+    const themeLight = this.props.tabIconColor === 'white'
+    const instanceStyles = { }
+    if (this.props.favicon) {
+      instanceStyles['--faviconsrc'] = `url(${this.props.favicon})`
+    }
 
     return <TabIcon
       data-test-favicon={this.props.favicon}
       data-test-id={this.testingIcon}
       className={css(
         styles.icon,
-        this.props.favicon && iconStyles.icon__favicon,
+        this.props.favicon && styles.icon_favicon,
+        this.props.favicon && themeLight && styles.icon_faviconLight,
         !this.props.isPinned && this.props.showIconWithLessMargin && styles.icon_lessMargin,
         !this.props.isPinned && this.props.showIconAtReducedSize && styles.icon_reducedSize
       )}
+      style={instanceStyles}
       symbol={
         this.props.tabLoading
           ? (
             // no loading icon if there's no room for the icon
             !this.props.showIconAtReducedSize &&
-            css(styles.icon__loading, iconStyles.icon__loading_color)
+            css(
+              styles.icon__loading,
+              themeLight && styles.icon__loading_colorLight
+            )
           )
           : (
             !this.props.favicon &&
-            css(styles.icon__default, iconStyles.icon__default_sizeAndColor)
+            css(
+              styles.icon__defaultIcon,
+              this.props.showIconAtReducedSize && styles.icon__defaultIcon_reducedSize,
+              themeLight && styles.icon__defaultIcon_colorLight
+            )
           )
       } />
   }
@@ -119,6 +114,14 @@ const styles = StyleSheet.create({
     alignSelf: 'center'
   },
 
+  icon_favicon: {
+    backgroundImage: 'var(--faviconsrc)'
+  },
+
+  icon_faviconLight: {
+    filter: filter.whiteShadow
+  },
+
   icon_lessMargin: {
     margin: 0
   },
@@ -143,9 +146,23 @@ const styles = StyleSheet.create({
     animationIterationCount: 'infinite'
   },
 
-  icon__default: {
+  icon__loading_colorLight: {
+    filter: filter.makeWhite
+  },
+
+  icon__defaultIcon: {
     WebkitMaskRepeat: 'no-repeat',
     WebkitMaskPosition: 'center',
-    WebkitMaskImage: `url(${defaultIconSvg})`
+    WebkitMaskImage: `url(${defaultIconSvg})`,
+    WebkitMaskSize: '12px',
+    backgroundColor: color.mediumGray
+  },
+
+  icon__defaultIcon_reducedSize: {
+    WebkitMaskSize: '10px'
+  },
+
+  icon__defaultIcon_colorLight: {
+    backgroundColor: color.white100
   }
 })

--- a/app/renderer/components/tabs/content/tabIcon.js
+++ b/app/renderer/components/tabs/content/tabIcon.js
@@ -16,19 +16,6 @@ const globalStyles = require('../../styles/global')
 
 class TabIcon extends ImmutableComponent {
   render () {
-    const styles = StyleSheet.create({
-      tabIcon: {
-        fontSize: this.props.symbolContent ? '8px' : 'inherit',
-        display: 'flex',
-        width: globalStyles.spacing.iconSize,
-        height: globalStyles.spacing.iconSize,
-        alignItems: 'center',
-        justifyContent: this.props.symbolContent ? 'flex-end' : 'center',
-        fontWeight: this.props.symbolContent ? 'bold' : 'normal',
-        color: this.props.symbolContent ? globalStyles.color.black100 : 'inherit'
-      }
-    })
-
     let altProps
     if (!this.props.symbol) {
       altProps = {
@@ -43,6 +30,7 @@ class TabIcon extends ImmutableComponent {
       onDragStart={this.props.onDragStart}
       draggable={this.props.draggable}
       onClick={this.props.onClick}
+      style={this.props.style}
       {...altProps}
     >
       {
@@ -50,7 +38,7 @@ class TabIcon extends ImmutableComponent {
           ? <span
             className={cx({
               [this.props.symbol]: true,
-              [css(styles.tabIcon)]: true
+              [css(styles.tabIcon, this.props.symbolContent && styles.tabIcon_hasSymbol)]: true
             })}
             data-test-id={this.props['data-test-id']}
             data-test2-id={this.props['data-test2-id']}
@@ -62,5 +50,25 @@ class TabIcon extends ImmutableComponent {
     </div>
   }
 }
+
+const styles = StyleSheet.create({
+  tabIcon: {
+    fontSize: 'inherit',
+    display: 'flex',
+    width: globalStyles.spacing.iconSize,
+    height: globalStyles.spacing.iconSize,
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontWeight: 'normal',
+    color: 'inherit'
+  },
+
+  tabIcon_hasSymbol: {
+    fontSize: '8px',
+    justifyContent: 'flex-end',
+    fontWeight: 'bold',
+    color: globalStyles.color.black100
+  }
+})
 
 module.exports = TabIcon

--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -282,16 +282,12 @@ class Tab extends React.Component {
 
   render () {
     // we don't want themeColor if tab is private
-    const perPageStyles = !this.props.isPrivateTab && StyleSheet.create({
-      tab_themeColor: {
-        color: this.props.themeColor ? getTextColorForBackground(this.props.themeColor) : 'inherit',
-        background: this.props.themeColor ? this.props.themeColor : 'inherit',
-        ':hover': {
-          color: this.props.themeColor ? getTextColorForBackground(this.props.themeColor) : 'inherit',
-          background: this.props.themeColor ? this.props.themeColor : 'inherit'
-        }
-      }
-    })
+    const isThemed = !this.props.isPrivateTab && this.props.isActive && this.props.themeColor
+    const instanceStyles = { }
+    if (isThemed) {
+      instanceStyles['--theme-color-fg'] = getTextColorForBackground(this.props.themeColor)
+      instanceStyles['--theme-color-bg'] = this.props.themeColor
+    }
     return <div
       data-tab-area
       className={cx({
@@ -322,13 +318,14 @@ class Tab extends React.Component {
           isWindows && styles.tab_forWindows,
           this.props.isPinnedTab && styles.tab_pinned,
           this.props.isActive && styles.tab_active,
-          this.props.isActive && this.props.themeColor && perPageStyles.tab_themeColor,
           this.props.showAudioTopBorder && styles.tab_audioTopBorder,
           // Private color should override themeColor
           this.props.isPrivateTab && styles.tab_private,
           this.props.isActive && this.props.isPrivateTab && styles.tab_active_private,
-          this.props.centralizeTabIcons && styles.tab__content_centered
+          this.props.centralizeTabIcons && styles.tab__content_centered,
+          isThemed && styles.tab_themed
         )}
+        style={instanceStyles}
         data-test-id='tab'
         data-test-active-tab={this.props.isActive}
         data-test-pinned-tab={this.props.isPinnedTab}
@@ -380,6 +377,15 @@ const styles = StyleSheet.create({
 
     ':hover': {
       background: theme.tab.hover.background
+    }
+  },
+
+  tab_themed: {
+    color: `var(--theme-color-fg, inherit)`,
+    background: `var(--theme-color-bg, inherit)`,
+    ':hover': {
+      color: `var(--theme-color-fg, inherit)`,
+      background: `var(--theme-color-bg, inherit)`,
     }
   },
 


### PR DESCRIPTION
Helps with (a very small amount of) performance - instead use css variables to pass state variables to css. But every little thing helps when working on tab re-ordering.

Fix #11465

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
Since this is a small refactor, suggested test plans from previous implementations welcome. There should be 0 visual regressions from master. Affected components:
- Tab theme color
- Tab text / filter when theme color is light or dark
- Favicon display
- General background / text / hover colors when there is and isn't a favicon, should match master


Reviewer Checklist:

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


