### PR TITLE
move spellcheck and language settings under advanced panel

### DIFF
--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -117,6 +117,7 @@ downloadsAskAlwaysSwitch=Always ask me where to save files
 downloadsInput=~/downloads/
 downloadsLabel=Save my downloads here:
 emailAddress=Email address
+spellcheck=Spell Check Options
 enableSpellCheck=Enable Spell Check *
 enableAutofill=Enable Autofill
 enableFlash=Enable Adobe Flash support

--- a/app/renderer/components/preferences/advancedTab.js
+++ b/app/renderer/components/preferences/advancedTab.js
@@ -6,6 +6,8 @@ const React = require('react')
 const ImmutableComponent = require('../immutableComponent')
 const {StyleSheet, css} = require('aphrodite/no-important')
 const commonStyles = require('../styles/commonStyles')
+const Select = require('react-select')
+const locale = require('../../../../js/l10n')
 
 // Actions
 const {getSetting} = require('../../../../js/settings')
@@ -23,8 +25,43 @@ const {scaleSize} = require('../../../common/constants/toolbarUserInterfaceScale
 const {changeSetting} = require('../../lib/settingsUtil')
 const platformUtil = require('../../../common/lib/platformUtil')
 const isDarwin = platformUtil.isDarwin()
+require('../../../../less/react-select.less')
 
 class AdvancedTab extends ImmutableComponent {
+  constructor (e) {
+    super()
+    this.onSpellCheckLangsChange = this.onSpellCheckLangsChange.bind(this)
+  }
+
+  onSpellCheckLangsChange (value) {
+    if (!value) {
+      this.props.onChangeSetting(settings.SPELLCHECK_LANGUAGES, [])
+    } else {
+      this.props.onChangeSetting(settings.SPELLCHECK_LANGUAGES, value.split(','))
+    }
+  }
+
+  get spellCheckLanguages () {
+    const spellCheckLangOptions = this.props.languageCodes.map(function (lc) {
+      return (
+        { value: lc, label: locale.translation(lc) }
+      )
+    })
+
+    return getSetting(settings.SPELLCHECK_ENABLED, this.props.settings)
+      ? <SettingItem dataL10nId='spellCheckLanguages'>
+        <Select
+          name='spellCheckLanguages'
+          value={getSetting(settings.SPELLCHECK_LANGUAGES, this.props.settings).join(',')}
+          multi='true'
+          options={spellCheckLangOptions}
+          onChange={this.onSpellCheckLangsChange}
+          placeholder={locale.translation('spellCheckLanguages')}
+        />
+      </SettingItem>
+      : null
+  }
+
   get swipeNavigationDistanceSetting () {
     if (isDarwin) {
       return <div>
@@ -81,6 +118,16 @@ class AdvancedTab extends ImmutableComponent {
         <SettingsList>
           <SettingCheckbox dataL10nId='disableTitleMode' prefKey={settings.DISABLE_TITLE_MODE} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
           <SettingCheckbox dataL10nId='wideURLbar' prefKey={settings.WIDE_URL_BAR} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
+        </SettingsList>
+        <DefaultSectionTitle data-l10n-id='spellcheck' />
+        <SettingsList>
+          <SettingCheckbox
+            dataL10nId='enableSpellCheck'
+            prefKey={settings.SPELLCHECK_ENABLED}
+            settings={this.props.settings}
+            onChangeSetting={this.props.onChangeSetting}
+          />
+          {this.spellCheckLanguages}
         </SettingsList>
       </main>
       <footer className={css(styles.moreInfo)}>

--- a/app/renderer/components/preferences/advancedTab.js
+++ b/app/renderer/components/preferences/advancedTab.js
@@ -62,6 +62,11 @@ class AdvancedTab extends ImmutableComponent {
       : null
   }
 
+  get defaultLanguage () {
+    return this.props.languageCodes
+      .find((lang) => lang.includes(navigator.language)) || 'en-US'
+  }
+
   get swipeNavigationDistanceSetting () {
     if (isDarwin) {
       return <div>
@@ -118,6 +123,24 @@ class AdvancedTab extends ImmutableComponent {
         <SettingsList>
           <SettingCheckbox dataL10nId='disableTitleMode' prefKey={settings.DISABLE_TITLE_MODE} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
           <SettingCheckbox dataL10nId='wideURLbar' prefKey={settings.WIDE_URL_BAR} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
+        </SettingsList>
+        <DefaultSectionTitle data-l10n-id='selectedLanguage' />
+        <SettingsList>
+          <SettingDropdown
+            value={(
+              getSetting(settings.LANGUAGE, this.props.settings) ||
+              this.defaultLanguage
+            )}
+            onChange={changeSetting.bind(
+              null,
+              this.props.onChangeSetting,
+              settings.LANGUAGE
+            )}>
+            {
+              this.props.languageCodes
+                .map((lc) => <option data-l10n-id={lc} value={lc} />)
+            }
+          </SettingDropdown>
         </SettingsList>
         <DefaultSectionTitle data-l10n-id='spellcheck' />
         <SettingsList>

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -130,15 +130,8 @@ class GeneralTab extends ImmutableComponent {
   }
 
   render () {
-    const languageOptions = this.props.languageCodes.map(function (lc) {
-      return (
-        <option data-l10n-id={lc} value={lc} />
-      )
-    })
-
     const homepage = getSetting(settings.HOMEPAGE, this.props.settings)
     const disableShowHomeButton = !homepage || !homepage.length
-    const defaultLanguage = this.props.languageCodes.find((lang) => lang.includes(navigator.language)) || 'en-US'
     const defaultBrowser = getSetting(settings.IS_DEFAULT_BROWSER, this.props.settings)
       ? <SettingItem dataL10nId='defaultBrowser' />
       : <SettingItem dataL10nId='notDefaultBrowser' >
@@ -210,12 +203,6 @@ class GeneralTab extends ImmutableComponent {
           <SettingCheckbox id='bookmarksBarSwitch' dataL10nId='bookmarkToolbar'
             prefKey={settings.SHOW_BOOKMARKS_TOOLBAR} settings={this.props.settings}
             onChangeSetting={this.props.onChangeSetting} />
-        </SettingItem>
-        <SettingItem dataL10nId='selectedLanguage'>
-          <SettingDropdown value={getSetting(settings.LANGUAGE, this.props.settings) || defaultLanguage}
-            onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.LANGUAGE)}>
-            {languageOptions}
-          </SettingDropdown>
         </SettingItem>
         <SettingItem dataL10nId='defaultZoomLevel'>
           <SettingDropdown

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -6,11 +6,9 @@
 const React = require('react')
 const ImmutableComponent = require('../../app/renderer/components/immutableComponent')
 const Immutable = require('immutable')
-const Select = require('react-select')
 const {StyleSheet, css} = require('aphrodite/no-important')
 const globalStyles = require('../../app/renderer/components/styles/global')
 const commonStyles = require('../../app/renderer/components/styles/commonStyles')
-const locale = require('../../js/l10n')
 
 // Components
 const PreferenceNavigation = require('../../app/renderer/components/preferences/preferenceNavigation')
@@ -70,7 +68,6 @@ require('../../less/about/preferences.less')
 require('../../less/forms.less')
 require('../../less/button.less')
 require('../../node_modules/font-awesome/css/font-awesome.css')
-require('../../less/react-select.less')
 
 const permissionNames = {
   'mediaPermission': ['boolean'],
@@ -103,7 +100,6 @@ class GeneralTab extends ImmutableComponent {
     this.importBrowserDataNow = this.importBrowserDataNow.bind(this)
     this.onChangeSetting = this.onChangeSetting.bind(this)
     this.setAsDefaultBrowser = this.setAsDefaultBrowser.bind(this)
-    this.onSpellCheckLangsChange = this.onSpellCheckLangsChange.bind(this)
   }
 
   importBrowserDataNow () {
@@ -119,14 +115,6 @@ class GeneralTab extends ImmutableComponent {
       }
     }
     this.props.onChangeSetting(key, value)
-  }
-
-  onSpellCheckLangsChange (value) {
-    if (!value) {
-      this.props.onChangeSetting(settings.SPELLCHECK_LANGUAGES, [])
-    } else {
-      this.props.onChangeSetting(settings.SPELLCHECK_LANGUAGES, value.split(','))
-    }
   }
 
   setAsDefaultBrowser () {
@@ -148,12 +136,6 @@ class GeneralTab extends ImmutableComponent {
       )
     })
 
-    const spellCheckLangOptions = this.props.languageCodes.map(function (lc) {
-      return (
-        { value: lc, label: locale.translation(lc) }
-      )
-    })
-
     const homepage = getSetting(settings.HOMEPAGE, this.props.settings)
     const disableShowHomeButton = !homepage || !homepage.length
     const defaultLanguage = this.props.languageCodes.find((lang) => lang.includes(navigator.language)) || 'en-US'
@@ -166,19 +148,6 @@ class GeneralTab extends ImmutableComponent {
           onClick={this.setAsDefaultBrowser}
         />
       </SettingItem>
-    const spellCheckLanguages = getSetting(settings.SPELLCHECK_ENABLED, this.props.settings)
-      ? <SettingItem dataL10nId='spellCheckLanguages'>
-        <Select
-          name='spellCheckLanguages'
-          value={getSetting(settings.SPELLCHECK_LANGUAGES, this.props.settings).join(',')}
-          multi='true'
-          options={spellCheckLangOptions}
-          onChange={this.onSpellCheckLangsChange}
-          placeholder={locale.translation('spellCheckLanguages')}
-        />
-      </SettingItem>
-      : null
-
     const defaultZoomSetting = getSetting(settings.DEFAULT_ZOOM_LEVEL, this.props.settings)
     return <SettingsList>
       <DefaultSectionTitle data-test-id='generalSettings' data-l10n-id='generalSettings' />
@@ -248,9 +217,6 @@ class GeneralTab extends ImmutableComponent {
             {languageOptions}
           </SettingDropdown>
         </SettingItem>
-        <SettingCheckbox dataL10nId='enableSpellCheck' prefKey={settings.SPELLCHECK_ENABLED}
-          settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
-        {spellCheckLanguages}
         <SettingItem dataL10nId='defaultZoomLevel'>
           <SettingDropdown
             value={defaultZoomSetting === undefined || defaultZoomSetting === null ? config.zoom.defaultValue : defaultZoomSetting}
@@ -1005,7 +971,10 @@ class AboutPreferences extends React.Component {
         tab = <SecurityTab settings={settings} siteSettings={siteSettings} braveryDefaults={braveryDefaults} onChangeSetting={this.onChangeSetting} />
         break
       case preferenceTabs.ADVANCED:
-        tab = <AdvancedTab settings={settings} onChangeSetting={this.onChangeSetting} />
+        tab = <AdvancedTab
+          settings={settings}
+          languageCodes={languageCodes}
+          onChangeSetting={this.onChangeSetting} />
         break
     }
     return <div>

--- a/test/unit/about/preferencesTest.js
+++ b/test/unit/about/preferencesTest.js
@@ -25,7 +25,7 @@ describe('Preferences component unittest', function () {
     mockery.registerMock('../../less/about/preferences.less', {})
     mockery.registerMock('../../less/forms.less', {})
     mockery.registerMock('../../less/button.less', {})
-    mockery.registerMock('../../less/react-select.less', {})
+    mockery.registerMock('../../../../less/react-select.less', {})
     mockery.registerMock('../../node_modules/font-awesome/css/font-awesome.css', {})
     mockery.registerMock('../../../extensions/brave/img/caret_down_grey.svg')
     mockery.registerMock('../../../extensions/brave/img/preferences/browser_prefs_general.svg', 'browser_prefs_general.svg')


### PR DESCRIPTION
fix #11811

address https://github.com/brave/browser-laptop/issues/2183#issuecomment-342078623
this also moves "language" setting under advanced panel too

fix #11814 

Auditors: @darkdh 

Test Plan:

* Languages and Spell Check options should be inside advanced panel
* Tests should pass :)
* They should work :)