### PR TITLE
Update the way default contribution amount is handled.

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -1547,6 +1547,19 @@ const getPaymentInfo = (state) => {
   return state
 }
 
+const lockInContributionAmount = (balance) => {
+  // Lock in contribution amount if amount hasn't been chosen and balance is non-zero
+  // (ex: they receive a grant or fund the wallet)
+  // Amount is only set when user explicitly picks a contribution amount
+  if (balance > 0) {
+    const value = getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT, undefined, false)
+    if (value === null) {
+      const defaultFromConfig = getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT)
+      appActions.changeSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT, defaultFromConfig)
+    }
+  }
+}
+
 const onWalletProperties = (state, body) => {
   if (body == null) {
     return state
@@ -1562,6 +1575,7 @@ const onWalletProperties = (state, body) => {
   const balance = parseFloat(body.get('balance'))
   if (balance >= 0) {
     state = ledgerState.setInfoProp(state, 'balance', balance)
+    lockInContributionAmount()
   }
 
   // Rates
@@ -2631,7 +2645,8 @@ const getMethods = () => {
       roundtrip,
       observeTransactions,
       onWalletRecovery,
-      getStateInfo
+      getStateInfo,
+      lockInContributionAmount
     }
   }
 

--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -1575,7 +1575,7 @@ const onWalletProperties = (state, body) => {
   const balance = parseFloat(body.get('balance'))
   if (balance >= 0) {
     state = ledgerState.setInfoProp(state, 'balance', balance)
-    lockInContributionAmount()
+    lockInContributionAmount(balance)
   }
 
   // Rates

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -101,7 +101,8 @@ module.exports = {
     url: adHost
   },
   payments: {
-    delayNotificationTryPayments: 1000 * 60 * 60 * 24 * 10 // 10 days (from firstRunTimestamp)
+    delayNotificationTryPayments: 1000 * 60 * 60 * 24 * 10, // 10 days (from firstRunTimestamp)
+    defaultContributionAmount: 5
   },
   updates: {
     // Check for front end updates every hour
@@ -187,7 +188,7 @@ module.exports = {
     // payments
     'payments.allow-media-publishers': true,
     'payments.allow-non-verified-publishers': true,
-    'payments.contribution-amount': 10, // BAT
+    'payments.contribution-amount': null, // BAT
     'payments.enabled': false,
     'payments.minimum-visit-time': 8000,
     'payments.minimum-visits': 1,

--- a/js/settings.js
+++ b/js/settings.js
@@ -38,13 +38,24 @@ const bookmarksBarDefault = (settingKey, settingsCollection) => {
   return bookmarksToolbarMode.TEXT_ONLY
 }
 
-// Retrofit a new setting based on old values; we don't want to lose existing user settings.
+const contributionDefaultAmount = (settingKey, settingsCollection) => {
+  return appConfig.payments.defaultContributionAmount
+}
+
 const getDefaultSetting = (settingKey, settingsCollection) => {
+  // Two use cases for this:
   switch (settingKey) {
+    // 1) Retrofit a new setting based on old values
+    // we don't want to lose existing user settings.
     case settings.ACTIVE_PASSWORD_MANAGER:
       return passwordManagerDefault(settingKey, settingsCollection)
     case settings.BOOKMARKS_TOOLBAR_MODE:
       return bookmarksBarDefault(settingKey, settingsCollection)
+
+    // 2) Get a default value when no value is set
+    // allows for default to change until user locks it in
+    case settings.PAYMENTS_CONTRIBUTION_AMOUNT:
+      return contributionDefaultAmount(settingKey, settingsCollection)
   }
   return undefined
 }
@@ -64,10 +75,12 @@ const resolveValue = (settingKey, settingsCollection) => {
   return appSettings.get(settingKey) !== undefined ? appSettings.get(settingKey) : appConfig.defaultSettings[settingKey]
 }
 
-module.exports.getSetting = (settingKey, settingsCollection) => {
+module.exports.getSetting = (settingKey, settingsCollection, defaultWhenNull = true) => {
   const setting = resolveValue(settingKey, settingsCollection)
   if (typeof setting !== 'undefined' && setting !== null) return setting
-  return getDefaultSetting(settingKey, settingsCollection)
+  return defaultWhenNull
+    ? getDefaultSetting(settingKey, settingsCollection)
+    : setting
 }
 
 module.exports.getActivePasswordManager = (settingsCollection) => {

--- a/test/unit/settingsTest.js
+++ b/test/unit/settingsTest.js
@@ -56,7 +56,7 @@ describe('settings unit test', function () {
       assert.equal(response, nonDefaultValue)
     })
 
-    describe('when setting default value for new config entries (based on previous session data)', function () {
+    describe('when setting default value for null/empty config entries (based on previous session data)', function () {
       describe('ACTIVE_PASSWORD_MANAGER', function () {
         it('returns `1Password` if ONE_PASSWORD_ENABLED was true', function () {
           settingsCollection[settingsConst.ONE_PASSWORD_ENABLED] = true
@@ -132,6 +132,29 @@ describe('settings unit test', function () {
           const response = settings.getSetting(settingsConst.BOOKMARKS_TOOLBAR_MODE, settingsCollection)
           assert.equal(response, bookmarksToolbarMode.TEXT_ONLY)
         })
+      })
+
+      describe('settings.PAYMENTS_CONTRIBUTION_AMOUNT', function () {
+        it('defaults to payments.defaultContributionAmount when null', function () {
+          settingsCollection[settingsConst.PAYMENTS_CONTRIBUTION_AMOUNT] = null
+          const response = settings.getSetting(settingsConst.PAYMENTS_CONTRIBUTION_AMOUNT, settingsCollection)
+          assert.equal(response, appConfig.payments.defaultContributionAmount)
+        })
+
+        it('does not modify value once set', function () {
+          const exampleAmount = 10
+          settingsCollection[settingsConst.PAYMENTS_CONTRIBUTION_AMOUNT] = exampleAmount
+          const response = settings.getSetting(settingsConst.PAYMENTS_CONTRIBUTION_AMOUNT, settingsCollection)
+          assert.equal(response, exampleAmount)
+        })
+      })
+    })
+
+    describe('when not setting default value for null/empty config entries', function () {
+      it('returns raw value when `defaultWhenNull` is false', function () {
+        settingsCollection[settingsConst.PAYMENTS_CONTRIBUTION_AMOUNT] = null
+        const response = settings.getSetting(settingsConst.PAYMENTS_CONTRIBUTION_AMOUNT, settingsCollection, false)
+        assert.equal(response, null)
       })
     })
   })


### PR DESCRIPTION
Instead of having a set value, the current value is read from a config.
Value is then locked in once a user chooses a value OR has a non-zero balance (ex: either a grant or adding funds)

Fixes https://github.com/brave/browser-laptop/issues/12573

Auditors: @mrose17

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
See https://github.com/brave/browser-laptop/issues/12573

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


