### PR TITLE
Set initial default download path

### DIFF
--- a/app/browser/reducers/downloadsReducer.js
+++ b/app/browser/reducers/downloadsReducer.js
@@ -14,6 +14,7 @@ const {cancelDownload, pauseDownload, resumeDownload} = require('../electronDown
 const {CANCEL, PAUSE, RESUME} = require('../../common/constants/electronDownloadItemActions')
 const appActions = require('../../../js/actions/appActions')
 const userPrefs = require('../../../js/state/userPrefs')
+const getSetting = require('../../../js/settings').getSetting
 
 const downloadsReducer = (state, action) => {
   const download = action.downloadId ? state.getIn(['downloads', action.downloadId]) : undefined
@@ -21,10 +22,17 @@ const downloadsReducer = (state, action) => {
       ![appConstants.APP_MERGE_DOWNLOAD_DETAIL,
         appConstants.APP_CLEAR_COMPLETED_DOWNLOADS,
         appConstants.APP_SELECT_DEFAULT_DOWNLOAD_PATH,
-        appConstants.APP_CHANGE_SETTING].includes(action.actionType)) {
+        appConstants.APP_CHANGE_SETTING,
+        appConstants.APP_SET_STATE].includes(action.actionType)) {
     return state
   }
   switch (action.actionType) {
+    case appConstants.APP_SET_STATE:
+      if (getSetting(settings.DOWNLOAD_DEFAULT_PATH) === '') {
+        const defaultPath = app.getPath('downloads')
+        appActions.changeSetting(settings.DOWNLOAD_DEFAULT_PATH, defaultPath)
+      }
+      break
     case appConstants.APP_DOWNLOAD_REVEALED:
       fs.access(download.get('savePath'), fs.constants.F_OK, (err) => {
         if (err) {


### PR DESCRIPTION
fix #9822

Auditors: @bridiver, @bbondy, @bsclifton

Test Plan:
1. Open Brave with fresh profile
2. Go to about:preferences#general
3. It should show default download path instead of empty

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


