### PR TITLE
Add "forget this domain" feature

### DIFF
--- a/app/browser/reducers/historyReducer.js
+++ b/app/browser/reducers/historyReducer.js
@@ -19,6 +19,7 @@ const messages = require('../../../js/constants/messages')
 const settings = require('../../../js/constants/settings')
 
 // Utils
+const urlParse = require('../../common/urlParse')
 const {makeImmutable} = require('../../common/state/immutableUtil')
 const {remove} = require('../../common/lib/siteSuggestions')
 const syncUtil = require('../../../js/state/syncUtil')
@@ -125,6 +126,24 @@ const historyReducer = (state, action, immutableAction) => {
         state = aboutHistoryState.setHistory(state, historyState.getSites(state))
         break
       }
+
+    case appConstants.APP_REMOVE_HISTORY_DOMAIN: {
+      const domain = action.get('domain')
+
+      if (!domain) {
+        break
+      }
+
+      historyState.getSites(state).forEach(historySite => {
+        if (urlParse(historySite.get('location')).hostname === domain) {
+          state = historyState.removeSite(state, historySite.get('key'))
+        }
+      })
+
+      state = aboutHistoryState.setHistory(state, historyState.getSites(state))
+
+      break
+    }
 
     case appConstants.APP_POPULATE_HISTORY:
       {

--- a/app/extensions/brave/locales/en-US/menu.properties
+++ b/app/extensions/brave/locales/en-US/menu.properties
@@ -45,6 +45,7 @@ cut=Cut
 delete=Delete
 deleteBookmark=Delete Bookmark
 deleteBookmarks=Delete Selected Bookmarks
+deleteDomainFromHistory=Delete Domain from History
 deleteFolder=Delete Folder
 deleteHistoryEntries=Delete Selected History Entries
 deleteHistoryEntry=Delete History Entry

--- a/app/locale.js
+++ b/app/locale.js
@@ -60,6 +60,7 @@ var rendererIdentifiers = function () {
     'deleteBookmarks',
     'deleteHistoryEntry',
     'deleteHistoryEntries',
+    'deleteDomainFromHistory',
     'deleteLedgerEntry',
     'ledgerBackupText1',
     'ledgerBackupText2',

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -362,12 +362,23 @@ const appActions = {
 
   /**
    * Removes a site from the site list
-   * @param {string|Immutable.List} historyKey - Hisotry item key that we want to remove, can be list of keys as well
+   * @param {string|Immutable.List} historyKey - History item key that we want to remove, can be list of keys as well
    */
   removeHistorySite: function (historyKey) {
     dispatch({
       actionType: appConstants.APP_REMOVE_HISTORY_SITE,
       historyKey
+    })
+  },
+
+  /**
+   * Removes all sites for the given domain from the site list
+   * @param {string} domain - Domain of the sites we want to remove
+   */
+  removeHistoryDomain: function (domain) {
+    dispatch({
+      actionType: appConstants.APP_REMOVE_HISTORY_DOMAIN,
+      domain
     })
   },
 

--- a/js/constants/appConstants.js
+++ b/js/constants/appConstants.js
@@ -18,6 +18,7 @@ const appConstants = {
   APP_ADD_HISTORY_SITE: _,
   APP_SET_STATE: _,
   APP_REMOVE_HISTORY_SITE: _,
+  APP_REMOVE_HISTORY_DOMAIN: _,
   APP_MERGE_DOWNLOAD_DETAIL: _, // Sets an individual download detail
   APP_CLEAR_COMPLETED_DOWNLOADS: _, // Removes all completed downloads
   APP_SET_DATA_FILE_ETAG: _,

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -358,7 +358,7 @@ const siteSingleDetailTemplate = (siteKey, type, activeFrame) => {
     })
 
     template.push({
-      label: 'Delete Domain from History',
+      label: locale.translation('deleteDomainFromHistory'),
       click: () => {
         const domain = urlParse(siteDetail.get('location')).hostname
         appActions.removeHistoryDomain(domain)

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -356,6 +356,14 @@ const siteSingleDetailTemplate = (siteKey, type, activeFrame) => {
         }
       }
     })
+
+    template.push({
+      label: 'Delete Domain from History',
+      click: () => {
+        const domain = urlParse(siteDetail.get('location')).hostname
+        appActions.removeHistoryDomain(domain)
+      }
+    })
   }
 
   if (type !== siteTags.HISTORY) {

--- a/test/unit/app/browser/reducers/historyReducerTest.js
+++ b/test/unit/app/browser/reducers/historyReducerTest.js
@@ -86,6 +86,17 @@ describe('historyReducer unit test', function () {
             partitionNumber: 0,
             themeColor: undefined,
             title: 'Brave'
+          },
+          {
+            count: 2,
+            favicon: undefined,
+            key: 'https://brave.com/|1',
+            lastAccessedTime: 0,
+            location: 'https://brave.com/',
+            objectId: null,
+            partitionNumber: 0,
+            themeColor: undefined,
+            title: 'Brave | Another Page'
           }
         ]
       }
@@ -347,6 +358,83 @@ describe('historyReducer unit test', function () {
       assert.equal(spy.calledOnce, true)
       assert.equal(spyAbout.calledOnce, true)
       assert.deepEqual(newState.toJS(), expectedState.toJS())
+    })
+  })
+
+  describe('APP_REMOVE_HISTORY_DOMAIN', function () {
+    let spy, spyAbout
+
+    before(function () {
+      spy = sinon.spy(historyState, 'removeSite')
+      spyAbout = sinon.spy(aboutHistoryState, 'setHistory')
+    })
+
+    afterEach(function () {
+      spy.reset()
+      spyAbout.reset()
+    })
+
+    after(function () {
+      spy.restore()
+      spyAbout.restore()
+    })
+
+    it('null case', function () {
+      const newState = historyReducer(state, {
+        actionType: appConstants.APP_REMOVE_HISTORY_DOMAIN
+      })
+      assert.equal(spy.notCalled, true)
+      assert.equal(spyAbout.notCalled, true)
+      assert.deepEqual(newState.toJS(), state.toJS())
+    })
+
+    it('domain is a string', function () {
+      const newState = historyReducer(stateWithData, {
+        actionType: appConstants.APP_REMOVE_HISTORY_DOMAIN,
+        domain: 'https://brave.com'
+      })
+      const expectedState = state
+        .set('historySites', Immutable.fromJS({
+          'https://clifton.io/|0': {
+            count: 1,
+            favicon: undefined,
+            key: 'https://clifton.io/|0',
+            lastAccessedTime: 0,
+            location: 'https://clifton.io/',
+            objectId: null,
+            partitionNumber: 0,
+            themeColor: undefined,
+            title: 'Clifton'
+          }
+        }))
+        .setIn(['about', 'history'], Immutable.fromJS({
+          entries: [
+            {
+              count: 1,
+              favicon: undefined,
+              key: 'https://clifton.io/|0',
+              lastAccessedTime: 0,
+              location: 'https://clifton.io/',
+              objectId: null,
+              partitionNumber: 0,
+              themeColor: undefined,
+              title: 'Clifton'
+            }
+          ],
+          updatedStamp: 0
+        }))
+
+      it('calls remove for each matching domain', () => {
+        assert.equal(spy.calledTwice, true)
+      })
+
+      it('sets the history with the update site list', () => {
+        assert.equal(spyAbout.calledOnce, true)
+      })
+
+      it('returns the updated state', () => {
+        assert.deepEqual(newState.toJS(), expectedState.toJS())
+      })
     })
   })
 


### PR DESCRIPTION
closes #3948

👋 Hey everyone, first time making a PR here. I was unsure what to put in the `Test Plan` section, any help there is appreciate.

This adds an item to the context menu for a url on the about:history page to remove all sites for the selected domain from the history list.

What it Looks Like:
<img width="756" alt="screen shot 2018-01-21 at 1 33 35 am" src="https://user-images.githubusercontent.com/4470300/35184604-207434ee-fe4c-11e7-982b-150467d30038.png">

![brave forget domain](https://user-images.githubusercontent.com/4470300/35184607-237a0f7e-fe4c-11e7-9438-9bdd0ddc800c.gif)

Auditors:

Test Plan:

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


