### PR TITLE
Fix displayed mixed content status

### DIFF
--- a/app/renderer/components/frame/frame.js
+++ b/app/renderer/components/frame/frame.js
@@ -682,16 +682,17 @@ class Frame extends React.Component {
       if (e.securityState === 'secure') {
         isSecure = true
       } else if (e.securityState === 'insecure') {
-        isSecure = false
+        // Passive mixed content should not upgrade an insecure connection to a
+        // partially-secure connection. It can only downgrade a secure
+        // connection.
+        isSecure =
+          e.securityInfo.mixedContentStatus === 'content-status-displayed' && this.props.isSecure !== false
+          ? 1
+          : false
       } else if (e.securityState === 'broken') {
         isSecure = false
         const parsedUrl = urlParse(this.props.location)
         ipc.send(messages.CHECK_CERT_ERROR_ACCEPTED, parsedUrl.host, this.props.tabId)
-      } else if (['warning', 'passive-mixed-content'].includes(e.securityState)) {
-        // Passive mixed content should not upgrade an insecure connection to a
-        // partially-secure connection. It can only downgrade a secure
-        // connection.
-        isSecure = this.props.isSecure !== false ? 1 : false
       }
       windowActions.setSecurityState(this.props.tabId, {
         secure: runInsecureContent ? false : isSecure,


### PR DESCRIPTION
Fix https://github.com/brave/browser-laptop/issues/12742

Test Plan:
1. test for 'shows partially-secure icon on a site with passive mixed content' should pass
2. follow test plan from https://github.com/brave/browser-laptop/issues/12742

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


