### PR TITLE
memoize state reading

### DIFF
--- a/app/common/state/notificationBarState.js
+++ b/app/common/state/notificationBarState.js
@@ -2,17 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const assert = require('assert')
 const Immutable = require('immutable')
-const {makeImmutable, isMap} = require('./immutableUtil')
+const { createSelector } = require('reselect')
+const frameStateUtil = require('../../../js/state/frameStateUtil')
+const { getOrigin } = require('../../../js/lib/urlutil')
+const { generateWindowStateSelector } = require('./windowState')
 
-const api = {
-  validateState: function (state) {
-    state = makeImmutable(state)
-    assert.ok(isMap(state), 'state must be an Immutable.Map')
-    return state
-  }
-}
+// the portion of the appStore state that concerns notifications
+const selectNotificationState = state => state.get('notifications', Immutable.List())
 
 const notificationBarState = {
   /**
@@ -20,20 +17,58 @@ const notificationBarState = {
    * @param {Map} appState - The app state object
    * @return {List} - immutable list of notifications
    */
-  getNotifications: (state) => {
-    state = api.validateState(state)
-    return state.get('notifications', Immutable.List())
-  },
+  getNotifications: selectNotificationState,
 
   /**
    * Gets an immutable list of global notifications (shown above tab bar)
    * @param {Map} appState - The app state object
    * @return {List} - immutable list of global notifications
    */
-  getGlobalNotifications: (state) => {
-    const notifications = notificationBarState.getNotifications(state)
-    return notifications.filter(item => item.get('position') === 'global')
-  }
+  getGlobalNotifications: createSelector(
+    selectNotificationState,
+    notifications => notifications.filter(item => item.get('position') === 'global')
+  ),
+
+  /**
+   * Get notifications which should be considered 'active',
+   * that is - notifications for the active frame origin,
+   * and all other notifications that are not from the ledger.
+   * Limited to the last 3 notifications.
+   */
+  getActiveNotifications: createSelector(
+    // select active frame origin
+    // since the active frame data changes extremely frequently,
+    // but the origin does not, do not perform the notifications
+    // filter on every change of every frame property, just the origin
+    createSelector(
+      // generateWindowStateSelector is required
+      // to convert to state.currentWindow since some selectors require appState
+      // and some require windowState
+      generateWindowStateSelector(
+        frameStateUtil.getActiveFrame
+      ),
+      // will only be re-computed if the active frame state changes (frequently)
+      activeFrame => getOrigin((activeFrame || Immutable.Map()).get('location'))
+    ),
+    // select all notifications
+    selectNotificationState,
+    // if either active frame origin, or all notifications change,
+    // then reevaluate what 'active notifications' are
+    (activeFrameOrigin, notifications) => {
+      console.log('re-eval active notifications')
+      return notifications
+        .filter((item) => {
+          const notificationFrameOrigin = item.get('frameOrigin')
+          return notificationFrameOrigin
+            ? activeFrameOrigin === notificationFrameOrigin
+            // filter to non-global notifications
+            // i.e. frame-only
+            : item.get('position') !== 'global'
+        })
+        .takeLast(3)
+    }
+  )
+
 }
 
 module.exports = notificationBarState

--- a/app/common/state/siteSettingsState.js
+++ b/app/common/state/siteSettingsState.js
@@ -3,7 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const Immutable = require('immutable')
-
+const { createSelector } = require('reselect')
 // Constants
 const appConfig = require('../../../js/constants/appConfig')
 
@@ -13,16 +13,24 @@ const siteSettings = require('../../../js/state/siteSettings')
 // Utils
 const {getHostPattern} = require('../../../js/lib/urlutil')
 
+const getAllSiteSettings = state => state.get('siteSettings')
+
 const api = {
+  getAllAndTemporarySiteSettingsSelector: createSelector(
+    getAllSiteSettings,
+    state => state.get('temporarySiteSettings'),
+    (allSiteSettings, temporarySiteSettings) => allSiteSettings.mergeDeep(temporarySiteSettings)
+  ),
+
   getAllSiteSettings: (state, isPrivate) => {
     if (isPrivate) {
-      return state.get('siteSettings').mergeDeep(state.get('temporarySiteSettings'))
+      return api.getAllAndTemporarySiteSettingsSelector(state)
     }
-    return state.get('siteSettings')
+    return getAllSiteSettings(state)
   },
 
   getSettingsByHost: (state, url) => {
-    const siteSettings = state.get('siteSettings')
+    const siteSettings = getAllSiteSettings(state)
     const hostPattern = getHostPattern(url)
 
     return siteSettings ? siteSettings.get(hostPattern) : Immutable.Map()

--- a/app/common/state/windowState.js
+++ b/app/common/state/windowState.js
@@ -2,9 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const { makeImmutable, isMap, isList } = require('./immutableUtil')
 const Immutable = require('immutable')
 const assert = require('assert')
+const { createSelector } = require('reselect')
+const { makeImmutable, isMap, isList } = require('./immutableUtil')
 
 // TODO(bridiver) - make these generic validation functions
 const validateId = function (propName, id) {
@@ -182,6 +183,18 @@ const api = {
       !windowState.getIn(['ui', 'noScriptInfo', 'isVisible']) &&
       frame && !frame.getIn(['security', 'loginRequiredDetail']) &&
       !windowState.getIn(['ui', 'menubar', 'selectedIndex'])
+  },
+
+  /**
+   * Allows a selector to be created from appStore state, that can call
+   * a child selector which expects windowStore state. Must be called from renderer
+   * component, which stores windowState on appState.currentWindow
+   */
+  generateWindowStateSelector: function generateWindowStateSelector (resultFunc) {
+    return createSelector(
+      state => state.get('currentWindow'),
+      resultFunc
+    )
   }
 }
 

--- a/app/renderer/components/frame/frame.js
+++ b/app/renderer/components/frame/frame.js
@@ -5,6 +5,7 @@
 const React = require('react')
 const Immutable = require('immutable')
 const ipc = require('electron').ipcRenderer
+const { createSelector } = require('reselect')
 
 // Actions
 const appActions = require('../../../../js/actions/appActions')
@@ -30,6 +31,7 @@ const tabState = require('../../../common/state/tabState')
 const tabMessageBoxState = require('../../../common/state/tabMessageBoxState')
 
 // Utils
+const { generateWindowStateSelector } = require('../../../common/state/windowState')
 const frameStateUtil = require('../../../../js/state/frameStateUtil')
 const UrlUtil = require('../../../../js/lib/urlutil')
 const cx = require('../../../../js/lib/classSet')
@@ -850,70 +852,88 @@ class Frame extends React.Component {
   }
 
   mergeProps (state, ownProps) {
-    const currentWindow = state.get('currentWindow')
-    const frame = frameStateUtil.getFrameByKey(currentWindow, ownProps.frameKey) || Immutable.Map()
-    const tabId = frame.get('tabId', tabState.TAB_ID_NONE)
+    // generate selector for this frame
+    const frameKey = ownProps.frameKey
+    const getFrameSelector = generateWindowStateSelector(windowState => frameStateUtil.getFrameByKey(windowState, frameKey)) || Immutable.Map()
+    const allSiteSettingsSelector = createSelector(
+      state => state,
+      createSelector(
+        getFrameSelector,
+        frame => frame.get('isPrivate', false)
+      ),
+      (state, isPrivate) => siteSettingsState.getAllSiteSettings(state, isPrivate)
+    )
+    const frameSiteSettingsSelector = createSelector(
+      (state) => getFrameSelector(state).get('location'),
+      allSiteSettingsSelector,
+      (location, allSettings) => siteSettings.getSiteSettingsForURL(allSettings, location) || Immutable.Map()
+    )
 
-    const location = frame.get('location')
-    const origin = tabState.getVisibleOrigin(state, tabId)
-    const isPrivate = frame.get('isPrivate', false)
+    return (state, ownProps) => {
+      const currentWindow = state.get('currentWindow')
+      const frame = getFrameSelector(state)
+      const tabId = frame.get('tabId', tabState.TAB_ID_NONE)
 
-    const allSiteSettings = siteSettingsState.getAllSiteSettings(state, isPrivate)
-    const frameSiteSettings = siteSettings.getSiteSettingsForURL(allSiteSettings, location) || Immutable.Map()
+      const location = frame.get('location')
+      const origin = tabState.getVisibleOrigin(state, tabId)
 
-    const contextMenu = currentWindow.get('contextMenuDetail')
-    const tab = tabId && tabId > -1 && tabState.getByTabId(state, tabId)
+      const allSiteSettings = allSiteSettingsSelector(state)
+      const frameSiteSettings = frameSiteSettingsSelector(state)
 
-    const props = {}
-    // used in renderer
-    props.transitionState = ownProps.transitionState
-    props.partition = frameStateUtil.getPartition(frame)
-    props.isFullScreen = frame.get('isFullScreen')
-    props.isPreview = frame.get('key') === currentWindow.get('previewFrameKey')
-    props.isActive = frameStateUtil.isFrameKeyActive(currentWindow, frame.get('key'))
-    props.showFullScreenWarning = frame.get('showFullScreenWarning')
-    props.location = location
-    props.isDefaultNewTabLocation = location === 'about:newtab'
-    props.isBlankLocation = location === 'about:blank'
-    props.tabId = tabId
-    props.showMessageBox = tabMessageBoxState.hasMessageBoxDetail(state, tabId)
-    props.isFocused = isFocused(state)
+      const contextMenu = currentWindow.get('contextMenuDetail')
+      const tab = tabId && tabId > -1 && tabState.getByTabId(state, tabId)
 
-    // used in other functions
-    props.frameKey = ownProps.frameKey
-    props.origin = origin
-    props.runInsecureContent = frameSiteSettings.get('runInsecureContent')
-    props.noScript = frameSiteSettings.get('noScript')
-    props.noScriptExceptions = frameSiteSettings.get('noScriptExceptions')
-    props.widevine = frameSiteSettings.get('widevine')
-    props.flash = frameSiteSettings.get('flash')
-    props.urlBarFocused = frame && frame.getIn(['navbar', 'urlbar', 'focused'])
-    props.isAutFillContextMenu = contextMenu && contextMenu.get('type') === 'autofill'
-    props.isSecure = frame.getIn(['security', 'isSecure'])
-    props.findbarShown = frame.get('findbarShown')
-    props.findDetailCaseSensitivity = frame.getIn(['findDetail', 'caseSensitivity'], undefined)
-    props.findDetailSearchString = frame.getIn(['findDetail', 'searchString'])
-    props.findDetailInternalFindStatePresent = frame.getIn(['findDetail', 'internalFindStatePresent'])
-    props.isPrivate = frame.get('isPrivate')
-    props.activeShortcut = frame.get('activeShortcut')
-    props.shortcutDetailsUsername = frame.getIn(['activeShortcutDetails', 'username'])
-    props.shortcutDetailsPassword = frame.getIn(['activeShortcutDetails', 'password'])
-    props.shortcutDetailsOrigin = frame.getIn(['activeShortcutDetails', 'origin'])
-    props.shortcutDetailsAction = frame.getIn(['activeShortcutDetails', 'action'])
-    props.provisionalLocation = frame.get('provisionalLocation')
-    props.src = frame.get('src')
-    props.guestInstanceId = frame.get('guestInstanceId')
-    props.aboutDetailsUrl = frame.getIn(['aboutDetails', 'url'])
-    props.aboutDetailsFrameKey = frame.getIn(['aboutDetails', 'frameKey'])
-    props.aboutDetailsErrorCode = frame.getIn(['aboutDetails', 'errorCode'])
-    props.unloaded = frame.get('unloaded')
-    props.isWidevineEnabled = state.get('widevine') && state.getIn(['widevine', 'enabled'])
-    props.siteZoomLevel = frameSiteSettings.get('zoomLevel')
-    props.hasAllSiteSettings = !!allSiteSettings
-    props.tabUrl = tab && tab.get('url')
-    props.partitionNumber = frame.get('partitionNumber')
+      const props = {}
+      // used in renderer
+      props.transitionState = ownProps.transitionState
+      props.partition = frameStateUtil.getPartition(frame)
+      props.isFullScreen = frame.get('isFullScreen')
+      props.isPreview = frame.get('key') === currentWindow.get('previewFrameKey')
+      props.isActive = frameStateUtil.isFrameKeyActive(currentWindow, frame.get('key'))
+      props.showFullScreenWarning = frame.get('showFullScreenWarning')
+      props.location = location
+      props.isDefaultNewTabLocation = location === 'about:newtab'
+      props.isBlankLocation = location === 'about:blank'
+      props.tabId = tabId
+      props.showMessageBox = tabMessageBoxState.hasMessageBoxDetail(state, tabId)
+      props.isFocused = isFocused(state)
 
-    return props
+      // used in other functions
+      props.frameKey = ownProps.frameKey
+      props.origin = origin
+      props.runInsecureContent = frameSiteSettings.get('runInsecureContent')
+      props.noScript = frameSiteSettings.get('noScript')
+      props.noScriptExceptions = frameSiteSettings.get('noScriptExceptions')
+      props.widevine = frameSiteSettings.get('widevine')
+      props.flash = frameSiteSettings.get('flash')
+      props.urlBarFocused = frame && frame.getIn(['navbar', 'urlbar', 'focused'])
+      props.isAutFillContextMenu = contextMenu && contextMenu.get('type') === 'autofill'
+      props.isSecure = frame.getIn(['security', 'isSecure'])
+      props.findbarShown = frame.get('findbarShown')
+      props.findDetailCaseSensitivity = frame.getIn(['findDetail', 'caseSensitivity'], undefined)
+      props.findDetailSearchString = frame.getIn(['findDetail', 'searchString'])
+      props.findDetailInternalFindStatePresent = frame.getIn(['findDetail', 'internalFindStatePresent'])
+      props.isPrivate = frame.get('isPrivate')
+      props.activeShortcut = frame.get('activeShortcut')
+      props.shortcutDetailsUsername = frame.getIn(['activeShortcutDetails', 'username'])
+      props.shortcutDetailsPassword = frame.getIn(['activeShortcutDetails', 'password'])
+      props.shortcutDetailsOrigin = frame.getIn(['activeShortcutDetails', 'origin'])
+      props.shortcutDetailsAction = frame.getIn(['activeShortcutDetails', 'action'])
+      props.provisionalLocation = frame.get('provisionalLocation')
+      props.src = frame.get('src')
+      props.guestInstanceId = frame.get('guestInstanceId')
+      props.aboutDetailsUrl = frame.getIn(['aboutDetails', 'url'])
+      props.aboutDetailsFrameKey = frame.getIn(['aboutDetails', 'frameKey'])
+      props.aboutDetailsErrorCode = frame.getIn(['aboutDetails', 'errorCode'])
+      props.unloaded = frame.get('unloaded')
+      props.isWidevineEnabled = state.get('widevine') && state.getIn(['widevine', 'enabled'])
+      props.siteZoomLevel = frameSiteSettings.get('zoomLevel')
+      props.hasAllSiteSettings = !!allSiteSettings
+      props.tabUrl = tab && tab.get('url')
+      props.partitionNumber = frame.get('partitionNumber')
+
+      return props
+    }
   }
 
   getTransitionStateClassName (stateName) {

--- a/app/renderer/components/main/main.js
+++ b/app/renderer/components/main/main.js
@@ -536,7 +536,6 @@ class Main extends React.Component {
     const activeTabId = activeFrame.get('tabId', tabState.TAB_ID_NONE)
     const nonPinnedFrames = frameStateUtil.getNonPinnedFrames(currentWindow)
     const tabsPerPage = Number(getSetting(settings.TABS_PER_PAGE))
-    const activeOrigin = !activeFrame.isEmpty() ? urlUtil.getOrigin(activeFrame.get('location')) : null
     const widevinePanelDetail = currentWindow.get('widevinePanelDetail', Immutable.Map())
     const loginRequiredDetails = basicAuthState.getLoginRequiredDetail(state, activeTabId)
     const focused = isFocused(state)
@@ -570,8 +569,6 @@ class Main extends React.Component {
     props.shouldAllowWindowDrag = windowState.shouldAllowWindowDrag(state, currentWindow, activeFrame, focused)
     props.isSinglePage = nonPinnedFrames.size <= tabsPerPage
     props.showTabPages = nonPinnedFrames.size > tabsPerPage
-    props.showNotificationBar = activeOrigin && state.get('notifications').filter((item) =>
-        item.get('frameOrigin') ? activeOrigin === item.get('frameOrigin') : true).size > 0
     props.showFindBar = activeFrame.get('findbarShown') && !activeFrame.get('isFullScreen')
     props.sortedFrames = frameStateUtil.getSortedFrameKeys(currentWindow)
     props.showDownloadBar = currentWindow.getIn(['ui', 'downloadsToolbar', 'isVisible']) &&
@@ -724,11 +721,7 @@ class Main extends React.Component {
           </div>
         }
         <TabsToolbar key='tab-bar' />
-        {
-          this.props.showNotificationBar
-          ? <NotificationBar />
-          : null
-        }
+        <NotificationBar />
         {
           this.props.showFindBar
           ? <FindBar />

--- a/app/renderer/components/main/notificationBar.js
+++ b/app/renderer/components/main/notificationBar.js
@@ -4,15 +4,12 @@
 
 const React = require('react')
 const {StyleSheet, css} = require('aphrodite/no-important')
-const Immutable = require('immutable')
 
 // Components
 const ReduxComponent = require('../reduxComponent')
 const NotificationItem = require('./notificationItem')
 
 // Utils
-const {getOrigin} = require('../../../../js/lib/urlutil')
-const frameStateUtil = require('../../../../js/state/frameStateUtil')
 const notificationBarState = require('../../../common/state/notificationBarState')
 
 // Styles
@@ -21,26 +18,14 @@ const globalStyles = require('../styles/global')
 
 class NotificationBar extends React.Component {
   mergeProps (state, ownProps) {
-    const currentWindow = state.get('currentWindow')
-    const activeFrame = frameStateUtil.getActiveFrame(currentWindow) || Immutable.Map()
-    const activeOrigin = getOrigin(activeFrame.get('location'))
-    const notifications = notificationBarState.getNotifications(state)
-
     const props = {}
-    props.activeNotifications = notifications
-      .filter((item) => {
-        return item.get('frameOrigin')
-          ? activeOrigin === item.get('frameOrigin')
-          : item.get('position') !== 'global'
-      })
-      .takeLast(3)
-    props.showNotifications = !props.activeNotifications.isEmpty()
+    props.activeNotifications = notificationBarState.getActiveNotifications(state)
     return props
   }
 
   render () {
     // Avoid rendering an empty notification wrapper
-    if (!this.props.showNotifications) {
+    if (this.props.activeNotifications.isEmpty()) {
       return null
     }
     return <div className={css(commonStyles.notificationBar)} data-test-id='notificationBar'>

--- a/app/renderer/components/reduxComponent.js
+++ b/app/renderer/components/reduxComponent.js
@@ -82,20 +82,21 @@ ipc.on(messages.DEBUG_REACT_PROFILE, (e, args) => {
       // sort by time taken
       let toLogArray = []
       for (const componentName in toLog) {
-        const { totalTime, invocations } = toLog[componentName]
-        toLogArray.push({ componentName, totalTime, invocations })
+        const { totalTime, wastedTime, invocations } = toLog[componentName]
+        toLogArray.push({ componentName, totalTime, wastedTime, invocations })
       }
-      toLogArray.sort((a, b) => b.totalTime - a.totalTime)
+      toLogArray.sort((a, b) => b.wastedTime - a.wastedTime)
       // get a pretty table in the format of: component-name : details
       toLog = { }
-      for (const {componentName, totalTime, invocations} of toLogArray) {
-        toLog[componentName] = { totalTime, invocations }
+      for (const {componentName, totalTime, wastedTime, invocations} of toLogArray) {
+        toLog[componentName] = { totalTime, wastedTime, invocations }
       }
       const totalBlockingTime = toLogArray.reduce((total, current) => total + current.totalTime, 0)
+      const totalBlockingTimeWasted = toLogArray.reduce((total, current) => total + current.wastedTime, 0)
       // Log time spent, but only if there was time spent in mergeProps.
       // App may have been inactive and we don't want to log '0' every 10 seconds, if so.
       if (totalBlockingTime) {
-        console.log(`MergeProps history over the last 10 seconds (total UI blocking time = ${totalBlockingTime}ms): `)
+        console.log(`MergeProps history over the last 10 seconds (total UI blocking time = ${totalBlockingTime}ms, wasted = ${totalBlockingTimeWasted}ms): `)
         console.table(toLog)
       }
     }
@@ -123,24 +124,29 @@ class ReduxComponent extends ImmutableComponent {
       const t0 = isProfiling && window.performance.now()
       const newState = this.buildProps(this.props)
       const t1 = isProfiling && window.performance.now()
-      if (didPropsChange(this.state, newState)) {
+      const propsDidChange = didPropsChange(this.state, newState)
+      // only set state on the component if properties are different
+      if (propsDidChange) {
         this.setState(newState)
-      } else if (isProfiling) {
-        // log time used up in mergeProps where nothing changed
-        const timeTaken = t1 - t0
-        mergePropsWasteMs += timeTaken
       }
       // log how much total time was taken, whether something changed or not,
       // so we can asses which Components mergeProps functions are taking the most time
       if (isProfiling) {
+        const timeTaken = t1 - t0
         const componentName = this.componentType.name
         let componentMergePropsHistory = mergePropsComponentHistory[componentName]
         if (!componentMergePropsHistory) {
-          componentMergePropsHistory = { totalTime: 0, invocations: 0 }
+          componentMergePropsHistory = { totalTime: 0, invocations: 0, wastedTime: 0 }
           mergePropsComponentHistory[componentName] = componentMergePropsHistory
         }
         componentMergePropsHistory.invocations++
-        componentMergePropsHistory.totalTime += (t1 - t0)
+        componentMergePropsHistory.totalTime += timeTaken
+        if (!propsDidChange) {
+          // log total time used up in mergeProps where nothing changed
+          mergePropsWasteMs += timeTaken
+          // log component's wasted time separately
+          componentMergePropsHistory.wastedTime += timeTaken
+        }
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17863,6 +17863,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.1.tgz",
       "integrity": "sha1-S0QUQR2d98hVmV3YmajHiilRwW0="
     },
+    "reselect": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
+      "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
+    },
     "resolve": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
     "react-dom": "^15.5.4",
     "react-select": "^0.9.1",
     "react-transition-group": "^2.2.1",
+    "reselect": "^3.0.1",
     "snazzy": "^7.0.0",
     "string.prototype.endswith": "^0.2.0",
     "string.prototype.startswith": "^0.2.0",

--- a/test/unit/app/renderer/components/reduxComponentTest.js
+++ b/test/unit/app/renderer/components/reduxComponentTest.js
@@ -1,0 +1,201 @@
+/* global describe, it, before, after, afterEach */
+const EventEmitter = require('events')
+const React = require('react')
+const { mount } = require('enzyme')
+const Immutable = require('immutable')
+const mockery = require('mockery')
+const sinon = require('sinon')
+const { assert } = require('chai')
+const fakeElectron = require('../../../lib/fakeElectron')
+
+function TestComponent () {
+  return <p>hi</p>
+}
+
+describe('ReduxComponent', function () {
+  const appState = Immutable.fromJS({
+    context: 'appState'
+  })
+  const windowState = Immutable.fromJS({
+    context: 'windowState'
+  })
+  let winStoreEmitter = new EventEmitter()
+  let appStoreEmitter = new EventEmitter()
+  const fakeWindowStore = {
+    state: windowState,
+    addChangeListener: (fn) => {
+      winStoreEmitter.on('change', fn)
+    }
+  }
+  const fakeAppStore = {
+    state: appState,
+    addChangeListener: (fn) => {
+      appStoreEmitter.on('change', fn)
+    }
+  }
+  let ReduxComponent
+
+  before(function () {
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    })
+    mockery.registerMock('electron', fakeElectron)
+    mockery.registerMock('../../../js/stores/windowStore', fakeWindowStore)
+    mockery.registerMock('../../../js/stores/appStoreRenderer', fakeAppStore)
+    ReduxComponent = require('../../../../../app/renderer/components/reduxComponent')
+  })
+
+  after(function () {
+    mockery.disable()
+  })
+
+  afterEach(function () {
+    winStoreEmitter.removeAllListeners()
+    appStoreEmitter.removeAllListeners()
+  })
+
+  it('calls mergeProps for each component', function () {
+    const mergeProps1 = sinon.stub().returns({ })
+    const mergeProps2 = sinon.stub().returns({ })
+    let Component1 = ReduxComponent.connect(TestComponent, mergeProps1)
+    let Component2 = ReduxComponent.connect(TestComponent, mergeProps2)
+    mount(<div><Component1 /><Component2 /></div>)
+    // make sure mergeProps was called
+    assert.equal(mergeProps1.callCount, 1, 'mergeProps was called once')
+    assert.equal(mergeProps2.callCount, 1, 'mergeProps was called once')
+  })
+
+  it('calls mergeProps when app state changes', function () {
+    const mergeProps1 = sinon.stub().returns({ })
+    const mergeProps2 = sinon.stub().returns({ })
+    let Component1 = ReduxComponent.connect(TestComponent, mergeProps1)
+    let Component2 = ReduxComponent.connect(TestComponent, mergeProps2)
+    mount(<div><Component1 /><Component2 /></div>)
+    appStoreEmitter.emit('change')
+    // make sure mergeProps was called
+    assert.equal(mergeProps1.callCount, 2, 'mergeProps was called once')
+    assert.equal(mergeProps2.callCount, 2, 'mergeProps was called once')
+  })
+
+  it('calls mergeProps when window state changes', function () {
+    const mergeProps1 = sinon.stub().returns({ })
+    const mergeProps2 = sinon.stub().returns({ })
+    let Component1 = ReduxComponent.connect(TestComponent, mergeProps1)
+    let Component2 = ReduxComponent.connect(TestComponent, mergeProps2)
+    mount(<div><Component1 /><Component2 /></div>)
+    winStoreEmitter.emit('change')
+    // make sure mergeProps was called
+    assert.equal(mergeProps1.callCount, 2, 'mergeProps was called once')
+    assert.equal(mergeProps2.callCount, 2, 'mergeProps was called once')
+  })
+
+  it('sets component props as returned by mergeProps', function () {
+    const testProps = {
+      testProp: 'testValue',
+      testDeepProps: {
+        testDeepProp: true
+      }
+    }
+    const mergeProps = sinon.stub().returns(Object.assign({}, testProps))
+    class ComponentPropsLogger extends React.Component {
+      render () {
+        return null
+      }
+    }
+    const renderFn = sinon.stub(ComponentPropsLogger.prototype, 'render').returns(null)
+    let Component = ReduxComponent.connect(ComponentPropsLogger, mergeProps)
+    mount(<Component />)
+    assert.equal(renderFn.callCount, 1, 'react component render was called once')
+    const actualRenderThis = renderFn.thisValues[0]
+    assert.isOk(actualRenderThis, 'react component render was providing a `this`')
+    assert.deepEqual(actualRenderThis.props, testProps, 'result of mergeProps was provided as `this.props` in react component render')
+  })
+
+  it('re-renders component if props change', function () {
+    const testProps = {
+      testProp: 'testValue',
+      testDeepProps: {
+        testDeepProp: true
+      }
+    }
+    const modifiedTestProps = Object.assign({}, testProps, { testProps: 'modified' })
+    const mergeProps = sinon.stub()
+    mergeProps.onCall(0).returns(Object.assign({}, testProps))
+    mergeProps.onCall(1).returns(Object.assign({}, modifiedTestProps))
+    class ComponentPropsLogger extends React.Component {
+      render () {
+        return null
+      }
+    }
+    const renderFn = sinon.stub(ComponentPropsLogger.prototype, 'render').returns(null)
+    let Component2 = ReduxComponent.connect(ComponentPropsLogger, mergeProps)
+    mount(<Component2 />)
+    // sanity check first render
+    assert.equal(renderFn.callCount, 1, 'react component render was called once')
+    assert.deepEqual(renderFn.thisValues[0].props, testProps, 'result of mergeProps was provided as `this.props` in react component render')
+    // modify state
+    appStoreEmitter.emit('change')
+    // check rendered twice
+    assert.equal(renderFn.callCount, 2, 'react component render was called after state change')
+    // check props
+    assert.deepEqual(renderFn.thisValues[1].props, modifiedTestProps, 'result of modified mergeProps was provided as `this.props` in react component render')
+  })
+
+  it('does not re-render component if props are the same', function () {
+    const testProps = {
+      testProp: 'testValue',
+      testDeepProps: {
+        testDeepProp: true
+      }
+    }
+    const mergeProps = sinon.stub().returns(Object.assign({}, testProps))
+    class ComponentPropsLogger extends React.Component {
+      render () {
+        return null
+      }
+    }
+    const renderFn = sinon.stub(ComponentPropsLogger.prototype, 'render').returns(null)
+    let Component = ReduxComponent.connect(ComponentPropsLogger, mergeProps)
+    mount(<Component />)
+    assert.equal(renderFn.callCount, 1, 'react component render was called once')
+    const actualRenderThis = renderFn.thisValues[0]
+    assert.isOk(actualRenderThis, 'react component render was providing a `this`')
+    assert.deepEqual(actualRenderThis.props, testProps, 'result of mergeProps was provided as `this.props` in react component render')
+    appStoreEmitter.emit('change')
+    assert.equal(renderFn.callCount, 1, 'react component render was called once')
+  })
+
+  it('provides windowState merged with appState', function () {
+    const mergeProps = sinon.stub().returns({ })
+    let Component = ReduxComponent.connect(TestComponent, mergeProps)
+    mount(<Component />)
+    assert.equal(mergeProps.callCount, 1, 'mergeProps was called once')
+    // check that we have the state structure we're looking for
+    const state = mergeProps.args[0][0]
+    assert.property(state, 'toJS', 'state is immutable object')
+    const rawState = state.toJS()
+    assert.propertyVal(rawState, 'context', 'appState', 'has app state properties')
+    assert.property(rawState, 'currentWindow', 'has window state')
+    assert.propertyVal(rawState.currentWindow, 'context', 'windowState', 'has window state properties')
+  })
+
+  it('provides the same state object to multiple components', function () {
+    let component1State
+    let component2State
+    const mergeProps1 = sinon.spy((state, ownProps) => {
+      component1State = state
+      return { }
+    })
+    const mergeProps2 = sinon.spy((state, ownProps) => {
+      component2State = state
+      return { }
+    })
+    let Component1 = ReduxComponent.connect(TestComponent, mergeProps1)
+    let Component2 = ReduxComponent.connect(TestComponent, mergeProps2)
+    mount(<div><Component1 /><Component2 /></div>)
+    // make sure the exact same state object is given to each component
+    assert.strictEqual(component1State, component2State, 'Each component state is strict equal')
+  })
+})


### PR DESCRIPTION
Fix #11515 

The [reactjs/reselect library](https://github.com/reactjs/reselec) is a common method to memoize the result of functions that read or compute data based on state. It creates functions that are only re-computed when the relevant state changes. It becomes useful when:
 1. A state tree is large
 2. When portions of the state tree are modified often, and not all of the state tree is modified on every action dispatch
3. When **immutablejs** is used to represent state, and therefore partial tree equality comparison oldstate.get('portion1') === newstate.get('portion2') can be used very effectively.

Problems this PR aims to solve
- Time spent recalculating react/redux component instance `mergeProps` functions
  - A high number of components exist that subscribe to state changes
  - A high number of actions are dispatched that change certain relevant state properties
  - A high number of time is spent re-computing state changes where dependent state properties have not changed
  - Many components run the same expensive state-parsing functions within the same render-cycle but re-run those functions nevertheless.

This PR adds the following features:
- Common state accessors that are not dynamic, and should only be re-evaluated when a portion of the state tree changes are turned in to static memoized functions (e.g. in _xxxState.js_)
  - [x] Identify and address some main ones
  - [ ] Create Issues for refactoring some others
- Component instance-specific state accessors that are computed from dynamic properties, e.g. the state of a specific tab, frame, etc, are memoized per-instance use-case
  - [ ] Allow mergeProps to return a function or instance-specific memoized selector
  - [ ] Consider [re-reselect](https://github.com/toomuchdesign/re-reselect) to cache common dynamic selectors (e.g. frames or tabs)
- [ ] Some components are passed data as ownProps, when a child's state is very closely tied to its immediate parent, instead of calculating the same props again, and will benefit from its parent's mergeProp memoization
- [x] Enhances equality comparison for appState / windowState by only merging the two when neccessary

This PR results in the following metric improvements:
...


Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


