### PR TITLE
Treat contribution amount as a decimal (instead of an integer)

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -1596,7 +1596,7 @@ const setPaymentInfo = (amount) => {
     }, 2 * ledgerUtil.milliseconds.second)
   }
 
-  amount = parseInt(amount, 10)
+  amount = parseFloat(amount)
   if (isNaN(amount) || (amount <= 0)) return
 
   let currency = 'USD'
@@ -1800,7 +1800,7 @@ const initialize = (state, paymentsEnabled) => {
 }
 
 const getContributionAmount = () => {
-  let amount = parseInt(getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT), 10)
+  let amount = parseFloat(getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT))
 
   // if amount is 5, 15, or 20... the amount wasn't updated when changing
   // from BTC to BAT (see https://github.com/brave/browser-laptop/issues/11719)


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/12533

Auditors: @kjozwiak, @NejcZdovc

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Fresh profile; launch with LEDGER_ENVIRONMENT=staging
2. Enable payments and pick a contribution amount ending in .5 (such as 17.5)
3. Exit Brave
4. View the `ledger-state.json` and confirm the contribution amount is saved as `17.5`
5. Launch Brave again using LEDGER_ENVIRONMENT=staging, visit sites until they show in payments tab
6. Fund wallet with slightly more than the requested amount (ex: 20)
7. Exit Brave
8. Open the `ledger-state.json` and manually update the `reconcileStamp` to be in the past. Using a site like https://www.freeformatter.com/epoch-timestamp-to-date-converter.html is handy
9. Launch with LEDGER_VERBOSE=true LEDGER_NO_DELAY=true LEDGER_NO_FUZZING=true LEDGER_ENVIRONMENT=staging and wait until a reconcile happens
10. Verify funds left are correct (ex: 2.50)


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


