### PR TITLE
Use non-persistent session for requests by default

### DIFF
--- a/js/lib/request.js
+++ b/js/lib/request.js
@@ -9,6 +9,15 @@ const session = electron.session
 const underscore = require('underscore')
 const urlParse = require('../../app/common/urlParse')
 
+var cachedDefaultSession = null
+
+const getDefaultSession = () => {
+  if (!cachedDefaultSession) {
+    cachedDefaultSession = session.fromPartition('default')
+  }
+  return cachedDefaultSession
+}
+
 /**
  * Sends a network request using Chromium's networks stack instead of Node's.
  * Depends on there being a loaded browser window available.
@@ -17,8 +26,8 @@ const urlParse = require('../../app/common/urlParse')
  */
 module.exports.request = (options, callback) => {
   var params
-  var defaultSession = session.defaultSession
   var responseType = options.responseType || 'text'
+  var defaultSession = getDefaultSession()
 
   if (!defaultSession) return callback(new Error('Request failed, no session available'))
 
@@ -56,7 +65,7 @@ module.exports.request = (options, callback) => {
 }
 
 module.exports.requestDataFile = (url, headers, path, reject, resolve) => {
-  let defaultSession = session.defaultSession
+  var defaultSession = getDefaultSession()
   if (!defaultSession) {
     reject('Request failed, no session available')
   } else {


### PR DESCRIPTION
Test Plan:
1. Turn on Brave payments in a fresh profile. Everything should work.
2. Click 'check for updates'. It should not show console errors. If in a packaged build, it should say 'no updates available'.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


