### PR TITLE
Don't use a different string for DuckDuckGo when performing private search

### DIFF
--- a/js/data/searchProviders.js
+++ b/js/data/searchProviders.js
@@ -25,7 +25,6 @@ module.exports = { "providers" :
       "base" : "https://duckduckgo.com",
       "image" : "https://duckduckgo.com/favicon.ico",
       "search" : "https://duckduckgo.com/?q={searchTerms}&t=brave",
-      "privateSearch" : "https://duckduckgo.com/?q={searchTerms}&t=bravep",
       "autocomplete" : "https://ac.duckduckgo.com/ac/?q={searchTerms}&type=list",
       "shortcut" : ":d"
     },


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/12347

Auditors: @petemill, @diracdeltas

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Test Plan:
1. Launch Brave and open a new private tab
2. Enable DDG as private search provider
3. Do a search (in the URL bar)
4. Confirm URL ends with "t=brave", not "t=bravep"

## Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


