### PR TITLE
Fix invalid icon path on Windows

### DIFF
--- a/tools/buildInstaller.js
+++ b/tools/buildInstaller.js
@@ -171,7 +171,7 @@ if (isDarwin) {
       authors: 'Brave Software',
       loadingGif: 'res/brave_splash_installing.gif',
       setupIcon: `res/${channel}/brave_installer.ico`,
-      iconUrl: `https://raw.githubusercontent.com/brave/browser-laptop/coexisted-channels/res/${channel}/app.ico`,
+      iconUrl: `https://raw.githubusercontent.com/brave/browser-laptop/master/res/${channel}/app.ico`,
       signWithParams: format('-a -fd sha256 -f "%s" -p "%s"', path.resolve(cert), certPassword),
       noMsi: true,
       exe: `${appName}.exe`,


### PR DESCRIPTION
fix #12940

Auditors: @bbondy

Test Plan:
1. Check uninstall menu right after install
2. App icon shouldn't be empty
3. Check install location, there should be a app.ico in it

Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:


Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


