### PR TITLE
newtab.less: fix whitespace after image overflow

### DIFF
--- a/less/about/newtab.less
+++ b/less/about/newtab.less
@@ -67,6 +67,7 @@ ul {
     width: 100%;
     height: 100%;
     object-fit: cover;
+    display: block;
     opacity: 0;
     transition: opacity .5s ease-in-out;
   }


### PR DESCRIPTION
This is quite a simple one line fix for the new tab page.
Because the image is per default set to `display: inline;` the white space after the image gets rendered and creates an ugly scrollbar (at least on windows). I fix this by making the image `display: block;`.
This is of course just one way to do this, we could also set the image to have a `float: left;` or use flexbox or grid.

Before:
![2018-01-05 09_19_23-developer tools - chrome-extension___mnojpmjdmbbfmejpflffifhffcmidifd_about-newt](https://user-images.githubusercontent.com/12650063/34600916-19562068-f1fa-11e7-8ddd-67fedb21b812.png)

After:
![2018-01-05 09_20_23-developer tools - chrome-extension___mnojpmjdmbbfmejpflffifhffcmidifd_about-newt](https://user-images.githubusercontent.com/12650063/34600926-1fd92b60-f1fa-11e7-940a-a125a7c54c53.png)

TBH I just found the submitter checklist while I was creating the pull request.
I didn't find any similar issues and can create one if needed.
Tests and Security stuff aren't really needed since this is a CSS change.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


