### PR TITLE
Do not register accelerator for Delete in Edit

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -163,7 +163,6 @@ const createEditSubmenu = () => {
     CommonMenu.separatorMenuItem,
     {
       label: locale.translation('delete'),
-      accelerator: 'Delete',
       click: function (item, focusedWindow) {
         focusedWindow.webContents.delete()
       }


### PR DESCRIPTION
parity: see Edit menu in Chrome
<img width="241" alt="screen shot 2017-11-08 at 5 03 05 pm" src="https://user-images.githubusercontent.com/11330831/32583114-bd5630ee-c4a6-11e7-9d06-35972e66d57e.png">

fix #11863

Auditors: @bsclifton, @bbondy

Test Plan:
a.1 type brave in text area
a.2 put I beam between r and a
a.3 press delete key (fn + delete or physical del button)
a.4 it should be "brve"

b.1 type brave in text area
b.2 double click brave to select the word
b.3 Click Delete in Edit menubar
b.4 The word "brave" is gone

c.1 type brave in text area
c.2 double click brave to select the word
c.3 Press backspace key
c.4 The word "brave" is gone

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


