### PR TITLE
Fix action buttons placement on torrentViewer

### DIFF
--- a/js/webtorrent/components/torrentViewer.js
+++ b/js/webtorrent/components/torrentViewer.js
@@ -1,7 +1,7 @@
 const React = require('react')
 const cx = require('../../lib/classSet')
 
-const {css} = require('aphrodite/no-important')
+const {StyleSheet, css} = require('aphrodite/no-important')
 const commonStyles = require('../../../app/renderer/components/styles/commonStyles')
 
 // Components
@@ -99,10 +99,10 @@ class TorrentViewer extends React.Component {
 
     return (
       <div className='siteDetailsPage'>
-        <div className='siteDetailsPageHeader'>
+        <div className={css(styles.siteDetailsPage__header)}>
           {titleElem}
 
-          <div className='headerActions'>
+          <div className={css(styles.siteDetailsPage__header__actions)}>
             {mainButton}
             {saveButton}
           </div>
@@ -126,5 +126,24 @@ class TorrentViewer extends React.Component {
     )
   }
 }
+
+const styles = StyleSheet.create({
+  siteDetailsPage__header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+
+    // See: .siteDetailsPageHeader
+    padding: '0 24px'
+  },
+
+  siteDetailsPage__header__actions: {
+    display: 'flex',
+    alignItems: 'center',
+
+    // See: .siteDetailsPageHeader
+    marginLeft: '24px'
+  }
+})
 
 module.exports = TorrentViewer

--- a/less/webtorrent.less
+++ b/less/webtorrent.less
@@ -9,12 +9,6 @@
 .siteDetailsPage {
   min-width: 704px;
 
-  .siteDetailsPageHeader {
-    .mainButton {
-      font-weight: 400;
-    }
-  }
-
   .siteDetailsPageContent {
     .sortableTable {
       user-select: none;


### PR DESCRIPTION
Fixes #11800

Fixes this:
<img width="375" alt="screenshot 2017-11-06 17 46 49" src="https://user-images.githubusercontent.com/3362943/32432301-6cfa0a9a-c31a-11e7-87ca-52b4b3ea69ea.png">

Auditors:

Test Plan:
1. Open https://webtorrent.io/torrents/big-buck-bunny.torrent
2. Make sure the action buttons are aligned horizontally with the title

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


