### PR TITLE
Restore disabled dragging and context menu for Bookmarks Bar on Windows

### DIFF
--- a/app/renderer/components/bookmarks/bookmarksToolbar.js
+++ b/app/renderer/components/bookmarks/bookmarksToolbar.js
@@ -178,8 +178,7 @@ class BookmarksToolbar extends React.Component {
     // used in renderer
     props.showOnlyFavicon = bookmarkUtil.showOnlyFavicon()
     props.showFavicon = bookmarkUtil.showFavicon()
-    props.shouldAllowWindowDrag = windowState.shouldAllowWindowDrag(state, currentWindow, activeFrame, isFocused(state)) &&
-      !isWindows
+    props.shouldAllowWindowDrag = !isWindows && windowState.shouldAllowWindowDrag(state, currentWindow, activeFrame, isFocused(state))
     props.visibleBookmarks = bookmarkToolbarState.getToolbar(state, currentWindowId)
     props.hiddenBookmarks = bookmarkToolbarState.getOther(state, currentWindowId)
 
@@ -196,6 +195,7 @@ class BookmarksToolbar extends React.Component {
     return <div className={css(
       styles.bookmarksToolbar,
       this.props.shouldAllowWindowDrag && styles.bookmarksToolbar_allowDragging,
+      !this.props.shouldAllowWindowDrag && styles.bookmarksToolbar_disallowDragging,
       this.props.showOnlyFavicon && styles.bookmarksToolbar_showOnlyFavicon
     )}
       data-test-id='bookmarksToolbar'
@@ -240,6 +240,10 @@ const styles = StyleSheet.create({
 
   bookmarksToolbar_allowDragging: {
     WebkitAppRegion: 'drag'
+  },
+
+  bookmarksToolbar_disallowDragging: {
+    WebkitAppRegion: 'no-drag'
   },
 
   bookmarksToolbar_showOnlyFavicon: {


### PR DESCRIPTION
Previously it was enough to not add 'drag' to the bookmarks bar on Windows, but now that it is added at a higher level in the DOM (so that dragging works in the margin between the bars) via #10512, we have to explicitly set it to 'no-drag' on each child.

Fix #11728

### Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

### Test Plan
_**Windows only**_
1. Turn on bookmarks bar
2. Add a bookmark to enable bookmark toolbar
3. Right click anywhere on the tool bar

#### Expected
- On a link / folder, shows relevant context menu, not system window context menu
- On an empty space, shows 'add folder' context menu, not system window context menu

### Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


