### PR TITLE
Exclude cookies from google.com domain

### DIFF
--- a/app/importer.js
+++ b/app/importer.js
@@ -223,8 +223,9 @@ importer.on('add-autofill-form-data-entries', (e, detail) => {
 const shouldSkipCookie = (cookie) => {
   // Bypassing cookie mismatch error in
   // https://github.com/brave/browser-laptop/issues/11401
-  if (['https://notifications.google.com', 'https://myaccount.google.com',
-    'https://accounts.google.com'].includes(cookie.url)) {
+  const googleDomain = /^.*\.google.com(\..+)*$/
+  if (cookie.domain.match(googleDomain) &&
+      ['OSID', 'LSID', 'SIDCC'].includes(cookie.name)) {
     return true
   }
   return false

--- a/test/unit/app/importerTest.js
+++ b/test/unit/app/importerTest.js
@@ -24,12 +24,18 @@ describe('importer unit tests', function () {
   })
 
   describe('shouldSkipCookie', function () {
-    it('returns true if domain is google and URL is one which has a mismatch', function () {
-      assert.equal(importer.shouldSkipCookie({domain: '.google.com', url: 'https://notifications.google.com'}), true)
+    it('returns true if domain is google and name is one which has a mismatch', function () {
+      assert.equal(importer.shouldSkipCookie({domain: '.google.com', name: 'OSID'}), true)
+      assert.equal(importer.shouldSkipCookie({domain: 'mail.google.com', name: 'LSID'}), true)
+      assert.equal(importer.shouldSkipCookie({domain: '.google.com.tw', name: 'SIDCC'}), true)
     })
 
     it('returns false for other cases', function () {
-      assert.equal(importer.shouldSkipCookie({domain: '.brave.com', url: 'https://brave.com'}), false)
+      assert.equal(importer.shouldSkipCookie({domain: '.brave.com', name: 'OSID'}), false)
+      assert.equal(importer.shouldSkipCookie({domain: 'ggoogle.com', name: 'OSID'}), false)
+      assert.equal(importer.shouldSkipCookie({domain: '.google.comm', name: 'OSID'}), false)
+      assert.equal(importer.shouldSkipCookie({domain: '.google.comm.', name: 'OSID'}), false)
+      assert.equal(importer.shouldSkipCookie({domain: '.google.com', name: 'BRAVE'}), false)
     })
   })
 })


### PR DESCRIPTION
fix #11401

Auditors: @bsclifton, @bbondy

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Test Plan:
1. https://github.com/brave/browser-laptop/issues/11401#issue-264003667
2. https://github.com/brave/browser-laptop/pull/11647#issue-267885634
3. https://github.com/brave/browser-laptop/issues/11401#issuecomment-339673873

4.
4.a Clear cookies on FF and Chrome, login to gmail account 1 and account 2
4.b Close FF and Chrome, Open Brave (clean profile)
4.c Import cookies only from FF and Chrome
4.d Navigate to mail.google.com --> you have to enter password for
account 1 and account 2 (but no 2FA)
4.e Import cookies from FF and Chrome again, refresh gmail page
(you will have to enter password again to login both accounts)
4.f Logout and you will see login page with both accounts loggout
(no cookie mismatch error)

5. unit test
`npm run unittest -- --grep="shouldSkipCookie"`

## Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


