### PR TITLE
Fix extension icons appearing in about: pages and context menu

### DIFF
--- a/app/common/state/extensionState.js
+++ b/app/common/state/extensionState.js
@@ -5,6 +5,7 @@
 const { makeImmutable } = require('./immutableUtil')
 const Immutable = require('immutable')
 const platformUtil = require('../lib/platformUtil')
+const {chromeUrl} = require('../../../js/lib/appUrlUtil')
 
 const browserActionDefaults = Immutable.fromJS({
   tabs: {}
@@ -77,7 +78,7 @@ const extensionState = {
   browserActionBackgroundImage: (browserAction, tabId) => {
     tabId = tabId ? tabId.toString() : '-1'
     let path = browserAction.getIn(['tabs', tabId, 'path']) || browserAction.get('path')
-    let basePath = browserAction.get('base_path')
+    let basePath = chromeUrl(browserAction.get('base_path'))
     if (path && basePath) {
       // Older extensions may provide a string path
       if (typeof path === 'string') {

--- a/app/extensions.js
+++ b/app/extensions.js
@@ -3,7 +3,7 @@ const contextMenus = require('./browser/extensions/contextMenus')
 const extensionActions = require('./common/actions/extensionActions')
 const config = require('../js/constants/config')
 const appConfig = require('../js/constants/appConfig')
-const {chromeUrl} = require('../js/lib/appUrlUtil')
+const {fileUrl} = require('../js/lib/appUrlUtil')
 const {getExtensionsPath, getBraveExtUrl, getBraveExtIndexHTML} = require('../js/lib/appUrlUtil')
 const {getSetting} = require('../js/settings')
 const settings = require('../js/constants/settings')
@@ -408,7 +408,7 @@ module.exports.init = () => {
     extensionInfo.setInstallInfo(installInfo.id, installInfo)
     installInfo.filePath = installInfo.base_path
 
-    installInfo.base_path = chromeUrl(installInfo.base_path)
+    installInfo.base_path = fileUrl(installInfo.base_path)
 
     extensionActions.extensionInstalled(installInfo.id, installInfo)
     extensionActions.extensionEnabled(installInfo.id)

--- a/js/lib/appUrlUtil.js
+++ b/js/lib/appUrlUtil.js
@@ -24,11 +24,11 @@ module.exports.fileUrl = (filePath) => {
   return encodeURI('file://' + fileUrlPath)
 }
 
-module.exports.chromeUrl = (filePath = '') => {
-  filePath = module.exports.fileUrl(filePath)
-  filePath = filePath.replace('file://', 'chrome://brave')
-
-  return filePath
+/**
+ * Converts file URL to chrome:// URL
+ */
+module.exports.chromeUrl = (fileUrl = '') => {
+  return fileUrl.replace('file://', 'chrome://brave')
 }
 
 /**

--- a/test/unit/lib/appUrlUtilTest.js
+++ b/test/unit/lib/appUrlUtilTest.js
@@ -81,7 +81,7 @@ describe('appUrlUtil test', function () {
   })
   describe('chromeUrl', function () {
     it('can convert file paths', function () {
-      const filePath = '/users/bbondy/space here/tesT.html'
+      const filePath = 'file:///users/bbondy/space%20here/tesT.html'
       const chromeUrl = appUrlUtil.chromeUrl(filePath)
       const expected = 'chrome://brave/users/bbondy/space%20here/tesT.html'
       assert.equal(chromeUrl, expected)


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/12409

Test Plan:
1. go to about:preferences#extensions, all icons should appear.
2. enable pocket. the browserAction icon should appear in the top right of the browser.
3. go to about:extensions. all icons should appear.
4. go to any page and right-click. the pocket icon should appear in the context menu.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


