### PR TITLE
Fixes cache migration from 0.19 to 0.20

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -804,7 +804,10 @@ module.exports.runPreMigrations = (data) => {
     }
 
     // Add cache to the state
-    data.cache = {}
+    if (!data.cache) {
+      data.cache = {}
+    }
+
     data.cache.bookmarkLocation = data.locationSiteKeysCache
     data.cache.bookmarkOrder = sortBookmarkOrder(bookmarkOrder)
 

--- a/test/unit/app/sessionStoreTest.js
+++ b/test/unit/app/sessionStoreTest.js
@@ -1372,7 +1372,7 @@ describe('sessionStore unit tests', function () {
           '12': {}
         },
         cache: {
-          fakeEntry: {}
+          ledgerVideos: {}
         },
         history: {
           'https://not-a-real-entry|0': {}
@@ -1700,8 +1700,8 @@ describe('sessionStore unit tests', function () {
           it('creates an entry for bookmark order', function () {
             assert(newValue.bookmarkOrder)
           })
-          it('destroys any existing values in `data.cache`', function () {
-            assert.equal(newValue.fakeEntry, undefined)
+          it('keep any existing values in `data.cache`', function () {
+            assert(newValue.ledgerVideos)
           })
         })
 


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Resolves #10595

Auditors:

## Test Plan:
- create profile on 0.19 and watch some youtube videos
- switch to 0.20+ and start brave
- close brave and check session file and make sure that `cache.ledgerVideos` object is there and that it has some data in from 0.19


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


