### PR TITLE
Prevent rendering a frame's <webview> when it is created in an unloaded state

### DIFF
--- a/app/renderer/components/frame/frame.js
+++ b/app/renderer/components/frame/frame.js
@@ -101,7 +101,7 @@ class Frame extends React.Component {
   }
 
   shouldCreateWebview () {
-    return !this.webview
+    return !this.webview && (!this.props.unloaded || this.props.isActive || this.props.isPreview)
   }
 
   allowRunningWidevinePlugin () {
@@ -190,7 +190,7 @@ class Frame extends React.Component {
   }
 
   componentDidMount () {
-    this.updateWebview(this.onPropsChanged)
+    this.updateWebview(() => this.onPropsChanged())
     if (this.props.activeShortcut) {
       this.handleShortcut()
     }

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -160,6 +160,7 @@ const newFrame = (state, frameOpts) => {
     const tabId = frameOpts.tabId
     const frame = frameStateUtil.getFrameByTabId(state, tabId)
     state = frameStateUtil.updateTabPageIndex(state, tabId)
+    state = frameStateUtil.setActiveFrameKey(state, nextKey)
     if (!active || !frame) {
       appActions.tabActivateRequested(tabId)
     }

--- a/test/unit/js/stores/windowStoreTest.js
+++ b/test/unit/js/stores/windowStoreTest.js
@@ -141,6 +141,7 @@ describe('Window store unit tests', function () {
       let windowState
       let tabDetachMenuItemClickedStub
       const demoWindowState = {
+        activeFrameKey: 2,
         frames: [{
           security: {
             isSecure: null
@@ -273,6 +274,7 @@ describe('Window store unit tests', function () {
         before(function () {
           const newAction = Object.assign(demoAction, {})
           newAction.frameOpts.active = false
+          newAction.frameOpts.disposition = 'background-tab'
           newAction.tabValue.active = false
 
           const fakeReducer = (state, action) => {
@@ -289,7 +291,7 @@ describe('Window store unit tests', function () {
         })
 
         it('does not set activeFrameKey', function () {
-          assert.equal(windowState.get('activeFrameKey'), undefined)
+          assert.equal(windowState.get('activeFrameKey'), demoWindowState.activeFrameKey)
         })
       })
     })


### PR DESCRIPTION
Preventing load of the `<webview>` of frames/tabs that are not to be loaded yet eliminates the 5+ minute lockup / wait for windows to be created with hundreds of tabs.

All the tabs from persisted state are created immediately on window creation after startup. Whilst the rapid fire of store actions causes some delay (which can also be improved, separately), rendering a `<webview>` for every frame, attaching it to a tab and hooking in to its events causes exponential growth in the time taken to load frames simultaneously.

This PR makes sure the `<webview>`, and its associated events, are not created until the associated tabs are made active, or previewed.

It's possible that we can achieve the same results by rendering the `<webview>` and handling / forwarding less events, or batching them, but this isolation at least shows where the bulk of the time is spent.

Issues with doing this:
- [ ] can't reorder never-loaded tabs (probably because we don't have an accurate tab id since we're not getting the 'tab-id-changed' event until the `<webview>` is created)
  - move the handling of some events that deal with this data from the renderer `<webview>` to browser tab API. Do this as minimally as possible to avoid regressions and get this PR out ASAP


## Results:
6 windows, 150 unique tabs in each window
Before - 5+ mins of 200% cpu and increasing memory usage [﻿video](https://www.dropbox.com/s/lfnvbggcsztong8/6windows-150tabs-each-master.mov?dl=0)
After - 22 seconds [video](https://www.dropbox.com/s/clqkr18krm95hgp/6windows-150tabs-each-noframerender.mov?dl=0)

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Test Plan:
 - Generate a state with many windows and unique tabs
    e.g.
    ```
    node generate-session-store.js --windows 6 --tabs 150 --out ~/Library/Application\ Support/brave-development/session-store-1 --unloadedtabs true
    ```
 - start the browser with the profile location of the generated profile
 - All windows and active tabs render in a considerably lower time than master
 - Repeat with blank, manually generated, profile, i.e. opening tabs in Brave, then restarting the browser.

## Reviewer Checklist:


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


