### PR TITLE
2 incredible ways to fix tab page previews that they don't want you to know

### DIFF
--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -159,6 +159,9 @@ class Tab extends React.Component {
     // if mouse entered a tab we only trigger a new preview
     // if user is in previewMode, which is defined by mouse move
     windowActions.setTabHoverState(this.props.frameKey, true, this.props.previewMode)
+    // In case there's a tab preview happening, cancel the preview
+    // when mouse is over a tab
+    windowActions.setTabPageHoverState(this.props.tabPageIndex, false)
   }
 
   onMouseMove () {
@@ -262,6 +265,7 @@ class Tab extends React.Component {
     props.tabWidth = currentWindow.getIn(['ui', 'tabs', 'fixTabWidth'])
     props.themeColor = tabUIState.getThemeColor(currentWindow, frameKey)
     props.title = frame.get('title')
+    props.tabPageIndex = frameStateUtil.getTabPageIndex(currentWindow)
     props.partOfFullPageSet = partOfFullPageSet
     props.showAudioTopBorder = audioState.showAudioTopBorder(currentWindow, frameKey, isPinned)
     props.centralizeTabIcons = tabUIState.centralizeTabIcons(currentWindow, frameKey, isPinned)

--- a/app/renderer/components/tabs/tabPage.js
+++ b/app/renderer/components/tabs/tabPage.js
@@ -79,6 +79,9 @@ class TabPage extends React.Component {
   }
 
   onCloseTabPage () {
+    // if a tab page is closed, cancel the tab preview
+    windowActions.setTabPageHoverState(this.props.index, false)
+
     return this.props.tabPageFrames
       .map(frame => appActions.tabCloseRequested(frame.get('tabId')))
   }
@@ -95,12 +98,13 @@ class TabPage extends React.Component {
         return
       case 1:
         // Close tab page with middle click
-        // and eventually cancel the hover state
         this.onCloseTabPage()
-        windowActions.setTabPageHoverState(this.props.index, false)
         break
       default:
+        // Setting the new active tab page
+        // should also cancel tab preview
         windowActions.setTabPageIndex(this.props.index)
+        windowActions.setTabPageHoverState(this.props.index, false)
     }
   }
 


### PR DESCRIPTION
Auditors: @bbondy
cc @srirambv

fix #11632

First fix for this was to remove `timeOut` for tabPages but the change lead to bad UX if the user has a lot of tab pages, causing flash while hovering. This part was not removed this time.

Now, this forces both setting an active tab page and closing it to cancel previews. Hovering over a tab also makes the cancellation.

Window draggability seemed to be related to this issue but removal was avoided to "do not break user-space" and avoid side-effects.

Test Plan:

1. Open 3 tab pages
2. Keep closing tabs
3. Should not trigger tab page preview
4. Other tab page functionalities should work as they are without this PR 