### PR TITLE
Avoid 'flashes of white' when tabs open or close

### DIFF
--- a/app/renderer/components/frame/frame.js
+++ b/app/renderer/components/frame/frame.js
@@ -859,12 +859,15 @@ class Frame extends React.Component {
 
     const props = {}
     // used in renderer
+    props.transitionState = ownProps.transitionState
     props.partition = frameStateUtil.getPartition(frame)
     props.isFullScreen = frame.get('isFullScreen')
     props.isPreview = frame.get('key') === currentWindow.get('previewFrameKey')
     props.isActive = frameStateUtil.isFrameKeyActive(currentWindow, frame.get('key'))
     props.showFullScreenWarning = frame.get('showFullScreenWarning')
     props.location = location
+    props.isDefaultNewTabLocation = location === 'about:newtab'
+    props.isBlankLocation = location === 'about:blank'
     props.tabId = tabId
     props.showMessageBox = tabMessageBoxState.hasMessageBoxDetail(state, tabId)
     props.isFocused = isFocused(state)
@@ -906,7 +909,17 @@ class Frame extends React.Component {
     return props
   }
 
+  getTransitionStateClassName (stateName) {
+    // handle missing data
+    if (!stateName) {
+      return null
+    }
+    // convert Transition element state string to a more consistent css classname
+    return `is${stateName[0].toUpperCase()}${stateName.slice(1)}`
+  }
+
   render () {
+    const transitionClassName = this.getTransitionStateClassName(this.props.transitionState)
     return <div
       data-partition={this.props.partition}
       data-test-id='frameWrapper'
@@ -914,8 +927,12 @@ class Frame extends React.Component {
       data-test3-id={this.props.isPreview ? 'previewFrame' : null}
       className={cx({
         frameWrapper: true,
+        [this.props.className]: this.props.className,
+        [transitionClassName]: transitionClassName,
         isPreview: this.props.isPreview,
-        isActive: this.props.isActive
+        isActive: this.props.isActive,
+        isDefaultNewTabLocation: this.props.isDefaultNewTabLocation,
+        isBlankLocation: this.props.isBlankLocation
       })}>
       {
         this.props.isFullScreen && this.props.showFullScreenWarning

--- a/app/renderer/components/main/main.js
+++ b/app/renderer/components/main/main.js
@@ -17,6 +17,7 @@ const contextMenus = require('../../../../js/contextMenus')
 const {getSetting} = require('../../../../js/settings')
 
 // Components
+const { Transition, TransitionGroup } = require('react-transition-group')
 const Navigator = require('../navigation/navigator')
 const Frame = require('../frame/frame')
 const TabPages = require('../tabs/tabPages')
@@ -733,15 +734,27 @@ class Main extends React.Component {
         }
       </div>
       <div className='mainContainer'>
-        <div className='tabContainer'>
+        <TransitionGroup className='tabContainer'>
           {
             this.props.sortedFrames.map((frameKey) =>
-              <Frame
-                frameKey={frameKey}
+              <Transition
                 key={frameKey}
-              />)
+                // after how long (ms)
+                // should the state 'entering' switch to 'entered'
+                // and also how long should state switch from 'exiting'
+                // to the <Frame /> component actually being removed
+                timeout={150}>
+                {
+                  (transitionState) =>
+                    <Frame
+                      frameKey={frameKey}
+                      transitionState={transitionState}
+                    />
+                }
+              </Transition>
+            )
           }
-        </div>
+        </TransitionGroup>
       </div>
       {
         this.props.showDownloadBar

--- a/app/renderer/components/styles/theme.js
+++ b/app/renderer/components/styles/theme.js
@@ -163,5 +163,12 @@
           color: 'inherit'
         }
       }
+    },
+
+    frame: {
+      defaultBackground: '#fff',
+      newTabBackground: '#222',
+      privateTabBackground: globalStyles.color.privateTabBackgroundActive,
+      privateTabBackground2: '#000'
     }
   }

--- a/js/about/newprivatetab.js
+++ b/js/about/newprivatetab.js
@@ -5,6 +5,7 @@
 const React = require('react')
 const {StyleSheet, css} = require('aphrodite')
 const globalStyles = require('../../app/renderer/components/styles/global')
+const { theme } = require('../../app/renderer/components/styles/theme')
 const Stats = require('./newTabComponents/stats')
 const Clock = require('./newTabComponents/clock')
 const privateTabIcon = require('../../app/extensions/brave/img/newtab/private_tab_pagearea_icon.svg')
@@ -39,8 +40,21 @@ const atBreakpoint = `@media screen and (max-width: ${globalStyles.breakpoint.br
 const styles = StyleSheet.create({
   newPrivateTab: {
     background: `linear-gradient(
-      ${globalStyles.color.privateTabBackgroundActive},
-      ${globalStyles.color.black100})`,
+      ${theme.frame.privateTabBackground},
+      ${theme.frame.privateTabBackground2}
+    )`,
+    backgroundAttachment: 'fixed',
+    // fade in from the new tab background color
+    animationName: {
+      '0%': {
+        opacity: '0'
+      },
+      '100%': {
+        opacity: '1'
+      }
+    },
+    animationDuration: `0.35s`,
+    animationTiming: 'ease-out',
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'flex-start',

--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -278,7 +278,7 @@ class NewTabPage extends React.Component {
         backgroundLoaded: this.state.imageLoadComplete,
         showImages: this.showImages
       })}>
-        <main>
+        <main className='newTabDashboard'>
           <div className='statsBar'>
             <Stats newTabData={this.state.newTabData} />
             <Clock />

--- a/less/about/newtab.less
+++ b/less/about/newtab.less
@@ -9,10 +9,21 @@
   box-sizing: border-box;
 }
 
+// match private tab js-css values
+@newTabAnimationDuration: 0.5s;
+@newTabAnimationEasing: ease-out;
+
 strong, div, span, li, em, p, a {
   font-family: "Helvetica Neue", Arial, sans-serif;
   font-weight: 400;
   -webkit-font-smoothing: antialiased;
+}
+
+.newTabDashboard
+{
+    animation: fadeIn;
+    animation-duration: .3s;
+    animation-timing-function: ease-out;
 }
 
 .copyrightNotice {

--- a/less/window.less
+++ b/less/window.less
@@ -62,16 +62,68 @@ html,
 .frameWrapper {
   height: 100%;
   width: 100%;
-  z-index: @zindexWindow;
+
   position: absolute;
   top: 0;
   left: 0;
 
   // Needed to be able to click and drag to select content in pages.
   user-select: none;
+  // default frame background
+  // TODO: use theme.frame.defaultBackground
+  --frame-bg: #fff;
+  // custom frame background(s)
+  &.isDefaultNewTabLocation {
+    // matches tab dashboard background
+    // will also show when about:newtab === about:blank or is Private Tab
+    // TODO: use theme.frame.newTabBackground
+    --frame-bg: #222;
+  }
+  // Webviews can cause flickers w/ Chrome  v49 if left visible
+  // in the background.  This also has a major benefit for background
+  // tabs that have video and animations in them.
+  visibility: hidden;
+  // delay frames getting hidden when new tabs show up
+  // in order to avoid showing 0 frames and just the window
+  // background
+  // whilst this does also affect visibility when switching tabs,
+  // z-index ensures the delayed-hidden tab is not visible
+  // Note that this value can be as large as we want, it does not
+  // need to match the timeout specified in the frame's <Transition /> element
+  // (in renderer main.js). However, there is no reason to set it higher than that.
+  transition: visibility 0s linear 150ms;
+  // 1000
+  z-index: @zindexWindow;
+  &:not(.isActive) {
+    // 900
+    z-index: @zindexWindowNotActive;
+  }
+  &.isPreview {
+    background: #222;
+    // 1100
+    z-index: @zindexWindowIsPreview;
+  }
+  // show frame when active or preview
+  &.isActive,
+  &.isPreview,
+  // keep window contents around when exiting, to allow
+  // time for next active frame to be shown
+  &.isExiting {
+    visibility: visible;
+    // show instantly
+    transition-delay: 0s;
+  }
+  // hide frame whilst it's figuring out which location to be
+  // note: that isEntering is timed-out at a value set in renderer main.js
+  // but isBlankLocation will change at the exact moment that the frame
+  // has an actual location
+  &.isEntering.isBlankLocation {
+    visibility: hidden;
+    transition-delay: 0s;
+  }
 
   webview {
-    background-color: #fff;
+    background-color: var(--frame-bg);
     border: 0;
     height: 100%;
     outline: none;
@@ -89,21 +141,6 @@ html,
     }
   }
 
-  &:not(.isActive) {
-    z-index: @zindexWindowNotActive;
-
-    &.isPreview {
-      background: gray;
-      z-index: @zindexWindowIsPreview;
-    }
-
-    // Webviews can cause flickers w/ Chrome  v49 if left visible
-    // in the background.  This also has a major benefit for background
-    // tabs that have video and animations in them.
-    &:not(.isPreview) {
-      visibility: hidden;
-    }
-  }
 }
 
 .hrefPreview {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2702,6 +2702,11 @@
       "integrity": "sha1-CdekApCKpw39vq1T5YU/x50+8hw=",
       "dev": true
     },
+    "chain-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/chain-function/-/chain-function-1.0.0.tgz",
+      "integrity": "sha1-DUqzfn4Y6tC9xHuSB2QRjOWHM9w="
+    },
     "chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
@@ -4770,6 +4775,11 @@
           "dev": true
         }
       }
+    },
+    "dom-helpers": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz",
+      "integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo="
     },
     "dom-serializer": {
       "version": "0.1.0",
@@ -16617,6 +16627,19 @@
         "object-assign": "4.1.1"
       }
     },
+    "react-transition-group": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.2.1.tgz",
+      "integrity": "sha512-q54UBM22bs/CekG8r3+vi9TugSqh0t7qcEVycaRc9M0p0aCEu+h6rp/RFiW7fHfgd1IKpd9oILFTl5QK+FpiPA==",
+      "requires": {
+        "chain-function": "1.0.0",
+        "classnames": "2.2.5",
+        "dom-helpers": "3.2.1",
+        "loose-envify": "1.3.1",
+        "prop-types": "15.6.0",
+        "warning": "3.0.0"
+      }
+    },
     "read-all-stream": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
@@ -19953,6 +19976,14 @@
       "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
       "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
       "dev": true
+    },
+    "warning": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
     },
     "watchpack": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "react-dnd-html5-backend": "^2.1.2",
     "react-dom": "^15.5.4",
     "react-select": "^0.9.1",
+    "react-transition-group": "^2.2.1",
     "snazzy": "^7.0.0",
     "string.prototype.endswith": "^0.2.0",
     "string.prototype.startswith": "^0.2.0",


### PR DESCRIPTION
Remove white flash for new tab pages which use about:newtab.
Sets the frame background to the same background as the newtab page, for a smooth transition between frame creation and the tab beginning to load content.
Keeps a closed frame around until the next frame is ready, to avoid flash when closing tabs.

Fix #11813
Addresses #5309

When opening a tab, there is a flash of the background of the <webview> component, which is explicitly set to white in window.less.
This is avoided by setting the background to the 'new tab dashboard' background color (only when that is the Url for the frame), and by hiding the frame if it's about:blank and for the first 150ms since when a frame is first created, it starts as about:blank and then sets its location to the specified Url.

When closing a tab, there is a flash of the background of the whole window (or at least div.tabContainer) as the active frame is removed, but the next active frame is not set active yet. This is avoided by keeping the `Element` for the frame around for 100ms, with a low z-index, so that the new / next active tab will show on top when it is ready.

Closing tabs - Before:
https://www.dropbox.com/s/aon11cov3nqcau2/p11813-close-tabs-before.mov?dl=0

Closing tabs - After:
https://www.dropbox.com/s/0x1n8msobxssihh/p11813-close-tabs-after.mov?dl=0

## Test Plan:
- When creating a new tab there is no flash between the frames (~difficult to see until #11817 lands since all new frames have white background, and the window has a white background~).
- When closing a tab with a loaded previous and next tab, there is no white flash between leaving the old tab and showing the next tab.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Security
Introduces new package: https://github.com/reactjs/react-transition-group

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


