### PR TITLE
Using composition event to detect IME composition stage ends

### DIFF
--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -51,11 +51,13 @@ class UrlBar extends React.Component {
     super(props)
     this.lastVal = ''
     this.lastSuffix = ''
+    this.isOnComposition = false
     this.onFocus = this.onFocus.bind(this)
     this.onBlur = this.onBlur.bind(this)
     this.onKeyDown = this.onKeyDown.bind(this)
     this.onKeyUp = this.onKeyUp.bind(this)
     this.onChange = this.onChange.bind(this)
+    this.onComposition = this.onComposition.bind(this)
     this.onKeyPress = this.onKeyPress.bind(this)
     this.onClick = this.onClick.bind(this)
     this.onContextMenu = this.onContextMenu.bind(this)
@@ -263,9 +265,19 @@ class UrlBar extends React.Component {
   }
 
   onChange (e) {
-    if (e.target.value !== this.lastVal + this.lastSuffix) {
+    if (e.target.value !== this.lastVal + this.lastSuffix &&
+        !this.isOnComposition) {
       e.preventDefault()
       this.setValue(e.target.value)
+    }
+  }
+
+  onComposition (e) {
+    if (e.type === 'compositionend') {
+      this.isOnComposition = false
+      this.onChange(e)
+    } else {
+      this.isOnComposition = true
     }
   }
 
@@ -521,6 +533,9 @@ class UrlBar extends React.Component {
           onKeyUp={this.onKeyUp}
           onChange={this.onChange}
           onKeyPress={this.onKeyPress}
+          onCompositionStart={this.onComposition}
+          onCompositionUpdate={this.onComposition}
+          onCompositionEnd={this.onComposition}
           onClick={this.onClick}
           onContextMenu={this.onContextMenu}
           data-l10n-id='urlbar'


### PR DESCRIPTION
fix #9139

Auditors: @bsclifton, @bbondy 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Test Plan:

(Use Google as search engine will emphasize the effect)
1. Go to Preferences > Search
2. Set Google as default search engine
3. Enable `Autocomplete search terms as you type`
4. Make sure you have IME which has composition state
(like Zhuyin in Chinese, some Japanese IME)
5. Enter the characters in the IME, make sure doing some
add/remove/select characters before ending composition state
(mostly pressing enter)
6. Autocomplete will show only after you complete the words/sentences


## Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


