### PR TITLE
Adds dynamic dropdown for monthly amounts

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -93,6 +93,7 @@ const clientOptions = {
   version: 'v2',
   environment: process.env.LEDGER_ENVIRONMENT || 'production'
 }
+
 const fileTypes = {
   bmp: Buffer.from([0x42, 0x4d]),
   gif: Buffer.from([0x47, 0x49, 0x46, 0x38, [0x37, 0x39], 0x61]),
@@ -1630,6 +1631,18 @@ const onWalletProperties = (state, body) => {
       state = ledgerState.setInfoProp(state, 'converted', converted)
     }
   }
+
+  // monthly amount list
+  let list = body.getIn(['parameters', 'adFree', 'choices', 'BAT'])
+  if (list == null || !Immutable.List.isList(list) || list.isEmpty()) {
+    list = ledgerUtil.defaultMonthlyAmounts
+  }
+
+  const currentAmount = ledgerState.getContributionAmount(state)
+  if (!list.includes(currentAmount)) {
+    list = list.push(currentAmount).sort()
+  }
+  state = ledgerState.setInfoProp(state, 'monthlyAmounts', list)
 
   // unconfirmed amount
   const unconfirmed = parseFloat(body.get('unconfirmed'))

--- a/app/common/lib/ledgerUtil.js
+++ b/app/common/lib/ledgerUtil.js
@@ -303,6 +303,8 @@ const getMediaProvider = (url) => {
   return provider
 }
 
+const defaultMonthlyAmounts = Immutable.List([5.0, 7.5, 10.0, 17.5, 25.0, 50.0, 75.0, 100.0])
+
 const milliseconds = {
   year: 365 * 24 * 60 * 60 * 1000,
   week: 7 * 24 * 60 * 60 * 1000,
@@ -330,7 +332,8 @@ const getMethods = () => {
     getMediaProvider,
     getMediaData,
     getMediaKey,
-    milliseconds
+    milliseconds,
+    defaultMonthlyAmounts
   }
 
   let privateMethods = {}

--- a/app/renderer/components/preferences/payment/enabledContent.js
+++ b/app/renderer/components/preferences/payment/enabledContent.js
@@ -10,6 +10,7 @@ const Immutable = require('immutable')
 // util
 const {batToCurrencyString, formatCurrentBalance, formattedDateFromTimestamp, walletStatus} = require('../../../../common/lib/ledgerUtil')
 const {l10nErrorText} = require('../../../../common/lib/httpUtil')
+const ledgerUtil = require('../../../../common/lib/ledgerUtil')
 const {changeSetting} = require('../../../lib/settingsUtil')
 const settings = require('../../../../../js/constants/settings')
 const locale = require('../../../../../js/l10n')
@@ -270,6 +271,7 @@ class EnabledContent extends ImmutableComponent {
     const walletStatusText = walletStatus(ledgerData)
     const contributionAmount = ledgerState.getContributionAmount(null, ledgerData.get('contributionAmount'), this.props.settings)
     const inTransition = ledgerData.getIn(['migration', 'btc2BatTransitionPending']) === true
+    const amountList = ledgerData.get('monthlyAmounts') || ledgerUtil.defaultMonthlyAmounts
 
     return <section className={css(styles.enabledContent)}>
       <div className={css(
@@ -309,9 +311,10 @@ class EnabledContent extends ImmutableComponent {
             data-isPanel
             data-test-id='fundsSelectBox'
             value={contributionAmount}
-            onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.PAYMENTS_CONTRIBUTION_AMOUNT)}>
+            onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.PAYMENTS_CONTRIBUTION_AMOUNT)}
+          >
             {
-              [5.0, 7.5, 10.0, 17.5, 25.0, 50.0, 75.0, 100.0].map((amount) => {
+              amountList.map((amount) => {
                 let alternative = ''
                 if (ledgerData.has('currentRate')) {
                   const converted = batToCurrencyString(amount, ledgerData)

--- a/docs/state.md
+++ b/docs/state.md
@@ -207,6 +207,7 @@ AppStore
       creating: boolean, // wallet is being created
       currentRate: number,
       hasBitcoinHandler: boolean, // brave browser has a `bitcoin:` URI handler
+      monthlyAmounts: Array<float> // list of all monthly amounts for the contribution
       passphrase: string, // the BAT wallet passphrase
       paymentId: string,
       probi: number,

--- a/test/unit/app/common/lib/ledgerUtilTest.js
+++ b/test/unit/app/common/lib/ledgerUtilTest.js
@@ -514,4 +514,10 @@ describe('ledgerUtil unit test', function () {
       assert.equal(result, 31536000000)
     })
   })
+
+  describe('defaultMonthlyAmounts', function () {
+    it('should match', function () {
+      assert.deepEqual(ledgerUtil.defaultMonthlyAmounts.toJS(), [5.0, 7.5, 10.0, 17.5, 25.0, 50.0, 75.0, 100.0])
+    })
+  })
 })


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Resolves #12727

Auditors:

Test Plan:

tests should be done on the staging

### regular
- clean profile
- enable ledger
- make sure that dropdown is populated

### inserting old users value
- clean profile
- enable ledger
- select 17.5 amount
- close browser
- modify session file and change `payments.contribution-amount` to 4
- start browser again and 4 should be in the drop down

Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


