### PR TITLE
remove tab page index update from WINDOW_CLOSE_FRAME

### DIFF
--- a/app/renderer/reducers/frameReducer.js
+++ b/app/renderer/reducers/frameReducer.js
@@ -239,8 +239,6 @@ const frameReducer = (state, action, immutableAction) => {
       break
     case windowConstants.WINDOW_CLOSE_FRAME:
       state = closeFrame(state, action)
-      const activeFrame = frameStateUtil.getActiveFrame(state)
-      state = frameStateUtil.updateTabPageIndex(state, activeFrame.get('tabId'))
       break
 
     case windowConstants.WINDOW_SET_FULL_SCREEN:


### PR DESCRIPTION
Tab page update is already handled by `APP_TAB_UPDATED`.

fix #11902
Auditors: @bbondy
cc @srirambv 

Test Plan:
1. Open 3 tab pages
2. Go back to tab page 1, select active tab
3. Sequentially close
4. Tab page shoudn't "flash"

Regression test:

1. Closing/Opening tabs should update the tab page as expected