### PR TITLE
Don't call transition if client/wallet is already v2

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -2369,7 +2369,20 @@ const transitionWalletToBat = () => {
   if (newClient === true) return
   clientprep()
 
-  // Restore newClient from the file
+  if (!client) {
+    console.log('Client is not initialized, will try again')
+    return
+  }
+
+  // only attempt this transition if the wallet is v1
+  if (client && client.options && client.options.version !== 'v1') {
+    // older versions incorrectly marked this for transition
+    // this will clean them up (no more bouncy ball)
+    appActions.onBitcoinToBatTransitioned()
+    return
+  }
+
+  // Restore newClient from the file (if one exists)
   if (!newClient) {
     const fs = require('fs')
     try {
@@ -2416,11 +2429,6 @@ const transitionWalletToBat = () => {
 
       setTimeout(() => transitionWalletToBat(), delayTime)
     })
-    return
-  }
-
-  if (!client) {
-    console.log('Client is not initialized, will try again')
     return
   }
 
@@ -2510,6 +2518,12 @@ const getMethods = () => {
       getSynopsis: () => synopsis,
       setSynopsis: (data) => {
         synopsis = data
+      },
+      resetNewClient: () => {
+        newClient = false
+      },
+      getClient: () => {
+        return client
       },
       setClient: (data) => {
         client = data


### PR DESCRIPTION
Properly fixes another use-case for https://github.com/brave/browser-laptop/issues/11566

Auditors: @evq, @NejcZdovc

Test Plan:
`npm run unittest -- --grep="transitionWalletToBat"`

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


