### PR TITLE
use `CHROME_USER_DATA_DIR` to set/override the user data dir in tests

### DIFF
--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -27,7 +27,7 @@ const logVerbose = (string, ...rest) => {
 }
 
 const generateUserDataDir = () => {
-  return path.join(os.tmpdir(), 'brave-test', (new Date().getTime()) + Math.floor(Math.random() * 1000).toString())
+  return process.env.BRAVE_USER_DATA_DIR || path.join(os.tmpdir(), 'brave-test', (new Date().getTime()) + Math.floor(Math.random() * 1000).toString())
 }
 
 const rmDir = (dirPath) => {
@@ -1156,7 +1156,7 @@ var exports = {
     }
     let env = {
       NODE_ENV: 'test',
-      BRAVE_USER_DATA_DIR: userDataDir,
+      CHROME_USER_DATA_DIR: userDataDir,
       SPECTRON: true
     }
     let args = ['./', '--enable-logging', '--v=1']


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
messages about deleting directories should mostly go away in automated test runs
BRAVE_USER_DATA_DIR can be used to override the directory for tests

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


