### PR TITLE
package-lock: Fix bat-publisher checksum

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1486,7 +1486,7 @@
     "bat-publisher": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/bat-publisher/-/bat-publisher-1.3.0.tgz",
-      "integrity": "sha1-5Jo5TDqsNOWF5D7jy7n0ShjXQK8=",
+      "integrity": "sha1-u+raH957YCEUZEYFFjGoFq2Eq5k=",
       "requires": {
         "@ambassify/backoff-strategies": "1.0.0",
         "async": "2.5.0",


### PR DESCRIPTION
in the commit to upgrade the module `bat-publisher` from 1.2.4 to 1.3.0 (67b1d5d23f952bfbc38a0cc6d2f2ab5f96faab68) we did not also update the checksum in package-lock.json. this we get integrity errors on `npm install`.

this fixes that.