### PR TITLE
Fix wide bravery panel to stop covering the webview

### DIFF
--- a/app/renderer/components/main/braveryPanel.js
+++ b/app/renderer/components/main/braveryPanel.js
@@ -928,7 +928,11 @@ const styles = StyleSheet.create({
   braveryPanel__body__ul__li: {
     listStyleType: 'none',
     padding: '10px 0',
-    cursor: 'text'
+    cursor: 'text',
+
+    // #9839 and #11878: Avoid the panel width from increasing.
+    width: 0,
+    whiteSpace: 'nowrap'
   },
   braveryPanel__body__hr: {
     background: globalStyles.braveryPanel.body.hr.background,
@@ -980,10 +984,6 @@ const styles = StyleSheet.create({
   },
   braveryPanel_compact__body__ul__li: {
     padding: '5px 0',
-
-    // #9839: Avoid the panel width from increasing
-    width: 0,
-    whiteSpace: 'nowrap',
 
     ':first-of-type': {
       paddingTop: 0

--- a/app/renderer/components/main/braveryPanel.js
+++ b/app/renderer/components/main/braveryPanel.js
@@ -661,7 +661,12 @@ const displayHost = {
   fontWeight: 'normal',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
-  overflow: 'hidden'
+  overflow: 'hidden',
+
+  // See #11878: avoid a very long domain drom covering the webview.
+  // The value should maintain the panel width until 0.19.
+  // https://github.com/brave/browser-laptop/blob/0.19.x/app/renderer/components/main/braveryPanel.js#L708
+  maxWidth: '320px'
 }
 const editGlobalMarginBottom = '.25rem'
 


### PR DESCRIPTION
Fixes #11878
Fixes #11899
Follow-up to #9839

Auditors:

Test Plan 1:
1. Open https://chiebukuro.yahoo.co.jp/
2. Click the adblock count
3. Make sure panel width does not change

Test Plan 2:
1. Open https://longextendedsubdomainnamewithoutdashesinordertotestwordwrapping.badssl.com/
2. Open the wide bravery panel
3. Make sure the panel does not cover the webview

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


