### PR TITLE
 filter ignored top sites immediately after user interaction

### DIFF
--- a/app/browser/api/topSites.js
+++ b/app/browser/api/topSites.js
@@ -28,10 +28,6 @@ const isPinned = (state, siteKey) => {
   })
 }
 
-const isIgnored = (state, siteKey) => {
-  return aboutNewTabState.getIgnoredTopSites(state).includes(siteKey)
-}
-
 const sortCountDescending = (left, right) => {
   const leftCount = left.get('count', 0)
   const rightCount = right.get('count', 0)
@@ -89,7 +85,6 @@ const getTopSiteData = () => {
   let sites = historyState.getSites(state)
     .filter((site, key) => !isSourceAboutUrl(site.get('location')) &&
       !isPinned(state, key) &&
-      !isIgnored(state, key) &&
       (minCountOfTopSites === undefined || (site.get('count') || 0) >= minCountOfTopSites) &&
       (minAccessOfTopSites === undefined || (site.get('lastAccessedTime') || 0) >= minAccessOfTopSites)
     )
@@ -123,7 +118,7 @@ const getTopSiteData = () => {
     const preDefined = staticData
       // TODO: this doesn't work properly
       .filter((site) => {
-        return !isPinned(state, site.get('key')) && !isIgnored(state, site.get('key'))
+        return !isPinned(state, site.get('key'))
       })
       .map(site => {
         const bookmarkKey = bookmarkLocationCache.getCacheKey(state, site.get('location'))

--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -201,10 +201,14 @@ class NewTabPage extends React.Component {
   onIgnoredTopSite (siteKey) {
     this.showNotification(siteKey)
 
-    // If a pinnedTopSite is ignored, remove it from the pinned list as well
     const newTabState = {}
+    // If a pinnedTopSite is ignored, remove it from the pinned list as well
     if (this.isPinned(siteKey)) {
-      newTabState.pinnedTopSites = this.pinnedTopSites.filter(site => site.get('key') !== siteKey)
+      const topSites = this.topSites
+      const currentPosition = topSites.find(site => site.get('key') === siteKey)
+      const currentPositionIndex = topSites.indexOf(currentPosition)
+      const pinnedTopSites = this.pinnedTopSites.splice(currentPositionIndex, 1, null)
+      newTabState.pinnedTopSites = pinnedTopSites
     }
 
     newTabState.ignoredTopSites = this.ignoredTopSites.push(siteKey)
@@ -214,7 +218,7 @@ class NewTabPage extends React.Component {
   onUndoIgnoredTopSite () {
     // Remove last List's entry
     const ignoredTopSites = this.ignoredTopSites.pop()
-    aboutActions.setNewTabDetail({ignoredTopSites: ignoredTopSites}, true)
+    aboutActions.setNewTabDetail({ignoredTopSites}, true)
     this.hideSiteRemovalNotification()
   }
 
@@ -295,8 +299,14 @@ class NewTabPage extends React.Component {
           <div className='topSitesContainer'>
             <nav className='topSitesGrid'>
               {
-                gridLayout.map(site =>
-                  <Block
+                gridLayout.map(site => {
+                  // the removal action should be immediate
+                  // which is why the logic is set here in the component
+                  // given that newtab updates can be debounced
+                  if (this.ignoredTopSites.includes(site.get('key'))) {
+                    return
+                  }
+                  return <Block
                     key={site.get('location')}
                     id={site.get('key')}
                     title={site.get('title')}
@@ -314,7 +324,7 @@ class NewTabPage extends React.Component {
                     isPinned={this.isPinned(site.get('key'))}
                     isBookmarked={site.get('bookmarked')}
                   />
-                )
+                })
               }
             </nav>
           </div>

--- a/test/unit/app/browser/api/topSitesTest.js
+++ b/test/unit/app/browser/api/topSitesTest.js
@@ -305,37 +305,6 @@ describe('topSites api', function () {
         assert.equal(newSitesData.size, maxSites)
         assert.equal(newSitesData.getIn([0, 'title']), 'sample ' + this.topSites.aboutNewTabMaxEntries)
       })
-
-      it('does not include items marked as ignored', function () {
-        const ignoredSites = Immutable.List().push('https://example1.com/|0').push('https://example3.com/|0')
-        const stateWithIgnoredSites = defaultAppState
-          .set(STATE_SITES.HISTORY_SITES, generateMap(site1, site2, site3, site4))
-          .setIn(['about', 'newtab', 'ignoredTopSites'], ignoredSites)
-        this.topSites.calculateTopSites(stateWithIgnoredSites)
-        getStateValue = stateWithIgnoredSites
-        this.clock.tick(calculateTopSitesClockTime)
-        assert.equal(this.appActions.topSiteDataAvailable.callCount, 1)
-        const newSitesData = this.appActions.topSiteDataAvailable.getCall(0).args[0]
-        const expectedSites = Immutable.fromJS([
-          {
-            location: 'https://example2.com/',
-            title: 'sample 2',
-            parentFolderId: 0,
-            count: 5,
-            bookmarked: false,
-            key: 'https://example2.com/|0'
-          },
-          {
-            location: 'https://example4.com/',
-            title: 'sample 4',
-            parentFolderId: 0,
-            count: 0,
-            bookmarked: false,
-            key: 'https://example4.com/|0'
-          }
-        ])
-        assert.deepEqual(newSitesData.toJS(), expectedSites.concat(staticNewData).toJS())
-      })
     })
   })
 })


### PR DESCRIPTION
address #12435
fix #10411

## Test plan:

1. Excluding a website should exclude it immediately
2. Excluding a pinned website should exclude it immediately
3. Undo excluding should display the website again (note: it will go back to its original position at the moment it was excluded)
4. Undo excluding of a pinned website should display the website again but **not pinned anymore**
5. Excluding several websites and restoring all of them should restore all of them gracefully