### PR TITLE
Fix automated tests for bookmark sync

### DIFF
--- a/test/misc-components/syncTest.js
+++ b/test/misc-components/syncTest.js
@@ -444,7 +444,7 @@ describe('Syncing bookmarks', function () {
   })
 
   it('create bookmark in folder', function * () {
-    const pageNthChild = 2 // TODO: This should be 1. See https://github.com/brave/sync/issues/104
+    const pageNthChild = 1
     const folderTitle = this.folder1Title
     const pageTitle = this.folder1Page1Title
     const folder = `[data-test-id="bookmarkToolbarButton"][title="${folderTitle}"]`
@@ -456,7 +456,7 @@ describe('Syncing bookmarks', function () {
   })
 
   it('update bookmark, moving it into the folder', function * () {
-    const pageNthChild = 1 // TODO: This should be 2
+    const pageNthChild = 2
     const folderTitle = this.folder1Title
     const pageTitle = this.folder1Page2Title
     const folder = `[data-test-id="bookmarkToolbarButton"][title="${folderTitle}"]`
@@ -599,7 +599,7 @@ describe('Syncing bookmarks from an existing profile', function () {
   })
 
   it('create bookmark in folder', function * () {
-    const pageNthChild = 2 // TODO: This should be 1
+    const pageNthChild = 1
     const folderTitle = this.folder1Title
     const pageTitle = this.folder1Page1Title
     const folder = `[data-test-id="bookmarkToolbarButton"][title="${folderTitle}"]`
@@ -611,7 +611,7 @@ describe('Syncing bookmarks from an existing profile', function () {
   })
 
   it('update bookmark, moving it into the folder', function * () {
-    const pageNthChild = 1 // TODO: This should be 2
+    const pageNthChild = 2
     const folderTitle = this.folder1Title
     const pageTitle = this.folder1Page2Title
     const folder = `[data-test-id="bookmarkToolbarButton"][title="${folderTitle}"]`


### PR DESCRIPTION
Fix automated sync tests finding order of bookmarks in a folder.

This *possibly* means that https://github.com/brave/sync/issues/104 which was mentioned in the previous code is now resolved.

Auditors: @brave/automated-tests-team


