### PR TITLE
Correct a mockery path that was preventing forcing the darwin platform in windowsTest

### DIFF
--- a/test/unit/app/browser/windowsTest.js
+++ b/test/unit/app/browser/windowsTest.js
@@ -83,7 +83,7 @@ describe('window API unit tests', function () {
     mockery.registerMock('electron', fakeElectron)
     mockery.registerMock('ad-block', fakeAdBlock)
     mockery.registerMock('../../js/stores/appStore', appStore)
-    mockery.registerMock('../../common/lib/platformUtil', fakePlatformUtil)
+    mockery.registerMock('../common/lib/platformUtil', fakePlatformUtil)
     mockery.registerMock('../../js/dispatcher/appDispatcher', fakeAppDispatcher)
     windows = require('../../../../app/browser/windows')
     appActions = require('../../../../js/actions/appActions')


### PR DESCRIPTION
This was causing unittests to fail on linux and windows

Fix #12090

Issue was introduced with #11764 which was merged to master, 0.21.x and 0.20.x

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
unit tests pass

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


