### PR TITLE
Add always deny options support

### DIFF
--- a/app/browser/reducers/autoplayReducer.js
+++ b/app/browser/reducers/autoplayReducer.js
@@ -12,12 +12,16 @@ const appActions = require('../../../js/actions/appActions')
 const {getOrigin} = require('../../../js/lib/urlutil')
 const locale = require('../../locale')
 const messages = require('../../../js/constants/messages')
+const getSetting = require('../../../js/settings').getSetting
+const settings = require('../../../js/constants/settings')
+const {autoplayOption} = require('../../common/constants/settingsEnums')
 
 let notificationCallbacks = []
 
 const showAutoplayMessageBox = (state, tabId) => {
   const tab = webContents.fromTabID(tabId)
-  if (!tab || tab.isDestroyed()) {
+  if (!tab || tab.isDestroyed() ||
+      getSetting(settings.AUTOPLAY_MEDIA) === autoplayOption.ALWAYS_DENY) {
     return
   }
   const location = tab.getURL()

--- a/app/common/constants/settingsEnums.js
+++ b/app/common/constants/settingsEnums.js
@@ -40,7 +40,8 @@ const fullscreenOption = {
 
 const autoplayOption = {
   ALWAYS_ASK: 'alwaysAsk',
-  ALWAYS_ALLOW: 'alwaysAllow'
+  ALWAYS_ALLOW: 'alwaysAllow',
+  ALWAYS_DENY: 'alwaysDeny'
 }
 
 module.exports = {

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -653,6 +653,7 @@ class SecurityTab extends ImmutableComponent {
             onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.AUTOPLAY_MEDIA)}>
             <option data-l10n-id='alwaysAsk' value={autoplayOption.ALWAYS_ASK} />
             <option data-l10n-id='alwaysAllow' value={autoplayOption.ALWAYS_ALLOW} />
+            <option data-l10n-id='alwaysDeny' value={autoplayOption.ALWAYS_DENY} />
           </SettingDropdown>
         </SettingItem>
       </SettingsList>


### PR DESCRIPTION
(It won't popup notification if media is blocked)

fix #9755

Auditors: @bsclifton

Test Plan:
a. Manual Test
1. Go to about:preferences#security
2. Set Autoplay Media to `Always deny`
3. Visit https://www.cnet.com/news/mozilla-layoff-firefox-device-relevance/
4. It should blocked video without asking users

b Automatic Test
Covered by unit test

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


