### PR TITLE
block access to fingerprinting methods pulled from child frames issue #11683

### DIFF
--- a/app/extensions/brave/content/scripts/blockCanvasFingerprinting.js
+++ b/app/extensions/brave/content/scripts/blockCanvasFingerprinting.js
@@ -267,4 +267,29 @@ if (chrome.contentSettings.canvasFingerprinting == 'block') {
     type: 'WebRTC',
     methodName: 'navigator.mediaDevices.enumerateDevices'
   })
+
+  // Prevent access to frames' contentDocument / contentWindow
+  // properties, to prevent the parent frame from pulling unblocked
+  // references to blocked standards from injected frames.
+  // This may break some sites, but, fingers crossed, its not too much.
+  var pageScriptToInject = `
+    (function () {
+        var frameTypesToModify = [window.HTMLIFrameElement, window.HTMLFrameElement]
+        var propertiesToBlock = ["contentDocument", "contentWindow"]
+        var proxyObject = window.HTMLCanvasElement.prototype.toDataURL
+        var returnProxyGetter = {
+          get: function () {
+            return proxyObject()
+          }
+        }
+
+        frameTypesToModify.forEach(function (frameType) {
+          propertiesToBlock.forEach(function (propertyName) {
+            Object.defineProperty(frameType.prototype, propertyName, returnProxyGetter)
+          })
+        })
+    }())
+  `
+
+  chrome.webFrame.executeJavaScript(pageScriptToInject)
 }

--- a/test/bravery-components/braveryPanelTest.js
+++ b/test/bravery-components/braveryPanelTest.js
@@ -895,6 +895,19 @@ describe('Bravery Panel', function () {
         .tabByIndex(0)
         .waitUntil(verifyProxyBlocking)
     })
+    it('blocking access to fingerprinting methods on iframe.contentWindow', function * () {
+      const url = Brave.server.url('fingerprinting-blocking-from-child-frames.html')
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(url)
+        .waitForUrl(url)
+        .openBraveMenu(braveMenu, braveryPanel)
+      yield changeFpSetting(this.app.client, blockFpOption)
+      yield this.app.client
+        .keys(Brave.keys.ESCAPE)
+        .tabByIndex(0)
+        .waitUntil(verifyProxyBlocking)
+    })
     it('block device enumeration', function * () {
       const url = Brave.server.url('enumerate_devices.html')
       yield this.app.client

--- a/test/fixtures/fingerprinting-blocking-from-child-frames.html
+++ b/test/fixtures/fingerprinting-blocking-from-child-frames.html
@@ -1,0 +1,28 @@
+<html>
+<head>
+</head>
+<body>
+<div id="target">
+proxy blocking being tested
+</div>
+<script>
+(function () {
+
+    let parentFrameMethod = window.HTMLCanvasElement.prototype.toDataURL
+
+    let iframe = document.createElement("iframe")
+    iframe.src = "https://www.brave.com/"
+    document.body.appendChild(iframe)
+
+    // Not blocked
+    let childFrameMethod = iframe.contentWindow.HTMLCanvasElement.prototype.toDataURL;
+
+    if (parentFrameMethod() === childFrameMethod()) {
+        // If an exception is thrown in the above code, the below line will never
+        // run, and the text in the div will never be changed (ie test fails).
+        document.getElementById('target').innerHTML = 'proxy blocking works'
+    }
+}())
+</script>
+</body>
+</html>


### PR DESCRIPTION
@diracdeltas 

This PR fixes #11683.  The fix is a little funky, since it requires injecting JS into child pages (the `chrome.webFrame.setGlobal` method wont work here, since we need to call to `Object.definePropery`) but it should be good.

Added a `blocking access to fingerprinting methods on iframe.contentWindow` test to test that things are actually getting blocked