### PR TITLE
Allow search provider to specify different search Url for private tabs

### DIFF
--- a/app/common/state/urlBarState.js
+++ b/app/common/state/urlBarState.js
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const Immutable = require('immutable')
+
+const api = {
+
+  /**
+   * Selects the portion of state related to the urlbar configuration
+   * for the current window's active frame
+   */
+  getActiveFrameUrlBarState: (activeFrame) =>
+    activeFrame.getIn(['navbar', 'urlbar'], Immutable.Map()),
+
+  /**
+   * Selects either the default search provider or the one overriden by
+   * the current frame
+   */
+  getSearchData: function (state, activeFrame) {
+    // TODO: don't have activeFrame param when reselect is used for state retrieval memoization
+    const urlbar = api.getActiveFrameUrlBarState(activeFrame)
+    const activeFrameIsPrivate = activeFrame.get('isPrivate')
+    const urlbarSearchDetail = urlbar.get('searchDetail')
+    const appSearchDetail = state.get('searchDetail')
+    const activateSearchEngine = urlbarSearchDetail && urlbarSearchDetail.get('activateSearchEngine')
+
+    // get default search provider from app state
+    let searchURL =
+      (activeFrameIsPrivate && appSearchDetail.has('privateSearchURL'))
+        ? appSearchDetail.get('privateSearchURL')
+        : appSearchDetail.get('searchURL')
+    let searchShortcut = ''
+    // change search url if overrided by active frame state or shortcut
+    if (activateSearchEngine) {
+      const provider = urlbarSearchDetail
+      searchShortcut = new RegExp('^' + provider.get('shortcut') + ' ', 'g')
+      searchURL =
+        (activeFrame.get('isPrivate') && provider.has('privateSearch'))
+          ? provider.get('privateSearch')
+          : provider.get('search')
+    }
+    return {
+      searchURL,
+      searchShortcut
+    }
+  }
+
+}
+
+module.exports = api

--- a/app/renderer/components/main/main.js
+++ b/app/renderer/components/main/main.js
@@ -306,6 +306,7 @@ class Main extends React.Component {
         if (entry.name === engine) {
           appActions.defaultSearchEngineLoaded(Immutable.fromJS({
             searchURL: entry.search,
+            privateSearchURL: entry.privateSearch,
             autocompleteURL: entry.autocomplete,
             platformClientId: entry.platformClientId
           }))

--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -25,6 +25,7 @@ const KeyCodes = require('../../../common/constants/keyCodes')
 // State
 const frameStateUtil = require('../../../../js/state/frameStateUtil')
 const siteSettings = require('../../../../js/state/siteSettings')
+const urlBarState = require('../../../common/state/urlBarState')
 const tabState = require('../../../common/state/tabState')
 const siteSettingsState = require('../../../common/state/siteSettingsState')
 const ledgerState = require('../../../common/state/ledgerState')
@@ -410,6 +411,7 @@ class UrlBar extends React.Component {
     const currentWindow = state.get('currentWindow')
     const activeFrame = frameStateUtil.getActiveFrame(currentWindow) || Immutable.Map()
     const activeTabId = activeFrame.get('tabId', tabState.TAB_ID_NONE)
+    const activeFrameIsPrivate = activeFrame.get('isPrivate')
 
     const location = tabState.getVisibleURL(state, activeTabId)
     const frameLocation = activeFrame.get('location', '')
@@ -418,25 +420,17 @@ class UrlBar extends React.Component {
     const hostValue = displayEntry.get('host', '')
 
     const baseUrl = getBaseUrl(location)
-    const urlbar = activeFrame.getIn(['navbar', 'urlbar'], Immutable.Map())
+    const urlbar = urlBarState.getActiveFrameUrlBarState(activeFrame)
     const urlbarLocation = urlbar.get('location')
     const selectedIndex = urlbar.getIn(['suggestions', 'selectedIndex'])
-    const allSiteSettings = siteSettingsState.getAllSiteSettings(state, activeFrame.get('isPrivate'))
+    const allSiteSettings = siteSettingsState.getAllSiteSettings(state, activeFrameIsPrivate)
     const braverySettings = siteSettings.getSiteSettingsForURL(allSiteSettings, location)
 
     // TODO(bridiver) - these definitely needs a helpers
     const publisherKey = ledgerState.getLocationProp(state, baseUrl, 'publisher')
 
-    const activateSearchEngine = urlbar.getIn(['searchDetail', 'activateSearchEngine'])
-    const urlbarSearchDetail = urlbar.get('searchDetail')
-    let searchURL = state.getIn(['searchDetail', 'searchURL'])
-    let searchShortcut = ''
-    // remove shortcut from the search terms
-    if (activateSearchEngine && urlbarSearchDetail !== null) {
-      const provider = urlbarSearchDetail
-      searchShortcut = new RegExp('^' + provider.get('shortcut') + ' ', 'g')
-      searchURL = provider.get('search')
-    }
+    // get search provider state
+    const { searchURL, searchShortcut } = urlBarState.getSearchData(state, activeFrame, urlbar)
     const suggestionList = urlbar.getIn(['suggestions', 'suggestionList'])
     const scriptsBlocked = activeFrame.getIn(['noScript', 'blocked'])
     const enableNoScript = siteSettingsState.isNoScriptEnabled(state, braverySettings)

--- a/js/data/searchProviders.js
+++ b/js/data/searchProviders.js
@@ -25,7 +25,7 @@ module.exports = { "providers" :
       "base" : "https://duckduckgo.com",
       "image" : "https://duckduckgo.com/favicon.ico",
       "search" : "https://duckduckgo.com/?q={searchTerms}&t=brave",
-      "privateSearch" : "https://duckduckgo.com/?q={searchTerms}&t=pbrave",
+      "privateSearch" : "https://duckduckgo.com/?q={searchTerms}&t=bravep",
       "autocomplete" : "https://ac.duckduckgo.com/ac/?q={searchTerms}&type=list",
       "shortcut" : ":d"
     },

--- a/js/data/searchProviders.js
+++ b/js/data/searchProviders.js
@@ -25,6 +25,7 @@ module.exports = { "providers" :
       "base" : "https://duckduckgo.com",
       "image" : "https://duckduckgo.com/favicon.ico",
       "search" : "https://duckduckgo.com/?q={searchTerms}&t=brave",
+      "privateSearch" : "https://duckduckgo.com/?q={searchTerms}&t=pbrave",
       "autocomplete" : "https://ac.duckduckgo.com/ac/?q={searchTerms}&type=list",
       "shortcut" : ":d"
     },

--- a/test/unit/app/common/state/urlBarStateTest.js
+++ b/test/unit/app/common/state/urlBarStateTest.js
@@ -1,0 +1,116 @@
+/* global describe, it */
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const Immutable = require('immutable')
+const { assert } = require('chai')
+const urlBarState = require('../../../../../app/common/state/urlBarState')
+
+describe('urlBarState', function () {
+  describe('getSearchData', function () {
+    const searchUrlDefault = 'url1'
+    const searchUrlDefaultPrivate = 'url2'
+    const searchUrlFrameOverride = 'url3'
+    const searchUrlFrameOverridePrivate = 'url4'
+
+    const activeFrameNoSearchOverride = Immutable.fromJS({
+    })
+
+    const privateActiveFrameNoSearchOverride = Immutable.fromJS({
+      isPrivate: true
+    })
+
+    const privateActiveFrameWithSearchOverride = Immutable.fromJS({
+      isPrivate: true,
+      navbar: {
+        urlbar: {
+          searchDetail: {
+            activateSearchEngine: true,
+            search: searchUrlFrameOverride
+          }
+        }
+      }
+    })
+
+    const privateActiveFrameWithSearchOverrideAndPrivateUrl = Immutable.fromJS({
+      isPrivate: true,
+      navbar: {
+        urlbar: {
+          searchDetail: {
+            activateSearchEngine: true,
+            search: searchUrlFrameOverride,
+            privateSearch: searchUrlFrameOverridePrivate
+          }
+        }
+      }
+    })
+
+    const activeFrameWithSearchOverrideAndPrivateUrl =
+      privateActiveFrameWithSearchOverrideAndPrivateUrl.set('isPrivate', false)
+
+    const appStateWithDefaultSearch = Immutable.fromJS({
+      searchDetail: {
+        searchURL: searchUrlDefault
+      }
+    })
+
+    const appStateWithDefaultSearchAndPrivateUrl =
+      appStateWithDefaultSearch.setIn(['searchDetail', 'privateSearchURL'], searchUrlDefaultPrivate)
+
+    it('gets default search url', function () {
+      const actual = urlBarState.getSearchData(
+        appStateWithDefaultSearch,
+        activeFrameNoSearchOverride
+      )
+      const expectedSearchUrl = searchUrlDefault
+      assert.equal(actual.searchURL, expectedSearchUrl)
+    })
+
+    it('gets default search url with private tab', function () {
+      const actual = urlBarState.getSearchData(
+        appStateWithDefaultSearch,
+        privateActiveFrameNoSearchOverride
+      )
+      const expectedSearchUrl = searchUrlDefault
+      assert.equal(actual.searchURL, expectedSearchUrl)
+    })
+
+    it('gets the default search private url in private tab', function () {
+      const actual = urlBarState.getSearchData(
+        appStateWithDefaultSearchAndPrivateUrl,
+        privateActiveFrameNoSearchOverride
+      )
+      const expectedSearchUrl = searchUrlDefaultPrivate
+      assert.equal(actual.searchURL, expectedSearchUrl)
+    })
+
+    it('gets the overriden non-private search url in non-private tab', function () {
+      const actual = urlBarState.getSearchData(
+        appStateWithDefaultSearchAndPrivateUrl,
+        activeFrameWithSearchOverrideAndPrivateUrl
+      )
+      const expectedSearchUrl = searchUrlFrameOverride
+      assert.equal(actual.searchURL, expectedSearchUrl)
+    })
+
+    it('gets the overriden non-private search url in a private tab, where there is no private search url', function () {
+      const actual = urlBarState.getSearchData(
+        appStateWithDefaultSearchAndPrivateUrl,
+        privateActiveFrameWithSearchOverride
+      )
+      const expectedSearchUrl = searchUrlFrameOverride
+      assert.equal(actual.searchURL, expectedSearchUrl)
+    })
+
+    it('gets the overriden private search url in a private tab', function () {
+      const actual = urlBarState.getSearchData(
+        appStateWithDefaultSearchAndPrivateUrl,
+        privateActiveFrameWithSearchOverrideAndPrivateUrl
+      )
+      const expectedSearchUrl = searchUrlFrameOverridePrivate
+      assert.equal(actual.searchURL, expectedSearchUrl)
+    })
+  })
+})


### PR DESCRIPTION
This 'privateSearch' Url will be used for all searches performed in a private tab, including if provider is default, is the Private Search provider, or is chosen due to a shortcut (e.g. ':d my search term').
Specify a different private search Url for DuckDuckGo.

Fix #12219

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Test Plan:
### Automated Tests
New tests added: `npm run unittest -- --grep "urlBarState"`

### Manual Tests

#### Default search
1. Preferences: Set default search engine to google
2. Open default session tab
3. Perform search
Expected: search performed with google

#### Default search with provider who defines privateSearch URL
1. Preferences: Set default search engine to DuckDuckGo
2. Open default session tab
3. Perform search
Expected: search performed using regular search url (t=brave at end, not t=(bravep)

#### Default search in private tab
1. Preferences: Set default search engine to google
2. Preferences: ensure 'Private Search' is switched off
2. Open private tab
3. Perform search
Expected: search performed with google

#### Default search in private tab with provider who defines privateSearch URL
1. Preferences: Set default search engine to DuckDuckGo
2. Preferences: ensure 'Private Search' is switched off
2. Open private tab
3. Perform search
Expected: search performed using private search url (t=bravep at end, not t=(brave)

#### Private Search in private tab with provider who defines privateSearch URL
1. Preferences: Set default search engine to google
2. Preferences: ensure 'Private Search' is switched on
2. Open private  tab
3. Perform search
Expected: search performed with DDG and using private search url (t=bravep at end, not t=(brave)

#### Shortcut search in private tab with provider who defines privateSearch URL
1. Preferences: Set default search engine to google
2. Preferences: ensure 'Private Search' is switched off
2. Open private  tab
3. Perform search prefixed with ':d'
Expected: search performed with DDG and using private search url (t=bravep at end, not t=(brave)


## Reviewer Checklist:

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


