### PR TITLE
Adds ability to change monthly amount via server

### DIFF
--- a/app/browser/api/ledgerNotifications.js
+++ b/app/browser/api/ledgerNotifications.js
@@ -42,7 +42,7 @@ const nextAddFundsTime = 3 * ledgerUtil.milliseconds.day
 const sufficientBalanceToReconcile = (state) => {
   const balance = Number(ledgerState.getInfoProp(state, 'balance') || 0)
   const unconfirmed = Number(ledgerState.getInfoProp(state, 'unconfirmed') || 0)
-  const budget = parseInt(getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT), 10) || 25
+  const budget = ledgerState.getContributionAmount(state)
   return balance + unconfirmed >= budget
 }
 const hasFunds = (state) => {

--- a/app/common/lib/ledgerUtil.js
+++ b/app/common/lib/ledgerUtil.js
@@ -102,7 +102,7 @@ const walletStatus = (ledgerData) => {
     const transactions = ledgerData.get('transactions')
     const pendingFunds = Number(ledgerData.get('unconfirmed') || 0)
     const balance = Number(ledgerData.get('balance') || 0)
-    const minBalance = parseInt(getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT), 10) || 25
+    const minBalance = ledgerState.getContributionAmount(null, ledgerData.get('contributionAmount'))
 
     if (pendingFunds + balance < minBalance) {
       status.id = 'insufficientFundsStatus'

--- a/app/common/state/ledgerState.js
+++ b/app/common/state/ledgerState.js
@@ -303,6 +303,33 @@ const ledgerState = {
   },
 
   /**
+   * Functions returns default monthly amount
+   * If user did not select it from the drop down we use defaults
+   *
+   * @param {any} state - app state
+   * @param {float} amount - custom amount, when we are using partial state
+   * @param {object} settingsCollection - settings object (used in about pages)
+   */
+  getContributionAmount: (state, amount, settingsCollection) => {
+    const value = getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT, settingsCollection, false)
+
+    if (value === null) {
+      amount = parseFloat(amount)
+
+      if (state != null) {
+        state = validateState(state)
+        amount = ledgerState.getInfoProp(state, 'contributionAmount')
+      }
+
+      if (amount > 0) {
+        return amount
+      }
+    }
+
+    return parseFloat(getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT, settingsCollection) || 5)
+  },
+
+  /**
    * OTHERS
    */
   setRecoveryStatus: (state, status) => {

--- a/app/renderer/components/preferences/payment/enabledContent.js
+++ b/app/renderer/components/preferences/payment/enabledContent.js
@@ -11,9 +11,11 @@ const Immutable = require('immutable')
 const {batToCurrencyString, formatCurrentBalance, formattedDateFromTimestamp, walletStatus} = require('../../../../common/lib/ledgerUtil')
 const {l10nErrorText} = require('../../../../common/lib/httpUtil')
 const {changeSetting} = require('../../../lib/settingsUtil')
-const getSetting = require('../../../../../js/settings').getSetting
 const settings = require('../../../../../js/constants/settings')
 const locale = require('../../../../../js/l10n')
+
+// State
+const ledgerState = require('../../../../common/state/ledgerState')
 
 // components
 const ImmutableComponent = require('../../immutableComponent')
@@ -266,6 +268,7 @@ class EnabledContent extends ImmutableComponent {
   render () {
     const ledgerData = this.props.ledgerData
     const walletStatusText = walletStatus(ledgerData)
+    const contributionAmount = ledgerState.getContributionAmount(null, ledgerData.get('contributionAmount'), this.props.settings)
     const inTransition = ledgerData.getIn(['migration', 'btc2BatTransitionPending']) === true
 
     return <section className={css(styles.enabledContent)}>
@@ -305,7 +308,7 @@ class EnabledContent extends ImmutableComponent {
           <FormDropdown
             data-isPanel
             data-test-id='fundsSelectBox'
-            value={getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT, this.props.settings)}
+            value={contributionAmount}
             onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.PAYMENTS_CONTRIBUTION_AMOUNT)}>
             {
               [5.0, 7.5, 10.0, 17.5, 25.0, 50.0, 75.0, 100.0].map((amount) => {

--- a/app/renderer/components/preferences/paymentsTab.js
+++ b/app/renderer/components/preferences/paymentsTab.js
@@ -31,6 +31,9 @@ const {LedgerRecoveryContent, LedgerRecoveryFooter} = require('./payment/ledgerR
 // Actions
 const appActions = require('../../../../js/actions/appActions')
 
+// State
+const ledgerState = require('../../../common/state/ledgerState')
+
 // Style
 const globalStyles = require('../styles/global')
 const {paymentStylesVariables} = require('../styles/payment')
@@ -79,7 +82,7 @@ class PaymentsTab extends ImmutableComponent {
     const walletQR = ledgerData.get('walletQR') || Immutable.List()
     const wizardData = ledgerData.get('wizardData') || Immutable.Map()
     const funds = formatCurrentBalance(ledgerData)
-    const budget = getSetting(settings.PAYMENTS_CONTRIBUTION_AMOUNT, this.props.settings)
+    const budget = ledgerState.getContributionAmount(null, ledgerData.get('contributionAmount'), this.props.settings)
     const minAmount = batToCurrencyString(budget, ledgerData)
 
     return <AddFundsDialog

--- a/docs/state.md
+++ b/docs/state.md
@@ -201,8 +201,9 @@ AppStore
         },
         setting: string
       },
+      contributionAmount: number,
       converted: string,
-      created, bolean, // wallet is created
+      created, boolean, // wallet is created
       creating: boolean, // wallet is being created
       currentRate: number,
       hasBitcoinHandler: boolean, // brave browser has a `bitcoin:` URI handler

--- a/test/unit/app/browser/api/ledgerTest.js
+++ b/test/unit/app/browser/api/ledgerTest.js
@@ -1212,6 +1212,9 @@ describe('ledger api unit tests', function () {
   })
 
   describe('onWalletProperties', function () {
+    const state = defaultAppState
+      .setIn(['ledger', 'info', 'contributionAmount'], 0)
+
     describe('generatePaymentData', function () {
       let generatePaymentDataSpy
 
@@ -1233,15 +1236,15 @@ describe('ledger api unit tests', function () {
       })
 
       it('we need to call generatePaymentData', function () {
-        ledgerApi.onWalletProperties(defaultAppState, Immutable.Map())
+        ledgerApi.onWalletProperties(state, Immutable.Map())
         assert(generatePaymentDataSpy.calledOnce)
       })
     })
 
     describe('addresses', function () {
       it('null case', function () {
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.Map())
-        assert.deepEqual(result.toJS(), defaultAppState.toJS())
+        const result = ledgerApi.onWalletProperties(state, Immutable.Map())
+        assert.deepEqual(result.toJS(), state.toJS())
       })
 
       it('set new addresses ', function () {
@@ -1252,41 +1255,41 @@ describe('ledger api unit tests', function () {
           ETH: 'ETH_address',
           LTC: 'LTC_address'
         }
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.fromJS({
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
           addresses: addresses
         }))
-        const expectedState = defaultAppState.setIn(['ledger', 'info', 'addresses'], Immutable.fromJS(addresses))
+        const expectedState = state.setIn(['ledger', 'info', 'addresses'], Immutable.fromJS(addresses))
         assert.deepEqual(result.toJS(), expectedState.toJS())
       })
     })
 
     describe('balance', function () {
       it('null case', function () {
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.Map())
-        assert.deepEqual(result.toJS(), defaultAppState.toJS())
+        const result = ledgerApi.onWalletProperties(state, Immutable.Map())
+        assert.deepEqual(result.toJS(), state.toJS())
       })
 
       it('balance is not a number', function () {
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.fromJS({
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
           balance: '.'
         }))
-        assert.deepEqual(result.toJS(), defaultAppState.toJS())
+        assert.deepEqual(result.toJS(), state.toJS())
       })
 
       it('set new balance', function () {
         const balance = 10.20
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.fromJS({
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
           balance: balance.toString()
         }))
-        const expectedState = defaultAppState.setIn(['ledger', 'info', 'balance'], balance)
+        const expectedState = state.setIn(['ledger', 'info', 'balance'], balance)
         assert.deepEqual(result.toJS(), expectedState.toJS())
       })
     })
 
     describe('rates', function () {
       it('null case', function () {
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.Map())
-        assert.deepEqual(result.toJS(), defaultAppState.toJS())
+        const result = ledgerApi.onWalletProperties(state, Immutable.Map())
+        assert.deepEqual(result.toJS(), state.toJS())
       })
 
       it('set new rates', function () {
@@ -1298,10 +1301,10 @@ describe('ledger api unit tests', function () {
           'EUR': 0.12100429176330299
         }
 
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.fromJS({
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
           rates: rates
         }))
-        const expectedState = defaultAppState
+        const expectedState = state
           .setIn(['ledger', 'info', 'rates'], Immutable.fromJS(rates))
           .setIn(['ledger', 'info', 'currentRate'], rate)
         assert.deepEqual(result.toJS(), expectedState.toJS())
@@ -1310,8 +1313,8 @@ describe('ledger api unit tests', function () {
 
     describe('current rate', function () {
       it('null case', function () {
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.Map())
-        assert.deepEqual(result.toJS(), defaultAppState.toJS())
+        const result = ledgerApi.onWalletProperties(state, Immutable.Map())
+        assert.deepEqual(result.toJS(), state.toJS())
       })
 
       it('rates are present, but there is no USD rate', function () {
@@ -1321,10 +1324,10 @@ describe('ledger api unit tests', function () {
           'EUR': 0.12100429176330299
         }
 
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.fromJS({
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
           rates: rates
         }))
-        const expectedState = defaultAppState.setIn(['ledger', 'info', 'rates'], Immutable.fromJS(rates))
+        const expectedState = state.setIn(['ledger', 'info', 'rates'], Immutable.fromJS(rates))
         assert.deepEqual(result.toJS(), expectedState.toJS())
       })
 
@@ -1337,12 +1340,78 @@ describe('ledger api unit tests', function () {
           'USD': rate
         }
 
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.fromJS({
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
           rates: rates
         }))
-        const expectedState = defaultAppState
+        const expectedState = state
           .setIn(['ledger', 'info', 'rates'], Immutable.fromJS(rates))
           .setIn(['ledger', 'info', 'currentRate'], rate)
+        assert.deepEqual(result.toJS(), expectedState.toJS())
+      })
+    })
+
+    describe('monthly amount', function () {
+      it('null case', function () {
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
+          parameters: {
+            adFree: {}
+          }
+        }))
+
+        const expectedState = state
+          .setIn(['ledger', 'info', 'contributionAmount'], 0)
+
+        assert.deepEqual(result.toJS(), expectedState.toJS())
+      })
+
+      it('amount is negative', function () {
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
+          parameters: {
+            adFree: {
+              fee: {
+                BAT: -25
+              }
+            }
+          }
+        }))
+
+        const expectedState = state
+          .setIn(['ledger', 'info', 'contributionAmount'], 0)
+
+        assert.deepEqual(result.toJS(), expectedState.toJS())
+      })
+
+      it('amount is not a number', function () {
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
+          parameters: {
+            adFree: {
+              fee: {
+                BAT: 'sdfsdf'
+              }
+            }
+          }
+        }))
+
+        const expectedState = state
+          .setIn(['ledger', 'info', 'contributionAmount'], 0)
+
+        assert.deepEqual(result.toJS(), expectedState.toJS())
+      })
+
+      it('amount is float', function () {
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
+          parameters: {
+            adFree: {
+              fee: {
+                BAT: 17.5
+              }
+            }
+          }
+        }))
+
+        const expectedState = state
+          .setIn(['ledger', 'info', 'contributionAmount'], 17.5)
+
         assert.deepEqual(result.toJS(), expectedState.toJS())
       })
     })
@@ -1358,34 +1427,34 @@ describe('ledger api unit tests', function () {
       }
 
       it('null case', function () {
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.Map())
-        assert.deepEqual(result.toJS(), defaultAppState.toJS())
+        const result = ledgerApi.onWalletProperties(state, Immutable.Map())
+        assert.deepEqual(result.toJS(), state.toJS())
       })
 
       it('probi is not a number', function () {
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.fromJS({
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
           probi: '.'
         }))
-        assert.deepEqual(result.toJS(), defaultAppState.toJS())
+        assert.deepEqual(result.toJS(), state.toJS())
       })
 
       it('rate is not present', function () {
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.fromJS({
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
           probi: probi,
           balance: 25
         }))
-        const expectedState = defaultAppState
+        const expectedState = state
           .setIn(['ledger', 'info', 'probi'], probi)
           .setIn(['ledger', 'info', 'balance'], 25)
         assert.deepEqual(result.toJS(), expectedState.toJS())
       })
 
       it('amount is null', function () {
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.fromJS({
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
           probi: probi,
           rates: rates
         }))
-        const expectedState = defaultAppState
+        const expectedState = state
           .setIn(['ledger', 'info', 'rates'], Immutable.fromJS(rates))
           .setIn(['ledger', 'info', 'currentRate'], rate)
           .setIn(['ledger', 'info', 'probi'], probi)
@@ -1393,12 +1462,12 @@ describe('ledger api unit tests', function () {
       })
 
       it('small probi', function () {
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.fromJS({
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
           probi: probi,
           balance: 25,
           rates: rates
         }))
-        const expectedState = defaultAppState
+        const expectedState = state
           .setIn(['ledger', 'info', 'rates'], Immutable.fromJS(rates))
           .setIn(['ledger', 'info', 'currentRate'], rate)
           .setIn(['ledger', 'info', 'converted'], '3.58')
@@ -1409,12 +1478,12 @@ describe('ledger api unit tests', function () {
 
       it('big probi', function () {
         const bigProbi = '7.309622404968674704085e+21'
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.fromJS({
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
           probi: bigProbi,
           balance: '7309.6224',
           rates: rates
         }))
-        const expectedState = defaultAppState
+        const expectedState = state
           .setIn(['ledger', 'info', 'rates'], Immutable.fromJS(rates))
           .setIn(['ledger', 'info', 'currentRate'], rate)
           .setIn(['ledger', 'info', 'converted'], '1047.80')
@@ -1426,22 +1495,22 @@ describe('ledger api unit tests', function () {
 
     describe('unconfirmed amount', function () {
       it('null case', function () {
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.Map())
-        assert.deepEqual(result.toJS(), defaultAppState.toJS())
+        const result = ledgerApi.onWalletProperties(state, Immutable.Map())
+        assert.deepEqual(result.toJS(), state.toJS())
       })
 
       it('amount is not a number', function () {
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.fromJS({
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
           unconfirmed: '.'
         }))
-        assert.deepEqual(result.toJS(), defaultAppState.toJS())
+        assert.deepEqual(result.toJS(), state.toJS())
       })
 
       it('amount is ok', function () {
-        const result = ledgerApi.onWalletProperties(defaultAppState, Immutable.fromJS({
+        const result = ledgerApi.onWalletProperties(state, Immutable.fromJS({
           unconfirmed: 50
         }))
-        const expectedState = defaultAppState
+        const expectedState = state
           .setIn(['ledger', 'info', 'unconfirmed'], 50)
         assert.deepEqual(result.toJS(), expectedState.toJS())
       })
@@ -1888,6 +1957,8 @@ describe('ledger api unit tests', function () {
   })
 
   describe('lockInContributionAmount', function () {
+    const state = defaultAppState
+      .setIn(['ledger', 'info', 'contributionAmount'], 10)
     beforeEach(function () {
       onChangeSettingSpy.reset()
       contributionAmountSet = true
@@ -1896,14 +1967,14 @@ describe('ledger api unit tests', function () {
     describe('when balance is greater than 0', function () {
       describe('when setting already has a value', function () {
         it('does not call appActions.changeSetting', function () {
-          ledgerApi.lockInContributionAmount(5)
+          ledgerApi.lockInContributionAmount(state, 5)
           assert(onChangeSettingSpy.notCalled)
         })
       })
       describe('when setting does not have a value', function () {
         it('calls appActions.changeSetting', function () {
           contributionAmountSet = false
-          ledgerApi.lockInContributionAmount(5)
+          ledgerApi.lockInContributionAmount(state, 5)
           assert(onChangeSettingSpy.withArgs(settings.PAYMENTS_CONTRIBUTION_AMOUNT, contributionAmount).calledOnce)
         })
       })
@@ -1911,7 +1982,7 @@ describe('ledger api unit tests', function () {
 
     describe('when balance is not greater than 0', function () {
       it('does not call appActions.changeSetting', function () {
-        ledgerApi.lockInContributionAmount(0)
+        ledgerApi.lockInContributionAmount(state, 0)
         assert(onChangeSettingSpy.notCalled)
       })
     })


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Resolves #12673

Auditors:

Test Plan:

we are doing all of this on staging, before PR is merged

### normal case
- clean profile
- enable payments
- ensure that monthly budget is 10 BAT
- restart brave
- check if amount is still correct

### user selects amount
- clean profile
- enable payments
- ensure that monthly budget is 10 BAT
- change amount to 100
- restart brave
- check if amount is still correct

### notification
- clean profile
- enable payments
- ensure that monthly budget is 10 BAT
- make contribution
- when you see notification about contribution make sure that it says 10 BAT

### Update Test Case A
- Use 0.19.134 to set up a profile with payments enabled (on staging) with an empty wallet. 
- Set monthly budget to be 50 BAT. 
- Close Brave. 
- Rename profile to brave-development, build & run PR. 
- Verify 50 BAT is still the monthly budget.

### Update Test Case B
- Use 0.19.134 to set up a profile with payments enabled (on staging) with an empty wallet. 
- Leave default amount of 7.5 BAT. 
- Close Brave. 
- Rename profile to brave-development, build & run PR. 
- Verify 10 BAT is now the monthly budget

### Update Test Case C
- Use 0.19.134 to set up a profile with payments enabled (on staging) with funded wallet (staging UGP grant or outside funds). 
- Leave default value of 7.5 BAT. 
- Close Brave. 
- Rename profile to brave-development, build & run PR. 
- Verify 7.5 BAT is still the monthly budget.

Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


