### PR TITLE
Store promo code in session file

### DIFF
--- a/app/updater.js
+++ b/app/updater.js
@@ -18,7 +18,6 @@ const appActions = require('../js/actions/appActions')
 const Immutable = require('immutable')
 const dates = require('./dates')
 const Channel = require('./channel')
-const buildConfig = require('../js/constants/buildConfig')
 
 const fs = require('fs')
 const path = require('path')
@@ -150,6 +149,10 @@ var requestVersionInfo = (done, pingOnly) => {
   const weekOfInstallation = state.getIn(['updates', 'weekOfInstallation'], null)
   debug(`weekOfInstallation= ${weekOfInstallation}`)
 
+  // The installation promoCode from buildConfig
+  const promoCode = state.getIn(['updates', 'promoCode'], 'none')
+  debug(`promoCode = ${promoCode}`)
+
   // Build query string based on the last date an update request was made
   const query = paramsFromLastCheckDelta(
     lastCheckYMD,
@@ -157,7 +160,7 @@ var requestVersionInfo = (done, pingOnly) => {
     lastCheckMonth,
     firstCheckMade,
     weekOfInstallation,
-    buildConfig.ref || null
+    promoCode
   )
   query.accept_preview = updateToPreviewReleases ? 'true' : 'false'
   const queryString = `${platformBaseUrl}?${querystring.stringify(query)}`

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -34,6 +34,7 @@ const {zoomLevel} = require('../../app/common/constants/toolbarUserInterfaceScal
 const {HrtimeLogger} = require('../../app/common/lib/logUtil')
 const platformUtil = require('../../app/common/lib/platformUtil')
 const urlUtil = require('../lib/urlutil')
+const buildConfig = require('../constants/buildConfig')
 
 // state helpers
 const {makeImmutable} = require('../../app/common/state/immutableUtil')
@@ -261,6 +262,9 @@ const handleAppAction = (action) => {
       appState = appState.setIn(['updates', 'firstCheckMade'], true)
       if (!appState.getIn(['updates', 'weekOfInstallation'])) {
         appState = appState.setIn(['updates', 'weekOfInstallation'], dates.lastMonday(new Date()))
+      }
+      if (!appState.getIn(['updates', 'promoCode'])) {
+        appState = appState.setIn(['updates', 'promoCode'], buildConfig.ref || 'none')
       }
       break
     case appConstants.APP_SET_UPDATE_STATUS:


### PR DESCRIPTION
  This is required so that requests to the updater will always send the
  initial ref code instead of the ref code from the current browser
  binary.

Auditors: @clifton, @bbondy

