### PR TITLE
do not store sites cache as a bookmark cache 

### DIFF
--- a/app/common/cache/bookmarkLocationCache.js
+++ b/app/common/cache/bookmarkLocationCache.js
@@ -14,24 +14,6 @@ const normalizeLocation = (location) => {
   return UrlUtil.getLocationIfPDF(location)
 }
 
-/**
- * Calculate location for siteKey
- *
- * @param siteKey The site key to to be calculated
- * @return {string|null}
- */
-const getLocationFromCacheKey = function (siteKey) {
-  if (!siteKey) {
-    return null
-  }
-
-  const splitKey = siteKey.split('|', 2)
-  if (typeof splitKey[0] === 'string' && typeof splitKey[1] === 'string') {
-    return splitKey[0]
-  }
-  return null
-}
-
 const generateCache = (state) => {
   const cache = state.getIn(['cache', 'bookmarkLocation']) || Immutable.Map()
   if (!cache.isEmpty()) {
@@ -41,11 +23,7 @@ const generateCache = (state) => {
   state = state.setIn(['cache', 'bookmarkLocation'], Immutable.Map())
   const bookmarksState = require('../state/bookmarksState')
   bookmarksState.getBookmarks(state).forEach((site, siteKey) => {
-    const location = getLocationFromCacheKey(siteKey)
-    if (!location) {
-      return
-    }
-    state = addCacheKey(state, location, siteKey)
+    state = addCacheKey(state, site.get('location'), siteKey)
   })
   return state
 }

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -839,6 +839,15 @@ module.exports.runPreMigrations = (data) => {
         }
       })
     }
+
+    // Bookmark cache was generated wrongly on and before 0.20.25 from 0.19.x upgrades
+    let runCacheClean = false
+    try { runCacheClean = compareVersions(data.lastAppVersion, '0.20.25') < 1 } catch (e) {}
+    if (runCacheClean) {
+      if (data.cache) {
+        delete data.cache.bookmarkLocation
+      }
+    }
   }
 
   return data

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -808,7 +808,6 @@ module.exports.runPreMigrations = (data) => {
       data.cache = {}
     }
 
-    data.cache.bookmarkLocation = data.locationSiteKeysCache
     data.cache.bookmarkOrder = sortBookmarkOrder(bookmarkOrder)
 
     // history

--- a/test/unit/app/sessionStoreTest.js
+++ b/test/unit/app/sessionStoreTest.js
@@ -1686,17 +1686,12 @@ describe('sessionStore unit tests', function () {
         })
 
         describe('adding cache to the state', function () {
-          let oldValue
           let newValue
 
           before(function () {
-            oldValue = data.get('locationSiteKeysCache')
             newValue = runPreMigrations.cache
           })
 
-          it('copies the entry for bookmark location from existing cache', function () {
-            assert.deepEqual(newValue.bookmarkLocation, oldValue.toJS())
-          })
           it('creates an entry for bookmark order', function () {
             assert(newValue.bookmarkOrder)
           })


### PR DESCRIPTION
in 6e607ef we also changed cache location to use actual url instead of site key (no-qa-needed for this -- please test just the below).

Fix #12903

Test Plan:

1. Clean session of 0.19.x
2. Visit brianbondy.com
3. Close app, move to 0.20.x branch
4. Run Brave
5. brianbondy.com shouldn't be bookmarked