### PR TITLE
Updated recovery key parsing code to not rely on OS specific line endings

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -266,9 +266,9 @@ const loadKeysFromBackupFile = (state, filePath) => {
     try {
       const recoveryFileContents = data.toString()
 
-      let messageLines = recoveryFileContents.split(os.EOL)
+      let messageLines = recoveryFileContents.match(/^.+$/gm)
 
-      let passphraseLine = '' || messageLines[3]
+      let passphraseLine = '' || messageLines[2]
 
       const passphrasePattern = new RegExp([locale.translation('ledgerBackupText4'), '(.+)$'].join(' '))
       recoveryKey = (passphraseLine.match(passphrasePattern) || [])[1]
@@ -2683,7 +2683,8 @@ const getMethods = () => {
       getStateInfo,
       lockInContributionAmount,
       callback,
-      uintKeySeed
+      uintKeySeed,
+      loadKeysFromBackupFile
     }
   }
 

--- a/test/unit/app/browser/api/ledgerTest.js
+++ b/test/unit/app/browser/api/ledgerTest.js
@@ -12,6 +12,7 @@ const appActions = require('../../../../../js/actions/appActions')
 const migrationState = require('../../../../../app/common/state/migrationState')
 const batPublisher = require('bat-publisher')
 const ledgerMediaProviders = require('../../../../../app/common/constants/ledgerMediaProviders')
+const fs = require('fs')
 
 describe('ledger api unit tests', function () {
   let ledgerApi
@@ -98,6 +99,7 @@ describe('ledger api unit tests', function () {
     onBitcoinToBatBeginTransitionSpy = sinon.spy(appActions, 'onBitcoinToBatBeginTransition')
     onChangeSettingSpy = sinon.spy(appActions, 'changeSetting')
     onPublisherOptionUpdate = sinon.spy(appActions, 'onPublisherOptionUpdate')
+    mockery.registerMock('fs', fs)
 
     // default to tab state which should be tracked
     tabState = tabState.setIn(['navigationState', 'activeEntry'], {
@@ -2005,6 +2007,40 @@ describe('ledger api unit tests', function () {
     it('seed needs to be converted', function () {
       const result = ledgerApi.uintKeySeed(buff)
       assert.deepStrictEqual(result, uint)
+    })
+  })
+
+  describe('loadKeysFromBackupFile', function () {
+    describe('when parsing the recovery key', function () {
+      let stub
+
+      afterEach(function () {
+        stub.restore()
+      })
+
+      it('works with \\n (Linux)', function () {
+        stub = sinon.stub(fs, 'readFileSync', (path, options) => {
+          return 'Brave Wallet Recovery Key\nDate created: 01/18/2018\n\nLEDGERBACKUPTEXT4 a b d e f g h i j k l m n o p q\n\nNote: This key is not stored on Brave servers. This key is your only method of recovering your Brave wallet. Save this key in a safe place, separate from your Brave browser. Make sure you keep this key private, or else your wallet will be compromised.'
+        })
+        const result = ledgerApi.loadKeysFromBackupFile(undefined, 'file.txt')
+        assert.equal(result.recoveryKey, 'a b d e f g h i j k l m n o p q')
+      })
+
+      it('works with \\r (Classic Mac OS)', function () {
+        stub = sinon.stub(fs, 'readFileSync', (path, options) => {
+          return 'Brave Wallet Recovery Key\rDate created: 01/18/2018\r\rLEDGERBACKUPTEXT4 a b d e f g h i j k l m n o p q\r\rNote: This key is not stored on Brave servers. This key is your only method of recovering your Brave wallet. Save this key in a safe place, separate from your Brave browser. Make sure you keep this key private, or else your wallet will be compromised.'
+        })
+        const result = ledgerApi.loadKeysFromBackupFile(undefined, 'file.txt')
+        assert.equal(result.recoveryKey, 'a b d e f g h i j k l m n o p q')
+      })
+
+      it('works with \\r\\n (Windows)', function () {
+        stub = sinon.stub(fs, 'readFileSync', (path, options) => {
+          return 'Brave Wallet Recovery Key\r\nDate created: 01/18/2018\r\n\r\nLEDGERBACKUPTEXT4 a b d e f g h i j k l m n o p q\r\nNote: This key is not stored on Brave servers. This key is your only method of recovering your Brave wallet. Save this key in a safe place, separate from your Brave browser. Make sure you keep this key private, or else your wallet will be compromised.'
+        })
+        const result = ledgerApi.loadKeysFromBackupFile(undefined, 'file.txt')
+        assert.equal(result.recoveryKey, 'a b d e f g h i j k l m n o p q')
+      })
     })
   })
 })


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/12716

Auditors: @kjozwiak, @NejcZdovc

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Automated Test Plan:
`npm run unittest -- --grep="loadKeysFromBackupFile"`

## Test plan
See https://github.com/brave/browser-laptop/issues/12716

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


