### PR TITLE
move pdf.js loading logic into browser-laptop

### DIFF
--- a/app/pdfJS.js
+++ b/app/pdfJS.js
@@ -5,23 +5,102 @@
 
 const UrlUtil = require('../js/lib/urlutil')
 const Filtering = require('./filtering')
-const config = require('../js/constants/config')
 const appActions = require('../js/actions/appActions')
 const getSetting = require('../js/settings').getSetting
 const settings = require('../js/constants/settings')
 
-const pdfjsBaseUrl = `chrome-extension://${config.PDFJSExtensionId}/`
-const viewerBaseUrl = `${pdfjsBaseUrl}content/web/viewer.html`
+const getViewerUrl = UrlUtil.getPDFViewerUrl
+
+/**
+ * Check if the request is a PDF file.
+ * @param {Object} details First argument of the webRequest.onHeadersReceived
+ *                         event. The properties "responseHeaders" and "url"
+ *                         are read.
+ * @return {boolean} True if the resource is a PDF file.
+ */
+function isPDFFile (details) {
+  var header = details.responseHeaders && details.responseHeaders['Content-Type']
+  if (header) {
+    if (header.includes('application/pdf')) {
+      return true
+    }
+    if (header.includes('application/octet-stream')) {
+      if (details.url.toLowerCase().indexOf('.pdf') > 0) {
+        return true
+      }
+      var cdHeader = details.responseHeaders['Content-Disposition']
+      if (cdHeader && /\.pdf(["']|$)/i.test(cdHeader[0])) {
+        return true
+      }
+    }
+  }
+}
+
+/**
+ * @param {Object} details First argument of the webRequest.onHeadersReceived
+ *                         event. The property "url" is read.
+ * @return {boolean} True if the PDF file should be downloaded.
+ */
+function isPDFDownloadable (details) {
+  if (details.url.indexOf('pdfjs.action=download') >= 0) {
+    return true
+  }
+  // Display the PDF viewer regardless of the Content-Disposition header if the
+  // file is displayed in the main frame, since most often users want to view
+  // a PDF, and servers are often misconfigured.
+  // If the query string contains "=download", do not unconditionally force the
+  // viewer to open the PDF, but first check whether the Content-Disposition
+  // header specifies an attachment. This allows sites like Google Drive to
+  // operate correctly (#6106).
+  if (details.type === 'main_frame' &&
+      details.url.indexOf('=download') === -1) {
+    return false
+  }
+  var cdHeader = (details.responseHeaders &&
+    details.responseHeaders['Content-Disposition'])
+  return (cdHeader && /^attachment/i.test(cdHeader[0]))
+}
+
+/**
+ * Takes a set of headers, and set "Content-Disposition: attachment".
+ * @param {Object} details First argument of the webRequest.onHeadersReceived
+ *                         event. The property "responseHeaders" is read and
+ *                         modified if needed.
+ * @return {Object|undefined} The return value for the responseHeaders property
+ */
+function getHeadersWithContentDispositionAttachment (details) {
+  var headers = details.responseHeaders
+  var cdHeader = headers['Content-Disposition'] || []
+  cdHeader.push('attachment')
+  headers['Content-Disposition'] = cdHeader
+  return headers
+}
 
 const onBeforeRequest = (details) => {
   const result = { resourceName: 'pdfjs' }
-  if (!(details.resourceType === 'mainFrame' &&
+  if (details.resourceType === 'mainFrame' &&
     UrlUtil.isFileScheme(details.url) &&
-    UrlUtil.isFileType(details.url, 'pdf'))) {
-    return result
+    UrlUtil.isFileType(details.url, 'pdf')) {
+    appActions.loadURLRequested(details.tabId, getViewerUrl(details.url))
+    result.cancel = true
   }
-  appActions.loadURLRequested(details.tabId, `${viewerBaseUrl}?file=${encodeURIComponent(details.url)}`)
-  result.cancel = true
+  return result
+}
+
+const onHeadersReceived = (details) => {
+  const result = { resourceName: 'pdfjs' }
+  // Don't intercept POST requests until http://crbug.com/104058 is fixed.
+  if (details.resourceType === 'mainFrame' && details.method === 'GET' && isPDFFile(details)) {
+    if (isPDFDownloadable(details)) {
+      // Force download by ensuring that Content-Disposition: attachment is set
+      result.responseHeaders = getHeadersWithContentDispositionAttachment(details)
+      return result
+    }
+
+    // Replace frame with viewer
+    appActions.loadURLRequested(details.tabId, getViewerUrl(details.url))
+    result.cancel = true
+  }
   return result
 }
 
@@ -31,5 +110,6 @@ const onBeforeRequest = (details) => {
 module.exports.init = () => {
   if (getSetting(settings.PDFJS_ENABLED)) {
     Filtering.registerBeforeRequestFilteringCB(onBeforeRequest)
+    Filtering.registerHeadersReceivedFilteringCB(onHeadersReceived)
   }
 }

--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -349,6 +349,12 @@ const UrlUtil = {
     return url.replace(`chrome-extension://${pdfjsExtensionId}/`, '')
   },
 
+  getPDFViewerUrl: function (url) {
+    const pdfjsBaseUrl = `chrome-extension://${pdfjsExtensionId}/`
+    const viewerBaseUrl = `${pdfjsBaseUrl}content/web/viewer.html`
+    return `${viewerBaseUrl}?file=${encodeURIComponent(url)}`
+  },
+
   /**
    * Converts a potential PDF URL to the PDFJS URL.
    * XXX: This only looks at the URL file extension, not MIME types.
@@ -357,7 +363,7 @@ const UrlUtil = {
    */
   toPDFJSLocation: function (url) {
     if (url && UrlUtil.isHttpOrHttps(url) && UrlUtil.isFileType(url, 'pdf')) {
-      return `chrome-extension://${pdfjsExtensionId}/${url}`
+      return UrlUtil.getPDFViewerUrl(url)
     }
     return url
   },

--- a/test/unit/lib/urlutilTest.js
+++ b/test/unit/lib/urlutilTest.js
@@ -195,7 +195,7 @@ describe('urlutil', function () {
   describe('toPDFJSLocation', function () {
     const baseUrl = 'chrome-extension://jdbefljfgobbmcidnmpjamcbhnbphjnb/'
     it('pdf', function () {
-      assert.equal(urlUtil.toPDFJSLocation('http://abc.com/test.pdf'), baseUrl + 'http://abc.com/test.pdf')
+      assert.equal(urlUtil.toPDFJSLocation('http://abc.com/test.pdf'), baseUrl + 'content/web/viewer.html?file=http%3A%2F%2Fabc.com%2Ftest.pdf')
     })
     it('non-pdf', function () {
       assert.equal(urlUtil.toPDFJSLocation('http://abc.com/test.pdf.txt'), 'http://abc.com/test.pdf.txt')
@@ -205,6 +205,16 @@ describe('urlutil', function () {
     })
     it('empty', function () {
       assert.equal(urlUtil.toPDFJSLocation(''), '')
+    })
+  })
+
+  describe('getPDFViewerUrl', function () {
+    const baseUrl = 'chrome-extension://jdbefljfgobbmcidnmpjamcbhnbphjnb/content/web/viewer.html?file='
+    it('regular url', function () {
+      assert.equal(urlUtil.getPDFViewerUrl('http://example.com'), baseUrl + 'http%3A%2F%2Fexample.com')
+    })
+    it('file url', function () {
+      assert.equal(urlUtil.getPDFViewerUrl('file:///Users/yan/some files/test.pdf'), baseUrl + 'file%3A%2F%2F%2FUsers%2Fyan%2Fsome%20files%2Ftest.pdf')
     })
   })
 


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/4651
probably fixes https://github.com/brave/browser-laptop/issues/2715 but ideally the workaround in brave/pdf.js should be removed too
may also fix other PDF loading errors

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Test Plan:
1. go to any page that contains PDF links such as https://letsencrypt.org/repository/
2. try to open the PDF links in a new session tab. it should work.

## Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


