### PR TITLE
Adding site to temporary allow callback only when no notification interaction

### DIFF
--- a/app/browser/reducers/autoplayReducer.js
+++ b/app/browser/reducers/autoplayReducer.js
@@ -85,9 +85,9 @@ const hideAutoplayMessageBox = (tabId) => {
   if (notificationCallbacks[tabId]) {
     ipcMain.removeListener(messages.NOTIFICATION_RESPONSE, notificationCallbacks[tabId])
     delete notificationCallbacks[tabId]
+    temporaryAllowPlays[tabId] = origin
+    appActions.changeSiteSetting(origin, 'autoplay', true)
   }
-  temporaryAllowPlays[tabId] = origin
-  appActions.changeSiteSetting(origin, 'autoplay', true)
 }
 
 const removeTemporaryAllowPlays = (tabId) => {


### PR DESCRIPTION
fix #12482

Auditors: @bsclifton

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Manual Test A
a.1 Set global autoplay to `Always Ask`
a.2 Make sure there is no rules for youtube.com
a.3 Watch any youtube video
a.4 There should be a popup asking for permission then click remember
and allow
a.5 Close the tab
a.6 There should be always allow for youtube in
about:preferences#security

2. Manual Test B
b.1 Set global autoplay to `Always Ask`
b.2 Make sure there is no rules for youtube.com
b.3 Watch any youtube video
b.4 There should be a popup asking for permission then do not click
anything
b.5 Click play button on youtube
b.6 There should be always allow for youtube in
about:preferences#security
b.7 Close the tab
b.8 There shouldn't be any rules for youtube.com

3. Unit test

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header



  
  