### PR TITLE
Replace user-select: initial with user-select: text

### DIFF
--- a/app/renderer/components/main/braveryPanel.js
+++ b/app/renderer/components/main/braveryPanel.js
@@ -921,7 +921,9 @@ const styles = StyleSheet.create({
     overflowY: 'auto',
     marginTop: '-20px',
     padding: '10px',
-    userSelect: 'initial'
+
+    // #11641
+    userSelect: 'text'
   },
   braveryPanel__body__ul__li: {
     listStyleType: 'none',

--- a/app/renderer/components/preferences/payment/ledgerBackup.js
+++ b/app/renderer/components/preferences/payment/ledgerBackup.js
@@ -95,7 +95,7 @@ const styles = StyleSheet.create({
 
     // See syncTab.js
     cursor: 'text',
-    userSelect: 'initial',
+    userSelect: 'text', // #11641
     color: globalStyles.color.braveDarkOrange,
 
     // See: https://github.com/Khan/aphrodite#object-key-ordering

--- a/app/renderer/components/preferences/syncTab.js
+++ b/app/renderer/components/preferences/syncTab.js
@@ -605,7 +605,7 @@ const styles = StyleSheet.create({
 
     // See ledgerBackup.js
     cursor: 'text',
-    userSelect: 'initial',
+    userSelect: 'text', // #11641
     color: globalStyles.color.braveDarkOrange
   },
 

--- a/app/renderer/components/styles/commonStyles.js
+++ b/app/renderer/components/styles/commonStyles.js
@@ -132,8 +132,10 @@ const styles = StyleSheet.create({
 
   // User select
   userSelect: {
-    userSelect: 'initial',
-    cursor: 'text'
+    cursor: 'text',
+
+    // #11641
+    userSelect: 'text'
   },
   userSelectNone: {
     userSelect: 'none',


### PR DESCRIPTION
Due to the Chromium 62 update

Fixes #11641

Auditors:

Test Plan:
1. Open about:preferences#sync
2. Enable Sync
3. Open 'Sync a new device'
4. Select `Show secret code words`
5. Make sure the words can be selected

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


