### PR TITLE
Add v8-compile-cache

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -7,6 +7,8 @@
 
 let ready = false
 
+require('v8-compile-cache')
+
 const CrashHerald = require('./crash-herald')
 const telemetry = require('./telemetry')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19810,6 +19810,11 @@
         "macaddress": "0.2.8"
       }
     },
+    "v8-compile-cache": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-1.1.0.tgz",
+      "integrity": "sha1-HcKjQPuOX4AKMrzb+4wjzXRwIbk="
+    },
     "v8flags": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "tldjs": "1.6.2",
     "underscore": "1.8.3",
     "url-loader": "~0.6.2",
+    "v8-compile-cache": "^1.1.0",
     "webtorrent-remote": "^2.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Related to #11944 

Cache results of Module.compile to tempfile for improved load times, using https://github.com/zertosh/v8-compile-cache

For me it saves 300 ms on startup beyond the first run.

Test Plan:
- Try to start Brave on the different platforms (macOS, Windoze, Linux).

Testing latency:

1. Log run time of app/index.js from 0 to perWindowStateLoaded ready = true
  a. To L10 add:
```js
const tStart = process.hrtime()
```
  b. To L361 after `ready = true` add:
```js
const tTime = process.hrtime(tStart)
console.log(`index.js window ready: ${tTime[0] * 1e3 + tTime[1] * 1e-6} ms`)
```
2. Start brave and record the run time.
3. Repeat

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


