### PR TITLE
Update rpm for OpenSUSE to include "suse" in the name

### DIFF
--- a/res/beta/suse.json
+++ b/res/beta/suse.json
@@ -1,5 +1,5 @@
 {
-  "name": "brave-beta",
+  "name": "brave-beta-suse",
   "bin": "brave-beta",
   "userDataDir": "brave-beta",
   "productName": "Brave Beta",

--- a/res/dev/suse.json
+++ b/res/dev/suse.json
@@ -1,5 +1,5 @@
 {
-  "name": "brave",
+  "name": "brave-suse",
   "bin": "brave",
   "userDataDir": "brave",
   "productName": "Brave",

--- a/res/developer/suse.json
+++ b/res/developer/suse.json
@@ -1,5 +1,5 @@
 {
-  "name": "brave-developer",
+  "name": "brave-developer-suse",
   "bin": "brave-developer",
   "userDataDir": "brave-developer",
   "productName": "Brave Developer",

--- a/res/nightly/suse.json
+++ b/res/nightly/suse.json
@@ -1,5 +1,5 @@
 {
-  "name": "brave-nightly",
+  "name": "brave-nightly-suse",
   "bin": "brave-nightly",
   "userDataDir": "brave-nightly",
   "productName": "Brave Nightly",


### PR DESCRIPTION
(avoiding conflict with standard RPM)

The upload script for Brave recurses through directories and will upload everything in dist into the same folder on GitHub... which fails because there ends up being two RPMs with the same name (one being OpenSUSE). The renaming by this PR doesn't affect the end-user binary (which gets installed by the RPM), only the name of the RPM itself

Fixes https://github.com/brave/browser-laptop/issues/11831

Auditors: @posix4e, @darkdh

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

  1. Go to https://jenkins.brave.com/view/laptop%20builds%20(child%20jobs)/
  2. Pick the "browser-laptop-build-linux" type and queue a build (beta channel, 0.20.x branch)


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


