### PR TITLE
webpack - fix fonts matching multiple webpack rules

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,14 +40,19 @@ function config () {
         // or language will be needed on every page and there are many small
         // size font files
         {
-          test: /\/fonts\/.*\.woff2?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
-          loader: 'file-loader'
+          test: /\.woff2?(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+          include: path.resolve(__dirname, 'fonts'),
+          loader: 'file-loader',
+          options: {
+            name: '[name]-[hash].[ext]'
+          }
         },
         // inline other asset files using data: uri unless they are larger than
         // a certain limit. it is implied that these files are used by all / most
         // users if they are `require`d and theferore inlined to the main js bundle
         {
-          test: /\.(woff2|woff|ttf|eot|svg|png|jpg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+          test: /\.(woff(2)?|ttf|eot|svg|png|jpg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+          exclude: path.resolve(__dirname, 'fonts'),
           loader: 'url-loader',
           options: {
             limit: 10000


### PR DESCRIPTION
Fixes fonts and icons not loading correctly due to new rules introduced in #12225
Fix #12280

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:
STR on #12280

Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


