### PR TITLE
Fix tabs briefly animating too wide after finishing closing some tabs

### DIFF
--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -295,29 +295,6 @@ class Tab extends React.Component {
     return props
   }
 
-  componentWillReceiveProps (nextProps) {
-    if (this.props.tabWidth && !nextProps.tabWidth) {
-      // remember the width so we can transition from it
-      this.originalWidth = this.elementRef.getBoundingClientRect().width
-    }
-  }
-
-  componentDidUpdate (prevProps) {
-    if (prevProps.tabWidth && !this.props.tabWidth) {
-      window.requestAnimationFrame(() => {
-        const newWidth = this.elementRef.getBoundingClientRect().width
-        this.elementRef.animate([
-          { flexBasis: `${this.originalWidth}px`, flexGrow: 0, flexShrink: 0 },
-          { flexBasis: `${newWidth}px`, flexGrow: 0, flexShrink: 0 }
-        ], {
-          duration: 250,
-          iterations: 1,
-          easing: 'ease-in-out'
-        })
-      })
-    }
-  }
-
   render () {
     // we don't want themeColor if tab is private
     const isThemed = !this.props.isPrivateTab && this.props.isActive && this.props.themeColor
@@ -334,16 +311,17 @@ class Tab extends React.Component {
         (this.isDraggingOverRight && !this.isDraggingOverSelf) && styles.tabArea_dragging_right,
         this.isDragging && styles.tabArea_isDragging,
         this.props.isPinnedTab && styles.tabArea_isPinned,
-        (this.props.partOfFullPageSet || !!this.props.tabWidth) && styles.tabArea_partOfFullPageSet
+        (this.props.partOfFullPageSet || !!this.props.tabWidth) && styles.tabArea_partOfFullPageSet,
+        this.props.tabWidth && styles.tabArea_forcedWidth
       )}
-      style={this.props.tabWidth ? { flex: `0 0 ${this.props.tabWidth}px` } : {}}
       onMouseMove={this.onMouseMove}
       onMouseEnter={this.onMouseEnter}
       onMouseLeave={this.onMouseLeave}
       data-test-id='tab-area'
       data-frame-key={this.props.frameKey}
       ref={elementRef => { this.elementRef = elementRef }}
-      >
+      style={this.props.tabWidth ? { '--tab-forced-width': `${this.props.tabWidth}px` } : { }}
+    >
       {
         this.props.isActive && this.props.notificationBarActive
           ? <NotificationBarCaret />
@@ -414,8 +392,8 @@ const styles = StyleSheet.create({
     verticalAlign: 'top',
     overflow: 'hidden',
     height: '-webkit-fill-available',
-    flex: 1,
-
+    flex: '1 1 0',
+    transition: 'flex .45s ease',
     // no-drag is applied to the button and tab area
     // ref: tabs__tabStrip__newTabButton on tabs.js
     WebkitAppRegion: 'no-drag',
@@ -445,6 +423,11 @@ const styles = StyleSheet.create({
 
   tabArea_partOfFullPageSet: {
     maxWidth: 'initial'
+  },
+
+  tabArea_forcedWidth: {
+    flex: '0 0 var(--tab-forced-width)',
+    transitionDuration: '0s'
   },
 
   tabArea__tab: {


### PR DESCRIPTION
Fix #12566

Since each tab's 'fixed width' was being removed at the same time, each one was measuring the width whilst other tab(s) were / were not reset eback to a fluid width, causing measurements to be off.
Flex supports transitions / animations by default, so we do not need to measure the element ourselves in this case, anyway.
Bonus for being able to move from in-component animation to purely defined in styles.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


