### PR TITLE
reduce webpack build time by ~50s

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,9 +106,7 @@ function production () {  // eslint-disable-line
   if (env !== 'test') {
     prod.plugins.push(new UglifyJsPlugin({
       uglifyOptions: {
-        compress: {
-          warnings: false
-        },
+        compress: false,
         mangle: {
           reserved: ['module', 'exports', 'require']
         }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -105,8 +105,11 @@ function production () {  // eslint-disable-line
   prod.plugins.push(new webpack.optimize.OccurrenceOrderPlugin(true))
   if (env !== 'test') {
     prod.plugins.push(new UglifyJsPlugin({
+      parallel: true,
       uglifyOptions: {
         compress: false,
+        // skip pre-minified libs
+        exclude: [/\.min\.js$/gi],
         mangle: {
           reserved: ['module', 'exports', 'require']
         }


### PR DESCRIPTION
Auditors: @bsclifton, @evq, @bbondy
close #11549
addresses #11476

We use most of UglifyJS `compress` options (at least we use all which are `on` by default), which makes no real difference in build size and ends up requiring more time to build. This PR removes them all.

Test Plan:
1. Before checking out this PR, run `CHANNEL=dev npm run build-package`
2. Pay attention to webpack time's, mine is described below
3. Pay attention to build size
4. Check out this PR
5. Go to step 2 and 3 again
6. You should see some improvements (mine was ~50s)
7. Build size should not be affected in a meaningful way (for me prior size was 374.4mb and now is 375.2mb)

Tests varied a bit but ranged around 45s-55s total time (all bundles together)

**without this change**

| bundle         | main bundle | devtools bundle | webtorrent bundle |
|--------|-------------|-----------------|--------------------|
| time     | 45415ms     | 49132ms            | 14508ms                 |

**after this change (first commit)**

| bundle         | main bundle | devtools bundle | webtorrent bundle |
|--------|-------------|-----------------|--------------------|
| time     | 25491ms     | 27002ms           | 12271ms                 |

## Edit

Turns out that letting uglify run in parallel + skipping already minified libs we did another **bold** perf gain

**after this change (second commit)**

| bundle         | main bundle | devtools bundle | webtorrent bundle |
|--------|-------------|-----------------|--------------------|
| time     | 15261ms     | 9533ms           | 8480ms                 |
