### PR TITLE
Fix clearing history data on shutdown

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -367,15 +367,13 @@ module.exports.cleanAppData = (immutableData, isShutdown) => {
     }
   })
 
-  if (immutableData.get('sites')) {
-    const clearHistory = isShutdown && getSetting(settings.SHUTDOWN_CLEAR_HISTORY) === true
-    if (clearHistory) {
-      immutableData = immutableData.set('historySites', Immutable.Map())
-      immutableData = deleteImmutablePaths(immutableData, [
-        ['about', 'history'],
-        ['about', 'newtab']
-      ])
-    }
+  const clearHistory = isShutdown && getSetting(settings.SHUTDOWN_CLEAR_HISTORY) === true
+  if (clearHistory) {
+    immutableData = immutableData.set('historySites', Immutable.Map())
+    immutableData = deleteImmutablePaths(immutableData, [
+      ['about', 'history'],
+      ['about', 'newtab']
+    ])
   }
 
   if (immutableData.get('downloads')) {


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/12427

Test Plan:
1. browse some sites
2. set Brave to clear browsing data on shutdown
3. shutdown
4. go to about:history. it should be blank.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


