### PR TITLE
Migrates the contribution amounts from old USD setting to new BAT setting

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -1867,7 +1867,7 @@ const onCallback = (state, result, delayTime) => {
 
   if (client && result.getIn(['properties', 'wallet'])) {
     if (!ledgerState.getInfoProp(state, 'created')) {
-      setPaymentInfo(getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT))
+      module.exports.setPaymentInfo(getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT))
     }
 
     state = getStateInfo(state, regularResults) // TODO optimize if possible
@@ -2014,6 +2014,24 @@ const initialize = (state, paymentsEnabled) => {
   }
 }
 
+const getContributionAmount = () => {
+  const amount = getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT)
+  // if amount is 5, 10, 15, or 20... the amount wasn't updated when changing
+  // from BTC to BAT (see https://github.com/brave/browser-laptop/issues/11719)
+  let updatedAmount
+  switch (amount) {
+    case 5: updatedAmount = 25; break
+    case 10: updatedAmount = 50; break
+    case 15: updatedAmount = 75; break
+    case 20: updatedAmount = 100; break
+  }
+  if (updatedAmount) {
+    appActions.changeSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT, updatedAmount)
+    return updatedAmount
+  }
+  return amount
+}
+
 const onInitRead = (state, parsedData) => {
   state = getStateInfo(state, parsedData)
 
@@ -2071,7 +2089,8 @@ const onInitRead = (state, parsedData) => {
     state = ledgerState.setInfoProp(state, 'address', client.getWalletAddress())
   }
 
-  setPaymentInfo(getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT))
+  const contributionAmount = getContributionAmount()
+  module.exports.setPaymentInfo(contributionAmount)
   getBalance(state)
 
   // Show relevant browser notifications on launch


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/11719

Auditors: @NejcZdovc, @evq, @petemill 

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
- Use an older version of Brave (0.18.36 for example)
- Enable payments and set contribution amount as one of the original amounts (like $10 for example)
- Run a build with this fix in it
- In preferences#payments, you should notice it should be 25 BAT if USD was $5, 50 if $10, 75 if $15, 100 if $20
- Exit Brave
- Open the ledger-state.json file and inspect, looking for properties.fee.amount
- This should have the new value (25, 50, 75, or 100) not the old value (5, 10, 15, 20)


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


