### PR TITLE
Hardening for ledger errors

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -1262,6 +1262,11 @@ const roundtrip = (params, options, callback) => {
     if (err) return callback(err, response)
 
     if (Math.floor(response.statusCode / 100) !== 2) {
+      if ((params.useProxy) && (response.statusCode === 403)) {
+        params.useProxy = false
+        return roundtrip(params, options, callback)
+      }
+
       return callback(
         new Error('HTTP response ' + response.statusCode + ' for ' + params.method + ' ' + params.path),
         response)

--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -2383,7 +2383,8 @@ const getMethods = () => {
       },
       getCurrentMediaKey: (key) => currentMediaKey,
       synopsisNormalizer,
-      checkVerifiedStatus
+      checkVerifiedStatus,
+      roundtrip
     }
   }
 

--- a/test/unit/app/browser/api/ledgerTest.js
+++ b/test/unit/app/browser/api/ledgerTest.js
@@ -435,8 +435,14 @@ describe('ledger api unit tests', function () {
   })
 
   describe('transitionWalletToBat', function () {
+    let fakeClock
+
+    before(function () {
+      fakeClock = sinon.useFakeTimers()
+    })
     after(function () {
       ledgerApi.setSynopsis(undefined)
+      fakeClock.restore()
     })
 
     describe('when client is not busy', function () {

--- a/test/unit/lib/fakeElectron.js
+++ b/test/unit/lib/fakeElectron.js
@@ -87,7 +87,11 @@ const fakeElectron = {
   },
   session: {
     defaultSession: {
-      partition: 'default'
+      partition: 'default',
+      webRequest: {
+        fetch: function (url, options, handler) {
+        }
+      }
     }
   },
   extensions: {


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/11936
Fixes https://github.com/brave/browser-laptop/issues/11945

Changes contain two fixes:
- for any calls: if a 403 is received back and proxy is enabled, ledger will disable proxy and try again
- for `transitionWalletToBat`: if busyP returns a truthy value, `transitionWalletToBat` will be retried up to 3 times before quitting.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).


## Reviewer Checklist:

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


