### PR TITLE
Reduce braveryPanelBodyList height

### DIFF
--- a/app/renderer/components/main/braveryPanel.js
+++ b/app/renderer/components/main/braveryPanel.js
@@ -922,17 +922,15 @@ const styles = StyleSheet.create({
   },
   braveryPanel__body__ul: {
     fontSize: 'smaller',
-    maxHeight: '300px',
+    maxHeight: 'calc(300px - 1rem - .25rem - 2rem - 1rem)', // #12041: Reduce the fingerprinting column (label and dropdown) height.
     overflowY: 'auto',
     marginTop: '-20px',
     padding: '10px',
-
-    // #11641
-    userSelect: 'text'
+    userSelect: 'text' // #11641
   },
   braveryPanel__body__ul__li: {
     listStyleType: 'none',
-    padding: '10px 0',
+    padding: '7px 0',
     cursor: 'text',
 
     // #9839 and #11878: Avoid the panel width from increasing.
@@ -1055,8 +1053,6 @@ const styles = StyleSheet.create({
     gridColumnGap: 0,
     gridTemplateColumns: 'initial',
     margin: 0,
-
-    // Align the advanced control wrapper with the counters
-    padding: '0 4px'
+    padding: '0 4px' // Align the advanced control wrapper with the counters
   }
 })


### PR DESCRIPTION
Closes #12041

Auditors:

Test Plan:
1. Open about about:preferences#shields
2. Disable the compact panel option if it is enabled
3. Open https://www.youtube.com/watch?v=kLiLOkzLetE
4. Click the lion icon
5. Click the blocked ads count
6. Make sure the panel height is same as 0.19.x (as long as the number of the blocked elements is same)

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


