### PR TITLE
Add new LEDGER_NO_DELAY flag to help make QA easier

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -1908,8 +1908,13 @@ const init = (state) => {
 }
 
 const run = (state, delayTime) => {
+  let noDelay = false
+  if (process.env.LEDGER_NO_DELAY) {
+    noDelay = ledgerClient.prototype.boolion(process.env.LEDGER_NO_DELAY)
+  }
+
   if (clientOptions.verboseP) {
-    console.log('\nledger client run: clientP=' + (!!client) + ' delayTime=' + delayTime)
+    console.log('\nledger client run: clientP=' + (!!client) + ' delayTime=' + delayTime + (noDelay ? ' LEDGER_NO_DELAY=true' : ''))
 
     const line = (fields) => {
       let result = ''
@@ -1993,6 +1998,8 @@ const run = (state, delayTime) => {
 
   if (delayTime > 0) {
     if (runTimeoutId) return
+    // useful for QA - #12249
+    if (noDelay) delayTime = 5000
 
     const active = client
     if (delayTime > (1 * ledgerUtil.milliseconds.hour)) {


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/12249

Auditors: @srirambv, @mrose17

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Test Plan:
1. Launch Brave from command line with `LEDGER_NO_DELAY=true` and `LEDGER_VERBOSE=true`
2. Observe that the `run` method runs every 5 seconds. You should see a message like:
```
ledger client run: clientP=true delayTime=526163 LEDGER_NO_DELAY=true
          publisher  blockedP   stickyP  verified  excluded eligibleP  visibleP  contribP  duration    visits
+++ busyP=false
```
3. Quit Brave
4. Launch without `LEDGER_NO_DELAY=true`
5. Verify it does not run the method every 5 seconds

## Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


