### PR TITLE
More robust way of detecting git revision for build-package

### DIFF
--- a/tools/buildPackage.js
+++ b/tools/buildPackage.js
@@ -1,12 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
-
+const path = require('path')
 var VersionInfo = require('./lib/versionInfo')
 var execute = require('./lib/execute')
 const ignoredPaths = require('./lib/ignoredPaths')
 const config = require('./lib/config')
-const path = require('path')
+const getGitRevision = require('./lib/getGitRevision')
 
 const isWindows = process.platform === 'win32'
 const isDarwin = process.platform === 'darwin'
@@ -72,104 +72,108 @@ if (channel !== 'dev') {
 
 const buildDir = appName + '-' + process.platform + '-' + arch
 
-console.log('Writing buildConfig.js...')
-config.writeBuildConfig(
-  {
-    channel: channel,
-    BROWSER_LAPTOP_REV: require('git-rev-sync').long(),
-    nodeEnv: env.NODE_ENV,
-    ref: ref || null
-  },
-  'buildConfig.js'
-)
+async function generateBuild () {
+  console.log('Writing buildConfig.js...')
+  config.writeBuildConfig(
+    {
+      channel: channel,
+      BROWSER_LAPTOP_REV: await getGitRevision(),
+      nodeEnv: env.NODE_ENV,
+      ref: ref || null
+    },
+    'buildConfig.js'
+  )
 
-var cmds = ['echo cleaning up target...']
+  var cmds = ['echo cleaning up target...']
 
-if (isWindows) {
-  cmds = cmds.concat([
-    'cmd.exe /c for /d %x in (*-win32-x64) do rmdir /s /q "%x"',
-    'cmd.exe /c for /d %x in (*-win32-ia32) do rmdir /s /q "%x"'
-  ])
+  if (isWindows) {
+    cmds = cmds.concat([
+      'cmd.exe /c for /d %x in (*-win32-x64) do rmdir /s /q "%x"',
+      'cmd.exe /c for /d %x in (*-win32-ia32) do rmdir /s /q "%x"'
+    ])
 
-  // Remove the destination folder
-  cmds = cmds.concat([
-    '(if exist dist rmdir /s /q dist)'
-  ])
-} else {
-  cmds = cmds.concat([
-    'rm -Rf ' + '*-' + process.platform + '-' + arch,
-    'rm -Rf dist',
-    `rm -f *.tar.bz2`
-  ])
-}
-
-cmds = cmds.concat([
-  'echo done',
-  'echo starting build...'
-])
-
-console.log('Building version ' + VersionInfo.braveVersion + ' in ' + buildDir + ' with Electron ' + VersionInfo.electronVersion)
-
-cmds = cmds.concat([
-  '"./node_modules/.bin/webpack"',
-  'npm run checks',
-  `node ./node_modules/electron-packager/cli.js . ${appName}` +
-    ' --overwrite=true' +
-    ' --ignore="' + ignoredPaths.join('|') + '"' +
-    ' --platform=' + process.platform +
-    ' --arch=' + arch +
-    ` --name="${appName}"` +
-    ' --version=' + VersionInfo.electronVersion +
-    ' --icon=' + appIcon +
-    ' --asar=true' +
-    ' --app-version=' + VersionInfo.braveVersion +
-    ' --build-version=' + VersionInfo.electronVersion +
-    ' --protocol="http" --protocol-name="HTTP Handler"' +
-    ' --protocol="https" --protocol-name="HTTPS Handler"' +
-    ` --product-dir-name="${productDirName}"` +
-    ' --version-string.CompanyName="Brave Software"' +
-    ` --version-string.ProductName="${appName}"` +
-    ' --version-string.Copyright="Copyright 2017, Brave Software"' +
-    ` --version-string.FileDescription="${appName}"`
-])
-
-function BuildManifestFile () {
-  const fs = require('fs')
-  const fileContents = fs.readFileSync('./res/Update.VisualElementsManifest.xml', 'utf8')
-  const versionedFileContents = fileContents.replace(/{{braveVersion}}/g, 'app-' + VersionInfo.braveVersion)
-  fs.writeFileSync('temp.VisualElementsManifest.xml', versionedFileContents, 'utf8')
-}
-
-if (isLinux) {
-  cmds.push('ncp ./app/extensions ' + path.join(buildDir, 'resources', 'extensions'))
-} else if (isDarwin) {
-  const macAppName = `${appName}.app`
-  cmds.push('ncp ./app/extensions ' + path.join(buildDir, macAppName, 'Contents', 'Resources', 'extensions'))
-} else if (isWindows) {
-  BuildManifestFile()
-  cmds.push('move .\\temp.VisualElementsManifest.xml "' + path.join(buildDir, 'resources', 'Update.VisualElementsManifest.xml') + '"')
-  cmds.push('copy .\\res\\start-tile-70.png "' + path.join(buildDir, 'resources', 'start-tile-70.png') + '"')
-  cmds.push('copy .\\res\\start-tile-150.png "' + path.join(buildDir, 'resources', 'start-tile-150.png') + '"')
-  cmds.push('makensis.exe -DARCH=' + arch + ` res/${channel}/braveDefaults.nsi`)
-  cmds.push('ncp ./app/extensions ' + path.join(buildDir, 'resources', 'extensions'))
-  // Make sure the Brave.exe binary is squirrel aware so we get squirrel events and so that Squirrel doesn't auto create shortcuts.
-  cmds.push(`"node_modules/rcedit/bin/rcedit.exe" ./${appName}-win32-` + arch + `/${appName}.exe --set-version-string "SquirrelAwareVersion" "1"`)
-}
-
-if (isDarwin) {
-  const macAppName = `${appName}.app`
-  cmds.push('mkdirp ' + path.join(buildDir, macAppName, 'Contents', 'Resources', 'app.asar.unpacked', 'node_modules', 'node-anonize2-relic-emscripten'))
-  cmds.push('ncp ' + path.join('node_modules', 'node-anonize2-relic-emscripten', 'anonize2.js.mem') + ' ' + path.join(buildDir, macAppName, 'Contents', 'Resources', 'app.asar.unpacked', 'node_modules', 'node-anonize2-relic-emscripten', 'anonize2.js.mem'))
-} else {
-  cmds.push('mkdirp ' + path.join(buildDir, 'resources', 'app.asar.unpacked', 'node_modules', 'node-anonize2-relic-emscripten'))
-  cmds.push('ncp ' + path.join('node_modules', 'node-anonize2-relic-emscripten', 'anonize2.js.mem') + ' ' + path.join(buildDir, 'resources', 'app.asar.unpacked', 'node_modules', 'node-anonize2-relic-emscripten', 'anonize2.js.mem'))
-}
-
-execute(cmds, env, (err) => {
-  if (err) {
-    console.error('buildPackage failed', err)
-    process.exit(1)
+    // Remove the destination folder
+    cmds = cmds.concat([
+      '(if exist dist rmdir /s /q dist)'
+    ])
+  } else {
+    cmds = cmds.concat([
+      'rm -Rf ' + '*-' + process.platform + '-' + arch,
+      'rm -Rf dist',
+      `rm -f *.tar.bz2`
+    ])
   }
-  config.clearBuildConfig()
-  console.log('done')
-})
+
+  cmds = cmds.concat([
+    'echo done',
+    'echo starting build...'
+  ])
+
+  console.log('Building version ' + VersionInfo.braveVersion + ' in ' + buildDir + ' with Electron ' + VersionInfo.electronVersion)
+
+  cmds = cmds.concat([
+    '"./node_modules/.bin/webpack"',
+    'npm run checks',
+    `node ./node_modules/electron-packager/cli.js . ${appName}` +
+      ' --overwrite=true' +
+      ' --ignore="' + ignoredPaths.join('|') + '"' +
+      ' --platform=' + process.platform +
+      ' --arch=' + arch +
+      ` --name="${appName}"` +
+      ' --version=' + VersionInfo.electronVersion +
+      ' --icon=' + appIcon +
+      ' --asar=true' +
+      ' --app-version=' + VersionInfo.braveVersion +
+      ' --build-version=' + VersionInfo.electronVersion +
+      ' --protocol="http" --protocol-name="HTTP Handler"' +
+      ' --protocol="https" --protocol-name="HTTPS Handler"' +
+      ` --product-dir-name="${productDirName}"` +
+      ' --version-string.CompanyName="Brave Software"' +
+      ` --version-string.ProductName="${appName}"` +
+      ' --version-string.Copyright="Copyright 2017, Brave Software"' +
+      ` --version-string.FileDescription="${appName}"`
+  ])
+
+  function BuildManifestFile () {
+    const fs = require('fs')
+    const fileContents = fs.readFileSync('./res/Update.VisualElementsManifest.xml', 'utf8')
+    const versionedFileContents = fileContents.replace(/{{braveVersion}}/g, 'app-' + VersionInfo.braveVersion)
+    fs.writeFileSync('temp.VisualElementsManifest.xml', versionedFileContents, 'utf8')
+  }
+
+  if (isLinux) {
+    cmds.push('ncp ./app/extensions ' + path.join(buildDir, 'resources', 'extensions'))
+  } else if (isDarwin) {
+    const macAppName = `${appName}.app`
+    cmds.push('ncp ./app/extensions ' + path.join(buildDir, macAppName, 'Contents', 'Resources', 'extensions'))
+  } else if (isWindows) {
+    BuildManifestFile()
+    cmds.push('move .\\temp.VisualElementsManifest.xml "' + path.join(buildDir, 'resources', 'Update.VisualElementsManifest.xml') + '"')
+    cmds.push('copy .\\res\\start-tile-70.png "' + path.join(buildDir, 'resources', 'start-tile-70.png') + '"')
+    cmds.push('copy .\\res\\start-tile-150.png "' + path.join(buildDir, 'resources', 'start-tile-150.png') + '"')
+    cmds.push('makensis.exe -DARCH=' + arch + ` res/${channel}/braveDefaults.nsi`)
+    cmds.push('ncp ./app/extensions ' + path.join(buildDir, 'resources', 'extensions'))
+    // Make sure the Brave.exe binary is squirrel aware so we get squirrel events and so that Squirrel doesn't auto create shortcuts.
+    cmds.push(`"node_modules/rcedit/bin/rcedit.exe" ./${appName}-win32-` + arch + `/${appName}.exe --set-version-string "SquirrelAwareVersion" "1"`)
+  }
+
+  if (isDarwin) {
+    const macAppName = `${appName}.app`
+    cmds.push('mkdirp ' + path.join(buildDir, macAppName, 'Contents', 'Resources', 'app.asar.unpacked', 'node_modules', 'node-anonize2-relic-emscripten'))
+    cmds.push('ncp ' + path.join('node_modules', 'node-anonize2-relic-emscripten', 'anonize2.js.mem') + ' ' + path.join(buildDir, macAppName, 'Contents', 'Resources', 'app.asar.unpacked', 'node_modules', 'node-anonize2-relic-emscripten', 'anonize2.js.mem'))
+  } else {
+    cmds.push('mkdirp ' + path.join(buildDir, 'resources', 'app.asar.unpacked', 'node_modules', 'node-anonize2-relic-emscripten'))
+    cmds.push('ncp ' + path.join('node_modules', 'node-anonize2-relic-emscripten', 'anonize2.js.mem') + ' ' + path.join(buildDir, 'resources', 'app.asar.unpacked', 'node_modules', 'node-anonize2-relic-emscripten', 'anonize2.js.mem'))
+  }
+
+  execute(cmds, env, (err) => {
+    if (err) {
+      console.error('buildPackage failed', err)
+      process.exit(1)
+    }
+    config.clearBuildConfig()
+    console.log('done')
+  })
+}
+
+generateBuild()

--- a/tools/lib/getGitRevision.js
+++ b/tools/lib/getGitRevision.js
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+const { exec } = require('child_process')
+
+module.exports = function getGitRevision () {
+  return new Promise((resolve, reject) => {
+    exec('git rev-parse --verify HEAD', (err, stdout, stderr) => {
+      if (err) return reject(err)
+      if (stderr) return reject(stderr)
+      resolve(stdout)
+    })
+  })
+}


### PR DESCRIPTION
Uses actual git command, which is compatible with a separate work-tree directory, and wraps build-package in an async function.

Fix #12391

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


