### PR TITLE
move appState to UserPrefs

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -96,23 +96,6 @@ const defaultProtocols = ['http', 'https']
   })
 })
 
-let loadAppStatePromise = SessionStore.loadAppState()
-
-// Some settings must be set right away on startup, those settings should be handled here.
-loadAppStatePromise.then((initialImmutableState) => {
-  const {HARDWARE_ACCELERATION_ENABLED, SMOOTH_SCROLL_ENABLED, SEND_CRASH_REPORTS} = require('../js/constants/settings')
-  CrashHerald.init(getSetting(SEND_CRASH_REPORTS, initialImmutableState.get('settings')))
-
-  telemetry.setCheckpointAndReport('state-loaded')
-  if (getSetting(HARDWARE_ACCELERATION_ENABLED, initialImmutableState.get('settings')) === false) {
-    app.disableHardwareAcceleration()
-  }
-
-  if (getSetting(SMOOTH_SCROLL_ENABLED, initialImmutableState.get('settings')) === false) {
-    app.commandLine.appendSwitch('disable-smooth-scrolling')
-  }
-})
-
 const notifyCertError = (webContents, url, error, cert) => {
   errorCerts[url] = {
     subjectName: cert.subjectName,
@@ -135,6 +118,23 @@ const notifyCertError = (webContents, url, error, cert) => {
 }
 
 app.on('ready', () => {
+  let loadAppStatePromise = SessionStore.loadAppState()
+
+  // Some settings must be set right away on startup, those settings should be handled here.
+  loadAppStatePromise.then((initialImmutableState) => {
+    const {HARDWARE_ACCELERATION_ENABLED, SMOOTH_SCROLL_ENABLED, SEND_CRASH_REPORTS} = require('../js/constants/settings')
+    CrashHerald.init(getSetting(SEND_CRASH_REPORTS, initialImmutableState.get('settings')))
+
+    telemetry.setCheckpointAndReport('state-loaded')
+    if (getSetting(HARDWARE_ACCELERATION_ENABLED, initialImmutableState.get('settings')) === false) {
+      app.disableHardwareAcceleration()
+    }
+
+    if (getSetting(SMOOTH_SCROLL_ENABLED, initialImmutableState.get('settings')) === false) {
+      app.commandLine.appendSwitch('disable-smooth-scrolling')
+    }
+  })
+
   app.on('certificate-error', (e, webContents, url, error, cert, resourceType, overridable, strictEnforcement, expiredPreviousDecision, muonCb) => {
     let host = urlParse(url).host
     if (host && acceptCertDomains[host] === true) {

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -19,6 +19,7 @@ const Immutable = require('immutable')
 const app = electron.app
 const compareVersions = require('compare-versions')
 const merge = require('deepmerge')
+const fs = require('fs-extra')
 
 // Constants
 const UpdateStatus = require('../js/constants/updateStatus')
@@ -43,6 +44,7 @@ const {isImmutable, makeImmutable, deleteImmutablePaths} = require('./common/sta
 const {getSetting} = require('../js/settings')
 const platformUtil = require('./common/lib/platformUtil')
 const historyUtil = require('./common/lib/historyUtil')
+const userPrefs = require('../js/state/userPrefs')
 
 const sessionStorageVersion = 1
 const sessionStorageName = `session-store-${sessionStorageVersion}`
@@ -55,7 +57,11 @@ const getTempStoragePath = (filename) => {
     : path.join(process.env.HOME, '.brave-test-session-store-' + filename + '-' + epochTimestamp)
 }
 
-const getStoragePath = () => {
+const getPrefsPath = () => {
+  return path.join(app.getPath('userData'), 'UserPrefs')
+}
+
+const getDeprecatedStoragePath = () => {
   return path.join(app.getPath('userData'), sessionStorageName)
 }
 /**
@@ -104,15 +110,12 @@ module.exports.saveAppState = (immutablePayload, isShutdown) => {
       module.exports.cleanSessionDataOnShutdown()
     }
 
-    const storagePath = getStoragePath()
-    const json = JSON.stringify(immutablePayload)
-    muon.file.writeImportant(storagePath, json, (success) => {
-      if (success) {
-        resolve()
-      } else {
-        reject(new Error('Could not save app state to ' + getStoragePath()))
-      }
-    })
+    try {
+      userPrefs.setUserPref('app_state', immutablePayload.toJS(), false)
+      resolve()
+    } catch (e) {
+      reject(new Error('Could not save app state to UserPrefs', e))
+    }
   })
 }
 
@@ -763,7 +766,6 @@ module.exports.runPreMigrations = (data) => {
     try { runWidevineCleanup = compareVersions(data.lastAppVersion, '0.18.25') < 1 } catch (e) {}
 
     if (runWidevineCleanup) {
-      const fs = require('fs-extra')
       const wvExtPath = path.join(app.getPath('userData'), 'Extensions', 'WidevineCdm')
       fs.remove(wvExtPath, (err) => {
         if (err) {
@@ -829,18 +831,30 @@ module.exports.runImportDefaultSettings = (data) => {
  */
 module.exports.loadAppState = () => {
   return new Promise((resolve, reject) => {
-    const fs = require('fs')
-
-    let data
-
-    try {
-      data = fs.readFileSync(getStoragePath())
-    } catch (e) {}
-
     let loaded = false
+    let data = null
+
     try {
-      data = JSON.parse(data)
-      loaded = true
+      data = userPrefs.getDictionaryPref('app_state')
+      const filePath = getDeprecatedStoragePath()
+      if (!data || Object.keys(data).length === 0) {
+        // look for a legacy session store file
+        try {
+          data = fs.readFileSync(filePath)
+          data = JSON.parse(data)
+          loaded = true
+        } catch (e) {
+          module.exports.backupSession(filePath)
+          data = {}
+        } finally {
+          // copy to .bak for deletion on next successful startup
+          module.exports.backupSession(filePath, filePath + '.bak')
+        }
+      } else {
+        // loaded successfully so go ahead and delete the old session store
+        fs.unlink(filePath + '.bak', () => {}) // eslint-disable-line handle-callback-err
+        loaded = true
+      }
     } catch (e) {
       // Session state might be corrupted; let's backup this
       // corrupted value for people to report into support.
@@ -896,11 +910,7 @@ module.exports.loadAppState = () => {
 /**
  * Called when session is suspected for corruption; this will move it out of the way
  */
-module.exports.backupSession = () => {
-  const fs = require('fs-extra')
-  const src = getStoragePath()
-  const dest = getTempStoragePath('backup')
-
+module.exports.backupSession = (src = getPrefsPath(), dest = getTempStoragePath('backup')) => {
   if (fs.existsSync(src)) {
     try {
       fs.copySync(src, dest)

--- a/js/state/userPrefs.js
+++ b/js/state/userPrefs.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const {session} = require('electron')
+
 let registeredCallbacks = []
 let registeredSessions = {}
 let registeredPrivateSessions = {}
@@ -49,6 +51,14 @@ const runCallback = (cb, incognito) => {
   return true
 }
 
+module.exports.getDictionaryPref = (path, ses = session.defaultSession) => {
+  if (ses) {
+    return ses.userPrefs.getDictionaryPref(path)
+  } else {
+    return null
+  }
+}
+
 module.exports.setUserPref = (path, value, incognito = false) => {
   value = value.toJS ? value.toJS() : value
 
@@ -56,7 +66,10 @@ module.exports.setUserPref = (path, value, incognito = false) => {
   for (let partition in partitions) {
     const ses = partitions[partition]
     setUserPrefType(ses, path, value)
-    ses.webRequest.handleBehaviorChanged()
+    if (path === 'content_settings') {
+      // TODO(bridiver) - move this to muon
+      ses.webRequest.handleBehaviorChanged()
+    }
   }
 }
 

--- a/test/unit/app/sessionStoreTest.js
+++ b/test/unit/app/sessionStoreTest.js
@@ -12,6 +12,7 @@ require('../braveUnit')
 
 describe('sessionStore unit tests', function () {
   let sessionStore
+  let userPrefs
   let shutdownClearHistory = false
   let shutdownClearAutocompleteData = false
   let shutdownClearAutofillData = false
@@ -90,6 +91,10 @@ describe('sessionStore unit tests', function () {
     })
     mockery.registerMock('./filtering', fakeFiltering)
     sessionStore = require('../../../app/sessionStore')
+    userPrefs = require('../../../js/state/userPrefs')
+    sinon.stub(userPrefs, 'setUserPref', (key, value) => {
+      fakeElectron.session.defaultSession.userPrefs.setDictionaryPref(key, value)
+    })
   })
 
   after(function () {
@@ -122,12 +127,6 @@ describe('sessionStore unit tests', function () {
     })
 
     describe('with isShutdown', function () {
-      before(function () {
-        this.writeImportantSpy = sinon.spy(muon.file, 'writeImportant')
-      })
-      after(function () {
-        this.writeImportantSpy.restore()
-      })
       it('calls cleanSessionDataOnShutdown if true', function (cb) {
         cleanSessionDataOnShutdownStub.reset()
         return sessionStore.saveAppState(Immutable.Map(), true)
@@ -153,7 +152,8 @@ describe('sessionStore unit tests', function () {
       it('sets cleanedOnShutdown for saveAppState', function (cb) {
         sessionStore.saveAppState(Immutable.Map(), true)
           .then(() => {
-            assert.equal(JSON.parse(this.writeImportantSpy.getCall(0).args[1]).cleanedOnShutdown, true)
+            console.log(fakeElectron.session.defaultSession.userPrefs.getDictionaryPref('app_state'))
+            assert.equal(fakeElectron.session.defaultSession.userPrefs.getDictionaryPref('app_state').cleanedOnShutdown, true)
             cb()
           }, function (err) {
             assert(!err)
@@ -163,7 +163,7 @@ describe('sessionStore unit tests', function () {
       it('sets lastAppVersion for saveAppState', function (cb) {
         sessionStore.saveAppState(Immutable.Map(), true)
           .then(() => {
-            assert.equal(JSON.parse(this.writeImportantSpy.getCall(0).args[1]).lastAppVersion, '0.14.0')
+            assert.equal(fakeElectron.session.defaultSession.userPrefs.getDictionaryPref('app_state').lastAppVersion, '0.14.0')
             cb()
           }, function (err) {
             assert(!err)
@@ -788,20 +788,20 @@ describe('sessionStore unit tests', function () {
 
     describe('when reading the session file', function () {
       describe('happy path', function () {
-        let readFileSyncSpy
+        let userPrefsSpy
 
         before(function () {
-          readFileSyncSpy = sinon.spy(fakeFileSystem, 'readFileSync')
+          userPrefsSpy = sinon.spy(userPrefs, 'getDictionaryPref')
         })
 
         after(function () {
-          readFileSyncSpy.restore()
+          userPrefsSpy.restore()
         })
 
-        it('calls fs.readFileSync', function () {
+        it('calls userPrefs.getDictionaryPref', function () {
           return sessionStore.loadAppState()
             .then(function (result) {
-              assert.equal(readFileSyncSpy.calledOnce, true)
+              assert.equal(userPrefsSpy.calledOnce, true)
             }, function (result) {
               assert.ok(false, 'promise was rejected: ' + JSON.stringify(result))
             })
@@ -809,94 +809,20 @@ describe('sessionStore unit tests', function () {
       })
 
       describe('when exception is thrown', function () {
-        let readFileSyncStub
+        let getUserPrefStub
 
         before(function () {
-          readFileSyncStub = sinon.stub(fakeFileSystem, 'readFileSync').throws('error reading file')
+          getUserPrefStub = sinon.stub(userPrefs, 'getDictionaryPref').throws('error reading file')
         })
 
         after(function () {
-          readFileSyncStub.restore()
+          getUserPrefStub.restore()
         })
 
         it('does not crash when exception thrown during read', function () {
           return sessionStore.loadAppState()
             .then(function (result) {
               assert.ok(result.get('firstRunTimestamp'))
-            }, function (result) {
-              assert.ok(false, 'promise was rejected: ' + JSON.stringify(result))
-            })
-        })
-      })
-    })
-
-    describe('when calling JSON.parse', function () {
-      describe('exception is thrown', function () {
-        let readFileSyncStub
-
-        before(function () {
-          readFileSyncStub = sinon.stub(fakeFileSystem, 'readFileSync').returns('this is not valid JSON')
-        })
-
-        after(function () {
-          readFileSyncStub.restore()
-        })
-
-        it('does not call runPreMigrations', function () {
-          runPreMigrationsSpy.reset()
-          return sessionStore.loadAppState()
-            .then(function (result) {
-              assert.equal(runPreMigrationsSpy.notCalled, true)
-            }, function (result) {
-              assert.ok(false, 'promise was rejected: ' + JSON.stringify(result))
-            })
-        })
-
-        it('does not call cleanAppData', function () {
-          cleanAppDataStub.reset()
-          return sessionStore.loadAppState()
-            .then(function (result) {
-              assert.equal(cleanAppDataStub.notCalled, true)
-            }, function (result) {
-              assert.ok(false, 'promise was rejected: ' + JSON.stringify(result))
-            })
-        })
-
-        it('calls defaultAppState to get a default app state', function () {
-          defaultAppStateSpy.reset()
-          return sessionStore.loadAppState()
-            .then(function (result) {
-              assert.equal(defaultAppStateSpy.calledOnce, true)
-            }, function (result) {
-              assert.ok(false, 'promise was rejected: ' + JSON.stringify(result))
-            })
-        })
-
-        it('does not call runPostMigrations', function () {
-          runPostMigrationsSpy.reset()
-          return sessionStore.loadAppState()
-            .then(function (result) {
-              assert.equal(runPostMigrationsSpy.notCalled, true)
-            }, function (result) {
-              assert.ok(false, 'promise was rejected: ' + JSON.stringify(result))
-            })
-        })
-
-        it('calls backupSessionStub', function () {
-          backupSessionStub.reset()
-          return sessionStore.loadAppState()
-            .then(function (result) {
-              assert.equal(backupSessionStub.calledOnce, true)
-            }, function (result) {
-              assert.ok(false, 'promise was rejected: ' + JSON.stringify(result))
-            })
-        })
-
-        it('calls runImportDefaultSettings', function () {
-          runImportDefaultSettings.reset()
-          return sessionStore.loadAppState()
-            .then(function (result) {
-              assert.equal(runImportDefaultSettings.calledOnce, true)
             }, function (result) {
               assert.ok(false, 'promise was rejected: ' + JSON.stringify(result))
             })
@@ -915,7 +841,7 @@ describe('sessionStore unit tests', function () {
     })
 
     describe('merge default state with the existing one', function () {
-      let readFileSyncStub, fileValue, defaultData, clock
+      let getUserPrefStub, prefsValue, defaultData, clock
 
       before(function () {
         clock = sinon.useFakeTimers()
@@ -930,8 +856,8 @@ describe('sessionStore unit tests', function () {
           }
         }
         runImportDefaultSettings.reset()
-        readFileSyncStub = sinon.stub(fakeFileSystem, 'readFileSync', () => {
-          return fileValue
+        getUserPrefStub = sinon.stub(userPrefs, 'getDictionaryPref', () => {
+          return prefsValue
         })
       })
 
@@ -941,7 +867,7 @@ describe('sessionStore unit tests', function () {
 
       after(function () {
         clock.restore()
-        readFileSyncStub.restore()
+        getUserPrefStub.restore()
       })
 
       it('deep objects merge', function () {
@@ -953,12 +879,12 @@ describe('sessionStore unit tests', function () {
           ledgerVideos: {}
         }
 
-        fileValue = JSON.stringify({
+        prefsValue = {
           cache: {
             bookmarkLocation: {},
             bookmarkOrder: {}
           }
-        })
+        }
         return sessionStore.loadAppState()
           .then(function () {
             assert(runImportDefaultSettings.withArgs(expectedData).calledOnce)
@@ -978,13 +904,13 @@ describe('sessionStore unit tests', function () {
           }
         }
 
-        fileValue = JSON.stringify({
+        prefsValue = {
           cache: {
             bookmarkLocation: {},
             bookmarkOrder: {},
             ledgerVideos: {data: 1}
           }
-        })
+        }
         return sessionStore.loadAppState()
           .then(function () {
             assert(runImportDefaultSettings.withArgs(expectedData).calledOnce)
@@ -995,17 +921,17 @@ describe('sessionStore unit tests', function () {
     })
 
     describe('when checking data.cleanedOnShutdown', function () {
-      let readFileSyncStub
+      let getUserPrefStub
 
       describe('when true', function () {
         before(function () {
-          readFileSyncStub = sinon.stub(fakeFileSystem, 'readFileSync').returns(JSON.stringify({
+          getUserPrefStub = sinon.stub(userPrefs, 'getDictionaryPref').returns({
             cleanedOnShutdown: true,
             lastAppVersion: fakeElectron.app.getVersion()
-          }))
+          })
         })
         after(function () {
-          readFileSyncStub.restore()
+          getUserPrefStub.restore()
         })
         it('does not call cleanAppData', function () {
           cleanAppDataStub.reset()
@@ -1020,13 +946,13 @@ describe('sessionStore unit tests', function () {
 
       describe('when NOT true', function () {
         before(function () {
-          readFileSyncStub = sinon.stub(fakeFileSystem, 'readFileSync').returns(JSON.stringify({
+          getUserPrefStub = sinon.stub(userPrefs, 'getDictionaryPref').returns({
             cleanedOnShutdown: false,
             lastAppVersion: fakeElectron.app.getVersion()
-          }))
+          })
         })
         after(function () {
-          readFileSyncStub.restore()
+          getUserPrefStub.restore()
         })
         it('calls cleanAppData', function () {
           cleanAppDataStub.reset()
@@ -1041,17 +967,17 @@ describe('sessionStore unit tests', function () {
     })
 
     describe('when checking data.lastAppVersion', function () {
-      let readFileSyncStub
+      let getUserPrefStub
 
       describe('when it matches app.getVersion', function () {
         before(function () {
-          readFileSyncStub = sinon.stub(fakeFileSystem, 'readFileSync').returns(JSON.stringify({
+          getUserPrefStub = sinon.stub(userPrefs, 'getDictionaryPref').returns({
             cleanedOnShutdown: true,
             lastAppVersion: fakeElectron.app.getVersion()
-          }))
+          })
         })
         after(function () {
-          readFileSyncStub.restore()
+          getUserPrefStub.restore()
         })
         it('does not call cleanAppData', function () {
           cleanAppDataStub.reset()
@@ -1066,13 +992,13 @@ describe('sessionStore unit tests', function () {
 
       describe('when it does NOT match app.getVersion', function () {
         before(function () {
-          readFileSyncStub = sinon.stub(fakeFileSystem, 'readFileSync').returns(JSON.stringify({
+          getUserPrefStub = sinon.stub(userPrefs, 'getDictionaryPref').returns({
             cleanedOnShutdown: true,
             lastAppVersion: 'NOT A REAL VERSION'
-          }))
+          })
         })
         after(function () {
-          readFileSyncStub.restore()
+          getUserPrefStub.restore()
         })
         it('calls cleanAppData', function () {
           cleanAppDataStub.reset()

--- a/test/unit/lib/fakeElectron.js
+++ b/test/unit/lib/fakeElectron.js
@@ -91,6 +91,15 @@ const fakeElectron = {
       webRequest: {
         fetch: function (url, options, handler) {
         }
+      },
+      userPrefs: {
+        prefs: {},
+        setDictionaryPref: (path, value) => {
+          fakeElectron.session.defaultSession.userPrefs.prefs[path] = value
+        },
+        getDictionaryPref: (path) => {
+          return fakeElectron.session.defaultSession.userPrefs.prefs[path]
+        }
       }
     }
   },

--- a/test/unit/lib/fakeFileSystem.js
+++ b/test/unit/lib/fakeFileSystem.js
@@ -22,6 +22,10 @@ const fakeFileSystem = {
   remove: (path, callback) => {
     console.log('calling mocked fs.remove')
     if (callback) callback()
+  },
+  unlink: (path, callback) => {
+    console.log('calling mocked fs.unlink')
+    if (callback) callback()
   }
 }
 


### PR DESCRIPTION
This is just a requirement for other perf related changes and general state bug fixes. The only significant change it makes is moving the app state from session-store-1 to UserPrefs (inside app_state key). This will be used to send the appState to the renderer process on initialization and also to simplify the session state serialization code.

fix #4011

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
1. Start with a fresh profile created before this change
2. Start Brave with this change
3. Verify that the old state was correctly loaded
4. Open a new tab
5. Shutdown Brave
6. Verify that the session-state-1 file has been copied to session-state-1.bak
7. Start Brave
8. Verify that the new tab is still there
9. Shutdown Brave
10. Verify that the session-state-1.bak file has been deleted
11. Start Brave
12. Verify that the state restores correctly

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


