### PR TITLE
ReduxComponent can accept any function for mergeProps

### DIFF
--- a/app/renderer/components/reduxComponent.js
+++ b/app/renderer/components/reduxComponent.js
@@ -8,8 +8,8 @@ const mergePropsImpl = (stateProps, ownProps) => {
   return Object.assign({}, stateProps, ownProps)
 }
 
-const buildPropsImpl = (props, componentType) => {
-  const fn = componentType.prototype.mergeProps || mergePropsImpl
+const buildPropsImpl = (props, componentType, mergeStateToProps) => {
+  const fn = mergeStateToProps || mergePropsImpl
   const state = appStore.state.set('currentWindow', windowStore.state)
   return fn(state, props)
 }
@@ -40,9 +40,10 @@ const didPropsChange = function (oldProps, newProps) {
 }
 
 class ReduxComponent extends ImmutableComponent {
-  constructor (componentType, props) {
+  constructor (componentType, mergeStateToProps, props) {
     super(props)
     this.componentType = componentType
+    this.mergeStateToProps = mergeStateToProps
     this.state = this.buildProps(this.props)
     this.checkForUpdates = this.checkForUpdates.bind(this)
     this.dontCheck = true
@@ -85,7 +86,7 @@ class ReduxComponent extends ImmutableComponent {
   }
 
   buildProps (props = this.props) {
-    return buildPropsImpl(props, this.componentType)
+    return buildPropsImpl(props, this.componentType, this.mergeStateToProps)
   }
 
   render () {
@@ -93,6 +94,6 @@ class ReduxComponent extends ImmutableComponent {
   }
 }
 
-module.exports.connect = (componentType) => {
-  return ReduxComponent.bind(null, componentType)
+module.exports.connect = (componentType, mergeStateToProps = componentType.prototype.mergeProps) => {
+  return ReduxComponent.bind(null, componentType, mergeStateToProps)
 }


### PR DESCRIPTION
Defaults to Component.prototype.mergeProps in order to maintain compatibility with all existing components.

This is necessary in order to create a higher-order-component that can be used in multiple places, e.g. in the pending #11720 

Submitter Checklist:


Test Plan:
Existing components still get their props built from state using existing mergeProps functions on Components' prototype


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header



  