### PR TITLE
cache-require-paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ public/built
 .DS-Store
 temp.VisualElementsManifest.xml
 app/extensions/gen/
+.cache-require-paths.json
 
 # electron-packager output dirs
 *-darwin-x64

--- a/app/index.js
+++ b/app/index.js
@@ -8,6 +8,7 @@
 let ready = false
 
 require('v8-compile-cache')
+require('cache-require-paths')
 
 const CrashHerald = require('./crash-herald')
 const telemetry = require('./telemetry')

--- a/package-lock.json
+++ b/package-lock.json
@@ -2666,6 +2666,11 @@
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
       "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
+    "cache-require-paths": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/cache-require-paths/-/cache-require-paths-0.3.0.tgz",
+      "integrity": "sha1-EqYHWj5JiNpMIvIY4pSFZj5MSmM="
+    },
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "bat-publisher": "^2.0.3",
     "bignumber.js": "^4.0.4",
     "bloodhound-js": "brave/bloodhound",
+    "cache-require-paths": "^0.3.0",
     "clipboard-copy": "^1.0.0",
     "compare-versions": "^3.0.1",
     "deepmerge": "^2.0.1",


### PR DESCRIPTION
Add [cache-require-paths](https://github.com/bahmutov/cache-require-paths).

BL version | 1st start | Subsequent starts
-- | -- | --
master 01477552d5268880c7abee24fad69a91e59b7a2b | 770 ms | 770 ms
feature/require-faster 9ffc7eed3de2bc63264b1a27dc6172672b314611 | 790 ms | 700 ms

The first start is slightly slower (maybe due to writing the cache) but subsequent starts are faster.

### Test plan:

1. Try packaged build on MacOS, Linux and Windows.
2. Try dev on MacOS, Linux and Windows.

#### Measuring perf
1. Log run time of app/index.js from 0 to perWindowStateLoaded ready = true
  a. To L10 add:
```js
const tStart = process.hrtime()
```
  b. To L361 after `ready = true` add:
```js
const tTime = process.hrtime(tStart)
console.log(`index.js window ready: ${tTime[0] * 1e3 + tTime[1] * 1e-6} ms`)
```
2. Start brave and record the run time.
3. Repeat

Note: when switching branches delete node_modules and reinstall to be sure the npm dedupe changes got applied

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:



Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


