### PR TITLE
Ensure context menus are able to be interacted with when they cover a title-bar area

### DIFF
--- a/app/common/state/windowState.js
+++ b/app/common/state/windowState.js
@@ -167,7 +167,7 @@ const api = {
     const checkDefaultBrowserDialogIsVisible = isFocused &&
       defaultBrowserState.shouldDisplayDialog(state)
 
-    return !state.get('contextMenuDetail') &&
+    return !windowState.has('contextMenuDetail') &&
       !windowState.get('popupWindowDetail') &&
       !windowState.get('bookmarkDetail') &&
       !windowState.getIn(['ui', 'siteInfo', 'isVisible']) &&


### PR DESCRIPTION
… (via '-webkit-app-region: drag') on Windows

`contextMenuDetail` is a property of a window's state, and not the app state

Fix #12590

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:
Specified on #12590

Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


