### PR TITLE
Don't ignore internal requests in app/filtering

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -683,11 +683,6 @@ module.exports.initPartition = initPartition
 const filterableProtocols = ['http:', 'https:', 'ws:', 'wss:', 'magnet:', 'file:']
 
 function shouldIgnoreUrl (details) {
-  // internal requests
-  if (details.tabId === -1) {
-    return true
-  }
-
   // data:, is a special origin from SecurityOrigin::urlWithUniqueSecurityOrigin
   // and usually occurs when there is an https in an http main frame
   if (details.firstPartyUrl === 'data:,') {
@@ -869,10 +864,10 @@ module.exports.getMainFrameUrl = (details) => {
     return details.url
   }
   const tab = webContents.fromTabID(details.tabId)
-  if (tab && !tab.isDestroyed()) {
+  try {
     return tab.getURL()
-  }
-  return null
+  } catch (ex) {}
+  return details.firstPartyUrl || null
 }
 
 module.exports.alwaysAllowFullscreen = () => {


### PR DESCRIPTION
Cherry pick of https://github.com/brave/browser-laptop/pull/12255/ for master, 0.21.x, 0.20.x, and 0.19.x
------------------
and return details.firstPartyUrl as a fallback for main frame URL.

Internal requests (tabId == -1) were ignored in order to fix https://github.com/brave/browser-laptop/issues/5934 in https://github.com/brave/browser-laptop/commit/6023abd171eb0ec582eb96e71f18ad30dddba32e. However (1) #5934 works without ignoring internal requests now and (2) generally speaking, non-webview requests should also be protected by HTTPS Everywhere, etc.

fix #12253
fix #12252

Test Plan:
1. confirm HTTPS Everywhere and Safebrowsing are working using the test plans in https://github.com/brave/browser-laptop/issues/12253 and https://github.com/brave/browser-laptop/issues/12252
2. confirm that https://github.com/brave/browser-laptop/issues/5934 has not regressed by enabling Pocket

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


