### PR TITLE
fix bad tab page preview while closing tabs

### DIFF
--- a/js/actions/windowActions.js
+++ b/js/actions/windowActions.js
@@ -274,18 +274,6 @@ const windowActions = {
   },
 
   /**
-   * Dispatches a message to the store to set the tab page index being previewed.
-   *
-   * @param {number} previewTabPageIndex - The tab page index to preview
-   */
-  setPreviewTabPageIndex: function (previewTabPageIndex) {
-    dispatch({
-      actionType: windowConstants.WINDOW_SET_PREVIEW_TAB_PAGE_INDEX,
-      previewTabPageIndex
-    })
-  },
-
-  /**
    * Dispatches a message to the store to set the tab page index.
    *
    * @param {number} frameProps - The frame props to center around

--- a/js/state/frameStateUtil.js
+++ b/js/state/frameStateUtil.js
@@ -21,7 +21,6 @@ const {getSetting} = require('../settings')
 const {isIntermediateAboutPage} = require('../lib/appUrlUtil')
 const urlParse = require('../../app/common/urlParse')
 
-let tabPageHoverTimeout
 let tabHoverTimeout = null
 
 const comparatorByKeyAsc = (a, b) => a.get('key') > b.get('key')
@@ -584,34 +583,14 @@ const getPreviewFrameKey = (state) => {
   return state.get('previewFrameKey')
 }
 
-const setPreviewTabPageIndex = (state, index, immediate = false) => {
-  clearTimeout(tabPageHoverTimeout)
+const setPreviewTabPageIndex = (state, index) => {
   const previewTabs = getSetting(settings.SHOW_TAB_PREVIEWS)
   const isActive = state.getIn(['ui', 'tabs', 'tabPageIndex']) === index
+  const hoverTabPageIndex = state.getIn(['ui', 'tabs', 'hoverTabPageIndex'])
   let newTabPageIndex = index
 
-  if (!previewTabs || state.getIn(['ui', 'tabs', 'hoverTabPageIndex']) !== index || isActive) {
+  if (!previewTabs || hoverTabPageIndex !== index || isActive) {
     newTabPageIndex = null
-  }
-
-  if (!immediate) {
-    // if there is an existing preview tab page index then we're already in preview mode
-    // we use actions here because that is the only way to delay updating the state
-    const previewMode = state.getIn(['ui', 'tabs', 'previewTabPageIndex']) != null
-    if (previewMode && newTabPageIndex == null) {
-      // add a small delay when we are clearing the preview frame key so we don't lose
-      // previewMode if the user mouses over another tab - see below
-      tabPageHoverTimeout = setTimeout(windowActions.setPreviewTabPageIndex.bind(null, null), 200)
-      return state
-    }
-
-    if (!previewMode) {
-      // If user isn't in previewMode so we add a bit of delay to avoid tab from flashing out
-      // as reported here: https://github.com/brave/browser-laptop/issues/1434
-      // using an action here because that is the only way we can do a delayed state update
-      tabPageHoverTimeout = setTimeout(windowActions.setPreviewTabPageIndex.bind(null, newTabPageIndex), 200)
-      return state
-    }
   }
 
   return state.setIn(['ui', 'tabs', 'previewTabPageIndex'], newTabPageIndex)

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -347,7 +347,7 @@ const doAction = (action) => {
       }
       break
     case windowConstants.WINDOW_SET_PREVIEW_TAB_PAGE_INDEX:
-      windowState = frameStateUtil.setPreviewTabPageIndex(windowState, action.previewTabPageIndex, true)
+      windowState = frameStateUtil.setPreviewTabPageIndex(windowState, action.previewTabPageIndex)
       break
     case windowConstants.WINDOW_SET_TAB_PAGE_INDEX:
       if (action.index != null) {


### PR DESCRIPTION
fix #11632

> Note for reviewers: There are some bad tab page functionality happening for latest versions so while this works on master it's better tested in 0.19.x

My take is that w/ previous timeout made tab page previews to happen unintentionally. I couldn't reproduce the bug again w/ this fix. No need to timeout for tab pages which was a copy of old preview mechanism for tabs.

Test plan (better tested in 0.19.x):

1. Open 3 tab pages
2. Sequentially close tabs
3. No tab preview should be triggered