### PR TITLE
Replace End-User-FAQ link on preferences.js

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -164,10 +164,16 @@ class GeneralTab extends ImmutableComponent {
         </SettingItem>
         <div className='iconTitle'>
           <span data-l10n-id='myHomepage' />
-          <span className='fa fa-info-circle iconLink' onClick={aboutActions.createTabRequested.bind(null, {
-            url: 'https://github.com/brave/browser-laptop/wiki/End-User-FAQ#how-to-set-up-multiple-home-pages'
-          })}
-            data-l10n-id='multipleHomePages' />
+          <BrowserButton
+            iconOnly
+            iconClass={globalStyles.appIcons.moreInfo}
+            size='.95rem'
+            custom={styles.appIcons_moreInfo}
+            onClick={aboutActions.createTabRequested.bind(null, {
+              url: 'https://community.brave.com/t/how-to-set-up-multiple-home-pages/'
+            })}
+            l10nId='multipleHomePages'
+          />
         </div>
         <SettingItem>
           <SettingTextbox
@@ -979,6 +985,10 @@ class AboutPreferences extends React.Component {
 }
 
 const styles = StyleSheet.create({
+  appIcons_moreInfo: {
+    marginLeft: '5px'
+  },
+
   sitePermissions: {
     listStyle: 'none',
     margin: '20px'

--- a/less/about/preferences.less
+++ b/less/about/preferences.less
@@ -173,16 +173,8 @@ span.settingsListCopy {
     margin: 1.2em 2px 7px;
     color: #444444;
     font-size: 0.9em;
-
-    span {
-      display: inline-block;
-    }
-
-    .iconLink {
-      margin-left: 5px;
-      cursor: pointer;
-      vertical-align: middle;
-    }
+    display: flex;
+    align-items: center;
   }
 }
 


### PR DESCRIPTION
Closes #11946

Auditors:

Test Plan:
1. Open about:preferences
2. Click the info icon
3. Make sure https://community.brave.com/t/how-to-set-up-multiple-home-pages/9998 is opened

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


