### PR TITLE
Make only BAT TOS text clickable

### DIFF
--- a/app/renderer/components/preferences/payment/disabledContent.js
+++ b/app/renderer/components/preferences/payment/disabledContent.js
@@ -68,12 +68,15 @@ class DisabledContent extends ImmutableComponent {
           })} data-test-id='paymentsMessage'>
             {this.text}
           </div>
-          <a data-l10n-id='termsOfService'
-            className={css(styles.disabledContent__message__toc)}
-            href='https://basicattentiontoken.org/contributor-terms-of-service/'
-            target='_blank'
-            rel='noreferrer noopener'
-          />
+          <div className={css(styles.disabledContent__message__toc)}>
+            <a data-l10n-id='termsOfService'
+              data-test-id='termsOfService'
+              className={css(styles.disabledContent__message__toc__link)}
+              href='https://basicattentiontoken.org/contributor-terms-of-service/'
+              target='_blank'
+              rel='noreferrer noopener'
+            />
+          </div>
           <div className={css(styles.disabledContent__footer)}>
             <div className={css(styles.disabledContent__commonText)} data-l10n-id='paymentsWelcomeText3' />
             <div className={css(styles.disabledContent__commonText)} data-l10n-id='paymentsWelcomeText4' />
@@ -135,9 +138,12 @@ const styles = StyleSheet.create({
     display: 'flex',
     flex: 1,
     justifyContent: 'flex-end',
-    fontSize: '13px',
-    color: '#666',
     padding: '20px 0'
+  },
+
+  disabledContent__message__toc__link: {
+    fontSize: '13px',
+    color: '#666'
   },
 
   disabledContent__sidebar: {

--- a/app/renderer/components/preferences/payment/enabledContent.js
+++ b/app/renderer/components/preferences/payment/enabledContent.js
@@ -341,11 +341,14 @@ class EnabledContent extends ImmutableComponent {
         settings={this.props.settings}
         onChangeSetting={this.props.onChangeSetting}
         siteSettings={this.props.siteSettings} />
-      <a data-l10n-id='termsOfService'
-        className={css(styles.enabledContent__tos)}
-        href='https://basicattentiontoken.org/contributor-terms-of-service/'
-        target='_blank'
-        rel='noreferrer noopener' />
+      <div className={css(styles.enabledContent__tos)}>
+        <a data-l10n-id='termsOfService'
+          data-test-id='termsOfService'
+          className={css(styles.enabledContent__tos__link)}
+          href='https://basicattentiontoken.org/contributor-terms-of-service/'
+          target='_blank'
+          rel='noreferrer noopener' />
+      </div>
     </section>
   }
 }
@@ -454,9 +457,12 @@ const styles = StyleSheet.create({
 
   enabledContent__tos: {
     float: 'right',
-    fontSize: '13px',
-    color: '#666',
     padding: '20px 60px'
+  },
+
+  enabledContent__tos__link: {
+    fontSize: '13px',
+    color: '#666'
   },
 
   enabledContent__loader: {

--- a/test/about/ledgerPanelTest.js
+++ b/test/about/ledgerPanelTest.js
@@ -27,6 +27,7 @@ const ledgerAPIWaitTimeout = 20000
 const site1 = 'http://example.com/'
 const site2 = 'https://www.eff.org/'
 const site3 = 'http://web.mit.edu/zyan/Public/wait.html'
+const BatTOSUrl = 'https://basicattentiontoken.org/contributor-terms-of-service/'
 
 function * setupBrave () {
   Brave.addCommands()
@@ -137,6 +138,39 @@ describe('Regular payment panel tests', function () {
         .waitForVisible(walletSwitch)
         .click(walletSwitch)
         .waitForEnabled(addFundsButton)
+    })
+
+    it('clicks BAT TOS link when payments are enabled', function * () {
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(prefsUrl)
+        .waitForVisible(paymentsTab)
+        .click(paymentsTab)
+        .waitForVisible(paymentsWelcomePage)
+        .waitForVisible(walletSwitch)
+        .click(walletSwitch)
+        .waitForEnabled(addFundsButton, ledgerAPIWaitTimeout)
+        .waitForVisible('[data-test-id="termsOfService"]')
+        .click('[data-test-id="termsOfService"]')
+        .tabByUrl(BatTOSUrl)
+        .waitForUrl(BatTOSUrl)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForHistoryEntry(BatTOSUrl)
+    })
+
+    it('clicks BAT TOS link when payments are disabled', function * () {
+      yield this.app.client
+        .tabByIndex(0)
+        .loadUrl(prefsUrl)
+        .waitForVisible(paymentsTab)
+        .click(paymentsTab)
+        .waitForVisible(paymentsWelcomePage)
+        .waitForVisible('[data-test-id="termsOfService"]')
+        .click('[data-test-id="termsOfService"]')
+        .tabByUrl(BatTOSUrl)
+        .waitForUrl(BatTOSUrl)
+        .windowByUrl(Brave.browserWindowUrl)
+        .waitForHistoryEntry(BatTOSUrl)
     })
   })
 


### PR DESCRIPTION
Closes #12137

Auditors:

Test Plan 1: `npm run test -- --grep='clicks BAT TOS link'`

Test Plan 2:
1. Open about:preferences#payments
2. Make sure the BAT TOS link text only is clickable
3. Enable/Disable payments
4. Make sure the BAT TOS link text only is clickable

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


