### PR TITLE
Automatically add user-data-dir-name to non Release channels

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -46,6 +46,10 @@ if (process.platform === 'win32') {
   require('./windowsInit')
 }
 
+if (process.platform === 'linux') {
+  require('./linuxInit')
+}
+
 const electron = require('electron')
 const app = electron.app
 const ipcMain = electron.ipcMain

--- a/app/linuxInit.js
+++ b/app/linuxInit.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const electron = require('electron')
+const app = electron.app
+const Channel = require('./channel')
+
+if (process.platform === 'linux') {
+  const channel = Channel.channel()
+
+  const userDataDirSwitch = '--user-data-dir-name=brave-' + channel
+  if (channel !== 'dev' && !process.argv.includes(userDataDirSwitch) &&
+      !process.argv.includes('--relaunch') &&
+      !process.argv.includes('--user-data-dir-name=brave-development')) {
+    delete process.env.CHROME_USER_DATA_DIR
+    app.relaunch({args: process.argv.slice(1).concat([userDataDirSwitch, '--relaunch'])})
+    app.exit()
+  }
+}


### PR DESCRIPTION
fix #11900

Auditors: @bsclifton

## Test Plan:
a. CHANNEL=beta npm start shouldn't relaunch

b. CHANNEL=beta npm build-package
b-1. ./brave-beta-linux-x64/brave-beta should relaunch and use
brave-beta as user dir
b-2 CHANNEL=beta npm build-installer
b-3 Install Brave by dist/x64/brave-beta_0.*.*_amd64.deb/x86_64.rpm
b-4 launch brave-beta from terminal should relaunch and use brave-beta
as user dir

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


