### PR TITLE
Fix Uppercase user-data-dir casued by

### DIFF
--- a/tools/buildPackage.js
+++ b/tools/buildPackage.js
@@ -95,6 +95,7 @@ cmds = cmds.concat([
     ' --build-version=' + VersionInfo.electronVersion +
     ' --protocol="http" --protocol-name="HTTP Handler"' +
     ' --protocol="https" --protocol-name="HTTPS Handler"' +
+    ' --product-dir-name="brave"' +
     ' --version-string.CompanyName="Brave Software"' +
     ' --version-string.ProductName="Brave"' +
     ' --version-string.Copyright="Copyright 2017, Brave Software"' +


### PR DESCRIPTION
https://github.com/brave/electron-packager/pull/3/

fix #11583

Auditors: @bsclifton, @bbondy

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:

1. make sure there is no user-data-dir in ~/Library/Application Support/
2. Launch Brave
3. Notice the user folder will be `brave`


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


