### PR TITLE
Fix automated download bar tests

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -569,9 +569,7 @@ function registerForDownloadListener (session) {
       webContents.forceClose()
     }
 
-    if (getSetting(settings.DOWNLOAD_ALWAYS_ASK)) {
-      item.setPrompt(true)
-    }
+    item.setPrompt(getSetting(settings.DOWNLOAD_ALWAYS_ASK) || false)
 
     const downloadId = item.getGuid()
     item.on('updated', function (e, st) {

--- a/test/misc-components/downloadItemTest.js
+++ b/test/misc-components/downloadItemTest.js
@@ -31,6 +31,8 @@ describe('downloadItem test', function () {
     yield setup(this.app.client)
 
     yield this.app.client
+      .changeSetting('general.download-always-ask', false)
+      .waitForSettingValue('general.download-always-ask', false)
       .waitForUrl(Brave.newTabUrl)
       .url(this.downloadSite)
   })


### PR DESCRIPTION
### Functional fixes:
 - Do not show 'save location' dialog when restarting a cancelled download

### Test fixes:
 - Fix automated download bar tests by preventing showing save location dialog for all file downloads

Auditors: @brave/automated-tests-team 

