### PR TITLE
Issue 12304: Updating UPDATE_HOST to point to brave.com cname

### DIFF
--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -5,8 +5,8 @@ const Immutable = require('immutable')
 const {getTargetAboutUrl} = require('../lib/appUrlUtil')
 
 // BRAVE_UPDATE_HOST should be set to the host name for the auto-updater server
-const updateHost = process.env.BRAVE_UPDATE_HOST || 'https://brave-laptop-updates.global.ssl.fastly.net'
-const winUpdateHost = process.env.BRAVE_WIN_UPDATE_HOST || 'https://brave-download.global.ssl.fastly.net'
+const updateHost = process.env.BRAVE_UPDATE_HOST || 'https://laptop-updates.brave.com'
+const winUpdateHost = process.env.BRAVE_WIN_UPDATE_HOST || 'https://download.brave.com'
 const adHost = process.env.AD_HOST || 'https://oip.brave.com'
 const isTest = process.env.NODE_ENV === 'test'
 


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/12304

Testing Notes: Geo logs for brave stats are captured using fastly. After this change download and update requests will go through brave domains which should go through fastly.net. Verify if `stats` is working correctly.