### PR TITLE
[WIP] comment out APP_TAB_ATTACHED and APP_TAB_WILL_ATTACH

### DIFF
--- a/app/browser/reducers/tabsReducer.js
+++ b/app/browser/reducers/tabsReducer.js
@@ -73,16 +73,18 @@ const tabsReducer = (state, action, immutableAction) => {
       state = tabState.maybeCreateTab(state, action)
       break
     case appConstants.APP_TAB_ATTACHED:
-      state = tabs.updateTabsStateForAttachedTab(state, action.get('tabId'))
+      // XXX Commented out for SCIENCE - Ayumi
+      // state = tabs.updateTabsStateForAttachedTab(state, action.get('tabId'))
       break
     case appConstants.APP_TAB_WILL_ATTACH: {
-      const tabId = action.get('tabId')
-      const tabValue = tabState.getByTabId(state, tabId)
-      if (!tabValue) {
-        break
-      }
-      const oldWindowId = tabState.getWindowId(state, tabId)
-      state = tabs.updateTabsStateForWindow(state, oldWindowId)
+      // XXX Commented out for SCIENCE - Ayumi
+      // const tabId = action.get('tabId')
+      // const tabValue = tabState.getByTabId(state, tabId)
+      // if (!tabValue) {
+      //   break
+      // }
+      // const oldWindowId = tabState.getWindowId(state, tabId)
+      // state = tabs.updateTabsStateForWindow(state, oldWindowId)
       break
     }
     case appConstants.APP_TAB_MOVED:


### PR DESCRIPTION
~20ms / tab is spent in these reducer actions when starting up.
Removing this logic doesn't seem to cause any new test failures.

Auditors:

Test Plan:

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


