### PR TITLE
make greeting notifications global

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -293,6 +293,7 @@ const notifications = {
       }
 
       appActions.showNotification({
+        from: 'ledger',
         greeting: locale.translation('updateHello'),
         message: notifications.text.tryPayments,
         buttons: [
@@ -310,6 +311,7 @@ const notifications = {
     appActions.changeSetting(settings.PAYMENTS_NOTIFICATION_RECONCILE_SOON_TIMESTAMP, nextTime)
 
     appActions.showNotification({
+      from: 'ledger',
       greeting: notifications.text.hello,
       message: notifications.text.reconciliation,
       buttons: [
@@ -325,6 +327,7 @@ const notifications = {
     appActions.changeSetting(settings.PAYMENTS_NOTIFICATION_ADD_FUNDS_TIMESTAMP, nextTime)
 
     appActions.showNotification({
+      from: 'ledger',
       greeting: notifications.text.hello,
       message: notifications.text.addFunds,
       buttons: [
@@ -343,6 +346,7 @@ const notifications = {
     // Hide the 'waiting for deposit' message box if it exists
     appActions.hideNotification(notifications.text.addFunds)
     appActions.showNotification({
+      from: 'ledger',
       greeting: locale.translation('updateHello'),
       message: notifications.text.paymentDone,
       buttons: [
@@ -356,6 +360,7 @@ const notifications = {
     appActions.onBitcoinToBatNotified()
 
     appActions.showNotification({
+      from: 'ledger',
       greeting: notifications.text.hello,
       message: notifications.text.walletConvertedToBat,
       // Learn More.

--- a/app/common/state/notificationBarState.js
+++ b/app/common/state/notificationBarState.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const assert = require('assert')
+const Immutable = require('immutable')
+const {makeImmutable, isMap} = require('./immutableUtil')
+
+const api = {
+  validateState: function (state) {
+    state = makeImmutable(state)
+    assert.ok(isMap(state), 'state must be an Immutable.Map')
+    return state
+  }
+}
+
+const notificationBarState = {
+  /**
+   * Gets an immutable list of notifications
+   * @param {Map} appState - The app state object
+   * @return {List} - immutable list of notifications
+   */
+  getNotifications: (state) => {
+    state = api.validateState(state)
+    return state.get('notifications', Immutable.List())
+  },
+
+  /**
+   * Gets an immutable list of ledger notifications
+   * @param {Map} appState - The app state object
+   * @return {List} - immutable list of ledger notifications
+   */
+  getLedgerNotifications: (state) => {
+    const notifications = notificationBarState.getNotifications(state)
+    return notifications.filter(item => item.get('from') === 'ledger')
+  }
+}
+
+module.exports = notificationBarState

--- a/app/renderer/components/main/main.js
+++ b/app/renderer/components/main/main.js
@@ -23,7 +23,7 @@ const TabPages = require('../tabs/tabPages')
 const TabsToolbar = require('../tabs/tabsToolbar')
 const FindBar = require('./findbar')
 const UpdateBar = require('./updateBar')
-const {NotificationBar} = require('./notificationBar')
+const {NotificationBar, BraveNotificationBar} = require('./notificationBar')
 const DownloadsBar = require('../download/downloadsBar')
 const SiteInfo = require('./siteInfo')
 const BraveryPanel = require('./braveryPanel')
@@ -688,6 +688,9 @@ class Main extends React.Component {
           this.props.showCheckDefault
             ? <CheckDefaultBrowserDialog />
             : null
+        }
+        {
+          <BraveNotificationBar />
         }
         {
           this.props.showUpdate

--- a/app/renderer/components/main/notificationBar.js
+++ b/app/renderer/components/main/notificationBar.js
@@ -13,6 +13,7 @@ const NotificationItem = require('./notificationItem')
 // Utils
 const {getOrigin} = require('../../../../js/lib/urlutil')
 const frameStateUtil = require('../../../../js/state/frameStateUtil')
+const notificationBarState = require('../../../common/state/notificationBarState')
 
 // Styles
 const commonStyles = require('../styles/commonStyles')
@@ -23,29 +24,64 @@ class NotificationBar extends React.Component {
     const currentWindow = state.get('currentWindow')
     const activeFrame = frameStateUtil.getActiveFrame(currentWindow) || Immutable.Map()
     const activeOrigin = getOrigin(activeFrame.get('location'))
-    const notifications = state.get('notifications', Immutable.List())
+    const notifications = notificationBarState.getNotifications(state)
 
     const props = {}
     props.activeNotifications = notifications
       .filter((item) => {
         return item.get('frameOrigin')
           ? activeOrigin === item.get('frameOrigin')
-          : true
+          // TODO: this should filter all cases
+          // for notifications that are not per-tab
+          // and not only ledger
+          : item.get('from') !== 'ledger'
       })
       .takeLast(3)
-      .map((notification) => notification.get('message'))
-
+    props.showNotifications = !props.activeNotifications.isEmpty()
     return props
   }
 
   render () {
+    // Avoid rendering an empty notification wrapper
+    if (!this.props.showNotifications) {
+      return null
+    }
     return <div className={css(commonStyles.notificationBar)} data-test-id='notificationBar'>
       {
-        this.props.activeNotifications.map((message) =>
-          <NotificationItem message={message} />
+        this.props.activeNotifications.map((notification) =>
+          <NotificationItem message={notification.get('message')} />
         )
       }
     </div>
+  }
+}
+
+// TODO maybe this should be merged in <NotificationBar /> and defined
+// per conditional prop such as isGlobal={conditional}
+class BraveNotificationBar extends React.Component {
+  mergeProps (state, ownProps) {
+    const props = {}
+    // TODO: for now we cover only ledger notifications in this method
+    // this should cover all notifications that are global
+    props.notifications = notificationBarState.getLedgerNotifications(state)
+    props.showNotifications = !props.notifications.isEmpty()
+    return props
+  }
+
+  render () {
+    // Avoid rendering an empty notification wrapper
+    if (!this.props.showNotifications) {
+      return null
+    }
+    return (
+      <div className={css(commonStyles.notificationBar)} data-test-id='braveNotificationBar'>
+        {
+          this.props.notifications.map((notification) =>
+            <NotificationItem message={notification.get('message')} />
+          )
+        }
+      </div>
+    )
   }
 }
 
@@ -86,5 +122,6 @@ const styles = StyleSheet.create({
 
 module.exports = {
   NotificationBar: ReduxComponent.connect(NotificationBar),
+  BraveNotificationBar: ReduxComponent.connect(BraveNotificationBar),
   NotificationBarCaret
 }

--- a/test/unit/app/common/state/notificationBarStateTest.js
+++ b/test/unit/app/common/state/notificationBarStateTest.js
@@ -1,0 +1,85 @@
+/* global describe, it, beforeEach */
+const notificationBarState = require('../../../../../app/common/state/notificationBarState')
+const {isList} = require('../../../../../app/common/state/immutableUtil')
+const Immutable = require('immutable')
+const assert = require('chai').assert
+
+const frameKey = 1
+const index = 0
+const site1 = 'https://nespressolovers.com'
+let state
+const defaultState = Immutable.fromJS({
+  notifications: [],
+  currentWindow: {
+    framesInternal: {
+      index: { 1: 0 },
+      tabIndex: { 1: 0 }
+    },
+    frames: [{
+      index,
+      key: frameKey,
+      tabId: 1,
+      location: site1
+    }],
+    activeFrameKey: frameKey,
+    tabs: [{
+      key: frameKey,
+      index: index
+    }]
+  }
+})
+
+describe('notificationBarState test', function () {
+  beforeEach(function () {
+    state = defaultState
+  })
+  describe('getNotifications', function () {
+    it('returns an immutable list of notifications', function () {
+      const notificationsList = Immutable.fromJS([
+        { greeting: 'House Brave', message: 'The BAT is coming' },
+        { frameOrigin: site1, message: 'nespresso site' }
+      ])
+      state = state.mergeIn(['notifications'], notificationsList)
+      const result = notificationBarState.getNotifications(state)
+      assert.equal(isList(result), true)
+      assert.equal(result.size, 2)
+    })
+
+    it('Fallback to an empty Immutable List if not defined', function () {
+      const result = notificationBarState.getNotifications(state)
+      assert.equal(result.isEmpty(), true)
+      assert.equal(isList(result), true)
+    })
+  })
+
+  describe('getLedgerNotifications', function () {
+    it('returns a list of ledger-related notifications', function () {
+      const notificationsList = Immutable.fromJS([
+        { from: 'ledger', message: 'HELLO LEDGER' },
+        { from: 'ledger', message: 'HELLO YOU' }
+      ])
+      state = state.mergeIn(['notifications'], notificationsList)
+      const result = notificationBarState.getLedgerNotifications(state)
+      assert.equal(result.size, 2)
+    })
+
+    it('does not show notifications that are not ledger-related', function () {
+      const notificationsList = Immutable.fromJS([
+        { from: 'ledger', message: 'HELLO LEDGER' },
+        { from: 'other place', message: 'HELLO YOU FROM OUTWHERE' }
+      ])
+      state = state.mergeIn(['notifications'], notificationsList)
+      const result = notificationBarState.getLedgerNotifications(state)
+      assert.equal(result.size, 1)
+    })
+
+    it('returns an empty Immutable list if no ledger-related notification is found', function () {
+      state = state.mergeIn(['notifications'], [
+        { from: 'Brazil', message: 'Hello from Brazil!' }
+      ])
+      const result = notificationBarState.getLedgerNotifications(state)
+      assert.equal(result.isEmpty(), true)
+      assert.equal(isList(result), true)
+    })
+  })
+})


### PR DESCRIPTION
fix #11256

Manual Test Plan:
* all ledger notifications should appear in the safe UI area
* other notifications should work the same

Test Plan:

```
npm run test -- --grep="notificationBarState test"
```