### PR TITLE
Create a flag which will output to the console a line for each event all tabs emit

### DIFF
--- a/app/cmdLine.js
+++ b/app/cmdLine.js
@@ -18,6 +18,7 @@ const fs = require('fs')
 const path = require('path')
 let appInitialized = false
 let newWindowURL
+const debugTabEventsFlagName = '--debug-tab-events'
 
 const focusOrOpenWindow = function (url) {
   // don't try to do anything if the app hasn't been initialized
@@ -136,3 +137,5 @@ module.exports.newWindowURL = () => {
   }
   return newWindowURL
 }
+
+module.exports.shouldDebugTabEvents = process.argv.includes(debugTabEventsFlagName)


### PR DESCRIPTION
This is a minor change that adds a new flag in order to view the as-yet undocumented events which come from the tab object in muon. It also helps for performance visualization in order to see what is happening at all times.

Command line flag is '--debug-tab-events', e.g. npm start -- --debug-tab-events
Console ouptut contains the tabId and the event name

Fix #12115

```
❯ npm run start -- --debug-tab-events

> brave@0.22.0 start /Users/petemill/Development/Brave/browser-laptop
> node ./tools/start.js --user-data-dir-name=brave-development --enable-logging --v=0 --enable-extension-activity-logging --enable-sandbox-logging --enable-dcheck "--debug-tab-events"

Tab [5] event 'set-active'
Tab [5] event 'will-attach'
Tab [5] event 'render-view-created'
Tab [5] event 'render-view-deleted'
Tab [5] event 'did-start-loading'
Tab [5] event 'load-progress-changed'
Tab [5] event 'did-attach'
Tab [9] event 'will-attach'
Tab [9] event 'render-view-created'
Tab [9] event 'render-view-deleted'
Tab [9] event 'did-start-loading'
Tab [9] event 'load-progress-changed'
Tab [9] event 'did-attach'
Tab [5] event 'render-view-ready'
Tab [5] event 'guest-ready'
Tab [9] event 'render-view-ready'
Tab [9] event 'guest-ready'
Tab [5] event 'did-start-navigation'
Tab [5] event 'load-start'
Tab [5] event 'preferred-size-changed'
Tab [9] event 'did-start-navigation'
Tab [9] event 'load-start'
Tab [9] event 'preferred-size-changed'
Tab [9] event 'did-get-response-details'
Tab [5] event 'did-get-response-details'
Tab [5] event 'load-progress-changed'
Tab [5] event 'security-style-changed'
Tab [5] event 'navigation-entry-commited'
Tab [5] event 'did-finish-navigation'
Tab [5] event 'did-navigate'
Tab [5] event 'update-target-url'
Tab [9] event 'load-progress-changed'
Tab [9] event 'security-style-changed'
Tab [9] event 'navigation-entry-commited'
Tab [9] event 'did-finish-navigation'
Tab [9] event 'did-navigate'
Tab [9] event 'update-target-url'
Tab [5] event 'document-available'
Tab [5] event 'did-get-redirect-request'
Tab [5] event 'did-get-response-details'
Tab [9] event 'document-available'
Tab [9] event 'did-get-redirect-request'
Tab [9] event 'did-get-response-details'
Tab [5] event 'did-get-response-details'
Tab [5] event 'dom-ready'
Tab [5] event 'did-get-response-details'
Tab [5] event 'ipc-message-host'
Tab [9] event 'dom-ready'
Tab [9] event 'did-get-response-details'
Tab [9] event 'ipc-message-host'
Tab [5] event 'page-title-updated'
Tab [5] event 'preferred-size-changed'
Tab [9] event 'preferred-size-changed'
Tab [9] event 'page-title-updated'
Tab [9] event 'did-get-response-details'
Tab [5] event 'load-progress-changed'
Tab [5] event 'console-message'
Tab [5] event 'console-message'
Tab [5] event 'ipc-message'
Tab [5] event 'ipc-message'
Tab [5] event 'document-onload'
Tab [5] event 'did-finish-load'
Tab [5] event 'load-progress-changed'
Tab [5] event 'load-progress-changed'
Tab [5] event 'did-stop-loading'
Tab [5] event 'preferred-size-changed'
Tab [5] event 'did-get-response-details'
Tab [5] event 'console-message'
Tab [9] event 'load-progress-changed'
Tab [9] event 'console-message'
Tab [9] event 'console-message'
Tab [9] event 'ipc-message'
Tab [9] event 'ipc-message'
Tab [9] event 'document-onload'
Tab [9] event 'did-finish-load'
Tab [9] event 'load-progress-changed'
Tab [9] event 'load-progress-changed'
Tab [9] event 'did-stop-loading'
Tab [9] event 'preferred-size-changed'
Tab [5] event 'console-message'
Tab [5] event 'console-message'
Tab [5] event 'console-message'
Tab [5] event 'console-message'
Tab [5] event 'console-message'
Tab [5] event 'did-get-response-details'
Tab [5] event 'console-message'
Tab [5] event 'console-message'
Tab [5] event 'console-message'
Tab [5] event 'console-message'
Tab [5] event 'console-message'
Tab [5] event 'did-get-redirect-request'
Tab [5] event 'did-get-response-details'
Tab [5] event 'did-get-response-details'
Tab [5] event 'did-get-response-details'
Tab [5] event 'did-get-response-details'
Tab [5] event 'did-get-response-details'
Tab [5] event 'preferred-size-changed'
Tab [5] event 'cursor-changed'
Tab [5] event 'update-target-url'
Tab [5] event 'cursor-changed'
Tab [5] event 'update-target-url'
Tab [9] event 'did-get-response-details'
Tab [9] event 'console-message'
Tab [5] event 'console-message'
Tab [5] event 'console-message'
Tab [5] event 'console-message'
Tab [5] event 'console-message'
Tab [5] event 'console-message'
^Cprocess exited with code null
Tab [5] event 'devtools-closed'
Tab [5] event 'will-destroy'
Tab [probably 5] event 'destroyed'
Tab [probably 5] event 'render-view-deleted'
Tab [probably 5] event 'render-view-deleted'
Tab [9] event 'devtools-closed'
Tab [9] event 'will-destroy'
Tab [probably 9] event 'destroyed'
Tab [probably 9] event 'render-view-deleted'
Tab [probably 9] event 'render-view-deleted'
```

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
- Run with flag, see extra console output, and no (new) errors
- Run without flag, do not see extra console output, and no (new) errors

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


