### PR TITLE
Correct relaunch logic

### DIFF
--- a/app/windowsInit.js
+++ b/app/windowsInit.js
@@ -76,13 +76,16 @@ if (process.platform === 'win32') {
   }
 
   const userDataDirSwitch = '--user-data-dir-name=brave-' + channel
-  if (channel && channel !== 'dev' && !process.argv.includes(userDataDirSwitch)) {
+  if (channel !== 'dev' && !process.argv.includes(userDataDirSwitch) &&
+      !process.argv.includes('--relaunch') &&
+      !process.argv.includes('--user-data-dir-name=brave-development')) {
+    delete process.env.CHROME_USER_DATA_DIR
     if (cmd === '--squirrel-firstrun') {
       app.relaunch({args: [userDataDirSwitch, '--relaunch']})
     } else {
-      app.relaunch({args: process.argv.slice(1) + [userDataDirSwitch, '--relaunch']})
+      app.relaunch({args: process.argv.slice(1).concat([userDataDirSwitch, '--relaunch'])})
     }
-    app.quit()
+    app.exit()
   }
 }
 

--- a/tools/buildInstaller.js
+++ b/tools/buildInstaller.js
@@ -178,9 +178,7 @@ if (isDarwin) {
       setupExe: `${appName}-Setup-${arch}.exe`
     })
     resultPromise.then(() => {
-      cmds = [
-      ]
-      execute(cmds, {}, console.log.bind(null, 'done'))
+      console.log('done')
     }, (e) => console.log(`No dice: ${e.message}`))
   })
 } else if (isLinux) {


### PR DESCRIPTION
fix #11821, fix #11824

~- [ ] blocked by https://github.com/brave/muon/issues/383~

Auditors: @bsclifton

Test Plan:
a. CHANNEL=beta npm start shouldn't relaunch

b. CHANNEL=beta npm build-package
b-1. ./BraveBeta-win32-x64/BraveBeta.exe should relaunch and use `brave-beta` as user dir
b-2 CHANNEL=beta npm build-installer
b-3 Install Brave by dist/x64/BraveBeta-Setup-x64.exe
b-4 After installation, the first time launch should relaunch and use `brave-beta` as user dir

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


