### PR TITLE
Update webtorrent-remote to 2.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,29 @@
       "integrity": "sha512-vs1IkxmbdYv0K8rPBXLl/qicRRF7CDjpOWHY1m+CUVByMkepJtWVlxtnszyY1rAWWL71IGc2JWRzJgUbHpzGDw==",
       "dev": true,
       "requires": {
-        "7zip-bin-mac": "1.0.1"
+        "7zip-bin-linux": "1.2.0",
+        "7zip-bin-mac": "1.0.1",
+        "7zip-bin-win": "2.1.1"
       }
+    },
+    "7zip-bin-linux": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin-linux/-/7zip-bin-linux-1.2.0.tgz",
+      "integrity": "sha512-umB98LN18XBGKPw4EKET2zPDqVhEU1mxXA1Gx0BM+DoBt4hnlZPNkpSMNzmuNbQshi9SzLhqlTAyKcAgNrbV3Q==",
+      "dev": true,
+      "optional": true
     },
     "7zip-bin-mac": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/7zip-bin-mac/-/7zip-bin-mac-1.0.1.tgz",
       "integrity": "sha1-Pmh3i78JJq3GgVlCcHRQXUdVXAI=",
+      "dev": true,
+      "optional": true
+    },
+    "7zip-bin-win": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/7zip-bin-win/-/7zip-bin-win-2.1.1.tgz",
+      "integrity": "sha512-6VGEW7PXGroTsoI2QW3b0ea95HJmbVBHvfANKLLMzSzFA1zKqVX5ybNuhmeGpf6vA0x8FJTt6twpprDANsY5WQ==",
       "dev": true,
       "optional": true
     },
@@ -5801,6 +5817,61 @@
       "requires": {
         "electron-download": "github:brave/electron-download#409b65caff14edeef1daa36a7445ba6334658d7c",
         "extract-zip": "1.6.5"
+      },
+      "dependencies": {
+        "electron-download": {
+          "version": "github:brave/electron-download#409b65caff14edeef1daa36a7445ba6334658d7c",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "home-path": "1.0.5",
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "mv": "2.1.1",
+            "nugget": "1.6.2",
+            "path-exists": "1.0.0",
+            "rc": "1.2.1"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "nugget": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/nugget/-/nugget-1.6.2.tgz",
+          "integrity": "sha1-iMpuA7pXBqmRc/XaCQJZPWvK4Qc=",
+          "dev": true,
+          "requires": {
+            "debug": "2.6.9",
+            "minimist": "1.2.0",
+            "pretty-bytes": "1.0.4",
+            "progress-stream": "1.2.0",
+            "request": "2.82.0",
+            "single-line-log": "0.4.1",
+            "throttleit": "0.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz",
+          "integrity": "sha1-1aiZjrce83p0w06w2eum6HjuoIE=",
+          "dev": true
+        },
+        "single-line-log": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-0.4.1.tgz",
+          "integrity": "sha1-h6VWSfdJ14PsDc2AToFA2Yc8fO4=",
+          "dev": true
+        },
+        "throttleit": {
+          "version": "0.0.2",
+          "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+          "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8=",
+          "dev": true
+        }
       }
     },
     "electron-publish": {
@@ -21061,9 +21132,9 @@
       }
     },
     "webtorrent-remote": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/webtorrent-remote/-/webtorrent-remote-2.0.2.tgz",
-      "integrity": "sha512-jEIld3f2jU8k2OpsRs3AqTog9kk+dyOWx4nf3wvwmcayh5kLLArcD7V6nQFl9POEQCUA3b9ik34PJ6ztUvCjQA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/webtorrent-remote/-/webtorrent-remote-2.1.0.tgz",
+      "integrity": "sha512-40nk0CG76CeGtHFvc+Y4rRxTjtK6dhIHlsxR6slMa8lYASh7S8vEjDsE8JFicIvfM1cRK0dIMvosPTjO7xbkuQ==",
       "requires": {
         "debug": "2.6.9",
         "throttleit": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "underscore": "1.8.3",
     "url-loader": "~0.6.2",
     "v8-compile-cache": "^1.1.0",
-    "webtorrent-remote": "^2.0.2"
+    "webtorrent-remote": ">=2.1.0"
   },
   "devDependencies": {
     "asar": "~0.13.0",


### PR DESCRIPTION
Fix https://github.com/brave/browser-laptop/issues/12400 using https://github.com/dcposch/webtorrent-remote/pull/8

Test Plan:
1. go to a torrent file, ex: https://zooqle.com/download/wiv7v.torrent.
2. after webtorrent opens, open page devtools and inspect a 'save file' icon to see the port number of the href attribute. ex: if the href is 'http://localhost:39292/0', the port is 39292.
3. use ifconfig or go to https://diafygi.github.io/webrtc-ips/ to find your private IP address
4. open a new tab and visit http://$PRIVATE_IP:$PORT where PRIVATE_IP is the IP from Step 3 and PORT is the port from step 2. nothing should happen.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


