### PR TITLE
Prevent tab icon 'appear' animations running again when tab is moved

### DIFF
--- a/app/renderer/components/styles/animations.js
+++ b/app/renderer/components/styles/animations.js
@@ -20,6 +20,10 @@ const opacityIncreaseKeyframes = {
   }
 }
 
+const opacityIncreaseElementKeyframes = {
+  opacity: [0, 1]
+}
+
 // TODO: this could be a function with param included
 // to which property should be changed
 const widthIncreaseKeyframes = (start, end) => ({
@@ -29,6 +33,10 @@ const widthIncreaseKeyframes = (start, end) => ({
   'to': {
     width: end
   }
+})
+
+const widthIncreaseElementKeyframes = (start, end) => ({
+  width: [start, end]
 })
 
 const loaderAnimation = {
@@ -46,6 +54,8 @@ const loaderAnimation = {
 module.exports = {
   spinKeyframes,
   opacityIncreaseKeyframes,
+  opacityIncreaseElementKeyframes,
   widthIncreaseKeyframes,
+  widthIncreaseElementKeyframes,
   loaderAnimation
 }

--- a/app/renderer/components/tabs/content/privateIcon.js
+++ b/app/renderer/components/tabs/content/privateIcon.js
@@ -3,6 +3,7 @@
 * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const React = require('react')
+const ReactDOM = require('react-dom')
 const {StyleSheet, css} = require('aphrodite/no-important')
 
 // Components
@@ -17,10 +18,15 @@ const tabState = require('../../../../common/state/tabState')
 // Styles
 const {theme} = require('../../styles/theme')
 const globalStyles = require('../../styles/global')
-const {opacityIncreaseKeyframes} = require('../../styles/animations')
+const {opacityIncreaseElementKeyframes} = require('../../styles/animations')
 const privateSvg = require('../../../../extensions/brave/img/tabs/private.svg')
 
 class PrivateIcon extends React.Component {
+  constructor (props) {
+    super(props)
+    this.setRef = this.setRef.bind(this)
+  }
+
   mergeProps (state, ownProps) {
     const currentWindow = state.get('currentWindow')
     const tabId = ownProps.tabId
@@ -33,6 +39,35 @@ class PrivateIcon extends React.Component {
     props.tabId = tabId
 
     return props
+  }
+
+  componentDidMount (props) {
+    this.transitionInIfRequired()
+  }
+
+  componentDidUpdate (prevProps) {
+    this.transitionInIfRequired(prevProps)
+  }
+
+  transitionInIfRequired (prevProps) {
+    const shouldTransitionIn = (
+      // need to have the element created already
+      this.element &&
+      // should show the icon
+      this.props.showPrivateIcon &&
+      // state has changed
+      (!prevProps || !prevProps.showPrivateIcon)
+    )
+    if (shouldTransitionIn) {
+      this.element.animate(opacityIncreaseElementKeyframes, {
+        duration: 200,
+        easing: 'linear'
+      })
+    }
+  }
+
+  setRef (ref) {
+    this.element = ReactDOM.findDOMNode(ref)
   }
 
   render () {
@@ -51,6 +86,7 @@ class PrivateIcon extends React.Component {
     return <TabIcon
       data-test-id='privateIcon'
       className={css(styles.private__icon, privateProps.private__icon_color)}
+      ref={this.setRef}
     />
   }
 }
@@ -59,14 +95,7 @@ module.exports = ReduxComponent.connect(PrivateIcon)
 
 const styles = StyleSheet.create({
   private__icon: {
-    opacity: 0,
     willChange: 'opacity',
-    animationName: opacityIncreaseKeyframes,
-    animationDelay: '100ms',
-    animationTimingFunction: 'linear',
-    animationDuration: '200ms',
-    animationFillMode: 'forwards',
-
     zIndex: globalStyles.zindex.zindexTabsThumbnail,
     boxSizing: 'border-box',
     WebkitMaskRepeat: 'no-repeat',


### PR DESCRIPTION
Fix #11470
Note that the following came up in my review of the existing code I saw whilst fixing this. They were beyond the scope of getting a small PR to fix the aforementioned issue though:
- If we want to animate the unmounting of the component (when audio is stopped for example), then we could use https://github.com/reactjs/react-transition-group - the existing code does not animate audio stopped so I did not put in a solution
- I'd also be inclined to suggest 'ease-out' easings should be used across the UI, and at the moment 'linear' is used
- This code could be simplified by changing the component structure somewhat and putting the transitions on the icon element, or similar
- When the tab is hovered, the close button shows, and the private icon / session icons are removed from the DOM rather than hidden. This causes the 'appear' animation to fire again. Perhaps this is intentional, and it's what is the case on master at the moment. But it might have better control (and performance) to simply add a class to these icons, and then they can hide / show using any or no transition
- Theres a bug with the audioTabIcon in that props.showAudioIcon goes from true to false to true when the tab is first loaded and immediately plays audio. This causes a flicker of the icon. Same is true on master.

Before
![brave-issue-tab-appear-animations-before2](https://user-images.githubusercontent.com/741836/31529829-9e296f0e-af90-11e7-9405-bc0636e31e5c.gif)


After
![brave-issue-tab-appear-animations-after](https://user-images.githubusercontent.com/741836/31529830-9fc9e8d4-af90-11e7-8abf-fe6dd630a0fc.gif)


Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Test Plan
From PR #10691 / issue #10883 (create smooth transitions for tab components)

- close icon, favicon, private, new session icons will have a smooth transition when enabled
- audio icon will slightly scroll to the right when enabled

Resolving this issue
- Create multiple tabs with favicons
- Have a tab with audio playing and audio icon shown
- Move the tabs around, there should be no flicker off / fade-in of favicon or audio icon
- Repeat with tabs showing private icon, and session icon


## Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


