### PR TITLE
Set max-width to dropdown

### DIFF
--- a/app/renderer/components/common/dropdown.js
+++ b/app/renderer/components/common/dropdown.js
@@ -53,7 +53,10 @@ const styles = StyleSheet.create({
     // right padding is larger, to account for the down arrow SVG
     padding: `${selectPadding} 2em ${selectPadding} ${selectPadding}`,
     '-webkit-appearance': 'none',
-    width: 'auto'
+    width: 'auto',
+
+    // See: #11646
+    maxWidth: '100%'
   },
 
   outlineable: {


### PR DESCRIPTION
Fixes #11646

Note that you cannot truncate the profile name with CSS because option element simply cannot be styled using CSS. See: https://developer.mozilla.org/en-US/docs/Learn/HTML/Forms/Styling_HTML_forms

Auditors: @cezaraugusto

Test Plan:
1. Create a Chrome profile with a long name
2. Open Import browser data dialog
3. Make sure that the dropdown wrapper does not overflow the dialog

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


