### PR TITLE
Properly encode entries when saving bookmarks to a file

### DIFF
--- a/app/browser/bookmarksExporter.js
+++ b/app/browser/bookmarksExporter.js
@@ -44,9 +44,25 @@ const showDialog = (state) => {
     if (fileName) {
       personal = createBookmarkArray(state)
       other = createBookmarkArray(state, -1, false)
-      fs.writeFileSync(fileName, createBookmarkHTML(personal, other))
+      try {
+        fs.writeFileSync(fileName, createBookmarkHTML(personal, other))
+      } catch (e) {
+        console.log('Error exporting bookmarks: ', e)
+      }
     }
   })
+}
+
+const encodeHref = (string) => {
+  return (string || '')
+    .replace(/"/g, '&quot;')
+}
+
+const encodeTitle = (string) => {
+  return (string || '')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
 }
 
 const createBookmarkArray = (state, parentFolderId = 0, first = true, depth = 1) => {
@@ -60,10 +76,12 @@ const createBookmarkArray = (state, parentFolderId = 0, first = true, depth = 1)
 
   for (let site of bookmarks) {
     if (bookmarkUtil.isBookmark(site) && site.get('location')) {
-      title = site.get('title', site.get('location'))
-      payload.push(`${indentNext}<DT><A HREF="${site.get('location')}">${title}</A>`)
+      title = encodeTitle(site.get('title', site.get('location')))
+      const href = encodeHref(site.get('location'))
+      payload.push(`${indentNext}<DT><A HREF="${href}">${title}</A>`)
     } else if (bookmarkFoldersUtil.isFolder(site)) {
-      payload.push(`${indentNext}<DT><H3>${site.get('title')}</H3>`)
+      title = encodeTitle(site.get('title'))
+      payload.push(`${indentNext}<DT><H3>${title}</H3>`)
       payload = payload.concat(createBookmarkArray(state, site.get('folderId'), true, (depth + 1)))
     }
   }

--- a/test/fixtures/bookmarkExport.html
+++ b/test/fixtures/bookmarkExport.html
@@ -17,10 +17,10 @@
       </DL><p>
       <DT><H3>folder 3</H3>
       <DL><p>
-        <DT><A HREF="https://brave.com/5">Website 5</A>
+        <DT><A HREF="https://brave.com/5">Title &lt;/A&gt; with &quot;characters&quot; in it</A>
       </DL><p>
     </DL><p>
-    <DT><A HREF="https://brave.com/6">Website 6</A>
+    <DT><A HREF="javascript:(function(){var x,n,nD,z,i; function htmlEscape(s){s=s.replace(/&/g,'&amp;');s=s.replace(/>/g,'&gt;');s=s.replace(/</g,'&lt;');return s;} function attrQuoteEscape(s){s=s.replace(/&/g,'&amp;'); s=s.replace(/&quot;/g, '&quot;');return s;} x=prompt(&quot;show links with this word/phrase in link text or target url (leave blank to list all links):&quot;, &quot;&quot;); n=0; if(x!=null) { x=x.toLowerCase(); nD = window.open().document; nD.writeln('<html><head><title>Links containing &quot;'+htmlEscape(x)+'&quot;</title><base target=&quot;_blank&quot;></head><body>'); nD.writeln('Links on <a href=&quot;'+attrQuoteEscape(location.href)+'&quot;>'+htmlEscape(location.href)+'</a><br> with link text or target url containing &quot;' + htmlEscape(x) + '&quot;<br><hr>'); z = document.links; for (i = 0; i < z.length; ++i) { if ((z[i].innerHTML && z[i].innerHTML.toLowerCase().indexOf(x) != -1) || z[i].href.toLowerCase().indexOf(x) != -1 ) { nD.writeln(++n + '. <a href=&quot;' + attrQuoteEscape(z[i].href) + '&quot;>' + (z[i].innerHTML || htmlEscape(z[i].href)) + '</a><br>'); } } nD.writeln('<hr></body></html>'); nD.close(); } })();">Bookmarklet example</A>
     <DT><H3>folder 4</H3>
     <DL><p>
     </DL><p>

--- a/test/unit/app/browser/exportBookmarksTest.js
+++ b/test/unit/app/browser/exportBookmarksTest.js
@@ -74,15 +74,15 @@ describe('Bookmarks export', function () {
         type: siteTags.BOOKMARK
       },
       'https://brave.com/5|0|3': {
-        title: 'Website 5',
+        title: 'Title </A> with "characters" in it',
         location: 'https://brave.com/5',
         parentFolderId: 3,
         key: 'https://brave.com/5|0|3',
         type: siteTags.BOOKMARK
       },
       'https://brave.com/6|0|0': {
-        title: 'Website 6',
-        location: 'https://brave.com/6',
+        title: 'Bookmarklet example',
+        location: 'javascript:(function(){var x,n,nD,z,i; function htmlEscape(s){s=s.replace(/&/g,\'&amp;\');s=s.replace(/>/g,\'&gt;\');s=s.replace(/</g,\'&lt;\');return s;} function attrQuoteEscape(s){s=s.replace(/&/g,\'&amp;\'); s=s.replace(/"/g, \'&quot;\');return s;} x=prompt("show links with this word/phrase in link text or target url (leave blank to list all links):", ""); n=0; if(x!=null) { x=x.toLowerCase(); nD = window.open().document; nD.writeln(\'<html><head><title>Links containing "\'+htmlEscape(x)+\'"</title><base target="_blank"></head><body>\'); nD.writeln(\'Links on <a href="\'+attrQuoteEscape(location.href)+\'">\'+htmlEscape(location.href)+\'</a><br> with link text or target url containing &quot;\' + htmlEscape(x) + \'&quot;<br><hr>\'); z = document.links; for (i = 0; i < z.length; ++i) { if ((z[i].innerHTML && z[i].innerHTML.toLowerCase().indexOf(x) != -1) || z[i].href.toLowerCase().indexOf(x) != -1 ) { nD.writeln(++n + \'. <a href="\' + attrQuoteEscape(z[i].href) + \'">\' + (z[i].innerHTML || htmlEscape(z[i].href)) + \'</a><br>\'); } } nD.writeln(\'<hr></body></html>\'); nD.close(); } })();',
         parentFolderId: 0,
         key: 'https://brave.com/6|0|0',
         type: siteTags.BOOKMARK
@@ -163,10 +163,10 @@ describe('Bookmarks export', function () {
     '      </DL><p>',
     '      <DT><H3>folder 3</H3>',
     '      <DL><p>',
-    '        <DT><A HREF="https://brave.com/5">Website 5</A>',
+    '        <DT><A HREF="https://brave.com/5">Title &lt;/A&gt; with &quot;characters&quot; in it</A>',
     '      </DL><p>',
     '    </DL><p>',
-    '    <DT><A HREF="https://brave.com/6">Website 6</A>',
+    '    <DT><A HREF="javascript:(function(){var x,n,nD,z,i; function htmlEscape(s){s=s.replace(/&/g,\'&amp;\');s=s.replace(/>/g,\'&gt;\');s=s.replace(/</g,\'&lt;\');return s;} function attrQuoteEscape(s){s=s.replace(/&/g,\'&amp;\'); s=s.replace(/&quot;/g, \'&quot;\');return s;} x=prompt(&quot;show links with this word/phrase in link text or target url (leave blank to list all links):&quot;, &quot;&quot;); n=0; if(x!=null) { x=x.toLowerCase(); nD = window.open().document; nD.writeln(\'<html><head><title>Links containing &quot;\'+htmlEscape(x)+\'&quot;</title><base target=&quot;_blank&quot;></head><body>\'); nD.writeln(\'Links on <a href=&quot;\'+attrQuoteEscape(location.href)+\'&quot;>\'+htmlEscape(location.href)+\'</a><br> with link text or target url containing &quot;\' + htmlEscape(x) + \'&quot;<br><hr>\'); z = document.links; for (i = 0; i < z.length; ++i) { if ((z[i].innerHTML && z[i].innerHTML.toLowerCase().indexOf(x) != -1) || z[i].href.toLowerCase().indexOf(x) != -1 ) { nD.writeln(++n + \'. <a href=&quot;\' + attrQuoteEscape(z[i].href) + \'&quot;>\' + (z[i].innerHTML || htmlEscape(z[i].href)) + \'</a><br>\'); } } nD.writeln(\'<hr></body></html>\'); nD.close(); } })();">Bookmarklet example</A>',
     '    <DT><H3>folder 4</H3>',
     '    <DL><p>',
     '    </DL><p>',
@@ -185,25 +185,29 @@ describe('Bookmarks export', function () {
     '    </DL><p>'
   ]
 
-  it('personal array', function () {
-    const gen = exporter.createBookmarkArray(state)
-    assert.deepEqual(gen, personalArray)
+  describe('createBookmarkArray', function () {
+    it('serializes the regular bookmarks', function () {
+      const gen = exporter.createBookmarkArray(state)
+      assert.deepEqual(gen, personalArray)
+    })
+
+    it('serializes the "other" bookmarks', function () {
+      const gen = exporter.createBookmarkArray(state, -1, false)
+      assert.deepEqual(gen, otherArray)
+    })
   })
 
-  it('other array', function () {
-    const gen = exporter.createBookmarkArray(state, -1, false)
-    assert.deepEqual(gen, otherArray)
-  })
+  describe('createBookmarkHTML', function () {
+    it('generates an HTML response', function () {
+      const personal = exporter.createBookmarkArray(state)
+      const other = exporter.createBookmarkArray(state, -1, false)
+      let result = exporter.createBookmarkHTML(personal, other)
+      let expected = fs.readFileSync('./test/fixtures/bookmarkExport.html', 'utf8')
 
-  it('generated html', function () {
-    const personal = exporter.createBookmarkArray(state)
-    const other = exporter.createBookmarkArray(state, -1, false)
-    let result = exporter.createBookmarkHTML(personal, other)
-    let expected = fs.readFileSync('./test/fixtures/bookmarkExport.html', 'utf8')
+      result = result.replace(/\s+/g, ' ').trim()
+      expected = expected.replace(/\s+/g, ' ').trim()
 
-    result = result.replace(/\s+/g, ' ')
-    expected = expected.replace(/\s+/g, ' ')
-
-    assert.equal(result, expected)
+      assert.equal(result, expected)
+    })
   })
 })


### PR DESCRIPTION
Also adds try/catch around export (including logging for exception)

Should fix https://github.com/brave/browser-laptop/issues/10587

Auditors: @NejcZdovc, @darkdh 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. New profile
2. Bookmark a site; edit the title, change it to "<test>"
3. Export bookmarks
4. Confirm export works and that file was saved
5. For extra confidence, import bookmark file into another browser

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


