### PR TITLE
Create a Buffer Window in order to pre-render and open new windows faster

### DIFF
--- a/app/browser/windows.js
+++ b/app/browser/windows.js
@@ -17,15 +17,20 @@ const {makeImmutable} = require('../common/state/immutableUtil')
 const {getPinnedTabsByWindowId} = require('../common/state/tabState')
 const messages = require('../../js/constants/messages')
 const settings = require('../../js/constants/settings')
+const appConfig = require('../../js/constants/appConfig')
 const config = require('../../js/constants/config')
 const appDispatcher = require('../../js/dispatcher/appDispatcher')
 const platformUtil = require('../common/lib/platformUtil')
+const browserWindowUtil = require('../common/lib/browserWindowUtil')
 const windowState = require('../common/state/windowState')
 const pinnedSitesState = require('../common/state/pinnedSitesState')
 const {zoomLevel} = require('../common/constants/toolbarUserInterfaceScale')
+const { shouldDebugWindowEvents } = require('../cmdLine')
 const activeTabHistory = require('./activeTabHistory')
 
 const isDarwin = platformUtil.isDarwin()
+const isWindows = platformUtil.isWindows()
+
 const {app, BrowserWindow, ipcMain} = electron
 
 // TODO(bridiver) - set window uuid
@@ -33,6 +38,8 @@ let currentWindows = {}
 const windowPinnedTabStateMemoize = new WeakMap()
 const publicEvents = new EventEmitter()
 let lastCreatedWindowIsRendererWindow = false
+const renderedWindows = new WeakSet()
+let bufferWindowId
 
 const getWindowState = (win) => {
   if (win.isFullScreen()) {
@@ -100,7 +107,13 @@ const updatePinnedTabs = (win, appState) => {
   const statePinnedSites = pinnedSitesState.getSites(appState)
   // no need to continue if we've already processed this state for this window
   if (windowPinnedTabStateMemoize.get(win) === statePinnedSites) {
+    if (shouldDebugWindowEvents) {
+      console.log(`not running updatePinnedTabs for win ${win.id} since nothing changed since last time`)
+    }
     return
+  }
+  if (shouldDebugWindowEvents) {
+    console.log(`performing updatePinnedTabs for win ${win.id} since state did change since last time`)
   }
   // cache that this state has been updated for this window,
   // so we do not repeat the operation until
@@ -135,6 +148,9 @@ const updatePinnedTabs = (win, appState) => {
 }
 
 function showDeferredShowWindow (win) {
+  if (shouldDebugWindowEvents) {
+    console.log(`Window [${win.id}] showDeferredShowWindow`)
+  }
   win.show()
   if (win.__shouldFullscreen) {
     // this timeout helps with an issue that
@@ -154,6 +170,38 @@ function showDeferredShowWindow (win) {
   win.__shouldMaximize = undefined
 }
 
+function openFramesInWindow (win, frames, activeFrameKey) {
+  if (frames && frames.length) {
+    let frameIndex = -1
+    for (const frame of frames) {
+      frameIndex++
+      if (frame.guestInstanceId) {
+        appActions.newWebContentsAdded(win.id, frame)
+      } else {
+        appActions.createTabRequested({
+          windowId: win.id,
+          url: frame.location || frame.src || frame.provisionalLocation || frame.url,
+          partitionNumber: frame.partitionNumber,
+          isPrivate: frame.isPrivate,
+          active: activeFrameKey ? frame.key === activeFrameKey : true,
+          discarded: frame.unloaded,
+          title: frame.title,
+          faviconUrl: frame.icon,
+          index: frameIndex
+        }, false, true)
+      }
+    }
+  }
+}
+
+function markWindowCreationTime (windowId) {
+  console.time(`windowRender:${windowId}`)
+}
+
+function markWindowRenderTime (windowId) {
+  console.timeEnd(`windowRender:${windowId}`)
+}
+
 const api = {
   init: (state, action) => {
     app.on('browser-window-created', function (event, win) {
@@ -164,6 +212,16 @@ const api = {
       }
       lastCreatedWindowIsRendererWindow = false
       let windowId = -1
+      if (shouldDebugWindowEvents) {
+        console.log(`Window created`)
+        // output console log for each event the tab receives
+        const oldEmit = win.emit
+        win.emit = function () {
+          const eventWindowId = win && !win.isDestroyed() ? win.id : `probably ${windowId}`
+          console.log(`Window [${eventWindowId}] event '${arguments[0]}'`)
+          oldEmit.apply(win, arguments)
+        }
+      }
       const updateWindowMove = debounce(updateWindow, 100)
       const updateWindowDebounce = debounce(updateWindow, 5)
       const onWindowResizeDebounce = debounce(onWindowResize, 5)
@@ -286,6 +344,8 @@ const api = {
         updateWindowDebounce(windowId)
       })
     })
+    // create a buffer window
+    api.getOrCreateBufferWindow()
     // TODO(bridiver) - handle restoring windows
     // windowState.getWindows(state).forEach((win) => {
     //   console.log('restore', win.toJS())
@@ -298,7 +358,7 @@ const api = {
     setImmediate(() => {
       const state = appStore.getState()
       for (let windowId in currentWindows) {
-        if (currentWindows[windowId].__ready) {
+        if (currentWindows[windowId].__ready && currentWindows[windowId] !== api.getBufferWindow()) {
           updatePinnedTabs(currentWindows[windowId], state)
         }
       }
@@ -363,8 +423,10 @@ const api = {
     setImmediate(() => {
       const win = currentWindows[windowId]
       if (win && !win.isDestroyed()) {
-        const state = appStore.getState()
-        updatePinnedTabs(win, state)
+        if (win !== api.getBufferWindow()) {
+          const state = appStore.getState()
+          updatePinnedTabs(win, state)
+        }
         win.__ready = true
         win.emit(messages.WINDOW_RENDERER_READY)
       }
@@ -372,10 +434,15 @@ const api = {
   },
 
   windowRendered: (windowIdOrWin) => {
-    setImmediate(() => {
-      const win = windowIdOrWin instanceof electron.BrowserWindow
+    const win = windowIdOrWin instanceof electron.BrowserWindow
         ? windowIdOrWin
         : currentWindows[windowIdOrWin]
+    if (shouldDebugWindowEvents) {
+      markWindowRenderTime(win.id)
+      console.log(`Window [${win.id}] rendered`)
+    }
+    renderedWindows.add(win)
+    setImmediate(() => {
       if (win && win.__showWhenRendered && !win.isDestroyed() && !win.isVisible()) {
         // window is hidden by default until we receive 'ready' message,
         // so show it now
@@ -389,7 +456,13 @@ const api = {
     try {
       setImmediate(() => {
         if (win && !win.isDestroyed()) {
-          win.close()
+          // do not allow the Buffer Window to be automatically closed
+          // e.g. when it has no tabs open
+          // In order to fully close the Buffer Window, first it will
+          // have to be detached from being the Buffer Window
+          if (win.id !== bufferWindowId) {
+            win.close()
+          }
         }
       })
     } catch (e) {
@@ -397,11 +470,93 @@ const api = {
     }
   },
 
+  /** Specialist function for providing an existing window for
+  * Buffer Window. Normally this should not be used as one
+  * will automatically be created with `getOrCreateBufferWindow`
+  */
+  setWindowIsBufferWindow: (dragBufferWindowId) => {
+    // close existing buffer window if it exists
+    const existingBufferWindow = api.getBufferWindow()
+    if (existingBufferWindow) {
+      api.closeBufferWindow()
+    }
+    bufferWindowId = dragBufferWindowId
+  },
+
+  clearBufferWindow: (createPinnedTabs = true) => {
+    const bufferWindow = api.getBufferWindow()
+    bufferWindowId = null
+    // Pinned tabs are not created for buffer windows.
+    // Now that this window is no longer a buffer window,
+    // create the pinned tabs unless explicitly told not to.
+    if (createPinnedTabs) {
+      const state = appStore.getState()
+      updatePinnedTabs(bufferWindow, state)
+    }
+  },
+
+  closeBufferWindow: () => {
+    const win = api.getBufferWindow()
+    if (win) {
+      if (shouldDebugWindowEvents) {
+        console.log(`Buffer Window [${win.id}] requested to be closed`)
+      }
+      win.close()
+      cleanupWindow(bufferWindowId)
+      bufferWindowId = null
+    } else {
+      if (shouldDebugWindowEvents) {
+        console.log('closeBufferWindow: nothing to close')
+      }
+    }
+  },
+
+  getBufferWindow: () => {
+    const win = currentWindows[bufferWindowId]
+    if (win && !win.isDestroyed()) {
+      return win
+    } else {
+      bufferWindowId = null
+    }
+  },
+
+  getOrCreateBufferWindow: function (options = { }) {
+    // only if we don't have one already
+    let win = api.getBufferWindow()
+    if (!win) {
+      options = Object.assign({ fullscreen: false, show: false }, options)
+      win = api.createWindow(options, null, false, null)
+      bufferWindowId = win.id
+      if (shouldDebugWindowEvents) {
+        console.log(`getOrCreateBufferWindow: created buffer window: ${win.id}`)
+      }
+    } else {
+      if (shouldDebugWindowEvents) {
+        console.log(`getOrCreateBufferWindow: already had buffer window ${win.id}`)
+      }
+    }
+    return win
+  },
+
   createWindow: function (windowOptionsIn, parentWindow, maximized, frames, immutableState = Immutable.Map(), hideUntilRendered = true, cb = null) {
     const defaultOptions = {
       // hide the window until the window reports that it is rendered
       show: true,
-      fullscreenable: true
+      fullscreenable: true,
+      // Neither a frame nor a titlebar
+      // frame: false,
+      // A frame but no title bar and windows buttons in titlebar 10.10 OSX and up only?
+      titleBarStyle: 'hidden-inset',
+      autoHideMenuBar: isDarwin || getSetting(settings.AUTO_HIDE_MENU),
+      title: appConfig.name,
+      frame: !isWindows,
+      minWidth: 480,
+      minHeight: 300,
+      webPreferences: {
+        // XXX: Do not edit without security review
+        sharedWorker: true,
+        partition: 'default'
+      }
     }
     const windowOptions = Object.assign(
       defaultOptions,
@@ -423,6 +578,58 @@ const api = {
     if (showWhenRendered && isDarwin && parentWindow && parentWindow.isFullScreen()) {
       windowOptions.fullscreen = true
     }
+    // use a buffer window if scenario is compatible
+    // determining when to use a buffer window and when to create a brand new window
+    const bufferWindow = api.getBufferWindow()
+    // can't use buffer window if one does not exist yet
+    let canUseBufferWindow = !!bufferWindow
+    // can't use buffer window if one does not exist
+    if (!canUseBufferWindow && shouldDebugWindowEvents) {
+      console.log('createWindow: not using buffer window because one did not exist')
+    }
+    // can't use buffer window if it has not finished rendering
+    if (canUseBufferWindow && !renderedWindows.has(bufferWindow)) {
+      canUseBufferWindow = false
+      if (shouldDebugWindowEvents) {
+        console.log('createWindow: not using buffer window because it has not completed render yet')
+      }
+    }
+    // can't use buffer window if we find incompatible options that we do not know how to set for buffer windows
+    // (those options would be fine for new windows passed in to BrowserWindow ctor)
+    if (canUseBufferWindow && !browserWindowUtil.canSetAllPropertiesOnExistingWindow(windowOptionsIn)) {
+      canUseBufferWindow = false
+      if (shouldDebugWindowEvents) {
+        console.log('createWindow: not using buffer window due to unsupported window creation options', windowOptionsIn)
+      }
+    }
+    // handle using a buffer window as the 'new' window
+    if (canUseBufferWindow) {
+      bufferWindow.webContents.browserWindowOptions.disposition = windowOptionsIn.disposition
+      if (shouldDebugWindowEvents) {
+        console.log('createWindow: using buffer window for new window, and setting properties', windowOptionsIn)
+      }
+      // detach buffer window (pinned tabs will be created)
+      api.clearBufferWindow()
+      // make a new buffer window to replace this one
+      setImmediate(() => {
+        if (shouldDebugWindowEvents) {
+          console.log('creating replacement buffer window...')
+        }
+        api.getOrCreateBufferWindow()
+      })
+      // set desired properties
+      browserWindowUtil.setPropertiesOnExistingWindow(bufferWindow, windowOptionsIn)
+      // create frames for 'new' window
+      openFramesInWindow(bufferWindow, frames, immutableState.get('activeFrameKey'))
+      // make fullscreen if applicable, as above
+      if (windowOptions.fullscreen) {
+        bufferWindow.setFullScreen(true)
+      }
+      if (maximized) {
+        bufferWindow.maximize()
+      }
+      return
+    }
     // if delaying window show, remember if the window should be opened fullscreen
     // and remove the fullscreen property for now
     // (otherwise the window will be shown immediately by macOS / muon)
@@ -438,8 +645,12 @@ const api = {
     // tabbed renderer window
     lastCreatedWindowIsRendererWindow = true
     const win = new electron.BrowserWindow(windowOptions)
+
     win.loadURL(appUrlUtil.getBraveExtIndexHTML())
 
+    if (shouldDebugWindowEvents) {
+      markWindowCreationTime(win.id)
+    }
     // TODO: pass UUID
     publicEvents.emit('new-window-state', win.id, immutableState)
     // let the windowReady handler know to show the window

--- a/app/cmdLine.js
+++ b/app/cmdLine.js
@@ -22,6 +22,7 @@ const debugTabEventsFlagName = '--debug-tab-events'
 
 let appInitialized = false
 let newWindowURL
+const debugWindowEventsFlagName = '--debug-window-events'
 
 const focusOrOpenWindow = function (url) {
   // don't try to do anything if the app hasn't been initialized
@@ -131,7 +132,7 @@ app.on('will-finish-launching', () => {
 process.on(messages.APP_INITIALIZED, () => { appInitialized = true })
 
 const api = module.exports = {
-  newWindowURL: () => {
+  newWindowURL () {
     const openUrl = newWindowURL || getUrlFromCommandLine(process.argv)
     if (openUrl) {
       const parsedUrl = urlParse(openUrl)
@@ -142,7 +143,7 @@ const api = module.exports = {
     return newWindowURL
   },
 
-  getValueForKey: function (key, args = process.argv) {
+  getValueForKey (key, args = process.argv) {
     // TODO: support --blah=bloop as well as the currently supported --blah bloop
     //       and also boolean values inferred by key existance or 'no-' prefix
     //       similar to https://github.com/substack/minimist/blob/master/index.js#97
@@ -154,7 +155,7 @@ const api = module.exports = {
     return null
   },
 
-  getFirstRunPromoCode: function (args = process.argv) {
+  getFirstRunPromoCode (args = process.argv) {
     const installerPath = api.getValueForKey('--squirrel-installer-path', args)
     if (!installerPath || typeof installerPath !== 'string') {
       return null
@@ -170,5 +171,6 @@ const api = module.exports = {
     return null
   },
 
-  shouldDebugTabEvents: process.argv.includes(debugTabEventsFlagName)
+  shouldDebugTabEvents: process.argv.includes(debugTabEventsFlagName),
+  shouldDebugWindowEvents: process.argv.includes(debugWindowEventsFlagName)
 }

--- a/app/common/lib/browserWindowUtil.js
+++ b/app/common/lib/browserWindowUtil.js
@@ -1,0 +1,113 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this file,
+* You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const { nativeImage } = require('electron')
+
+// BrowserWindow ctor options which can be manually
+// set after window creation
+const optionsSetCompatible = new Set([
+  'width',
+  'height',
+  'x',
+  'y',
+  'show',
+  // `disposition` prop does not do anything except get read on later events
+  // by our own code for checking whether a window should
+  // receive pinned sites (e.g. not for popup windows)
+  'disposition',
+  'inactive',
+  'fullscreen',
+  'center',
+  'minWidth',
+  'minHeight',
+  'maxWidth',
+  'maxHeight',
+  'resizable',
+  'movable',
+  'alwaysOnTop',
+  'focusable',
+  'icon'
+])
+
+function canSetAllPropertiesOnExistingWindow (properties) {
+  // cannot set properties we don't know about
+  const anyPropertiesNotCompatible = Object.keys(properties)
+    .some(optionKey =>
+      !optionsSetCompatible.has(optionKey) && properties[optionKey] != null
+    )
+  return !anyPropertiesNotCompatible
+}
+
+function setPropertiesOnExistingWindow (browserWindow, properties, debug = false) {
+  // set size and position
+  if (properties.x != null && properties.y != null) {
+    browserWindow.setPosition(properties.x, properties.y)
+  }
+  if (properties.width != null && properties.height != null) {
+    browserWindow.setSize(properties.width, properties.height)
+  }
+  if (properties.maxWidth != null && properties.maxHeight != null) {
+    browserWindow.setMaximumSize(properties.maxWidth, properties.maxHeight)
+  }
+  if (properties.minWidth != null && properties.minHeight != null) {
+    browserWindow.setMinimumSize(properties.minWidth, properties.minHeight)
+  }
+  if (properties.resizable != null) {
+    browserWindow.setResizable(properties.resizable)
+  }
+  if (properties.center === true) {
+    browserWindow.center()
+  }
+  if (properties.movable != null) {
+    browserWindow.setMovable(properties.movable)
+  }
+  if (properties.parent != null || properties.parent === null) {
+    browserWindow.setParent(properties.parent)
+  }
+  if (properties.icon != null) {
+    let windowIcon
+    if (typeof properties.icon === 'string') {
+      try {
+        windowIcon = nativeImage.createFromPath(properties.icon)
+      } catch (e) {
+        console.error('Error creating nativeImage instance from window icon path: ' + e.message)
+        console.error(e)
+      }
+    } else { // there is no electron.nativeImage fn for detecting instanceof, so assume
+      windowIcon = properties.icon
+    }
+    if (windowIcon) {
+      browserWindow.setIcon(windowIcon)
+    }
+  }
+  if (properties.show !== false) {
+    if (properties.inactive === true) {
+      if (debug) {
+        console.log('showing existing window inactive', browserWindow.id)
+      }
+      browserWindow.showInactive()
+    } else {
+      if (debug) {
+        console.log('showing existing window', browserWindow.id)
+      }
+      browserWindow.show()
+    }
+  } else if (properties.inactive === false) {
+    browserWindow.blur()
+  }
+  if (properties.fullscreen) {
+    browserWindow.setFullScreen(true)
+  }
+  if (properties.alwaysOnTop) {
+    browserWindow.setAlwaysOnTop(true)
+  }
+  if (properties.focusable != null) {
+    browserWindow.setFocusable(properties.focusable)
+  }
+}
+
+module.exports = {
+  canSetAllPropertiesOnExistingWindow,
+  setPropertiesOnExistingWindow
+}

--- a/app/common/state/pinnedSitesState.js
+++ b/app/common/state/pinnedSitesState.js
@@ -55,7 +55,9 @@ const pinnedSiteState = {
     site = site.set('order', sites.size)
 
     const key = pinnedSitesUtil.getKey(site)
-    if (key === null) {
+    // check if key is valid
+    // or if key already exists so we do not mutate state unneccessarily
+    if (key === null || state.hasIn([STATE_SITES.PINNED_SITES, key])) {
       return state
     }
 

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -231,6 +231,9 @@ const appActions = {
   /**
    * A request for a new tab has been made with the specified createProperties
    * @param {Object} createProperties
+   * @param {Boolean} activateIfOpen if the tab is already open with the same properties,
+   * switch to it instead of creating a new one
+   * @param {Boolean} isRestore when true, won't try to activate the new tab, even if the user preference indicates to
    */
   createTabRequested: function (createProperties, activateIfOpen = false, isRestore = false) {
     dispatch({

--- a/js/entry.js
+++ b/js/entry.js
@@ -92,21 +92,22 @@ const fireOnReactRender = (windowValue) => {
 
 const generateTabs = (windowState, frames, windowId) => {
   const activeFrameKey = windowState.get('activeFrameKey')
-
-  frames.forEach((frame, i) => {
-    if (frame.guestInstanceId) {
-      appActions.newWebContentsAdded(windowId, frame)
-    } else {
-      appActions.createTabRequested({
-        url: frame.location || frame.src || frame.provisionalLocation || frame.url,
-        partitionNumber: frame.partitionNumber,
-        isPrivate: frame.isPrivate,
-        active: activeFrameKey ? frame.key === activeFrameKey : true,
-        discarded: frame.unloaded,
-        title: frame.title,
-        faviconUrl: frame.icon,
-        index: i
-      }, false, true /* isRestore */)
-    }
-  })
+  if (frames && frames.length) {
+    frames.forEach((frame, i) => {
+      if (frame.guestInstanceId) {
+        appActions.newWebContentsAdded(windowId, frame)
+      } else {
+        appActions.createTabRequested({
+          url: frame.location || frame.src || frame.provisionalLocation || frame.url,
+          partitionNumber: frame.partitionNumber,
+          isPrivate: frame.isPrivate,
+          active: activeFrameKey ? frame.key === activeFrameKey : true,
+          discarded: frame.unloaded,
+          title: frame.title,
+          faviconUrl: frame.icon,
+          index: i
+        }, false, true /* isRestore */)
+      }
+    })
+  }
 }

--- a/js/state/frameStateUtil.js
+++ b/js/state/frameStateUtil.js
@@ -49,21 +49,20 @@ function getFrames (state) {
 }
 
 function getSortedFrames (state) {
-  return state.get('frames').sort(comparatorByKeyAsc)
+  return state.get('frames', Immutable.List()).sort(comparatorByKeyAsc)
 }
 
 function getSortedFrameKeys (state) {
-  return state.get('frames')
-    .sort(comparatorByKeyAsc)
+  return getSortedFrames(state)
     .map(frame => frame.get('key'))
 }
 
 function getPinnedFrames (state) {
-  return state.get('frames').filter((frame) => frame.get('pinnedLocation'))
+  return state.get('frames', Immutable.List()).filter((frame) => frame.get('pinnedLocation'))
 }
 
 function getNonPinnedFrames (state) {
-  return state.get('frames').filter((frame) => !frame.get('pinnedLocation')) || Immutable.List()
+  return state.get('frames', Immutable.List()).filter((frame) => !frame.get('pinnedLocation'))
 }
 
 function getFrameIndex (state, frameKey) {
@@ -202,7 +201,8 @@ const getTabIdByFrameKey = (state, frameKey) => {
 
 function getActiveFrame (state) {
   const activeFrameIndex = getActiveFrameIndex(state)
-  return state.get('frames').get(activeFrameIndex)
+  const frames = state.get('frames')
+  return frames ? frames.get(activeFrameIndex) : null
 }
 
 // Returns the same as the active frame's location, but returns the requested
@@ -331,7 +331,7 @@ const frameOptsFromFrame = (frame) => {
 * @return Immutable top level application state ready to merge back in
 */
 function addFrame (state, frameOpts, newKey, partitionNumber, openInForeground, insertionIndex) {
-  const frames = state.get('frames')
+  const frames = state.get('frames', Immutable.List())
 
   const location = frameOpts.location // page url
   const displayURL = frameOpts.displayURL == null ? location : frameOpts.displayURL

--- a/test/unit/app/sessionStoreTest.js
+++ b/test/unit/app/sessionStoreTest.js
@@ -388,11 +388,13 @@ describe('sessionStore unit tests', function () {
       })
       it('calls cleanPerWindowData for each item', function () {
         const data = Immutable.fromJS({
-          perWindowState: ['window1', 'window2']
+          perWindowState: [{ 'window': 1 }, { 'window': 2 }]
         })
+        const window1 = data.getIn(['perWindowState', 0])
+        const window2 = data.getIn(['perWindowState', 1])
         sessionStore.cleanAppData(data, 'IS_SHUTDOWN_VALUE')
-        assert.equal(cleanPerWindowDataStub.withArgs('window1', 'IS_SHUTDOWN_VALUE').calledOnce, true)
-        assert.equal(cleanPerWindowDataStub.withArgs('window2', 'IS_SHUTDOWN_VALUE').calledOnce, true)
+        assert.equal(cleanPerWindowDataStub.withArgs(window1, 'IS_SHUTDOWN_VALUE').calledOnce, true)
+        assert.equal(cleanPerWindowDataStub.withArgs(window2, 'IS_SHUTDOWN_VALUE').calledOnce, true)
       })
 
       it('removes state for windows which have no frames', function () {


### PR DESCRIPTION
A buffer window is created at startup, and any time a previous buffer window is detached in order to be utilized as a real window.
This type of window is not shown and has no tabs (pinned or non-pinned) until it is shown.
State is not persisted for Buffer Windows until they are utilized as real windows.

A new command-line flag is introduced: '--debug-window-events' which shows logging around Buffer Window creation and utilization, as well as all other window events. No additional logging should be present without this flag.

I had built some of this functionality for #11720 (Tabs transitions) in order to decrease the time to detach a tab to a new window. At the same time, a request came through Asana for the performance initiative to do this same thing for every window. This PR is the result of adapting the code from #11720 for all (compatible) window creation.

Fix #12437

### Test Plan:

#### Window creation
- Brave starts with 1 window
- A new window can be opened
   - The window opens instantly without any wait

#### Window + frame creation
- Open a tab that has links on it
- Right-click any link and choose 'Open in New Window'
   - The window opens instantly, and the tab with the link's url is opened

#### Window persistance
 - Open at least 2 windows, with at least 2 tabs in each
 - Quit Brave
 - Open Brave again
     - All windows and tabs are re-opened
     - No extra windows are re-opened

#### Pinned tabs
 - Open 2 windows
 - Pin a tab in window 1
    - Tab is pinned in window 1 and window 2
 - Open a new window
     - Window opens instantly
     - new window (3) has the pinned tab

#### Window focus (especially for Windows OS due to brave/muon#424)
- Create a new window
    - The window opens instantly
    - The window gets focus instantly
    - The window does not lose focus, and the urlbar can be typed in without any further action
Especially on Windows: ensure that always when a new window is created, that the new window gets and keeps focus (in the url bar for example)

#### Detach tab to new window
- Create 1 window with mulitple tabs
- Detach a tab (right-click --> Detach, or drag the tab away from Window)
    - Ensure the tab's new window was created from a buffer window
    - Ensure the window is positioned correctly by the mouse cursor (if dragged out), as per previous version of Brave.

#### Popup window
- Open two windows with two different sites in each window
- Pin 1 site in 1 window
   - Site will be pinned in Window 1 and Window 2
- Visit http://www.popuptest.com/goodpopups.html
- Click "Good Popup #1"
     - Popup should open in a new window
     - Popup window should be buffer window
     - Popup window should be sized small (according to the popup request)
     - Popup window **should not have any pinned tabs**
- Pin 1 site in window 2
     - Window 1 and Window 2 should get the new pinned site
     - Popup window should still not have any pinned tabs

#### Logging
 - start Brave with the flag `--debug-window-events`
    - observe console log entries for all window events

 - start brave without the above flag
    - observe no console log entries

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)





Reviewer Checklist:

- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


