### PR TITLE
Bypass local cache for checking data file

### DIFF
--- a/app/dataFile.js
+++ b/app/dataFile.js
@@ -19,14 +19,15 @@ const downloadPath = (url) => `${storagePath(url)}.temp`
 
 function downloadSingleFile (resourceName, url, version, force, resolve, reject) {
   // console.log('downloading file for: ', resourceName, url)
-  let headers = {}
+  let headers = {
+    'Cache-Control': 'no-cache, no-store, must-revalidate',
+    Pragma: 'no-cache',
+    Expires: '0'
+  }
   const AppStore = require('../js/stores/appStore')
   const etag = AppStore.getState().getIn([resourceName, 'etag'])
   if (!force && etag) {
-    // console.log('setting etag: ', etag)
-    headers = {
-      'If-None-Match': etag
-    }
+    headers['If-None-Match'] = etag
   }
   const tmpPath = downloadPath(url)
 


### PR DESCRIPTION
Fix #11752

This combination of headers will bypass local cache but still return an HTTP status code of not modified with a request to the server if the etag matches



Test Plan:
See issue.

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


