### PR TITLE
do not resize other tabs if closed tab is pinned

### DIFF
--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -190,9 +190,12 @@ class Tab extends React.Component {
 
     if (frame && !frame.isEmpty()) {
       const tabWidth = this.fixTabWidth
-      windowActions.onTabClosedWithMouse({
-        fixTabWidth: tabWidth
-      })
+      // do not mimic tab size if closed tab is a pinned tab
+      if (!this.props.isPinnedTab) {
+        windowActions.onTabClosedWithMouse({
+          fixTabWidth: tabWidth
+        })
+      }
       appActions.tabCloseRequested(this.props.tabId)
     }
   }


### PR DESCRIPTION
fix #11825
Auditors: @bsclifton, @petemill 

cc @srirambv 

Test Plan:
1. have some tabs open
2. pin one
3. middle-click to close it

Result:
1. tab should close
2. other tabs shouldn't _look_ like a pinned tab 