### PR TITLE
Update content setttings after site settings cleared

### DIFF
--- a/js/state/contentSettings.js
+++ b/js/state/contentSettings.js
@@ -373,6 +373,7 @@ const doAction = (action) => {
   switch (action.actionType) {
     case appConstants.APP_REMOVE_SITE_SETTING:
     case appConstants.APP_CHANGE_SITE_SETTING:
+    case appConstants.APP_CLEAR_SITE_SETTINGS:
     case appConstants.APP_ADD_NOSCRIPT_EXCEPTIONS:
       appDispatcher.waitFor([AppStore.dispatchToken], () => {
         userPrefsUpdateTrigger(action.temporary)


### PR DESCRIPTION
fix #12514

Auditors: @bridiver, @bsclifton

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Set autoplay global setting to `Always Ask`
2. Make sure there is autoplay always allow for youtube (if not just
                                                         make one)
3. Go to any youtube video, it should be autoplaying
4. Go to about:preferences#security
5. `Clear all` on autoplay site settings
6. Go to any youtube video, it should ask you about autoplay permission

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


