### PR TITLE
Fix PDF reloading

### DIFF
--- a/app/renderer/components/frame/frame.js
+++ b/app/renderer/components/frame/frame.js
@@ -57,11 +57,14 @@ const appConfig = require('../../../../js/constants/appConfig')
 const messages = require('../../../../js/constants/messages')
 const config = require('../../../../js/constants/config')
 
-const pdfjsOrigin = `chrome-extension://${config.PDFJSExtensionId}/`
-
 function isTorrentViewerURL (url) {
   const isEnabled = getSetting(settings.TORRENT_VIEWER_ENABLED)
   return isEnabled && isSourceMagnetUrl(url)
+}
+
+function isPDFJSURL (url) {
+  const pdfjsOrigin = `chrome-extension://${config.PDFJSExtensionId}/`
+  return url && url.startsWith(pdfjsOrigin)
 }
 
 class Frame extends React.Component {
@@ -288,7 +291,9 @@ class Frame extends React.Component {
         if (this.props.tabUrl !== this.props.location &&
           !this.isAboutPage() &&
           !isTorrentViewerURL(this.props.location)) {
-          appActions.loadURLRequested(this.props.tabId, this.props.location)
+        } else if (isPDFJSURL(this.props.location)) {
+          appActions.loadURLRequested(this.props.tabId,
+            UrlUtil.getLocationIfPDF(this.props.location))
         } else {
           tabActions.reload(this.props.tabId)
         }
@@ -620,7 +625,7 @@ class Frame extends React.Component {
         }, 250)
       }
 
-      if (url.startsWith(pdfjsOrigin)) {
+      if (isPDFJSURL(url)) {
         let displayLocation = UrlUtil.getLocationIfPDF(url)
         windowActions.setSecurityState(this.props.tabId, {
           secure: urlParse(displayLocation).protocol === 'https:',


### PR DESCRIPTION
fix #12408

Test plan:
1. load any PDF
2. hit reload
3. it should reload the PDF instead of 'file not found'

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


