### PR TITLE
Fix some PDF handing bugs

### DIFF
--- a/app/pdfJS.js
+++ b/app/pdfJS.js
@@ -52,7 +52,7 @@ function isPDFDownloadable (details) {
   // viewer to open the PDF, but first check whether the Content-Disposition
   // header specifies an attachment. This allows sites like Google Drive to
   // operate correctly (#6106).
-  if (details.type === 'main_frame' &&
+  if (details.resourceType === 'mainFrame' &&
       details.url.indexOf('=download') === -1) {
     return false
   }


### PR DESCRIPTION
Fix resourceType check for session.webRequest

Test Plan:

~0. Enable payments. Close Brave.~
~1. npm run add-simulated-payment-history~
~2. Go to Brave payments, open your contribution history.~
~3. Click on a PDF file in your contribution history. It should offer to save the file.~

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


