### PR TITLE
fix restart notification showing wrong action order

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -249,8 +249,8 @@ app.on('ready', () => {
       } else {
         appActions.showNotification({
           buttons: [
-            {text: locale.translation('yes')},
-            {text: locale.translation('no')}
+            {text: locale.translation('no')},
+            {text: locale.translation('yes')}
           ],
           options: {
             persist: false
@@ -260,7 +260,7 @@ app.on('ready', () => {
         })
         prefsRestartCallbacks[message] = (buttonIndex, persist) => {
           delete prefsRestartCallbacks[message]
-          if (buttonIndex === 0) {
+          if (buttonIndex === 1) {
             const args = process.argv.slice(1)
             args.push('--relaunch')
             app.relaunch({args})


### PR DESCRIPTION
close #9750
per https://github.com/brave/browser-laptop/pull/10180#issuecomment-353686272
Auditors: @srirambv 

Test plan:
1. try disabling pdfjs in extensions tab
2. ensure buttons order is "no/yes" and "no" does nothing and "yes" restarts