### PR TITLE
Improves verified-caching

### DIFF
--- a/app/browser/reducers/ledgerReducer.js
+++ b/app/browser/reducers/ledgerReducer.js
@@ -402,7 +402,11 @@ const ledgerReducer = (state, action, immutableAction) => {
       }
     case appConstants.APP_ON_PUBLISHER_TIMESTAMP:
       {
+        const oldValue = ledgerState.getLedgerValue(state, 'publisherTimestamp')
         state = ledgerState.setLedgerValue(state, 'publisherTimestamp', action.get('timestamp'))
+        if (action.get('updateList')) {
+          ledgerApi.onPublisherTimestamp(state, oldValue, action.get('timestamp'))
+        }
         break
       }
     case appConstants.APP_SAVE_LEDGER_PROMOTION:

--- a/docs/state.md
+++ b/docs/state.md
@@ -186,19 +186,19 @@ AppStore
     },
     info: {
       addresses: {
-        BAT: string, 
-        BTC: string, 
-        CARD_ID: string, 
-        ETH: string, 
+        BAT: string,
+        BTC: string,
+        CARD_ID: string,
+        ETH: string,
         LTC: string
       },
       balance: number, // confirmed balance in BAT.toFixed(2)
       bravery: {
-        days: number, 
+        days: number,
         fee: {
           amount: number,
           currency: string
-        }, 
+        },
         setting: string
       },
       converted: string,
@@ -210,9 +210,9 @@ AppStore
       paymentId: string,
       probi: number,
       rates:{
-        BTC: string, 
-        ETH: number, 
-        EUR: number, 
+        BTC: string,
+        ETH: number,
+        EUR: number,
         USD: number
       },
       reconcileFrequency: number // duration between each reconciliation in days
@@ -265,7 +265,7 @@ AppStore
             options: {
               persist: boolean,
               style: string
-            }        
+            }
           },
           panel: {
             optInMarkup: {
@@ -288,7 +288,7 @@ AppStore
             options: {
               persist: boolean,
               style: string
-            }        
+            }
           },
           panel: {
             disclaimer: string,
@@ -313,7 +313,7 @@ AppStore
             options: {
               persist: boolean,
               style: string
-            }        
+            }
           },
           panel: {
             disclaimer: string,
@@ -348,7 +348,7 @@ AppStore
           options: {
             exclude: boolean,
             verified: boolean,
-            verifiedTimestamp: number, // timestamp of the last change 
+            verifiedTimestamp: number, // timestamp of the last change
             stickyP: boolean
           },
           pinPercentage: number,

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -1826,10 +1826,11 @@ const appActions = {
     })
   },
 
-  onPublisherTimestamp: function (timestamp) {
+  onPublisherTimestamp: function (timestamp, updateList) {
     dispatch({
       actionType: appConstants.APP_ON_PUBLISHER_TIMESTAMP,
-      timestamp
+      timestamp,
+      updateList
     })
   },
 


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Resolves #12272

Auditors:

## Test Plan:

Plan 1
1) enable wallet
2) close preference page
3) visit some pages (stay on this pages more then 15s), some of the verified as well (for example clifton, coinmarket, ddg, etc)
4) open preference page and go to payments
5) make sure that all sites that should be verified are verified (to trigger table refresh just visit another site)

Plan 2
1) enable wallet
2) every hour there should be call to the server to get publisher timestamp


## Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header



  