### PR TITLE
Add falsey checks for frames and closed frames

### DIFF
--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -435,6 +435,8 @@ function tabTemplateInit (frameProps) {
   const template = [CommonMenu.newTabMenuItem(frameProps.get('tabId'))]
   const location = frameProps.get('location')
   const store = windowStore.getState()
+  const frames = store.get('frames')
+  const closedFrames = store.get('closedFrames')
 
   if (location !== 'about:newtab') {
     template.push(
@@ -454,7 +456,7 @@ function tabTemplateInit (frameProps) {
       })
   }
 
-  if (windowStore.getState().get('frames').size > 1 &&
+  if (frames && frames.size > 1 &&
       !frameProps.get('pinnedLocation')) {
     template.push({
       label: locale.translation('detach'),
@@ -486,7 +488,6 @@ function tabTemplateInit (frameProps) {
   //   }
   // })
 
-  const frames = windowStore.getState().get('frames')
   const frameToSkip = frameProps.get('key')
   const frameList = frames.map((frame) => {
     return {
@@ -551,7 +552,7 @@ function tabTemplateInit (frameProps) {
 
   template.push(Object.assign({},
     CommonMenu.reopenLastClosedTabItem(),
-    { enabled: store.get('closedFrames').size > 0 }
+    { enabled: closedFrames ? closedFrames.size > 0 : false }
   ))
 
   return menuUtil.sanitizeTemplateItems(template)

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -324,7 +324,7 @@ const doAction = (action) => {
     case windowConstants.WINDOW_UNDO_CLOSED_FRAME:
       {
         const closedFrames = windowState.get('closedFrames')
-        if (closedFrames.size === 0) {
+        if (!closedFrames || closedFrames.size === 0) {
           break
         }
         const frame = closedFrames.last()


### PR DESCRIPTION
Fix https://github.com/brave/browser-laptop/issues/12345

Test Plan:
1. open brave
2. right-click on a tab
3. the context menu should appear and 'Re-open last closed tab' menu item should be disabled
4. open a new tab, go to any website. close the tab
5. repeat step 3. now the menu item should be enabled.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Test Plan:


Reviewer Checklist:

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


