### PR TITLE
Only ask Renderer Windows for saved state, on shutdown

### DIFF
--- a/test/unit/app/sessionStoreShutdownTest.js
+++ b/test/unit/app/sessionStoreShutdownTest.js
@@ -139,6 +139,7 @@ describe('sessionStoreShutdown unit tests', function () {
 
   describe('app before-quit event', function () {
     before(function () {
+      this.windowsAPI = require('../../../app/browser/windows')
       this.appStoreGetStateStub = sinon.stub(appStore, 'getState', () => {
         return Immutable.fromJS({})
       })
@@ -160,7 +161,7 @@ describe('sessionStoreShutdown unit tests', function () {
     describe('with no windows', function () {
       before(function () {
         this.requestId = 1
-        this.getAllWindowsStub = sinon.stub(fakeElectron.BrowserWindow, 'getAllWindows', () => {
+        this.getAllWindowsStub = sinon.stub(this.windowsAPI, 'getAllRendererWindows', () => {
           return []
         })
       })
@@ -234,7 +235,7 @@ describe('sessionStoreShutdown unit tests', function () {
       before(function () {
         this.fakeWindow1 = new FakeWindow(1)
         this.requestId = 1
-        this.getAllWindowsStub = sinon.stub(fakeElectron.BrowserWindow, 'getAllWindows', () => {
+        this.getAllWindowsStub = sinon.stub(this.windowsAPI, 'getAllRendererWindows', () => {
           return [this.fakeWindow1]
         })
       })
@@ -286,7 +287,7 @@ describe('sessionStoreShutdown unit tests', function () {
         this.fakeWindow2 = new FakeWindow(2)
         this.fakeWindow3 = new FakeWindow(3)
         this.requestId = 1
-        this.getAllWindowsStub = sinon.stub(fakeElectron.BrowserWindow, 'getAllWindows', () => {
+        this.getAllWindowsStub = sinon.stub(this.windowsAPI, 'getAllRendererWindows', () => {
           return [this.fakeWindow1, this.fakeWindow2, this.fakeWindow3]
         })
       })


### PR DESCRIPTION
Create a new windows API method to retrieve renderer windows.
Avoid circular dependency in sessionStoreShutdown / windows.js by exposing a 'new-window-state' event that the session store can subscribe to in order to set state.

Fix #12488 since state was being asked from all windows, even non-renderer windows, which causes a timeout waiting for a state response.

Should test #12564 with this fix to see if it happens to be addressed by it.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:
STR on #12488 

Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


