### PR TITLE
Make sure temporary media autoplay setting is not removed until after media is played

### DIFF
--- a/app/browser/reducers/autoplayReducer.js
+++ b/app/browser/reducers/autoplayReducer.js
@@ -56,7 +56,7 @@ const showAutoplayMessageBox = (state, tabId) => {
             const temporaryAllow = (e) => {
               tab.removeListener('media-started-playing', temporaryAllow)
               if (!persist) {
-                appActions.removeSiteSetting(origin, 'autoplay')
+                setTimeout(() => appActions.removeSiteSetting(origin, 'autoplay'), 5000)
               }
             }
             tab.on('media-started-playing', temporaryAllow)


### PR DESCRIPTION
Fix #12382

It's a bit dirty, just setting a timeout, but there appears to be a race condition here with changing the autoplay setting for the origin to true, and then back to false too quickly. Previously (in 0.19.x), the setting was changed back when the tab was destroyed. In the latest (master down to 0.20.x), the setting is changed back as soon as the event `media-started-playing` is received by the tab. Perhaps this event is too early? Adding this timeout solves it but perhaps there's a better way?

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


