### PR TITLE
fix topsites never returning after exclusion

### DIFF
--- a/app/browser/api/topSites.js
+++ b/app/browser/api/topSites.js
@@ -28,6 +28,10 @@ const isPinned = (state, siteKey) => {
   })
 }
 
+const isIgnored = (state, siteKey) => {
+  return aboutNewTabState.getIgnoredTopSites(state).includes(siteKey)
+}
+
 const sortCountDescending = (left, right) => {
   const leftCount = left.get('count', 0)
   const rightCount = right.get('count', 0)
@@ -85,6 +89,7 @@ const getTopSiteData = () => {
   let sites = historyState.getSites(state)
     .filter((site, key) => !isSourceAboutUrl(site.get('location')) &&
       !isPinned(state, key) &&
+      !isIgnored(state, key) &&
       (minCountOfTopSites === undefined || (site.get('count') || 0) >= minCountOfTopSites) &&
       (minAccessOfTopSites === undefined || (site.get('lastAccessedTime') || 0) >= minAccessOfTopSites)
     )
@@ -118,7 +123,7 @@ const getTopSiteData = () => {
     const preDefined = staticData
       // TODO: this doesn't work properly
       .filter((site) => {
-        return !isPinned(state, site.get('key'))
+        return !isPinned(state, site.get('key')) && !isIgnored(state, site.get('key'))
       })
       .map(site => {
         const bookmarkKey = bookmarkLocationCache.getCacheKey(state, site.get('location'))


### PR DESCRIPTION
cc @LaurenWags 

fix #10411

STR:

1. Exclude a top site
2. With 5 tiles only, visit a new website
3. Website tile should be shown with a total of 6 tiles in newtab page

Please note that we debounce all newtab page data so the sixth tile will be shown only after a new site visit, even if you have other sites on the list.