### PR TITLE
Fix ledger state persistence, add recovery for improperly persisted state

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -2254,6 +2254,13 @@ const deleteSynopsis = () => {
   synopsis.publishers = {}
 }
 
+const yoDawg = (stateState) => {
+  while (stateState.hasOwnProperty('state') && stateState.state.persona) {
+    stateState = stateState.state
+  }
+  return stateState
+}
+
 let newClient = null
 const transitionWalletToBat = () => {
   let newPaymentId, result
@@ -2271,9 +2278,10 @@ const transitionWalletToBat = () => {
           return
         }
         const parsedData = JSON.parse(data)
-        newClient = ledgerClient(parsedData.state.personaId,
-          underscore.extend(parsedData.options, {roundtrip: roundtrip}, clientOptions),
-          parsedData)
+        const state = yoDawg(parsedData)
+        newClient = ledgerClient(state.personaId,
+          underscore.extend(state.options, {roundtrip: roundtrip}, clientOptions),
+          state)
         transitionWalletToBat()
       })
       return
@@ -2287,7 +2295,7 @@ const transitionWalletToBat = () => {
     try {
       clientprep()
       newClient = ledgerClient(null, underscore.extend({roundtrip: roundtrip}, clientOptions), null)
-      muonWriter(newClientPath, newClient)
+      muonWriter(newClientPath, newClient.state)
     } catch (ex) {
       return console.error('ledger client creation error(2): ', ex)
     }
@@ -2302,7 +2310,7 @@ const transitionWalletToBat = () => {
 
       if (typeof delayTime === 'undefined') delayTime = random.randomInt({ min: 1, max: 500 })
 
-      muonWriter(newClientPath, newClient)
+      muonWriter(newClientPath, newClient.state)
 
       setTimeout(() => transitionWalletToBat(), delayTime)
     })

--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -2254,6 +2254,7 @@ const deleteSynopsis = () => {
   synopsis.publishers = {}
 }
 
+// fix for incorrectly persisted state (see #11585)
 const yoDawg = (stateState) => {
   while (stateState.hasOwnProperty('state') && stateState.state.persona) {
     stateState = stateState.state


### PR DESCRIPTION
Fixes: #11585

Auditors:
@bsclifton

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Performed:

Common steps:
1. Created a new browser profile using a pre mercury browser release and saved for later use

Stuck transition scenario
1. Used copy of empty BTC wallet profile
2. By repetitively closing the browser on master, ended up with a profile stuck in transition (manifests as 422 errors as described in issue above)
3. Opened the above profile using the browser based on this branch
4. Ensured that the browser now proceeds to finish the "holding screen" and that wallet addresses, backup codes, etc are visible.

New transition scenario, best case
1. Used copy of empty BTC wallet profile
2. Ensured that the browser now proceeds to finish the "holding screen" and that wallet addresses, backup codes, etc are visible.

New transition scenario, worst case
1. Used copy of empty BTC wallet profile
2. Repeatedly open and close the browser multiple times
3. Ensured that the browser on next start proceeds to finish the "holding screen" and that wallet addresses, backup codes, etc are visible.

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


