### PR TITLE
Fix "Error: global leak detected: @@any-promise/REGISTRATION" unit test error

### DIFF
--- a/test/unit/app/browser/api/ledgerTest.js
+++ b/test/unit/app/browser/api/ledgerTest.js
@@ -149,10 +149,13 @@ describe('ledger api unit tests', function () {
 
   describe('initialize', function () {
     let notificationsInitSpy
+    let fakeClock
     beforeEach(function () {
       notificationsInitSpy = sinon.spy(ledgerApi.notifications, 'init')
+      fakeClock = sinon.useFakeTimers()
     })
     afterEach(function () {
+      fakeClock.restore()
       notificationsInitSpy.restore()
     })
     it('calls notifications.init', function () {


### PR DESCRIPTION
I believe this was introduced with https://github.com/brave/browser-laptop/pull/11700/ when the tests were reworked (regarding the fake timers).
Initialize calls setInterval() and didn't have timers stubbed

Auditors: @NejcZdovc, @bbondy

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
Ensure Travis tests pass for unit test

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


