### PR TITLE
Add waitForVisible to about:history and about:bookmarks automated tests

### DIFF
--- a/test/about/bookmarksManagerTest.js
+++ b/test/about/bookmarksManagerTest.js
@@ -182,6 +182,7 @@ describe('about:bookmarks', function () {
 
     it('selects multiple rows when clicked with cmd/control', function * () {
       yield this.app.client
+        .waitForVisible('table.sortableTable td.title[data-sort="Brave"]')
         .click('table.sortableTable td.title[data-sort="Brave"]')
         .isDarwin().then((val) => {
           if (val === true) {
@@ -213,6 +214,7 @@ describe('about:bookmarks', function () {
     })
     it('selects multiple contiguous rows when shift clicked', function * () {
       yield this.app.client
+        .waitForVisible('table.sortableTable td.title[data-sort="Brave"]')
         .click('table.sortableTable td.title[data-sort="Brave"]')
         .keys(Brave.keys.SHIFT)
         .click('table.sortableTable td.title[data-sort="https://www.youtube.com"]')

--- a/test/about/historyTest.js
+++ b/test/about/historyTest.js
@@ -83,6 +83,7 @@ describe('about:history', function () {
       const site = Brave.server.url(browseableSiteUrl)
       yield this.app.client
         .tabByUrl(aboutHistoryUrl)
+        .waitForVisible('table.sortableTable td.title[data-sort="' + browseableSiteTitle + '"]')
         .doubleClick('table.sortableTable td.title[data-sort="' + browseableSiteTitle + '"]')
         .waitForTabCount(2)
         .waitForUrl(site)
@@ -102,6 +103,7 @@ describe('about:history', function () {
       yield this.app.client
         .tabByUrl(aboutHistoryUrl)
         .loadUrl(aboutHistoryUrl)
+        .waitForVisible('table.sortableTable td.title[data-sort="Brave"]')
         .click('table.sortableTable td.title[data-sort="Brave"]')
         .isDarwin().then((val) => {
           if (val === true) {
@@ -135,6 +137,7 @@ describe('about:history', function () {
       yield this.app.client
         .tabByUrl(aboutHistoryUrl)
         .loadUrl(aboutHistoryUrl)
+        .waitForVisible('table.sortableTable td.title[data-sort="Brave"]')
         .click('table.sortableTable td.title[data-sort="Brave"]')
         .keys(Brave.keys.SHIFT)
         .click('table.sortableTable td.title[data-sort="https://www.youtube.com"]')
@@ -195,6 +198,7 @@ describe('about:history', function () {
       yield this.app.client
         .tabByUrl(aboutHistoryUrl)
         .loadUrl(aboutHistoryUrl)
+        .waitForVisible('table.sortableTable td.title[data-sort="Brave"]')
         // Click one bookmark, to select it
         .click('table.sortableTable td.title[data-sort="Brave"]')
         .waitForVisible('table.sortableTable tr.selected td.title[data-sort="Brave"]')
@@ -206,6 +210,7 @@ describe('about:history', function () {
       yield this.app.client
         .tabByUrl(aboutHistoryUrl)
         .loadUrl(aboutHistoryUrl)
+        .waitForVisible('table.sortableTable td.title[data-sort="Brave"]')
         // Click one bookmark, to select it
         .click('table.sortableTable td.title[data-sort="Brave"]')
         .waitForVisible('table.sortableTable tr.selected td.title[data-sort="Brave"]')


### PR DESCRIPTION
Closes #11914

Auditors:

Test Plan:
1. npm run test -- --grep='about:bookmarks'
2. npm run test -- --grep='about:history'

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


