### PR TITLE
Improve Ubuntu installation instructions

### DIFF
--- a/docs/linuxInstall.md
+++ b/docs/linuxInstall.md
@@ -34,11 +34,13 @@ sudo apt update
 sudo apt install brave
 ```
 
-To install the latest which also often has early staging builds:
+To install the latest `brave-beta` which often has early staging builds:
 
 ```
 curl https://s3-us-west-2.amazonaws.com/brave-apt-staging/keys.asc | sudo apt-key add -
 echo "deb [arch=amd64] https://s3-us-west-2.amazonaws.com/brave-apt-staging `lsb_release -sc` main" | sudo tee -a /etc/apt/sources.list.d/brave-`lsb_release -sc`.list
+sudo apt update
+sudo apt install brave-beta
 ```
 
 Upgrades can be done via:


### PR DESCRIPTION
Add a mention that the Staging package for Debian/Ubuntu is called `brave-beta` and must be installed with `sudo apt install brave-beta` instead of `sudo apt install brave`.

Closes #12030.

**Submitter Checklist:**

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process). @posix4e 

**Test Plan:**
It should be confirmed that `brave-beta` is also the package name in Debian Jesse.

**Reviewer Checklist:**

**Tests**


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


