### PR TITLE
Remove Masthead Ads on YouTube

### DIFF
--- a/app/extensions/brave/content/styles/removeEmptyElements.css
+++ b/app/extensions/brave/content/styles/removeEmptyElements.css
@@ -18,3 +18,9 @@ link[href*='files.coinmarketcap.com'] ~ .container #leaderboard,
 link[href*='files.coinmarketcap.com'] ~ .container #leaderboard-bottom {
   display: none !important;
 }
+
+/* YouTube Masthead and Sidebar Ads */
+#player-ads.ytd-watch,
+ytd-page-manager #masthead-ad.ytd-browse {
+  display: none !important;
+}


### PR DESCRIPTION
Fixes #12845 

![youtube-masthead-ad-gone](https://user-images.githubusercontent.com/815158/35413693-e9b6d220-01e5-11e8-837b-4b145b358e8c.gif)

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

1. Navigate to youtube.com
2. Confirm that large empty ad-container is not visible

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


