### PR TITLE
Redo exception to cover Chrome's case

### DIFF
--- a/app/importer.js
+++ b/app/importer.js
@@ -225,8 +225,8 @@ importer.on('add-autofill-form-data-entries', (e, detail) => {
 const shouldSkipCookie = (cookie) => {
   // Bypassing cookie mismatch error in
   // https://github.com/brave/browser-laptop/issues/11401
-  if (cookie.domain === '.google.com' &&
-      ['https://notifications.google.com', 'https://accounts.google.com'].includes(cookie.url)) {
+  if (['https://notifications.google.com', 'https://myaccount.google.com',
+    'https://accounts.google.com'].includes(cookie.url)) {
     return true
   }
   return false


### PR DESCRIPTION
fix #11401 AGAIN

Auditors: @bbondy

Test Plan:
1. Clean cookies on Chrome/Firefox and login in google account
2. Import cookies from Chrome/Firefox to Brave
3. Login google account on Brave
4. Import cookies from Chrome/Firefox to Brave and refresh
5. Logout google account on Brave
6. There shouldn't be any cookie mismatch error pages displayed within these steps

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


