### PR TITLE
Fix buttons wrap on about:preferences#payments (l10n)

### DIFF
--- a/app/renderer/components/preferences/paymentsTab.js
+++ b/app/renderer/components/preferences/paymentsTab.js
@@ -383,7 +383,9 @@ const styles = StyleSheet.create({
     top: '3.5px',
 
     // See: #11367
-    right: '1rem'
+    right: '1rem',
+
+    whiteSpace: 'nowrap'
   },
   switchWrap__mainIcons: {
     backgroundColor: globalStyles.color.braveOrange,


### PR DESCRIPTION
Closes #11580

This is required for `0.19.x` and `0.20.x` only, like #11368

For `0.21.x` and `master` a manual fix ~~will be~~ was applied to #10913

<img width="325" alt="screenshot 2017-10-18 1 51 23" src="https://user-images.githubusercontent.com/3362943/31677792-dd74f3da-b3a6-11e7-9051-06a43b36d88e.png">

The switch label alignment has been addressed with another PR. On `master` it looks good.

<img width="298" alt="screenshot 2017-10-18 2 02 05" src="https://user-images.githubusercontent.com/3362943/31678206-5b10ab80-b3a8-11e7-9e62-d3436b75c98a.png">


Auditors:

Test Plan:
1. Change the lang setting to German (DE)
2. Restart the browser
3. Open about:preferences#payments
4. Make sure the buttons on the title row do not wrap

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


