### PR TITLE
Add warning about the privacy risks of torrenting

### DIFF
--- a/app/extensions/torrent/locales/en-US/app.properties
+++ b/app/extensions/torrent/locales/en-US/app.properties
@@ -1,9 +1,10 @@
-startPrompt=Start Downloading "{{name}}"?
-startPromptUntitled=Start Downloading?
-startDownload=Start Download
+startPrompt=Start Torrenting "{{name}}"?
+startPromptUntitled=Start Torrenting?
+startDownload=Start Torrent
 saveTorrentFile=Save Torrent File...
-legalNotice=When you start a torrent, its data will be made available to others by means of upload. You are responsible for abiding by your local laws.
-missingFilesList=Click "Start Download" to load the torrent file list.
+privacyNoticeTitle=Privacy Warning: 
+privacyNotice=When you click "Start Torrent", Brave will download pieces of the torrent file from other users and upload pieces to them in turn. This will share the fact that you're downloading this file: other people will know what you're downloading, and they may also have access to your public IP address.
+missingFilesList=Click "Start Torrent" to load the torrent file list.
 loadingFilesList=Loading the torrent file list...
 name=Name
 size=Size

--- a/js/webtorrent/components/torrentViewer.js
+++ b/js/webtorrent/components/torrentViewer.js
@@ -28,7 +28,7 @@ class TorrentViewer extends React.Component {
       dispatch
     } = this.props
 
-    let titleElem, mainButton, saveButton, legalNotice
+    let titleElem, mainButton, saveButton, privacyNotice
 
     if (torrent) {
       if (name) {
@@ -47,9 +47,9 @@ class TorrentViewer extends React.Component {
           onClick={() => dispatch('stop')}
         />
       )
-      legalNotice = (
+      privacyNotice = (
         <a className={cx({
-          legalNotice: true,
+          footerText: true,
           [css(commonStyles.userSelectNone)]: true
         })}
           data-l10n-id='poweredByWebTorrent'
@@ -73,10 +73,17 @@ class TorrentViewer extends React.Component {
           onClick={() => dispatch('start')}
         />
       )
-      legalNotice = <div className={cx({
-        legalNotice: true,
-        [css(commonStyles.userSelectNone)]: true
-      })} data-l10n-id='legalNotice' />
+      privacyNotice = <div className={
+        cx({
+          privacyNotice: true,
+          [css(commonStyles.userSelectNone)]: true
+        })
+      }>
+        <span className={cx({
+          boldFooterText: true,
+        })} data-l10n-id='privacyNoticeTitle' />
+        <span  data-l10n-id='privacyNotice' />
+      </div>
     }
 
     if (torrentIdProtocol === 'magnet:') {
@@ -120,7 +127,7 @@ class TorrentViewer extends React.Component {
             stateOwner={this}
           />
 
-          {legalNotice}
+          {privacyNotice}
         </div>
       </div>
     )

--- a/less/webtorrent.less
+++ b/less/webtorrent.less
@@ -58,13 +58,22 @@
   color: red;
 }
 
-.legalNotice {
-  font-size: 9pt;
+.privacyNotice {
   margin-top: 15px;
-  color: @gray;
+  margin-right: 15px;
+  font-size: 12pt;
   text-decoration: none; // for when legal notice is a link
 }
 
+.boldFooterText {
+  font-weight: bold;
+}
+
+.footerText {
+  font-size: 9pt;
+  margin-top: 15px;
+  color: @gray;
+}
 
 .content {
   margin-top: 20px;


### PR DESCRIPTION
Fix https://github.com/brave/browser-laptop/issues/12631

Old page:
![screen shot 2018-01-12 at 11 26 03 pm](https://user-images.githubusercontent.com/549654/34900499-8c8a893a-f7f8-11e7-896b-4a933d1b3968.png)

New page:
![screen shot 2018-01-13 at 12 22 46 am](https://user-images.githubusercontent.com/549654/34900505-973349a8-f7f8-11e7-95bb-7763c24d015f.png)


Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


