### PR TITLE
Fixes #11937 for 0.19.x

### DIFF
--- a/app/renderer/components/preferences/payment/advancedSettings.js
+++ b/app/renderer/components/preferences/payment/advancedSettings.js
@@ -86,6 +86,7 @@ class AdvancedSettingsContent extends ImmutableComponent {
             prefKey={settings.PAYMENTS_ALLOW_MEDIA_PUBLISHERS}
             settings={this.props.settings}
             onChangeSetting={this.props.onChangeSetting}
+            className={css(styles.listItem)}
             switchClassName={css(styles.checkboxSwitch, commonStyles.noMarginBottom)}
             labelClassName={css(commonStyles.noMarginBottom)}
           />


### PR DESCRIPTION
Fixes #11937 for 0.19.x 

switchControl label alignment on advancedSettings.js

Auditors:

Test Plan:
1. Open about:preferences#payments
2. Enable payments
3. Click on Advanced Settings

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


