### PR TITLE
Fixes Issue #10752, allows for sorting by publisher verification

### DIFF
--- a/app/renderer/components/preferences/payment/ledgerTable.js
+++ b/app/renderer/components/preferences/payment/ledgerTable.js
@@ -169,7 +169,7 @@ class LedgerTable extends ImmutableComponent {
     return [
       {
         html: verified && this.getVerifiedIcon(synopsis),
-        value: verified ? 1 : 0
+        value: verified ? (this.enabledForSite(synopsis) ? 2 : 1) : 0
       },
       {
         html: <div className={css(styles.siteData)}>

--- a/app/renderer/components/preferences/payment/ledgerTable.js
+++ b/app/renderer/components/preferences/payment/ledgerTable.js
@@ -169,7 +169,7 @@ class LedgerTable extends ImmutableComponent {
     return [
       {
         html: verified && this.getVerifiedIcon(synopsis),
-        value: ''
+        value: verified ? 1 : 0
       },
       {
         html: <div className={css(styles.siteData)}>


### PR DESCRIPTION
Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Resolves #10752

Test Plan:
   This can be done through the UI.

   1. Navigate to about:preferences#payments
   2. Click on the first column header to sort by publisher verification status
   3. Ensure that the ordering toggles for verified publishers (ASC/DESC)

Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

This is a very simple fix for issue #10752. The SortableTable component looks to the 'value' property of a row object as its basis for sorting (We should mimic the configuration for the included row object, where the value property is either set to 1 or 0, depending on whether its turned on). Now the Verified Publisher column sorts as expected. Thanks!


