### PR TITLE
reduce (slightly) all About Pages load time using webpack code-splitting

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,6 +9,7 @@
   ],
   "plugins": [
     "transform-react-inline-elements",
-    "transform-react-constant-elements"
+    "transform-react-constant-elements",
+    "syntax-dynamic-import"
   ]
 }

--- a/js/about/entry.js
+++ b/js/about/entry.js
@@ -3,7 +3,7 @@ const {getSourceAboutUrl, getBaseUrl} = require('../lib/appUrlUtil')
 const {ABOUT_COMPONENT_INITIALIZED} = require('../constants/messages')
 const ipc = window.chrome.ipcRenderer
 
-let element
+let getElementOp
 
 ipc.on('language', (e, detail) => {
   if (document.l10n) {
@@ -17,64 +17,66 @@ ipc.send('request-language')
 
 switch (getBaseUrl(getSourceAboutUrl(window.location.href))) {
   case 'about:about':
-    element = require('./about')
+    getElementOp = import('./about')
     break
   case 'about:adblock':
-    element = require('./adblock')
+    getElementOp = import('./adblock')
     break
   case 'about:autofill':
-    element = require('./autofill')
+    getElementOp = import('./autofill')
     break
   case 'about:brave':
-    element = require('./brave')
+    getElementOp = import('./brave')
     break
   case 'about:bookmarks':
-    element = require('../../app/renderer/about/bookmarks/bookmarks')
+    getElementOp = import('../../app/renderer/about/bookmarks/bookmarks')
     break
   case 'about:certerror':
-    element = require('./certerror')
+    getElementOp = import('./certerror')
     break
   case 'about:downloads':
-    element = require('./downloads')
+    getElementOp = import('./downloads')
     break
   case 'about:error':
-    element = require('./errorPage')
+    getElementOp = import('./errorPage')
     break
   case 'about:extensions':
-    element = require('./extensions')
+    getElementOp = import('./extensions')
     break
   case 'about:history':
-    element = require('./history')
+    getElementOp = import('./history')
     break
   case 'about:newtab':
-    element = require('./newtab').AboutNewTab
+    getElementOp = import('./newtab').then(module => module.AboutNewTab)
     break
   case 'about:passwords':
-    element = require('./passwords')
+    getElementOp = import('./passwords')
     break
   case 'about:preferences':
-    element = require('./preferences').AboutPreferences
+    getElementOp = import('./preferences').then(module => module.AboutPreferences)
     break
   case 'about:safebrowsing':
-    element = require('./safebrowsing')
+    getElementOp = import('./safebrowsing')
     break
   case 'about:styles':
-    element = require('./styles')
+    getElementOp = import('./styles')
     break
   case 'about:contributions':
-    element = require('./contributionStatement')
+    getElementOp = import('./contributionStatement')
     break
   case 'about:welcome':
-    element = require('../../app/renderer/about/welcome')
+    getElementOp = import('../../app/renderer/about/welcome')
     break
 }
 
-if (element) {
-  const component = ReactDOM.render(element, document.querySelector('#appContainer'))
-  ipc.on('state-updated', (e, detail) => {
-    if (detail) {
-      component.setState(detail)
-    }
+if (getElementOp) {
+  getElementOp.then(element => {
+    const component = ReactDOM.render(element, document.querySelector('#appContainer'))
+    ipc.on('state-updated', (e, detail) => {
+      if (detail) {
+        component.setState(detail)
+      }
+    })
+    ipc.send(ABOUT_COMPONENT_INITIALIZED)
   })
-  ipc.send(ABOUT_COMPONENT_INITIALIZED)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,156 @@
       "resolved": "https://registry.npmjs.org/@ambassify/backoff-strategies/-/backoff-strategies-1.0.0.tgz",
       "integrity": "sha1-6salmVHxSXdAY2wGRi2QbXKfQ6U="
     },
+    "@babel/code-frame": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz",
+      "integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.31.tgz",
+      "integrity": "sha512-c+DAyp8LMm2nzSs2uXEuxp4LYGSUYEyHtU3fU57avFChjsnTmmpWmXj2dv0yUxHTEydgVAv5fIzA+4KJwoqWDA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "7.0.0-beta.31",
+        "@babel/template": "7.0.0-beta.31",
+        "@babel/traverse": "7.0.0-beta.31",
+        "@babel/types": "7.0.0-beta.31"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.31.tgz",
+      "integrity": "sha512-m7rVVX/dMLbbB9NCzKYRrrFb0qZxgpmQ4Wv6y7zEsB6skoJHRuXVeb/hAFze79vXBbuD63ci7AVHXzAdZSk9KQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "7.0.0-beta.31"
+      }
+    },
+    "@babel/template": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.31.tgz",
+      "integrity": "sha512-97IRmLvoDhIDSQkqklVt3UCxJsv0LUEVb/0DzXWtc8Lgiyxj567qZkmTG9aR21CmcJVVIvq2Y/moZj4oEpl5AA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.31",
+        "@babel/types": "7.0.0-beta.31",
+        "babylon": "7.0.0-beta.31",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.31",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
+          "integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.31.tgz",
+      "integrity": "sha512-3N+VJW+KlezEjFBG7WSYeMyC5kIqVLPb/PGSzCDPFcJrnArluD1GIl7Y3xC7cjKiTq2/JohaLWHVPjJWHlo9Gg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.31",
+        "@babel/helper-function-name": "7.0.0-beta.31",
+        "@babel/types": "7.0.0-beta.31",
+        "babylon": "7.0.0-beta.31",
+        "debug": "3.1.0",
+        "globals": "10.4.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.31",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
+          "integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "globals": {
+          "version": "10.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+          "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.31.tgz",
+      "integrity": "sha512-exAHB+NeFGxkfQ5dSUD03xl3zYGneeSk2Mw2ldTt/nTvYxuDiuSp3DlxgUBgzbdTFG4fbwPk0WtKWOoTXCmNGg==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "2.0.0"
+      },
+      "dependencies": {
+        "to-fast-properties": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+          "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+          "dev": true
+        }
+      }
+    },
     "@types/node": {
       "version": "6.0.88",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
@@ -676,6 +826,26 @@
         "source-map": "0.5.7"
       }
     },
+    "babel-eslint": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.0.3.tgz",
+      "integrity": "sha512-7D4iUpylEiKJPGbeSAlNddGcmA41PadgZ6UAb6JVyh003h3d0EbZusYFBR/+nBgqtaVJM2J2zUVa3N0hrpMH6g==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "7.0.0-beta.31",
+        "@babel/traverse": "7.0.0-beta.31",
+        "@babel/types": "7.0.0-beta.31",
+        "babylon": "7.0.0-beta.31"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "7.0.0-beta.31",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
+          "integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
+          "dev": true
+        }
+      }
+    },
     "babel-generator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
@@ -869,6 +1039,12 @@
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
       "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
+    },
+    "babel-plugin-syntax-dynamic-import": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz",
+      "integrity": "sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=",
       "dev": true
     },
     "babel-plugin-syntax-exponentiation-operator": {
@@ -5307,6 +5483,61 @@
         }
       }
     },
+    "electron-download": {
+      "version": "github:brave/electron-download#409b65caff14edeef1daa36a7445ba6334658d7c",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "home-path": "1.0.5",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "mv": "2.1.1",
+        "nugget": "1.6.2",
+        "path-exists": "1.0.0",
+        "rc": "1.2.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "nugget": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/nugget/-/nugget-1.6.2.tgz",
+          "integrity": "sha1-iMpuA7pXBqmRc/XaCQJZPWvK4Qc=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "minimist": "1.2.0",
+            "pretty-bytes": "1.0.4",
+            "progress-stream": "1.2.0",
+            "request": "2.82.0",
+            "single-line-log": "0.4.1",
+            "throttleit": "0.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
+          "dev": true
+        },
+        "single-line-log": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz",
+          "integrity": "sha1-h6VWSfdJ14PsDc2AToFA2Yc8fO4=",
+          "dev": true
+        },
+        "throttleit": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+          "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
+          "dev": true
+        }
+      }
+    },
     "electron-download-tf": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/electron-download-tf/-/electron-download-tf-4.3.1.tgz",
@@ -5492,20 +5723,6 @@
           "integrity": "sha1-HUixB9ghJqLz4hHC6iX4A7pVGyE=",
           "dev": true
         },
-        "electron-download": {
-          "version": "github:brave/electron-download#409b65caff14edeef1daa36a7445ba6334658d7c",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "home-path": "1.0.5",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "mv": "2.1.1",
-            "nugget": "1.6.2",
-            "path-exists": "1.0.0",
-            "rc": "1.2.1"
-          }
-        },
         "electron-osx-sign": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.3.2.tgz",
@@ -5555,27 +5772,6 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
-        "nugget": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/nugget/-/nugget-1.6.2.tgz",
-          "integrity": "sha1-iMpuA7pXBqmRc/XaCQJZPWvK4Qc=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "minimist": "1.2.0",
-            "pretty-bytes": "1.0.4",
-            "progress-stream": "1.2.0",
-            "request": "2.82.0",
-            "single-line-log": "0.4.1",
-            "throttleit": "0.0.2"
-          }
-        },
-        "path-exists": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
-          "dev": true
-        },
         "plist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/plist/-/plist-1.2.0.tgz",
@@ -5587,18 +5783,6 @@
             "xmlbuilder": "4.0.0",
             "xmldom": "0.1.27"
           }
-        },
-        "single-line-log": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz",
-          "integrity": "sha1-h6VWSfdJ14PsDc2AToFA2Yc8fO4=",
-          "dev": true
-        },
-        "throttleit": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-          "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
-          "dev": true
         },
         "xmlbuilder": {
           "version": "4.0.0",
@@ -5617,61 +5801,6 @@
       "requires": {
         "electron-download": "github:brave/electron-download#409b65caff14edeef1daa36a7445ba6334658d7c",
         "extract-zip": "1.6.5"
-      },
-      "dependencies": {
-        "electron-download": {
-          "version": "github:brave/electron-download#409b65caff14edeef1daa36a7445ba6334658d7c",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "home-path": "1.0.5",
-            "minimist": "1.2.0",
-            "mkdirp": "0.5.1",
-            "mv": "2.1.1",
-            "nugget": "1.6.2",
-            "path-exists": "1.0.0",
-            "rc": "1.2.1"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "nugget": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/nugget/-/nugget-1.6.2.tgz",
-          "integrity": "sha1-iMpuA7pXBqmRc/XaCQJZPWvK4Qc=",
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "minimist": "1.2.0",
-            "pretty-bytes": "1.0.4",
-            "progress-stream": "1.2.0",
-            "request": "2.82.0",
-            "single-line-log": "0.4.1",
-            "throttleit": "0.0.2"
-          }
-        },
-        "path-exists": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
-          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
-          "dev": true
-        },
-        "single-line-log": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz",
-          "integrity": "sha1-h6VWSfdJ14PsDc2AToFA2Yc8fO4=",
-          "dev": true
-        },
-        "throttleit": {
-          "version": "0.0.2",
-          "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-          "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
-          "dev": true
-        }
       }
     },
     "electron-publish": {

--- a/package.json
+++ b/package.json
@@ -134,7 +134,9 @@
     "asar": "~0.13.0",
     "babel": "^6.1.18",
     "babel-core": "^6.3.15",
+    "babel-eslint": "^8.0.3",
     "babel-loader": "^7.1.1",
+    "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-react-constant-elements": "^6.4.0",
     "babel-plugin-transform-react-inline-elements": "^6.4.0",
     "babel-polyfill": "^6.3.14",
@@ -205,6 +207,7 @@
       "muon",
       "postMessage"
     ],
+    "parser": "babel-eslint",
     "ignore": [
       "app/extensions/**",
       "app/browser/ads/adDivCandidates.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -158,6 +158,7 @@ var app = {
   output: {
     path: path.resolve(__dirname, 'app', 'extensions', 'brave', 'gen'),
     filename: '[name].entry.js',
+    chunkFilename: '[name].chunk.js',
     publicPath: './gen/'
   }
 }


### PR DESCRIPTION
So it's only about 50ms - 100ms of saving, but another way to put it is 15% - 30% 😸 

Uses webpacks dynamic import capability, which will split the entry.js file in to multiple chunks, saving the browser having to retrieve and parse the parts of javascript that are not necessary for the specific about page that is to be loaded. Most useful for the 'new tab' page which is likely the most common extension page loaded, but before this PR, has to load and parse (although not run) all of the JS for about:preferences too...

I measured the performance by both:
- looking at the network panel 'load' time (after turning off the preference for wallpaper images on the 'new tab' page.
- adding `console.timeStamp('reactrendered')` as the third argument to `ReactDOM.render` in _js/about/entry.js_
   - then, running a dev tools Performance profile for page-load (using the refresh icon), and searching for the event 'reactrendered', noting the reported time the event occurred.

In a few tests I noticed that the average time to load and render the first react component for the 'new tab' page was:

- before this change: ~300ms - 350ms using a build (~600ms - 600ms on dev)
- after this change: ~250ms using a build (~420ms on dev)

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
load `about:about` and click all of the about pages, checking they work as before

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


