### PR TITLE
Only sort ledger transactions once (on initialization)

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -1818,6 +1818,12 @@ const getContributionAmount = () => {
 }
 
 const onInitRead = (state, parsedData) => {
+  if (Array.isArray(parsedData.transactions)) {
+    parsedData.transactions.sort((transaction1, transaction2) => {
+      return transaction1.submissionStamp - transaction2.submissionStamp
+    })
+  }
+
   state = getStateInfo(state, parsedData)
 
   try {

--- a/app/renderer/components/preferences/payment/history.js
+++ b/app/renderer/components/preferences/payment/history.js
@@ -29,7 +29,6 @@ class HistoryContent extends ImmutableComponent {
   render () {
     const transactions = Immutable.fromJS(
       addExportFilenamePrefixToTransactions(this.props.ledgerData.get('transactions').toJS())
-        .sort((transaction1, transaction2) => transaction2.submissionStamp - transaction1.submissionStamp)
     )
 
     return <table className={css(styles.paymentHistoryTable)}>


### PR DESCRIPTION
Fixes #12119

Auditors: @sergiorojasa

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. New profile, enable payments (this creates a new wallet)
2. Exit and run `npm add-simulated-payment-history 50`
3. Open the `ledger-state.json` at `~/Library/Application Support/brave-development` (or `%APPDATA%\brave` on Windows)
4. Manually edit the transactions in the JSON so that some of the newest ones (near the bottom) are at the top of the transactions array
5. Launch browser, verify transactions look correct
6. Exit browser, re-open `ledger-state.json` and notice it's now sorted also

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


