### PR TITLE
Fix time zone unittest failure on Travis

### DIFF
--- a/test/unit/app/browser/datesTest.js
+++ b/test/unit/app/browser/datesTest.js
@@ -7,7 +7,7 @@ let dates
 require('../../braveUnit')
 
 describe('update date handling', function () {
-  const exampleDate = 1510708981887 // Tuesday November 14th 2017, 6:23:01 PM
+  const exampleDate = 1510687381887 // Tuesday November 14th 2017, 12:23:01 PM
   const exampleDate2 = 1512304291746 // Monday December 04th 2017, 9:18:11 AM
   let fakeClock
   before(function () {


### PR DESCRIPTION
Fix https://github.com/brave/browser-laptop/issues/12191 by using a time that is 11/14 in both US local time (what most developers are using) and UTC (what Travis is probably using).

Test plan: unittest should pass in Travis

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


