### PR TITLE
'New tab' dashboard images fade in from dark

### DIFF
--- a/app/extensions/brave/about-newtab.html
+++ b/app/extensions/brave/about-newtab.html
@@ -4,6 +4,11 @@
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
 <html>
   <head>
+    <style>
+      html, body {
+        background: #222;
+      }
+    </style>
     <meta charset="utf-8">
     <meta name="availableLanguages" content="">
     <meta name="defaultLanguage" content="en-US">

--- a/less/about/newtab.less
+++ b/less/about/newtab.less
@@ -9,21 +9,10 @@
   box-sizing: border-box;
 }
 
-
 strong, div, span, li, em, p, a {
   font-family: "Helvetica Neue", Arial, sans-serif;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
-}
-
-body {
-  background: #fff;
-}
-
-body, .dynamicBackground, bgGradient {
-  opacity: 0;
-  animation: fadeIn 200ms;
-  animation-fill-mode: forwards;
 }
 
 .copyrightNotice {
@@ -45,33 +34,27 @@ ul {
 }
 
 .dynamicBackground {
-  background-position: top center;
-  background-repeat: no-repeat;
-  background-size: cover;
   display: flex;
   flex: 1;
+}
 
-  > img {
-    display: none;
+.imageBackground {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 1;
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    opacity: 0;
+    transition: opacity .5s ease-in-out;
   }
-}
-
-.gradient {
-  background: radial-gradient(circle farthest-corner at right bottom,#ff4444 0,rgb(9, 14, 160) 100%);
-  height: 100%;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 100%;
-}
-
-.bgGradient {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  background: linear-gradient(rgba(0, 0, 0, 1), rgba(0, 0, 0, 0));
-  height: 400px;
+  &.hasLoaded img {
+    opacity: 1;
+  }
 }
 
 .content {
@@ -86,6 +69,11 @@ ul {
   height: 100%;
   min-height: 100vh;
   padding: 40px 60px;
+  background: transparent;
+  background: radial-gradient(circle farthest-corner at right bottom,#ff4444 0,rgb(9, 14, 160) 100%);
+  &.showImages {
+    background: linear-gradient(to bottom, rgba(34, 34, 34, 1) 0%, rgba(0, 0, 0, 0) 400px);
+  }
 
   .topSitesContainer {
     width: 100%;

--- a/test/unit/about/newTabPageTest.js
+++ b/test/unit/about/newTabPageTest.js
@@ -46,9 +46,7 @@ describe('NewTab component unit tests', function () {
 
   let wrapper, incognitoWrapper
   const backgroundImage = {
-    style: {
-      backgroundImage: 'url(testing123.jpg)'
-    }
+    source: 'testing123.jpg'
   }
   const TIME_UNIT = {
     SECOND: 'S',
@@ -116,23 +114,19 @@ describe('NewTab component unit tests', function () {
         assert.equal(randomSpy.calledOnce, true)
       })
 
-      it('returns an object which has a value set for `style.backgroundImage`', function () {
+      it('returns an object which has a value set for `source`', function () {
         const instance = wrapper.instance()
         const result = instance.randomBackgroundImage
         assert.notEqual(result, undefined)
-        assert.notEqual(result.style, undefined)
-        assert.notEqual(result.style.backgroundImage, undefined)
-        assert.equal(!!result.style.backgroundImage.match(/^url\(/), true)
+        assert.notEqual(result.source, undefined)
       })
     })
     describe('fallbackImage', function () {
-      it('returns an object which has a value set for `style.backgroundImage`', function () {
+      it('returns an object which has a value set for `source`', function () {
         const instance = wrapper.instance()
         const result = instance.fallbackImage
         assert.notEqual(result, undefined)
-        assert.notEqual(result.style, undefined)
-        assert.notEqual(result.style.backgroundImage, undefined)
-        assert.equal(!!result.style.backgroundImage.match(/^url\(/), true)
+        assert.notEqual(result.source, undefined)
       })
     })
     describe('topSites', function () {
@@ -192,18 +186,14 @@ describe('NewTab component unit tests', function () {
           })
         })
 
+        it('includes wallpaper background element', function () {
+          assert.equal(wrapper.find('[data-test-id="backgroundImage"]').length, 1)
+        })
+
         it('sets backgroundImage for root element to the URL of the image', function () {
-          const node = wrapper.find('[data-test-id="dynamicBackground"]').node
+          const node = wrapper.find('[data-test-id="backgroundImage"]').node
           assert.notEqual(node, undefined)
-          assert.deepEqual(node.props.style, backgroundImage.style)
-        })
-
-        it('includes div element with class bgGradient', function () {
-          assert.equal(wrapper.find('div[data-test-id="bgGradient"]').length, 1)
-        })
-
-        it('includes img element (used to detect onError)', function () {
-          assert.equal(wrapper.find('img[data-test-id="backgroundImage"]').length, 1)
+          assert.deepEqual(node.props.src, backgroundImage.source)
         })
       })
 
@@ -217,12 +207,8 @@ describe('NewTab component unit tests', function () {
           })
         })
 
-        it('includes element with class gradient', function () {
-          assert.equal(wrapper.find('div[data-test-id="gradient"]').length, 1)
-        })
-
-        it('does NOT include img element (used to detect onError)', function () {
-          assert.equal(wrapper.find('img[data-test-id="backgroundImage"]').length, 0)
+        it('does NOT include wallpaper background', function () {
+          assert.equal(wrapper.find('[data-test-id="backgroundImage"]').length, 0)
         })
       })
     })


### PR DESCRIPTION
Fix #5309

Addresses new tab when in 'Dashboard' mode. Sets default background color so that the text is readable without the background having loaded. Waits for image to load completely before fading it in. Also general clean up to remove separate gradient element and double-setting of wallpaper image source. 

Note: I noticed after I had done this that this had been attempted before in #6590, but that was abandoned because of the white flash before the tab loads. This minimizes it by further explicitly setting the background color in html before the JS / react components have loaded (although webpack can be configured to output the css as a .css file which can be included in about-newtab.html). The flashes of white that are still present on both tab open and close are from both the <webview> background on open, and the window background on close (when no other tab is shown). These will be addressed in #11813.

Here's what it looks like: https://www.dropbox.com/s/qpsk8fk3m5rpx3f/newtab-fade-i5309.mov?dl=0

Here's what it looked like before (with empty profile): https://www.dropbox.com/s/05mz3expvewmcsv/newtab-fade-before-i5309.mov?dl=0

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
Automated tests included.

Manual tests include checking that image loads with good network, that fallback image loads with no network and clear cache, and that when settings are set to no images on Dashboard, that the very colorful gradient shows.

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


