### PR TITLE
Fix loading of remote PDF files

### DIFF
--- a/app/pdfJS.js
+++ b/app/pdfJS.js
@@ -15,9 +15,8 @@ const viewerBaseUrl = `${pdfjsBaseUrl}content/web/viewer.html`
 
 const onBeforeRequest = (details) => {
   const result = { resourceName: 'pdfjs' }
-  if (!(details.resourceType === 'mainFrame' &&
-    UrlUtil.isFileScheme(details.url) &&
-    UrlUtil.isFileType(details.url, 'pdf'))) {
+  if (details.resourceType != 'mainFrame' ||
+    !UrlUtil.isFileType(details.url, 'pdf')) {
     return result
   }
   appActions.loadURLRequested(details.tabId, `${viewerBaseUrl}?file=${encodeURIComponent(details.url)}`)


### PR DESCRIPTION
Remote PDF files were downloaded instead of showed in browser
with pdfJS. Brave rewrites the URL for those resources so that
the pdfJS extension can show it. The regression appeared after
ba8e3f52a94 which was fixing the loading of local PDF files.

The problem was the condition used to filter those PDF files
which was excluding remote PDF files (only local ones where
properly shown).
