### PR TITLE
Fix tabs briefly animating too wide after finishing closing some tabs (ver. 2)

### DIFF
--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -189,9 +189,9 @@ class Tab extends React.Component {
     const frame = this.frame
 
     if (frame && !frame.isEmpty()) {
-      const tabWidth = this.fixTabWidth
       // do not mimic tab size if closed tab is a pinned tab
       if (!this.props.isPinnedTab) {
+        const tabWidth = this.fixTabWidth
         windowActions.onTabClosedWithMouse({
           fixTabWidth: tabWidth
         })
@@ -276,7 +276,7 @@ class Tab extends React.Component {
     props.isPinnedTab = isPinned
     props.isPrivateTab = privateState.isPrivateTab(currentWindow, frameKey)
     props.isActive = frameStateUtil.isFrameKeyActive(currentWindow, frameKey)
-    props.tabWidth = currentWindow.getIn(['ui', 'tabs', 'fixTabWidth'])
+    props.tabWidth = isPinned ? null : currentWindow.getIn(['ui', 'tabs', 'fixTabWidth'])
     props.themeColor = tabUIState.getThemeColor(currentWindow, frameKey)
     props.title = frame.get('title')
     props.tabPageIndex = frameStateUtil.getTabPageIndex(currentWindow)
@@ -295,25 +295,15 @@ class Tab extends React.Component {
     return props
   }
 
-  componentWillReceiveProps (nextProps) {
-    if (this.props.tabWidth && !nextProps.tabWidth) {
-      // remember the width so we can transition from it
-      this.originalWidth = this.elementRef.getBoundingClientRect().width
-    }
-  }
-
   componentDidUpdate (prevProps) {
-    if (prevProps.tabWidth && !this.props.tabWidth) {
-      window.requestAnimationFrame(() => {
-        const newWidth = this.elementRef.getBoundingClientRect().width
-        this.elementRef.animate([
-          { flexBasis: `${this.originalWidth}px`, flexGrow: 0, flexShrink: 0 },
-          { flexBasis: `${newWidth}px`, flexGrow: 0, flexShrink: 0 }
-        ], {
-          duration: 250,
-          iterations: 1,
-          easing: 'ease-in-out'
-        })
+    if (prevProps.tabWidth && !this.props.tabWidth && !this.props.partOfFullPageSet) {
+      this.elementRef.animate([
+          { flexBasis: `${prevProps.tabWidth}px`, flexGrow: 0, flexShrink: 0 },
+          { flexBasis: 0, flexGrow: 1, flexShrink: 1 }
+      ], {
+        duration: 250,
+        iterations: 1,
+        easing: 'ease-in-out'
       })
     }
   }
@@ -414,7 +404,7 @@ const styles = StyleSheet.create({
     verticalAlign: 'top',
     overflow: 'hidden',
     height: '-webkit-fill-available',
-    flex: 1,
+    flex: '1 1 0',
 
     // no-drag is applied to the button and tab area
     // ref: tabs__tabStrip__newTabButton on tabs.js


### PR DESCRIPTION
This PR replaces #12567 (and contains the revert from #12718)

Fix #12566

Since each tab's 'fixed width' was being removed at the same time, each one was measuring the width whilst other tab(s) were / were not reset back to a fluid width, causing measurements to be off.
Flex supports transitions / animations by default, so we do not need to measure the element ourselves in this case, anyway.
Also prevents pinned tabs from fixing tab width and prevents fixing tab width when tab page remains full.

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


