### PR TITLE
Disable spellcheck when language list is empty

### DIFF
--- a/app/browser/reducers/spellCheckerReducer.js
+++ b/app/browser/reducers/spellCheckerReducer.js
@@ -32,11 +32,12 @@ const migrate = (state) => {
 }
 
 const setSpellCheckerSettings = () => {
-  const enabled = getSetting(settings.SPELLCHECK_ENABLED)
+  const langs = getSetting(settings.SPELLCHECK_LANGUAGES)
+  const enabled = getSetting(settings.SPELLCHECK_ENABLED) && !!langs.size
+
   setUserPref('browser.enable_spellchecking', enabled)
   if (enabled) {
-    setUserPref('spellcheck.dictionaries',
-                getSetting(settings.SPELLCHECK_LANGUAGES))
+    setUserPref('spellcheck.dictionaries', langs)
   }
 }
 

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -122,7 +122,11 @@ class GeneralTab extends ImmutableComponent {
   }
 
   onSpellCheckLangsChange (value) {
-    this.props.onChangeSetting(settings.SPELLCHECK_LANGUAGES, value.split(','))
+    if (!value) {
+      this.props.onChangeSetting(settings.SPELLCHECK_LANGUAGES, [])
+    } else {
+      this.props.onChangeSetting(settings.SPELLCHECK_LANGUAGES, value.split(','))
+    }
   }
 
   setAsDefaultBrowser () {

--- a/test/unit/app/browser/reducers/spellCheckerReducerTest.js
+++ b/test/unit/app/browser/reducers/spellCheckerReducerTest.js
@@ -15,12 +15,12 @@ describe('spellCheckerReducer unit tests', function () {
   let getWebContentsSpy, replaceMisspellingSpy, replaceSpy, addWordSpy, removeWordSpy,
     setUserPrefSpy, getSettingSpy
   let spellCheckEnabled
+  let dicts
   const dictionaryWord = 'braave'
   const dictionarySuggestion = 'brave'
   const tabId = 111
   const enabledPref = 'browser.enable_spellchecking'
   const dictsPref = 'spellcheck.dictionaries'
-  const dicts = ['en-US', 'fr-FR']
 
   before(function () {
     mockery.enable({
@@ -158,6 +158,7 @@ describe('spellCheckerReducer unit tests', function () {
         getSettingSpy.reset()
         setUserPrefSpy.reset()
         spellCheckEnabled = true
+        dicts = Immutable.fromJS(['en-US', 'fr-FR'])
         spellCheckerReducer(Immutable.Map(), Immutable.fromJS({
           actionType: appConstants.APP_WINDOW_CREATED
         }))
@@ -174,6 +175,7 @@ describe('spellCheckerReducer unit tests', function () {
         getSettingSpy.reset()
         setUserPrefSpy.reset()
         spellCheckEnabled = false
+        dicts = Immutable.fromJS(['en-US', 'fr-FR'])
         spellCheckerReducer(Immutable.Map(), Immutable.fromJS({
           actionType: appConstants.APP_WINDOW_CREATED
         }))
@@ -193,6 +195,7 @@ describe('spellCheckerReducer unit tests', function () {
         getSettingSpy.reset()
         setUserPrefSpy.reset()
         spellCheckEnabled = true
+        dicts = Immutable.fromJS(['en-US', 'fr-FR'])
         spellCheckerReducer(Immutable.Map(), Immutable.fromJS({
           actionType: appConstants.APP_CHANGE_SETTING,
           key: settings.SPELLCHECK_ENABLED
@@ -210,6 +213,7 @@ describe('spellCheckerReducer unit tests', function () {
         getSettingSpy.reset()
         setUserPrefSpy.reset()
         spellCheckEnabled = false
+        dicts = Immutable.fromJS(['en-US', 'fr-FR'])
         spellCheckerReducer(Immutable.Map(), Immutable.fromJS({
           actionType: appConstants.APP_CHANGE_SETTING,
           key: settings.SPELLCHECK_ENABLED
@@ -227,6 +231,7 @@ describe('spellCheckerReducer unit tests', function () {
         getSettingSpy.reset()
         setUserPrefSpy.reset()
         spellCheckEnabled = true
+        dicts = Immutable.fromJS(['en-US', 'fr-FR'])
         spellCheckerReducer(Immutable.Map(), Immutable.fromJS({
           actionType: appConstants.APP_CHANGE_SETTING,
           key: settings.SPELLCHECK_LANGUAGES
@@ -239,11 +244,30 @@ describe('spellCheckerReducer unit tests', function () {
         assert(setUserPrefSpy.withArgs(dictsPref, dicts).calledOnce)
       })
     })
+    describe('empty SPELLCHECK_LANGUAGES with enabled', function () {
+      before(function () {
+        getSettingSpy.reset()
+        setUserPrefSpy.reset()
+        spellCheckEnabled = true
+        dicts = Immutable.fromJS([])
+        spellCheckerReducer(Immutable.Map(), Immutable.fromJS({
+          actionType: appConstants.APP_CHANGE_SETTING,
+          key: settings.SPELLCHECK_LANGUAGES
+        }))
+      })
+      it('not calls setUserPref to set enabledPref to true', function () {
+        assert(setUserPrefSpy.withArgs(enabledPref, true).notCalled)
+      })
+      it('not calls setUserPref to set dictionaries', function () {
+        assert(setUserPrefSpy.withArgs(dictsPref, dicts).notCalled)
+      })
+    })
     describe('SPELLCHECK_LANGUAGES with disabled', function () {
       before(function () {
         getSettingSpy.reset()
         setUserPrefSpy.reset()
         spellCheckEnabled = false
+        dicts = Immutable.fromJS(['en-US', 'fr-FR'])
         spellCheckerReducer(Immutable.Map(), Immutable.fromJS({
           actionType: appConstants.APP_CHANGE_SETTING,
           key: settings.SPELLCHECK_LANGUAGES
@@ -261,6 +285,7 @@ describe('spellCheckerReducer unit tests', function () {
         getSettingSpy.reset()
         setUserPrefSpy.reset()
         spellCheckEnabled = false
+        dicts = Immutable.fromJS(['en-US', 'fr-FR'])
         spellCheckerReducer(Immutable.Map(), Immutable.fromJS({
           actionType: appConstants.APP_CHANGE_SETTING,
           key: 'other-settings'


### PR DESCRIPTION
fix #11739

Auditors: @bbondy, @bsclifton

Test Plan:
a. Covered by unittest
b. Manuall test:
1. Make spellchecker lang lists empty
2. Type some random word on about:styles
3. There shouldn't be any red underline

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


