### PR TITLE
Set transition back to false when not needed to avoid being stuck in limbo

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -2367,8 +2367,8 @@ const yoDawg = (stateState) => {
   return stateState
 }
 
-const checkBtcBatMigrated = (state, status) => {
-  if (!status) {
+const checkBtcBatMigrated = (state, paymentsEnabled) => {
+  if (!paymentsEnabled) {
     return state
   }
 
@@ -2378,6 +2378,8 @@ const checkBtcBatMigrated = (state, status) => {
   if (!isNewInstall && !hasUpgradedWallet) {
     state = migrationState.setTransitionStatus(state, true)
     module.exports.transitionWalletToBat()
+  } else {
+    state = migrationState.setTransitionStatus(state, false)
   }
 
   return state
@@ -2513,6 +2515,7 @@ const getMethods = () => {
     privateMethods = {
       enable,
       addVisit,
+      checkBtcBatMigrated,
       clearVisitsByPublisher: function () {
         visitsByPublisher = {}
       },

--- a/app/common/state/migrationState.js
+++ b/app/common/state/migrationState.js
@@ -23,6 +23,11 @@ const migrationState = {
     return state.setIn(['migrations', 'btc2BatTransitionPending'], value)
   },
 
+  inTransition: (state) => {
+    state = validateState(state)
+    return state.getIn(['migrations', 'btc2BatTransitionPending']) === true
+  },
+
   setConversionTimestamp: (state, value) => {
     state = validateState(state)
     if (value == null) {

--- a/docs/state.md
+++ b/docs/state.md
@@ -285,6 +285,7 @@ AppStore
     batMercuryTimestamp: integer, // when session is upgraded (and this new schema added)
     btc2BatTimestamp: integer, // when call was made to backend to convert BTC => BAT
     btc2BatNotifiedTimestamp: integer, // when user was shown "wallet upgraded" notification
+    btc2BatTransitionPending: boolean // true if user is being shown transition screen
   },
   menu: {
     template: object // used on Windows and by our tests: template object with Menubar control


### PR DESCRIPTION
This commit also fixes a leak that the tests had (which was due to tests running and including bat-publisher).

Fixes https://github.com/brave/browser-laptop/issues/11566
Fixes https://github.com/brave/browser-laptop/issues/11757

Auditors: @NejcZdovc, @bbondy

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


