### PR TITLE
hidden top site fixes you wouldn't believe existed

### DIFF
--- a/app/browser/api/topSites.js
+++ b/app/browser/api/topSites.js
@@ -121,6 +121,7 @@ const getTopSiteData = () => {
 
   if (sites.size < 18) {
     const preDefined = staticData
+      // TODO: this doesn't work properly
       .filter((site) => {
         return !isIgnored(state, site.get('key'))
       })
@@ -131,23 +132,23 @@ const getTopSiteData = () => {
     sites = sites.concat(preDefined)
   }
 
-  sites = removeDuplicateDomains(sites)
-
-  // TODO: newer sites should skip pinned position
-  let gridSites = aboutNewTabState.getPinnedTopSites(state)
-
-  sites.forEach((site) => {
-    const siteExists = gridSites.some(pinnedSite => {
-      if (!pinnedSite) {
-        return false
-      }
-      return site.get('key') === pinnedSite.get('key')
-    })
-
-    if (!siteExists) {
-      gridSites.unshift(site)
+  const pinnedTopSites = aboutNewTabState.getPinnedTopSites(state)
+  let gridSites = pinnedTopSites.map(pinned => {
+    // topsites are populated once user visit a new site.
+    // pinning a site to a given index is a user decision
+    // and should be taken as priority. If there's an empty
+    // space we just fill it with visited sites. Otherwise
+    // fallback to the pinned item.
+    if (!pinned) {
+      const firstSite = sites.first()
+      sites = sites.shift()
+      return firstSite
     }
+    return pinned
   })
+
+  gridSites = gridSites.filter(site => site != null)
+  gridSites = removeDuplicateDomains(gridSites)
 
   appActions.topSiteDataAvailable(gridSites)
 }

--- a/app/browser/api/topSites.js
+++ b/app/browser/api/topSites.js
@@ -123,7 +123,7 @@ const getTopSiteData = () => {
     const preDefined = staticData
       // TODO: this doesn't work properly
       .filter((site) => {
-        return !isIgnored(state, site.get('key'))
+        return !isPinned(state, site.get('key')) && !isIgnored(state, site.get('key'))
       })
       .map(site => {
         const bookmarkKey = bookmarkLocationCache.getCacheKey(state, site.get('location'))
@@ -132,8 +132,11 @@ const getTopSiteData = () => {
     sites = sites.concat(preDefined)
   }
 
-  const pinnedTopSites = aboutNewTabState.getPinnedTopSites(state)
-  let gridSites = pinnedTopSites.map(pinned => {
+  let gridSites = aboutNewTabState.getPinnedTopSites(state).map(pinned => {
+    // do not allow duplicates
+    if (pinned) {
+      sites = sites.filter(site => site.get('key') !== pinned.get('key'))
+    }
     // topsites are populated once user visit a new site.
     // pinning a site to a given index is a user decision
     // and should be taken as priority. If there's an empty
@@ -148,7 +151,6 @@ const getTopSiteData = () => {
   })
 
   gridSites = gridSites.filter(site => site != null)
-  gridSites = removeDuplicateDomains(gridSites)
 
   appActions.topSiteDataAvailable(gridSites)
 }

--- a/app/common/state/aboutNewTabState.js
+++ b/app/common/state/aboutNewTabState.js
@@ -4,7 +4,7 @@
 
 const Immutable = require('immutable')
 const {makeImmutable} = require('./immutableUtil')
-
+const topSites = require('../../browser/api/topSites')
 /**
  * topSites are defined by users. Pinned sites are attached to their positions
  * in the grid, and the non pinned indexes are populated with newly accessed sites
@@ -16,9 +16,11 @@ const aboutNewTabState = {
   },
 
   getPinnedTopSites: (state) => {
+    // add same number as fallback to avoid race condition on startup
+    const maxEntries = topSites.aboutNewTabMaxEntries || 100
     // we need null spaces in order to proper pin a topSite in the right position.
-    // historically defined with 3 rows of 6 and kept as-is for parity with other areas.
-    return state.getIn(['about', 'newtab', 'pinnedTopSites'], Immutable.List()).setSize(18)
+    // so let's set it to the same number as max new tab entries.
+    return state.getIn(['about', 'newtab', 'pinnedTopSites'], Immutable.List()).setSize(maxEntries)
   },
 
   getIgnoredTopSites: (state) => {

--- a/app/common/state/aboutNewTabState.js
+++ b/app/common/state/aboutNewTabState.js
@@ -16,7 +16,9 @@ const aboutNewTabState = {
   },
 
   getPinnedTopSites: (state) => {
-    return state.getIn(['about', 'newtab', 'pinnedTopSites'], Immutable.List())
+    // we need null spaces in order to proper pin a topSite in the right position.
+    // historically defined with 3 rows of 6 and kept as-is for parity with other areas.
+    return state.getIn(['about', 'newtab', 'pinnedTopSites'], Immutable.List()).setSize(18)
   },
 
   getIgnoredTopSites: (state) => {

--- a/app/common/state/aboutNewTabState.js
+++ b/app/common/state/aboutNewTabState.js
@@ -5,11 +5,12 @@
 const Immutable = require('immutable')
 const {makeImmutable} = require('./immutableUtil')
 const topSites = require('../../browser/api/topSites')
+const newTabData = require('../../../js/data/newTabData')
 /**
  * topSites are defined by users. Pinned sites are attached to their positions
  * in the grid, and the non pinned indexes are populated with newly accessed sites
  */
-
+const defaultPinnedSite = Immutable.fromJS(newTabData.pinnedTopSites)
 const aboutNewTabState = {
   getSites: (state) => {
     return state.getIn(['about', 'newtab', 'sites'])
@@ -18,9 +19,12 @@ const aboutNewTabState = {
   getPinnedTopSites: (state) => {
     // add same number as fallback to avoid race condition on startup
     const maxEntries = topSites.aboutNewTabMaxEntries || 100
+
     // we need null spaces in order to proper pin a topSite in the right position.
     // so let's set it to the same number as max new tab entries.
-    return state.getIn(['about', 'newtab', 'pinnedTopSites'], Immutable.List()).setSize(maxEntries)
+    return state
+      .getIn(['about', 'newtab', 'pinnedTopSites'], Immutable.List())
+      .setSize(maxEntries)
   },
 
   getIgnoredTopSites: (state) => {
@@ -32,7 +36,11 @@ const aboutNewTabState = {
     if (!props) {
       return state
     }
-
+    // list is only empty if there's no pinning interaction.
+    // in this case we include the default pinned top sites list
+    if (state.getIn(['about', 'newtab', 'pinnedTopSites']).isEmpty()) {
+      state = state.setIn(['about', 'newtab', 'pinnedTopSites'], defaultPinnedSite)
+    }
     state = state.mergeIn(['about', 'newtab'], props.newTabPageDetail)
     return state.setIn(['about', 'newtab', 'updatedStamp'], new Date().getTime())
   },

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -32,7 +32,6 @@ const windowState = require('./common/state/windowState')
 
 // Utils
 const locale = require('./locale')
-const {pinnedTopSites} = require('../js/data/newTabData')
 const {defaultSiteSettingsList} = require('../js/data/siteSettingsList')
 const filtering = require('./filtering')
 const autofill = require('./autofill')
@@ -1019,7 +1018,7 @@ module.exports.defaultAppState = () => {
         gridLayoutSize: 'small',
         sites: [],
         ignoredTopSites: [],
-        pinnedTopSites: pinnedTopSites
+        pinnedTopSites: []
       },
       welcome: {
         showOnLoad: !['test', 'development'].includes(process.env.NODE_ENV)

--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -97,7 +97,7 @@ class NewTabPage extends React.Component {
   }
 
   get pinnedTopSites () {
-    return this.state.newTabData.getIn(['newTabDetail', 'pinnedTopSites'], Immutable.List())
+    return this.state.newTabData.getIn(['newTabDetail', 'pinnedTopSites'], Immutable.List()).setSize(100)
   }
 
   get ignoredTopSites () {
@@ -120,7 +120,6 @@ class NewTabPage extends React.Component {
   get gridLayout () {
     const sizeToCount = {large: 18, medium: 12, small: 6}
     const count = sizeToCount[this.gridLayoutSize]
-
     return this.topSites.take(count)
   }
 

--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -176,15 +176,26 @@ class NewTabPage extends React.Component {
   }
 
   onPinnedTopSite (siteKey) {
-    const currentSiteIndex = this.topSites.findIndex(site => site.get('key') === siteKey)
-    const siteProps = this.topSites.find(site => site.get('key') === siteKey)
-    // ensure pinned sites are pinned in the right order
-    // do not edit these lines unless you've manually tested site visits
-    // after pinning and after dnd reordering
+    let sites = this.topSites
     let pinnedTopSites = this.pinnedTopSites
-      .splice(currentSiteIndex, 1, this.isPinned(siteKey) ? null : siteProps)
 
-    aboutActions.setNewTabDetail({pinnedTopSites: pinnedTopSites}, true)
+    const siteProps = sites.find(site => site.get('key') === siteKey)
+
+    const currentSiteIndex = sites.findIndex(site => site.get('key') === siteKey)
+    const currentPinnedSiteIndex = pinnedTopSites
+      .findIndex(site => site && site.get('key') === siteKey)
+
+    // ensure pinned sites are pinned in the right order when pinned
+    // if not pinned, pin and attach it to its position
+    if (!this.isPinned(siteKey)) {
+      pinnedTopSites = pinnedTopSites.splice(currentSiteIndex, 1, siteProps)
+    } else {
+      pinnedTopSites = pinnedTopSites.splice(currentPinnedSiteIndex, 1, null)
+      sites = sites.splice(currentPinnedSiteIndex, 1, siteProps)
+      aboutActions.setNewTabDetail({sites}, true)
+    }
+
+    aboutActions.setNewTabDetail({pinnedTopSites}, true)
   }
 
   onIgnoredTopSite (siteKey) {

--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -109,20 +109,19 @@ class NewTabPage extends React.Component {
   }
 
   isPinned (siteKey) {
-    return this.pinnedTopSites.find(site => site.get('key') === siteKey)
+    return this.pinnedTopSites.some(site => {
+      if (!site || !site.get) {
+        return false
+      }
+      return site.get('key') === siteKey
+    })
   }
 
   get gridLayout () {
     const sizeToCount = {large: 18, medium: 12, small: 6}
     const count = sizeToCount[this.gridLayoutSize]
 
-    let sites = this.pinnedTopSites.take(count)
-
-    if (sites.size < count) {
-      sites = sites.concat(this.topSites.take(count - sites.size))
-    }
-
-    return sites
+    return this.topSites.take(count)
   }
 
   showNotification () {
@@ -178,14 +177,13 @@ class NewTabPage extends React.Component {
   }
 
   onPinnedTopSite (siteKey) {
-    let pinnedTopSites = this.pinnedTopSites
+    const currentSiteIndex = this.topSites.findIndex(site => site.get('key') === siteKey)
     const siteProps = this.topSites.find(site => site.get('key') === siteKey)
-
-    if (this.isPinned(siteKey)) {
-      pinnedTopSites = pinnedTopSites.filter(site => site.get('key') !== siteKey)
-    } else {
-      pinnedTopSites = pinnedTopSites.push(siteProps)
-    }
+    // ensure pinned sites are pinned in the right order
+    // do not edit these lines unless you've manually tested site visits
+    // after pinning and after dnd reordering
+    let pinnedTopSites = this.pinnedTopSites
+      .splice(currentSiteIndex, 1, this.isPinned(siteKey) ? null : siteProps)
 
     aboutActions.setNewTabDetail({pinnedTopSites: pinnedTopSites}, true)
   }

--- a/test/unit/app/browser/reducers/aboutNewTabsReducerTest.js
+++ b/test/unit/app/browser/reducers/aboutNewTabsReducerTest.js
@@ -50,7 +50,7 @@ describe('aboutNewTabReducerTest', function () {
     const initialState = Immutable.fromJS({
       settings: { },
       about: {
-        newtab: { }
+        newtab: { pinnedTopSites: [] }
       }
     })
     it('gets a value from default settings when nothing is set', () => {


### PR DESCRIPTION
address #12435
fix #12027
fix #12026 
fix #11102
fix #5768
fix #5413

## Test plan:

Please note that several topSites features are broken and tracked in #12435 (there's likely more issues). This PR only addresses what's covered by referenced issues.

Covered by `npm run test -- --grep="respects position of pinned items when populating results"`

## Manual test plan (ensure you're on a fresh profile first):

### #12027 

visit some websites and ensure they're on the topsites list. Restart browser several times, sites shouldn't be missing

### #12026 

visit some websites and ensure they're on the topsites list. Restart. You shouldn't see default topSites anywhere else as previous position (they shouldn't appear momentarily)

### #11102
visit some websites and ensure they're on the topsites list. Restart. Visit other sites. Top sites shouldn't be missing

### #5768 
visit some websites and ensure they're on the topsites list. pin 2nd and 4th websites. Visited site should be stored in the first position.

### #5413
bookmark any default topsite using the star icon inside tile. Shouldn't jump position. Visit some websites and repeat operation. They shouldn't jump positions.
  