### PR TITLE
migrate fingerprinting site settings when fingerprinting has not been toggled globally

### DIFF
--- a/test/unit/app/sessionStoreTest.js
+++ b/test/unit/app/sessionStoreTest.js
@@ -1742,6 +1742,47 @@ describe('sessionStore unit tests', function () {
   })
 
   describe('runPostMigrations', function () {
-    // TODO:
+    describe('when `fingerprintingProtectionAll` is set', function () {
+      it('does not modify anything', function () {
+        let exampleState = Immutable.fromJS(sessionStore.defaultAppState())
+        exampleState = exampleState.set('fingerprintingProtectionAll', {enabled: false})
+        const returnedAppState = sessionStore.runPostMigrations(exampleState)
+        assert.equal(returnedAppState, exampleState)
+      })
+    })
+
+    describe('when `fingerprintingProtectionAll` is not set', function () {
+      describe('when `fingerprintingProtection` is `true` for a site', function () {
+        it('updates to a text status of `blockAllFingerprinting`', function () {
+          let exampleState = Immutable.fromJS(sessionStore.defaultAppState())
+          exampleState = exampleState.setIn(['siteSettings', 'example.com', 'fingerprintingProtection'], true)
+          const returnedAppState = sessionStore.runPostMigrations(exampleState)
+          assert.equal(returnedAppState.getIn(['siteSettings', 'example.com', 'fingerprintingProtection']), 'blockAllFingerprinting')
+        })
+      })
+
+      describe('when `fingerprintingProtection` is `false` for a site', function () {
+        it('updates to a text status of `allowAllFingerprinting`', function () {
+          let exampleState = Immutable.fromJS(sessionStore.defaultAppState())
+          exampleState = exampleState.setIn(['siteSettings', 'example.com', 'fingerprintingProtection'], false)
+          const returnedAppState = sessionStore.runPostMigrations(exampleState)
+          assert.equal(returnedAppState.getIn(['siteSettings', 'example.com', 'fingerprintingProtection']), 'allowAllFingerprinting')
+        })
+      })
+
+      it('sets a new global fingerprinting value (based on existing value truthy-ness)', function () {
+        let exampleState = Immutable.fromJS(sessionStore.defaultAppState())
+        exampleState = exampleState.setIn(['settings', 'privacy.block-canvas-fingerprinting'], 'EXAMPLE TRUTHY VALUE')
+        const returnedAppState = sessionStore.runPostMigrations(exampleState)
+        assert.equal(returnedAppState.getIn(['fingerprintingProtectionAll', 'enabled']), true)
+      })
+
+      it('deletes the old global fingerprinting value', function () {
+        let exampleState = Immutable.fromJS(sessionStore.defaultAppState())
+        exampleState = exampleState.setIn(['settings', 'privacy.block-canvas-fingerprinting'], true)
+        const returnedAppState = sessionStore.runPostMigrations(exampleState)
+        assert.equal(returnedAppState.getIn(['siteSettings', 'privacy.block-canvas-fingerprinting']), undefined)
+      })
+    })
   })
 })


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/12497 by doing the site settings migration even when fingerprinting protection's global setting has not been changed.

Test Plan:
1. in a fresh 0.19.x profile, go to any website and enable fingerprinting protection on it
2. now update to 0.20.x or later
3. re-open brave and go to the website from step 1
4. open page shields. it should say 'block all fingerprinting'.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


