### PR TITLE
reduce webpack build time by 55% with this one simple trick

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,10 @@ function config () {
             path.resolve(__dirname, 'app', 'browser', '*'),
             path.resolve(__dirname, 'app', 'extensions', '*')
           ],
-          loader: 'babel-loader'
+          loader: 'babel-loader',
+          options: {
+            cacheDirectory: true
+          }
         },
         {
           test: /\.less$/,


### PR DESCRIPTION
This make use of cache option for `babel-loader` which is huge by itself

close #11473
Auditors: @bsclifton, @evq

tests has a margin of sampling error of plus or minus ~300ms

* main bundle down from ~2.7s to ~1.3s
* `devtools` bundle down from ~1.9s to ~1.5s
* `webtorrent` bundle down from ~2.1s to ~0.9s

Verbose: 

**with cache**

|     ⚡️     | main bundle | `devtools` bundle | `webtorrent` bundle |
|------------|-------------|-----------------|-------------------|
| 1st try    | 13946ms     | 14816ms         | 8718ms            |
| 2nd try    | 14840ms     | 15693ms         | 9361ms            |
| 3rd try    | 14842ms     | 15685ms         | 9830ms            |


**without cache**

|     💩     | main bundle | devtools bundle | webtorrent bundle |
|------------|-------------|-----------------|-------------------|
| 1st try    | 28841ms     | 19936ms         | 22718ms           |
| 2nd try    | 28845ms     | 18899ms         | 21738ms           |
| 3rd try    | 26166ms     | 19773ms         | 20894ms           |


Test Plan:

* Try running `npm run watch` and look for `time` hint in webpack stats
* You should still be able to make changes and they should hot-reaload as usual