### PR TITLE
Fix switch placement of pinned site on ledgerTable

### DIFF
--- a/app/renderer/components/preferences/payment/ledgerTable.js
+++ b/app/renderer/components/preferences/payment/ledgerTable.js
@@ -184,7 +184,7 @@ class LedgerTable extends ImmutableComponent {
             small
             disabled
             checkedOn
-            switchClassName={css(styles.switchControl_center)}
+            customWrapperClassName={css(styles.switchControl_center)}
             indicatorClassName={css(styles.pinnedToggle)}
             testId='pinnedDisabled'
             onClick={() => {}}


### PR DESCRIPTION
This is a follow-up to #10789

Regression caused by https://github.com/brave/browser-laptop/commit/685380896390719b5800ce3d84a6677df5143e8a#diff-e168dd994d1e4de3f340af83899a20f5R187

Auditors: @cezaraugusto

Test Plan:
1. Run `npm run add-simulated-synopsis-visits 100`
2. Pin a site on about:preferences#payments
3. Make sure the switch appears at the center of the column

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


