### PR TITLE
Close sub-menus when different item at the same level is selected

### DIFF
--- a/app/renderer/components/common/contextMenu/contextMenuItem.js
+++ b/app/renderer/components/common/contextMenu/contextMenuItem.js
@@ -123,19 +123,42 @@ class ContextMenuItem extends ImmutableComponent {
 
   onMouseEnter (e) {
     if (this.props.contextMenuItem.has('folderKey')) {
+      // Context menu item in bookmarks toolbar (bookmarks always have a folder id)
       const yAxis = this.getYAxis(e)
       windowActions.onShowBookmarkFolderMenu(this.props.contextMenuItem.get('folderKey'), yAxis, null, this.props.submenuIndex)
     } else if (this.hasSubmenu) {
+      // Regular context menu with submenu (ex: hamburger menu)
       let openedSubmenuDetails = this.props.contextMenuDetail.get('openedSubmenuDetails')
+
       openedSubmenuDetails = openedSubmenuDetails
         ? openedSubmenuDetails.splice(this.props.submenuIndex, openedSubmenuDetails.size)
         : new Immutable.List()
       const yAxis = this.getYAxis(e)
+
       openedSubmenuDetails = openedSubmenuDetails.push(Immutable.fromJS({
         y: yAxis,
-        template: this.submenu
+        template: this.submenu,
+        openerSubmenuIndex: this.props.submenuIndex,
+        openerDataIndex: this.props.dataIndex
       }))
+
       windowActions.setContextMenuDetail(this.props.contextMenuDetail.set('openedSubmenuDetails', openedSubmenuDetails))
+    } else {
+      // Regular context menu item (no children)
+      let openedSubmenuDetails = this.props.contextMenuDetail && this.props.contextMenuDetail.get('openedSubmenuDetails')
+
+      // If a menu is open, see if the submenuIndex matches
+      if (openedSubmenuDetails) {
+        for (let i = 0; i < openedSubmenuDetails.size; i++) {
+          if (this.props.submenuIndex === openedSubmenuDetails.getIn([i, 'openerSubmenuIndex'])) {
+            // When index matches, menu should be closed
+            // User is hovering over a different item at the same level
+            openedSubmenuDetails = openedSubmenuDetails.remove(i)
+            windowActions.setContextMenuDetail(this.props.contextMenuDetail.set('openedSubmenuDetails', openedSubmenuDetails))
+            break
+          }
+        }
+      }
     }
   }
   getLabelForItem (item) {


### PR DESCRIPTION
Close sub-menus when different item at the same level is selected (which doesn't have children)

Fixes https://github.com/brave/browser-laptop/issues/12363

Auditors: @petemill, @NejcZdovc 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Launch Brave and open the Hamburger / Kabob / Food menu
2. Move mouse to "New Session Tab" and observe menu come up
3. Move mouse down to next item, "New Window"
4. Submenu for "New Session Tab" should now disappear

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


