### PR TITLE
Reinstate call to cleanup window data

### DIFF
--- a/app/browser/reducers/windowsReducer.js
+++ b/app/browser/reducers/windowsReducer.js
@@ -329,9 +329,8 @@ const windowsReducer = (state, action, immutableAction) => {
       break
     case appConstants.APP_WINDOW_CLOSED:
       state = windowState.removeWindow(state, action)
-      const windowId = action.getIn(['windowValue', 'windowId'])
+      const windowId = action.get('windowId')
       sessionStoreShutdown.removeWindowFromCache(windowId)
-      windows.cleanupWindow(windowId)
       break
     case appConstants.APP_WINDOW_CREATED:
     case appConstants.APP_WINDOW_RESIZED:

--- a/app/browser/windows.js
+++ b/app/browser/windows.js
@@ -236,6 +236,8 @@ const api = {
         appActions.windowCreated(windowValue, windowId)
       })
       win.once('closed', () => {
+        appActions.windowClosed(windowId)
+        cleanupWindow(windowId)
       })
       win.on('blur', () => {
         appActions.windowBlurred(windowId)

--- a/app/common/state/windowState.js
+++ b/app/common/state/windowState.js
@@ -115,8 +115,7 @@ const api = {
   removeWindow: (state, action) => {
     action = validateAction(action)
     state = validateState(state)
-    let windowValue = validateWindowValue(action.get('windowValue'))
-    let windowId = validateId('windowId', windowValue.get('windowId'))
+    const windowId = action.get('windowId')
     return api.removeWindowByWindowId(state, windowId)
   },
 

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -65,10 +65,10 @@ const appActions = {
     })
   },
 
-  windowClosed: function (windowValue) {
+  windowClosed: function (windowId) {
     dispatch({
       actionType: appConstants.APP_WINDOW_CLOSED,
-      windowValue
+      windowId
     })
   },
 

--- a/test/unit/common/state/windowStateTest.js
+++ b/test/unit/common/state/windowStateTest.js
@@ -116,12 +116,12 @@ const shouldValidateWindowValue = function (check) {
   })
 }
 
-const shouldValidateAction = function (check) {
+const shouldValidateAction = function (check, payload = { windowValue: { windowId: 1 } }) {
   it('throws an AssertionError if action does not contain a `windowValue` that is convertable to an Immutable.Map', function () {
     assert.doesNotThrow(
       () => {
-        check(Immutable.fromJS({ windowValue: { windowId: 1 } }))
-        check({ windowValue: { windowId: 1 } })
+        check(Immutable.fromJS(payload))
+        check(payload)
       },
       AssertionError
     )
@@ -142,7 +142,7 @@ const shouldValidateAction = function (check) {
   it('throws an AssertionError if `action` is not convertable to an Immutable.Map', function () {
     assert.doesNotThrow(
       () => {
-        check({ windowValue: { windowId: 1 } })
+        check(payload)
       },
       AssertionError
     )
@@ -327,24 +327,20 @@ describe('windowState', function () {
 
     it('returns a new immutable state with the window removed by `windowId`', function () {
       assert.deepEqual(
-        windowState.removeWindow(this.appState, { windowValue: { windowId: 2 } }).get('windows').toJS(),
+        windowState.removeWindow(this.appState, { windowId: 2 }).get('windows').toJS(),
         [{ windowId: 1 }])
     })
 
     shouldValidateAction((action) => {
       windowState.removeWindow(defaultAppState, action)
-    })
-
-    shouldValidateWindowValue((windowValue) => {
-      windowState.removeWindow(defaultAppState, { windowValue })
-    })
+    }, { windowId: 1 })
 
     shouldValidateId((windowId) => {
-      windowState.removeWindow(defaultAppState, { windowValue: { windowId } })
+      windowState.removeWindow(defaultAppState, { windowId })
     })
 
     shouldValidateWindowState((state) => {
-      windowState.removeWindow(state, { windowValue: { windowId: 1 } })
+      windowState.removeWindow(state, { windowId: 1 })
     })
   })
 


### PR DESCRIPTION
Removes window data from state and static reference when window has been closed

Fix #11859

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:

Unit tests

Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


