### PR TITLE
More robust next tab selection after closing an active tab

### DIFF
--- a/app/browser/activeTabHistory.js
+++ b/app/browser/activeTabHistory.js
@@ -1,0 +1,61 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this file,
+* You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// static
+const activeTabsByWindow = new Map()
+
+const api = {
+  /**
+   * Inform this store that a tab is active for a window.
+   * This information will be added to index 0 in the
+   * active-tab history for the window.
+   */
+  setActiveTabForWindow: function (windowId, tabId) {
+    const existing = activeTabsByWindow.get(windowId)
+    if (existing) {
+      existing.unshift(tabId)
+    } else {
+      activeTabsByWindow.set(windowId, [ tabId ])
+    }
+  },
+
+  /**
+   * Retrieve the tabId that was active at the specified history index,
+   * 0 for most recent (default)
+   */
+  getActiveTabForWindow: function (windowId, historyIndex = 0) {
+    // get history of active tabs for specified window
+    const windowActiveTabs = activeTabsByWindow.get(windowId)
+    // handle no history for specified window
+    if (!windowActiveTabs || !windowActiveTabs.length) {
+      return null
+    }
+    // verify specified index in active-tab history exists
+    const lastIndex = windowActiveTabs.length - 1
+    if (lastIndex < historyIndex) {
+      return null
+    }
+    // get tabId at specified index in active-tab history
+    return windowActiveTabs[historyIndex]
+  },
+
+  /**
+   * Removes specified tab from active-tab history in specified window
+   */
+  clearTabFromWindow: function (windowId, tabId) {
+    const windowActiveTabs = activeTabsByWindow.get(windowId)
+    if (windowActiveTabs && windowActiveTabs.length) {
+      activeTabsByWindow.set(windowId, windowActiveTabs.filter(previousTabId => previousTabId !== tabId))
+    }
+  },
+
+  /**
+   * Forget history of active tabs for specified window
+   */
+  clearTabbedWindow: function (windowId) {
+    activeTabsByWindow.delete(windowId)
+  }
+}
+
+module.exports = api

--- a/app/browser/reducers/tabsReducer.js
+++ b/app/browser/reducers/tabsReducer.js
@@ -201,8 +201,6 @@ const tabsReducer = (state, action, immutableAction) => {
         if (tabId === tabState.TAB_ID_NONE) {
           break
         }
-        const nextActiveTabId = tabs.getNextActiveTab(state, tabId)
-
         // Must be called before tab is removed
         // But still check for no tabId because on tab detach there's a dummy tabId
         const tabValue = tabState.getByTabId(state, tabId)
@@ -211,11 +209,6 @@ const tabsReducer = (state, action, immutableAction) => {
           state = tabs.updateTabsStateForWindow(state, windowIdOfTabBeingRemoved)
         }
         state = tabState.removeTabByTabId(state, tabId)
-        setImmediate(() => {
-          if (nextActiveTabId !== tabState.TAB_ID_NONE) {
-            tabs.setActive(nextActiveTabId)
-          }
-        })
         tabs.forgetTab(tabId)
       }
       break

--- a/app/browser/webContentsCache.js
+++ b/app/browser/webContentsCache.js
@@ -11,16 +11,31 @@ const cleanupWebContents = (tabId) => {
 }
 
 const getWebContents = (tabId) => {
-  return currentWebContents[tabId]
+  const tabData = currentWebContents[tabId]
+  return tabData ? tabData.tab : null
 }
 
-const updateWebContents = (tabId, tab) => {
-  currentWebContents[tabId] = tab
+const getOpenerTabId = (tabId) => {
+  const tabData = currentWebContents[tabId]
+  return tabData ? tabData.openerTabId : null
+}
+
+const updateWebContents = (tabId, tab, openerTabId) => {
+  currentWebContents[tabId] = { tab, openerTabId }
+}
+
+const forgetOpenerForTabId = (tabId) => {
+  const tabData = currentWebContents[tabId]
+  if (tabData) {
+    tabData.openerTabId = null
+  }
 }
 
 module.exports = {
   cleanupWebContents,
   getWebContents,
+  getOpenerTabId,
+  forgetOpenerForTabId,
   updateWebContents,
   currentWebContents
 }

--- a/app/browser/windows.js
+++ b/app/browser/windows.js
@@ -22,6 +22,7 @@ const platformUtil = require('../common/lib/platformUtil')
 const windowState = require('../common/state/windowState')
 const pinnedSitesState = require('../common/state/pinnedSitesState')
 const {zoomLevel} = require('../common/constants/toolbarUserInterfaceScale')
+const activeTabHistory = require('./activeTabHistory')
 
 const isDarwin = platformUtil.isDarwin()
 const {app, BrowserWindow, ipcMain} = electron
@@ -43,6 +44,7 @@ const getWindowState = (win) => {
 
 const cleanupWindow = (windowId) => {
   delete currentWindows[windowId]
+  activeTabHistory.clearTabbedWindow(windowId)
 }
 
 const getWindowValue = (windowId) => {

--- a/test/unit/lib/fakeTab.js
+++ b/test/unit/lib/fakeTab.js
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const EventEmitter = require('events')
+const util = require('util')
+
+let nextGuestInstanceId = 0
+
+function FakeTab (id, windowId, guestInstanceId = nextGuestInstanceId++) {
+  this.id = id
+  this.windowId = windowId
+  this.guestInstanceId = guestInstanceId
+  this.session = {
+    partition: 'persist:partition-0'
+  }
+  this._isDestroyed = false
+  this._canGoBack = false
+  this._canGoForward = false
+}
+
+util.inherits(FakeTab, EventEmitter)
+
+const proto = FakeTab.prototype
+
+proto.getId = function () {
+  return this.id
+}
+
+proto.tabValue = function () {
+  return {
+    id: this.id,
+    windowId: this.windowId
+  }
+}
+
+proto.isDestroyed = function () {
+  return this._isDestroyed
+}
+
+proto.canGoBack = function () {
+  return this._canGoBack
+}
+
+proto.canGoForward = function () {
+  return this._canGoForward
+}
+
+module.exports = FakeTab


### PR DESCRIPTION
Set next active tab before closing, instead of after. Avoids race-condition with muon's index-change and active-change tab update events.

Fix #11981
Fix #11526

Notable changes:
- *remove* setting next active tab id in tabReducer, due to out-of-date tab state
- **tab creation:** store the opener tabId
- **tab set-active:** remember the history of active tabs
- **tab will-destroy:** remove the tabId from the history of active tabs, and override muon's next active tab, if appropriate
- **tab did-detach:** remove the opener for the detached tab, and remove the tab from active tabs window history

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Test Plan:

### Automatic Tests

`npm run unittest -- --grep "tabs API"`

### Manual Tests
Manual steps (perform on all platforms since this bug was timing-specific and affected Windows mostly).

_All automatic tab active changes should be observed as immediate, without visually seeing one tab become active and then quickly another tab getting focus._

#### Parent tab
- Preferences: detault (When closing an active tab, select its parent tab)
- Open the new tab page
- Cmd-click all the top sites icons to open 'child' tabs
- Switch active focus to the 3rd tab
- Close the 3rd (current) tab
- Expected: Tab active focus switches to the 1st tab (new tab page)

#### Next tab
- Close the (active) new tab page
- Expected: Tab active focus switches to the tab that was 2nd, and now is 1st
- Preferences: When closing an active tab Select the next tab
- Open the new tab page
- Cmd-click all the top sites icons to open 'child' tabs
- Switch active focus to the 3rd tab
- Close the 3rd (current) tab
- Expected: Tab active focus switches to the tab that was 4th, and is now 3rd

#### Last active tab
- Preferences: When closing an active tab Select the last viewed tab
- Open at least 5 tabs
- Make the 1st tab active
- Make the 3rd tab active
- Make the last tab active
- Close the currently-active tab (the last tab)
- Expected: Tab active focus switches to the 3rd tab
- Close the currently-active tab (the 3rd tab)
- Expected: Tab active focus switches to the 1st tab
- Close the currently-active tab (the 1st tab)
- Expected: Tab active focus switches to the 2nd tab

#### Detached parent tab
- Preferences: detault (When closing an active tab, select its parent tab)
- Open the new tab page
- Cmd-click all the top sites icons to open 'child' tabs
- Detach the parent tab (the first tab) to a new window
- Open another tab in the new window and keep it active (so the original parent is **in**active in the new window)
- In the _original_ window, switch active focus to the 3rd tab in the original window
- Close the 3rd (current) tab
- Expected: Tab active focus switches to the 4th tab in the first window, and no change of active tab changes in the second window, i.e. the parent tab is **not** made active.


Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


