### PR TITLE
C63: Remove 'overridable' from the 'certificate-error' event

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -135,7 +135,7 @@ const notifyCertError = (webContents, url, error, cert) => {
 }
 
 app.on('ready', () => {
-  app.on('certificate-error', (e, webContents, url, error, cert, resourceType, overridable, strictEnforcement, expiredPreviousDecision, muonCb) => {
+  app.on('certificate-error', (e, webContents, url, error, cert, resourceType, strictEnforcement, expiredPreviousDecision, muonCb) => {
     let host = urlParse(url).host
     if (host && acceptCertDomains[host] === true) {
       // Ignore the cert error


### PR DESCRIPTION
Fixes #12107

This is needed for the C63 rebase.

Test Plan:
1. Open https://expired.badssl.com/
2. Make sure the tab does not keep hanging