### PR TITLE
removes "update to preview" from preferences

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -309,13 +309,12 @@ app.on('ready', () => {
     })
     // DO NOT TO THIS LIST - see above
 
-    // We need the initial state to read the UPDATE_TO_PREVIEW_RELEASES preference
     loadAppStatePromise.then((initialImmutableState) => {
       updater.init(
         process.platform,
         process.arch,
         process.env.BRAVE_UPDATE_VERSION || app.getVersion(),
-        initialImmutableState.getIn(['settings', settings.UPDATE_TO_PREVIEW_RELEASES])
+        process.env.BRAVE_ENABLE_PREVIEW_UPDATES !== undefined
       )
 
       // This is fired by a menu entry

--- a/app/renderer/components/preferences/advancedTab.js
+++ b/app/renderer/components/preferences/advancedTab.js
@@ -21,27 +21,13 @@ const {scaleSize} = require('../../../common/constants/toolbarUserInterfaceScale
 
 // Utils
 const {changeSetting} = require('../../lib/settingsUtil')
-const platformUtil = require('../../../common/lib/platformUtil')
-const isLinux = platformUtil.isLinux()
 
 class AdvancedTab extends ImmutableComponent {
-  previewReleases () {
-    return isLinux
-      ? null
-      : <SettingCheckbox
-        dataL10nId='updateToPreviewReleases'
-        data-test-id='update-to-preview-releases'
-        prefKey={settings.UPDATE_TO_PREVIEW_RELEASES}
-        settings={this.props.settings}
-        onChangeSetting={this.props.onChangeSetting} />
-  }
-
   render () {
     return <section>
       <main className={css(styles.advancedTabMain)}>
         <DefaultSectionTitle data-l10n-id='contentSettings' />
         <SettingsList>
-          {this.previewReleases()}
           <SettingCheckbox dataL10nId='useHardwareAcceleration' prefKey={settings.HARDWARE_ACCELERATION_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
           <SettingCheckbox dataL10nId='useSmoothScroll' prefKey={settings.SMOOTH_SCROLL_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
           <SettingCheckbox dataL10nId='sendCrashReports' prefKey={settings.SEND_CRASH_REPORTS} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -838,8 +838,7 @@ class AboutPreferences extends React.Component {
       settings.PDFJS_ENABLED,
       settings.TORRENT_VIEWER_ENABLED,
       settings.SMOOTH_SCROLL_ENABLED,
-      settings.SEND_CRASH_REPORTS,
-      settings.UPDATE_TO_PREVIEW_RELEASES
+      settings.SEND_CRASH_REPORTS
     ]
     if (settingsRequiringRestart.includes(key)) {
       ipc.send(messages.PREFS_RESTART, key, value)

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -193,7 +193,6 @@ module.exports = {
     'advanced.smooth-scroll-enabled': false,
     'advanced.send-crash-reports': true,
     'advanced.send-usage-statistics': false,
-    'advanced.update-to-preview-releases': false,
     'advanced.toolbar-ui-scale': 'normal',
     'shutdown.clear-history': false,
     'shutdown.clear-downloads': false,

--- a/js/constants/settings.js
+++ b/js/constants/settings.js
@@ -75,7 +75,6 @@ const settings = {
   SMOOTH_SCROLL_ENABLED: 'advanced.smooth-scroll-enabled',
   SEND_CRASH_REPORTS: 'advanced.send-crash-reports',
   SEND_USAGE_STATISTICS: 'advanced.send-usage-statistics',
-  UPDATE_TO_PREVIEW_RELEASES: 'advanced.update-to-preview-releases',
   ADBLOCK_CUSTOM_RULES: 'adblock.customRules',
   TOOLBAR_UI_SCALE: 'advanced.toolbar-ui-scale',
   // Sync settings

--- a/test/unit/app/renderer/components/preferences/advancedTabTest.js
+++ b/test/unit/app/renderer/components/preferences/advancedTabTest.js
@@ -1,17 +1,14 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
-/* global describe, before, afterEach, it */
+/* global describe */
 
-const mockery = require('mockery')
-const {mount} = require('enzyme')
-const assert = require('assert')
-const fakeElectron = require('../../../../lib/fakeElectron')
-let AdvancedTab
+// const mockery = require('mockery')
+// const fakeElectron = require('../../../../lib/fakeElectron')
 require('../../../../braveUnit')
 
 describe('AdvancedTab component', function () {
-  const testSetup = (customLogic) => {
+  /* const testSetup = (customLogic) => {
     mockery.enable({
       warnOnReplace: false,
       warnOnUnregistered: false,
@@ -30,49 +27,13 @@ describe('AdvancedTab component', function () {
 
     mockery.registerMock('electron', fakeElectron)
     window.chrome = fakeElectron
-
     AdvancedTab = require('../../../../../../app/renderer/components/preferences/advancedTab')
   }
 
   afterEach(function () {
     mockery.disable()
-  })
-
-  const platformUtilMac = {isLinux: () => false, isWindows: () => false, isDarwin: () => true}
-  const platformUtilLinux = {isLinux: () => true, isWindows: () => false, isDarwin: () => false}
+  }) */
 
   describe('AdvancedTab', function () {
-    describe('previewReleases', function () {
-      describe('on macOS', function () {
-        before(function () {
-          testSetup(function () {
-            mockery.registerMock('../../../common/lib/platformUtil', platformUtilMac)
-          })
-        })
-        it('is shown', function () {
-          const wrapper = mount(
-            <AdvancedTab onChangeSetting={null} />
-          )
-          const instance = wrapper.instance()
-          assert(instance.previewReleases())
-        })
-      })
-
-      describe('on Linux', function () {
-        before(function () {
-          testSetup(function () {
-            mockery.registerMock('../../../common/lib/platformUtil', platformUtilLinux)
-          })
-        })
-
-        it('is hidden', function () {
-          const wrapper = mount(
-            <AdvancedTab onChangeSetting={null} />
-          )
-          const instance = wrapper.instance()
-          assert.equal(instance.previewReleases(), null)
-        })
-      })
-    })
   })
 })


### PR DESCRIPTION
Fix #11638

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:

Test Case 1:

* launch brave and load about:preferences#advanced
* ensure that "Update to preview releases" has been removed

Test Case 2:

* launch brave using the `BRAVE_ENABLE_PREVIEW_UPDATES` environmental variable
* ensure that your'e prompted to update if there's an update available
* ensure that brave updates and relaunches without any issues

Reviewer Checklist:

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header