### PR TITLE
disable sharedArrayBuffer and add tests for API blocking

### DIFF
--- a/app/extensions/brave/content/scripts/navigator.js
+++ b/app/extensions/brave/content/scripts/navigator.js
@@ -19,3 +19,6 @@ if (chrome.contentSettings.doNotTrack == 'allow') {
 if (chrome.contentSettings.ads == 'block') {
   chrome.webFrame.setGlobal("window.google_onload_fired", true)
 }
+
+// Spectre hotfix (https://github.com/brave/browser-laptop/issues/12570)
+chrome.webFrame.setGlobal('window.SharedArrayBuffer', false)

--- a/test/contents/contentLoadingTest.js
+++ b/test/contents/contentLoadingTest.js
@@ -33,4 +33,22 @@ describe('content loading', function () {
       .windowByUrl(Brave.browserWindowUrl)
       .waitForTextValue('[data-test-id="tabTitle"]', 'fail')
   })
+
+  it('does not support credentials API', function * () {
+    const page1 = Brave.fixtureUrl('credentials.html')
+    yield this.app.client
+      .tabByIndex(0)
+      .url(page1)
+      .windowByUrl(Brave.browserWindowUrl)
+      .waitForTextValue('[data-test-id="tabTitle"]', 'fail')
+  })
+
+  it('does not support sharedarraybuffer API', function * () {
+    const page1 = Brave.fixtureUrl('sharedArrayBuffer.html')
+    yield this.app.client
+      .tabByIndex(0)
+      .url(page1)
+      .windowByUrl(Brave.browserWindowUrl)
+      .waitForTextValue('[data-test-id="tabTitle"]', 'fail')
+  })
 })

--- a/test/fixtures/credentials.html
+++ b/test/fixtures/credentials.html
@@ -1,0 +1,20 @@
+<script>
+if ('credentials' in navigator) {
+  var c = new PasswordCredential({
+    id: 'id',
+    password: 'password',
+    name: 'name'
+  });
+  navigator.credentials.store(c).then(() => {
+    navigator.credentials.get({password: true}).then((cred) => {
+      if (cred) {
+        document.title = 'success'
+      } else {
+        document.title = 'fail'
+      }
+    })
+  })
+} else {
+  document.title = 'fail'
+};
+</script>

--- a/test/fixtures/sharedArrayBuffer.html
+++ b/test/fixtures/sharedArrayBuffer.html
@@ -1,0 +1,7 @@
+<script>
+  if (window.SharedArrayBuffer) {
+    document.title = 'success'
+  } else {
+    document.title = 'fail'
+  }
+</script>


### PR DESCRIPTION
Fix https://github.com/brave/browser-laptop/issues/12570. Note that @jumde is working on a block for `sharedArrayBuffer` in muon, which is a better solution long-term, but this PR still adds some useful tests.

Test Plan:
1. Enable 'Strict Site Isolation' in about:preferences#security, then restart
2. Go to http://xlab.tencent.com/special/spectre/spectre_check.html
3. Click the button to check your browser. It should report as not vulnerable.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


