### PR TITLE
Correctly converts key from pre-split sites to post-split pinned sites

### DIFF
--- a/app/browser/windows.js
+++ b/app/browser/windows.js
@@ -109,7 +109,8 @@ const updatePinnedTabs = (win, appState) => {
   // sites are instructions of what should be pinned
   // tabs are sites our window already has pinned
   // for each site which should be pinned, find if it's already pinned
-  for (const site of statePinnedSites.values()) {
+  const statePinnedSitesOrdered = statePinnedSites.sort((a, b) => a.get('order') - b.get('order'))
+  for (const site of statePinnedSitesOrdered.values()) {
     const existingPinnedTabIdx = pinnedWindowTabs.findIndex(tab => siteMatchesTab(site, tab))
     if (existingPinnedTabIdx !== -1) {
       // if it's already pinned we don't need to consider the tab in further searches

--- a/app/common/state/pinnedSitesState.js
+++ b/app/common/state/pinnedSitesState.js
@@ -59,6 +59,10 @@ const pinnedSiteState = {
       return state
     }
 
+    if (state.hasIn([STATE_SITES.PINNED_SITES, key])) {
+      return state
+    }
+
     state = state.setIn([STATE_SITES.PINNED_SITES, key], site)
     return state
   },

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -672,12 +672,19 @@ module.exports.runPreMigrations = (data) => {
   if (data.sites) {
     // pinned sites
     data.pinnedSites = {}
-    for (let key of Object.keys(data.sites)) {
-      const site = data.sites[key]
-      if (site.tags && site.tags.includes('pinned')) {
-        delete site.tags
-        data.pinnedSites[key] = site
-      }
+    // get pre-site split pinned sites, in order
+    const sitesToPin = Object.keys(data.sites)
+      .map(key => data.sites[key])
+      .filter(site => site.tags && site.tags.includes('pinned'))
+      .sort((a, b) => a.order - b.order)
+    for (const site of sitesToPin) {
+      // convert to new format (split to its own pinnedSites key)
+      // reset 'order', same as pinnedSitesState
+      const pinnedSite = Object.assign({}, site, { order: Object.keys(data.pinnedSites).length })
+      delete pinnedSite.tags
+      // matches `getKey` from pinnedSitesUtil
+      const pinnedSiteKey = `${site.location}|${site.partitionNumber}`
+      data.pinnedSites[pinnedSiteKey] = pinnedSite
     }
 
     // default sites

--- a/test/unit/app/sessionStoreTest.js
+++ b/test/unit/app/sessionStoreTest.js
@@ -1540,14 +1540,14 @@ describe('sessionStore unit tests', function () {
 
           before(function () {
             oldValue = data.getIn(['sites', 'https://pinned-tab.com|0|0'])
-            newValue = runPreMigrations.pinnedSites['https://pinned-tab.com|0|0']
+            newValue = runPreMigrations.pinnedSites['https://pinned-tab.com|0']
           })
 
           it('copies lastAccessedTime', function () {
             assert.equal(oldValue.get('lastAccessedTime'), newValue.lastAccessedTime)
           })
-          it('copies order', function () {
-            assert.equal(oldValue.get('order'), newValue.order)
+          it('resets order', function () {
+            assert.equal(newValue.order, 0)
           })
           it('copies partitionNumber', function () {
             assert.equal(oldValue.get('partitionNumber'), newValue.partitionNumber)


### PR DESCRIPTION
Fix #12580
Prevents duplicated pinned sites
Migration was attempting to insert pinned site with key format [location]|[partition]|0 when expected format is [location]|[partition]
Also ensures pinned site order stays consistent across migrations, windows, and app starts

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:
STR on #12580 

Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


