### PR TITLE
Fix unittest for people in New Zealand

### DIFF
--- a/test/unit/app/browser/datesTest.js
+++ b/test/unit/app/browser/datesTest.js
@@ -7,7 +7,7 @@ let dates
 require('../../braveUnit')
 
 describe('update date handling', function () {
-  const exampleDate = 1510687381887 // Tuesday November 14th 2017, 12:23:01 PM
+  const exampleDate = 1510654981887 // Tuesday November 14th 2017, 10:23:01 UTC
   const exampleDate2 = 1512304291746 // Monday December 04th 2017, 9:18:11 AM
   let fakeClock
   before(function () {


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/12370 by changing the test to use a time of day that is on the same day in all timezones

Test Plan:
Change local timezone to New Zealand
unittests should pass

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


