### PR TITLE
Tighten webpack rules for which assets to inline as data URIs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,14 +36,22 @@ function config () {
           test: /\.css$/,
           loader: 'style-loader!css-loader?-minimize'
         },
-        // Loads font files for Font Awesome
+        // load font files with url, not data: uri since not every unicode char
+        // or language will be needed on every page and there are many small
+        // size font files
         {
-          test: /\.woff(2)?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-          loader: 'url-loader?limit=10000&minetype=application/font-woff'
-        },
-        {
-          test: /\.(ttf|eot|svg|png|jpg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+          test: /\/fonts\/.*\.woff2?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
           loader: 'file-loader'
+        },
+        // inline other asset files using data: uri unless they are larger than
+        // a certain limit. it is implied that these files are used by all / most
+        // users if they are `require`d and theferore inlined to the main js bundle
+        {
+          test: /\.(woff2|woff|ttf|eot|svg|png|jpg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+          loader: 'url-loader',
+          options: {
+            limit: 10000
+          }
         }
       ]
     },


### PR DESCRIPTION
Do not inline our included font files, since there are many small files, which fell under the 10kb limit and were being sent to everyone despite different languages / character ranges covered by each file.
Do inline other small SVG / asset files that fall under the 10kb limit, since they are presumed to be always used by the client for most places they are require'd

Relevant docs: https://github.com/webpack-contrib/url-loader

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


