### PR TITLE
Gray out label when disabled

### DIFF
--- a/app/renderer/components/common/switchControl.js
+++ b/app/renderer/components/common/switchControl.js
@@ -131,6 +131,7 @@ class SwitchControl extends ImmutableComponent {
               styles.switchControl__text__label,
               styles.switchControl__text__label_right,
               this.props.small && styles.switchControl__text__label_small,
+              this.props.disabled && styles.switchControl__text_disabled,
               this.props.customStyleTextRight
             )}
               data-l10n-id={this.props.rightl10nId}


### PR DESCRIPTION
Fix #7634

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
go to about:preferences#plugins without installing Pepper Flash and observe label is gray out.
<img width="639" alt="screen shot 2018-01-01 at 2 27 36 pm" src="https://user-images.githubusercontent.com/8117421/34471499-3601a874-ef00-11e7-879f-ce8551160d04.png">

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


