### PR TITLE
Check nullity of webcontents and empty url from getURL()

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -863,11 +863,15 @@ module.exports.getMainFrameUrl = (details) => {
   if (details.resourceType === 'mainFrame') {
     return details.url
   }
+  let url = null
   const tab = webContents.fromTabID(details.tabId)
-  try {
-    return tab.getURL()
-  } catch (ex) {}
-  return details.firstPartyUrl || null
+  if (tab && !tab.isDestroyed()) {
+    url = tab.getURL()
+  }
+  if (!url && details.firstPartyUrl) {
+    url = details.firstPartyUrl
+  }
+  return url
 }
 
 module.exports.alwaysAllowFullscreen = () => {


### PR DESCRIPTION
https://github.com/brave/browser-laptop/issues/12508 is caused by empty
url which will leads to sending {cancel: true} to callback of
`session.webRequest.onBeforeRequest` and download process will be
aborted.
Also verified this won't break the issues which
https://github.com/brave/browser-laptop/pull/12256 fixes

fix #12508

Auditors: @bridiver, @diracdeltas, @bsclifton

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


