### PR TITLE
Fix spacing between icons and labels on contextMenuItem.js

### DIFF
--- a/app/renderer/components/common/contextMenu/contextMenuItem.js
+++ b/app/renderer/components/common/contextMenu/contextMenuItem.js
@@ -289,7 +289,6 @@ const styles = StyleSheet.create({
     boxSizing: 'border-box',
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'space-between',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     overflow: 'hidden',
@@ -354,6 +353,7 @@ const styles = StyleSheet.create({
   },
 
   item__text: {
+    flex: 1,
     marginTop: 'auto',
     marginBottom: 'auto',
     paddingRight: '10px',
@@ -369,10 +369,9 @@ const styles = StyleSheet.create({
     backgroundColor: theme.contextMenu.item.isMulti.backgroundColor,
     color: theme.contextMenu.item.isMulti.color,
     display: 'flex',
-    flexGrow: 1,
     justifyContent: 'center',
     margin: '1px',
-    padding: '4px'
+    padding: '4px 1rem'
   },
 
   item__submenuIndicator: {


### PR DESCRIPTION
Fixes #12064

<img width="267" alt="screenshot 2017-11-23 3 45 50" src="https://user-images.githubusercontent.com/3362943/33144569-dd8425dc-d000-11e7-999b-7c0da4a86ee8.png">

<img width="258" alt="screenshot 2017-11-23 3 46 01" src="https://user-images.githubusercontent.com/3362943/33144568-dd5cb218-d000-11e7-8156-f745eef08ae0.png">

Auditors: @cezaraugusto

Test Plan:
1. Add bookmarks as many as you see the overflow indicator on the bookmarks toolbar
2. Click the indicator button
3. Make sure there is not spacing between the icons and labels
4. Click the menu button on tabs bar
5. Make sure the label 'Zoom' is displayed

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


