### PR TITLE
 macOS: end-user postinstall script to parse promo code from installer .pkg filename

### DIFF
--- a/build/pkg-scripts/postinstall
+++ b/build/pkg-scripts/postinstall
@@ -1,0 +1,35 @@
+#!/bin/sh
+# This postinstall script is run on macOS pkg installers
+
+# Extract a referral / promo code from the installer path of the format /dir/path/Setup-Brave-Anything-xxx001.pkg
+# where the promo code would be xxx001
+installerPath=$1
+installerPathPromoCodeRegex='.+-([a-zA-Z0-9]{3}[0-9]{3})\.pkg$'
+userDataDir="$HOME/Library/Application Support/brave"
+promoCodePath="$userDataDir/promoCode"
+# pkg runs this script as root so we need to get current username
+userName="$USER"
+echo "Installer path is: $installerPath"
+echo "Username is: $userName"
+
+if [[ $installerPath =~ $installerPathPromoCodeRegex ]]; then
+  echo "Installer path matched for promo code"
+  n=${#BASH_REMATCH[*]}
+  if [ $n -ge 1 ]; then
+    promoCode=${BASH_REMATCH[1]}
+    echo "Got promo code: $promoCode"
+    echo "Writing to user data directory at: $userDataDir/promoCode"
+    # TODO: it is a bit ugly to assume the user-data path here, and to manually
+    # write to it and hopefully set the correct permissions. An alternative would
+    # be to run Brave with a flag, similar to the process for Windows.
+    mkdir -p "$userDataDir"
+    echo "$promoCode" > "$promoCodePath"
+    # fix permissions
+    sudo chown "$userName" "$userDataDir"
+    sudo chown "$userName" "$promoCodePath"
+  fi
+else
+  echo "Installer path did not match for promo code"
+fi
+
+exit 0

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,22 +5,24 @@
   "requires": true,
   "dependencies": {
     "7zip-bin": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-2.2.4.tgz",
-      "integrity": "sha512-vs1IkxmbdYv0K8rPBXLl/qicRRF7CDjpOWHY1m+CUVByMkepJtWVlxtnszyY1rAWWL71IGc2JWRzJgUbHpzGDw==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-2.4.1.tgz",
+      "integrity": "sha512-QU3oR1dLLVrYGRkb7LU17jMCpIkWtXXW7q71ECXWXkR9vOv37VjykqpvFgs29HgSCNLZHnNKJzdG6RwAW0LwIA==",
       "dev": true,
       "requires": {
-        "7zip-bin-linux": "1.2.0",
+        "7zip-bin-linux": "1.3.1",
         "7zip-bin-mac": "1.0.1",
         "7zip-bin-win": "2.1.1"
+      },
+      "dependencies": {
+        "7zip-bin-linux": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/7zip-bin-linux/-/7zip-bin-linux-1.3.1.tgz",
+          "integrity": "sha512-Wv1uEEeHbTiS1+ycpwUxYNuIcyohU6Y6vEqY3NquBkeqy0YhVdsNUGsj0XKSRciHR6LoJSEUuqYUexmws3zH7Q==",
+          "dev": true,
+          "optional": true
+        }
       }
-    },
-    "7zip-bin-linux": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/7zip-bin-linux/-/7zip-bin-linux-1.2.0.tgz",
-      "integrity": "sha512-umB98LN18XBGKPw4EKET2zPDqVhEU1mxXA1Gx0BM+DoBt4hnlZPNkpSMNzmuNbQshi9SzLhqlTAyKcAgNrbV3Q==",
-      "dev": true,
-      "optional": true
     },
     "7zip-bin-mac": {
       "version": "1.0.1",
@@ -552,6 +554,16 @@
         }
       }
     },
+    "asar-integrity": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asar-integrity/-/asar-integrity-0.2.4.tgz",
+      "integrity": "sha512-6UDOmyl4RUo8i/0Sem/UKFJ70XZrXLCDQcILTbjTjAKZrSA3JbXVnWRFi2ZFEbeZxQ2LVCc3CWHnDlqj2AyVXg==",
+      "dev": true,
+      "requires": {
+        "bluebird-lst": "1.0.5",
+        "fs-extra-p": "4.5.0"
+      }
+    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -604,6 +616,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "dev": true
+    },
+    "async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
       "dev": true
     },
     "async-limiter": {
@@ -2214,12 +2232,20 @@
       "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
     },
     "bluebird-lst": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.3.tgz",
-      "integrity": "sha512-NKk/GQk5fXcLKt4USI1htGuMwXHhKLa2a32FCNBFAOcpL0k8U5yFpusr3+NKc6RjytL8umW5pSQmtJCWWhiLrQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.5.tgz",
+      "integrity": "sha512-Ey0bDNys5qpYPhZ/oQ9vOEvD0TYQDTILMXWP2iGfvMg7rSDde+oV4aQQgqRH+CvBFNz2BSDQnPGMUl6LKBUUQA==",
       "dev": true,
       "requires": {
-        "bluebird": "3.5.0"
+        "bluebird": "3.5.1"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+          "dev": true
+        }
       }
     },
     "bmp-js": {
@@ -2302,18 +2328,18 @@
       "integrity": "sha1-UEvbQxGMqNucu63yj9YPJlr5bk8="
     },
     "boxen": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.2.1.tgz",
-      "integrity": "sha1-DxHn/jRO25OXl3/BPt5/ZNlWSB0=",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
+      "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
         "ansi-align": "2.0.0",
         "camelcase": "4.1.0",
-        "chalk": "2.1.0",
+        "chalk": "2.3.0",
         "cli-boxes": "1.0.0",
         "string-width": "2.1.1",
         "term-size": "1.2.0",
-        "widest-line": "1.0.0"
+        "widest-line": "2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2328,7 +2354,7 @@
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.0"
+            "color-convert": "1.9.1"
           }
         },
         "camelcase": {
@@ -2338,20 +2364,20 @@
           "dev": true
         },
         "chalk": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-          "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
           "dev": true,
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.4.0"
+            "supports-color": "4.5.0"
           }
         },
         "color-convert": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-          "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
           "dev": true,
           "requires": {
             "color-name": "1.1.3"
@@ -2383,9 +2409,9 @@
           }
         },
         "supports-color": {
-          "version": "4.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
             "has-flag": "2.0.0"
@@ -2680,6 +2706,128 @@
         }
       }
     },
+    "builder-util": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-4.2.1.tgz",
+      "integrity": "sha512-yebI1DSH5YMGNtwGyrJclhun4HdKvYbDa/iYiZgTb8XwMp7Qx/i1j+JEEBFWTwG+wWOkNnP2EnVQfGPqtVMYSA==",
+      "dev": true,
+      "requires": {
+        "7zip-bin": "2.4.1",
+        "bluebird-lst": "1.0.5",
+        "builder-util-runtime": "4.0.3",
+        "chalk": "2.3.0",
+        "debug": "3.1.0",
+        "fs-extra-p": "4.5.0",
+        "ini": "1.3.5",
+        "is-ci": "1.1.0",
+        "js-yaml": "3.10.0",
+        "lazy-val": "1.0.3",
+        "semver": "5.5.0",
+        "source-map-support": "0.5.3",
+        "stat-mode": "0.2.2",
+        "temp-file": "3.1.1",
+        "tunnel-agent": "0.6.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ini": {
+          "version": "1.3.5",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-support": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
+          "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
+          "dev": true,
+          "requires": {
+            "source-map": "0.6.1"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "builder-util-runtime": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-4.0.3.tgz",
+      "integrity": "sha512-OgrYhUr/neAXSAIR4zw9icC8dbqs8lT23L3KpXX+htl6y3rPLVt3U2Y2b+8zURx6qgG19454V3Kr++XQKB5DMQ==",
+      "dev": true,
+      "requires": {
+        "bluebird-lst": "1.0.5",
+        "debug": "3.1.0",
+        "fs-extra-p": "4.5.0",
+        "sax": "1.2.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -2960,9 +3108,9 @@
       }
     },
     "ci-info": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
-      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
       "dev": true
     },
     "cipher-base": {
@@ -4837,6 +4985,28 @@
       "resolved": "https://registry.npmjs.org/disposables/-/disposables-1.0.1.tgz",
       "integrity": "sha1-BkcnoltU9QK9griaot+4358bOeM="
     },
+    "dmg-builder": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-3.1.3.tgz",
+      "integrity": "sha512-gysVZIdmAdfB3FFa7UBERESNobQVE+Z40up1LlRBHtVyCXPUc/1XOLU2wsC0ySvL76OZA6vxeqFJrnCjp6l37A==",
+      "dev": true,
+      "requires": {
+        "bluebird-lst": "1.0.5",
+        "builder-util": "4.2.1",
+        "fs-extra-p": "4.5.0",
+        "iconv-lite": "0.4.19",
+        "js-yaml": "3.10.0",
+        "parse-color": "1.0.0"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+          "dev": true
+        }
+      }
+    },
     "dnd-core": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/dnd-core/-/dnd-core-2.5.1.tgz",
@@ -4953,6 +5123,18 @@
       "requires": {
         "is-obj": "1.0.1"
       }
+    },
+    "dotenv": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-4.0.0.tgz",
+      "integrity": "sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=",
+      "dev": true
+    },
+    "dotenv-expand": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.0.1.tgz",
+      "integrity": "sha1-aP3cFWGBTgoQlkERBX/xOM7X16g=",
+      "dev": true
     },
     "drbg.js": {
       "version": "1.0.1",
@@ -5076,40 +5258,24 @@
       "dev": true
     },
     "electron-builder": {
-      "version": "17.10.0",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-17.10.0.tgz",
-      "integrity": "sha1-W3M1d/dYUL0wO0g1sGL5FTOLStI=",
+      "version": "19.55.3",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-19.55.3.tgz",
+      "integrity": "sha512-unCLWKJAmvdfDkzujm6J6+qDLeutd90jWlOZCtHMkXITdtLkj4Omk9oDiDhCmjiFoiHlvnFy4v9xuh/IJXZBSA==",
       "dev": true,
       "requires": {
-        "7zip-bin": "2.2.4",
-        "ajv": "5.2.3",
-        "ajv-keywords": "2.1.0",
-        "bluebird-lst": "1.0.3",
-        "chalk": "1.1.3",
-        "chromium-pickle-js": "0.2.0",
-        "cuint": "0.2.2",
-        "debug": "2.6.8",
-        "electron-builder-core": "17.2.0",
-        "electron-builder-http": "17.9.0",
-        "electron-builder-util": "17.9.0",
-        "electron-download-tf": "4.3.1",
-        "electron-osx-sign": "0.4.4",
-        "electron-publish": "17.9.0",
-        "fs-extra-p": "4.4.2",
-        "hosted-git-info": "2.5.0",
-        "is-ci": "1.0.10",
-        "isbinaryfile": "3.0.2",
-        "js-yaml": "3.10.0",
-        "minimatch": "3.0.4",
-        "node-forge": "0.7.1",
-        "normalize-package-data": "2.4.0",
-        "parse-color": "1.0.0",
-        "plist": "2.1.0",
+        "bluebird-lst": "1.0.5",
+        "builder-util": "4.2.1",
+        "builder-util-runtime": "4.0.3",
+        "chalk": "2.3.0",
+        "electron-builder-lib": "19.55.3",
+        "electron-download-tf": "4.3.4",
+        "fs-extra-p": "4.5.0",
+        "is-ci": "1.1.0",
+        "lazy-val": "1.0.3",
+        "read-config-file": "2.1.1",
         "sanitize-filename": "1.6.1",
-        "semver": "5.4.1",
-        "update-notifier": "2.2.0",
-        "uuid-1345": "0.99.6",
-        "yargs": "8.0.2"
+        "update-notifier": "2.3.0",
+        "yargs": "11.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5118,19 +5284,87 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
         "camelcase": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
           "dev": true
         },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "cliui": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.0.0.tgz",
+          "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
+          "dev": true,
+          "requires": {
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "electron-download-tf": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/electron-download-tf/-/electron-download-tf-4.3.4.tgz",
+          "integrity": "sha512-SQYDGMLpTgty1bx3NycuDb7dNPzktVSdK2sqPZjyRocauq/uN/V4S2lcpFVLupaHhKlD8zozm9fTpm5UdohvTg==",
+          "dev": true,
+          "requires": {
+            "debug": "3.1.0",
+            "env-paths": "1.0.0",
+            "fs-extra": "4.0.3",
+            "minimist": "1.2.0",
+            "nugget": "2.0.1",
+            "path-exists": "3.0.0",
+            "rc": "1.2.1",
+            "semver": "5.4.1",
+            "sumchecker": "2.0.2"
+          }
+        },
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
           }
         },
         "is-fullwidth-code-point": {
@@ -5139,17 +5373,20 @@
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
+            "graceful-fs": "4.1.11"
           }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
@@ -5160,36 +5397,6 @@
             "execa": "0.7.0",
             "lcid": "1.0.0",
             "mem": "1.1.0"
-          }
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "2.3.0"
-          }
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "2.1.0",
-            "read-pkg": "2.0.0"
           }
         },
         "string-width": {
@@ -5211,11 +5418,14 @@
             "ansi-regex": "3.0.0"
           }
         },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         },
         "which-module": {
           "version": "2.0.0",
@@ -5224,30 +5434,29 @@
           "dev": true
         },
         "yargs": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.0.0.tgz",
+          "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
           "dev": true,
           "requires": {
-            "camelcase": "4.1.0",
-            "cliui": "3.2.0",
+            "cliui": "4.0.0",
             "decamelize": "1.2.0",
+            "find-up": "2.1.0",
             "get-caller-file": "1.0.2",
             "os-locale": "2.1.0",
-            "read-pkg-up": "2.0.0",
             "require-directory": "2.1.1",
             "require-main-filename": "1.0.1",
             "set-blocking": "2.0.0",
             "string-width": "2.1.1",
             "which-module": "2.0.0",
             "y18n": "3.2.1",
-            "yargs-parser": "7.0.0"
+            "yargs-parser": "9.0.2"
           }
         },
         "yargs-parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
           "dev": true,
           "requires": {
             "camelcase": "4.1.0"
@@ -5255,61 +5464,53 @@
         }
       }
     },
-    "electron-builder-core": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/electron-builder-core/-/electron-builder-core-17.2.0.tgz",
-      "integrity": "sha1-4jXRGq5kv/utNrYBrFgXP5N39hk=",
-      "dev": true
-    },
-    "electron-builder-http": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/electron-builder-http/-/electron-builder-http-17.9.0.tgz",
-      "integrity": "sha1-52CUe4bF3qH7mgzv+EXMIef4gcw=",
+    "electron-builder-lib": {
+      "version": "19.55.3",
+      "resolved": "https://registry.npmjs.org/electron-builder-lib/-/electron-builder-lib-19.55.3.tgz",
+      "integrity": "sha512-bFhCq/upE6xfzkGEH33iXSk6dguf9QId3BsYW9Dn3dhnWG6TNeRpLQEZsy4u7bf52QVW65St7UruaUO1zr6p9w==",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
-        "fs-extra-p": "4.4.2"
+        "7zip-bin": "2.4.1",
+        "asar-integrity": "0.2.4",
+        "async-exit-hook": "2.0.1",
+        "bluebird-lst": "1.0.5",
+        "builder-util": "4.2.1",
+        "builder-util-runtime": "4.0.3",
+        "chromium-pickle-js": "0.2.0",
+        "debug": "3.1.0",
+        "dmg-builder": "3.1.3",
+        "ejs": "2.5.7",
+        "electron-osx-sign": "0.4.8",
+        "electron-publish": "19.55.2",
+        "fs-extra-p": "4.5.0",
+        "hosted-git-info": "2.5.0",
+        "is-ci": "1.1.0",
+        "isbinaryfile": "3.0.2",
+        "js-yaml": "3.10.0",
+        "lazy-val": "1.0.3",
+        "minimatch": "3.0.4",
+        "normalize-package-data": "2.4.0",
+        "plist": "2.1.0",
+        "read-config-file": "2.1.1",
+        "sanitize-filename": "1.6.1",
+        "semver": "5.5.0",
+        "temp-file": "3.1.1"
       },
       "dependencies": {
         "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
-        }
-      }
-    },
-    "electron-builder-util": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/electron-builder-util/-/electron-builder-util-17.9.0.tgz",
-      "integrity": "sha1-/uHkBruhAK/dBhFmHjnxq94rU/c=",
-      "dev": true,
-      "requires": {
-        "7zip-bin": "2.2.4",
-        "bluebird-lst": "1.0.3",
-        "chalk": "1.1.3",
-        "debug": "2.6.8",
-        "electron-builder-http": "17.9.0",
-        "fs-extra-p": "4.4.2",
-        "ini": "1.3.4",
-        "is-ci": "1.0.10",
-        "node-emoji": "1.8.1",
-        "source-map-support": "0.4.18",
-        "stat-mode": "0.2.2",
-        "tunnel-agent": "0.6.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
         }
       }
     },
@@ -5403,51 +5604,6 @@
         }
       }
     },
-    "electron-download-tf": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/electron-download-tf/-/electron-download-tf-4.3.1.tgz",
-      "integrity": "sha1-eTDySgjjZp6q04pffyiKEEYcr3I=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "env-paths": "1.0.0",
-        "fs-extra": "3.0.1",
-        "minimist": "1.2.0",
-        "nugget": "2.0.1",
-        "path-exists": "3.0.0",
-        "rc": "1.2.1",
-        "semver": "5.4.1",
-        "sumchecker": "2.0.2"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-          "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "3.0.1",
-            "universalify": "0.1.1"
-          }
-        },
-        "jsonfile": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-          "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
     "electron-installer-debian": {
       "version": "github:brave/electron-installer-debian#5f37713f52437678e5cbf9b17500fba4ae7cb5ad",
       "optional": true,
@@ -5456,7 +5612,7 @@
         "async": "2.5.0",
         "debug": "2.6.9",
         "fs-extra": "1.0.0",
-        "get-folder-size": "1.0.0",
+        "get-folder-size": "1.0.1",
         "glob": "7.1.2",
         "lodash": "4.17.4",
         "temp": "0.8.3",
@@ -5522,9 +5678,9 @@
       "integrity": "sha1-xOJow4puQvQN5WGPyQbR7WCPEao="
     },
     "electron-osx-sign": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.4.tgz",
-      "integrity": "sha1-r984RQzK6+bavspx+w+tYpSoxXw=",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/electron-osx-sign/-/electron-osx-sign-0.4.8.tgz",
+      "integrity": "sha1-8Ln63e2eHlTsNfqJh3tcbDTHvEA=",
       "dev": true,
       "requires": {
         "bluebird": "3.5.0",
@@ -5532,8 +5688,7 @@
         "debug": "2.6.9",
         "isbinaryfile": "3.0.2",
         "minimist": "1.2.0",
-        "plist": "2.1.0",
-        "tempfile": "1.1.1"
+        "plist": "2.1.0"
       },
       "dependencies": {
         "minimist": {
@@ -5669,24 +5824,62 @@
       }
     },
     "electron-publish": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-17.9.0.tgz",
-      "integrity": "sha1-WCbOIqBv+V6dHNb07jZ3A4EKJLs=",
+      "version": "19.55.2",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-19.55.2.tgz",
+      "integrity": "sha512-SVfyAxUiOTAt2XtR508Ud27N9xJ63os3AGUj7Cchk0tBTME2HlbPgal4e5UJuw15N8jPCAsttu96AaRhFbGq5Q==",
       "dev": true,
       "requires": {
-        "bluebird-lst": "1.0.3",
-        "chalk": "1.1.3",
-        "electron-builder-http": "17.9.0",
-        "electron-builder-util": "17.9.0",
-        "fs-extra-p": "4.4.2",
-        "mime": "1.4.1"
+        "bluebird-lst": "1.0.5",
+        "builder-util": "4.2.1",
+        "builder-util-runtime": "4.0.3",
+        "chalk": "2.3.0",
+        "fs-extra-p": "4.5.0",
+        "mime": "2.2.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
         "mime": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-          "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.2.0.tgz",
+          "integrity": "sha512-0Qz9uF1ATtl8RKJG4VRfOymh7PyEor6NbrI/61lRfuRe4vx9SNATrvAeTj2EWVRKjEQGskrzWkJBBY5NbaVHIA==",
           "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         }
       }
     },
@@ -7110,19 +7303,19 @@
       }
     },
     "fs-extra-p": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.4.2.tgz",
-      "integrity": "sha512-M13CUDkid+xqp8Z5GAwrUiuPcV/eEG9fOz/p9rZYm2H9eNO7qqvgsqxUly3CzQzOiXoihvGbqbvSuNWt0RgvUw==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/fs-extra-p/-/fs-extra-p-4.5.0.tgz",
+      "integrity": "sha512-V/sdZmV+Yx3+nfXmjRTdBP4mVWCt7hZ0+ZOv+IZo+6fdkBxafaGsI7mYeNv/J3rWyz+mIToCFQORFSwt1bZw8Q==",
       "dev": true,
       "requires": {
-        "bluebird-lst": "1.0.3",
-        "fs-extra": "4.0.2"
+        "bluebird-lst": "1.0.5",
+        "fs-extra": "5.0.0"
       },
       "dependencies": {
         "fs-extra": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+          "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -8145,6 +8338,12 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
+    "gar": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.2.tgz",
+      "integrity": "sha512-Zn3tdQgiXQlVHiASU/cXzpo+EOC1qE/tOPdge6SjgJC39MxHFlESOHN38a9htTszCQy8rMWiPzoypL8sNv0ifg==",
+      "optional": true
+    },
     "gather-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/gather-stream/-/gather-stream-1.0.0.tgz",
@@ -8201,25 +8400,19 @@
       "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
     },
     "get-folder-size": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-1.0.0.tgz",
-      "integrity": "sha1-E01mOg50VhG3L3HIOxPxsS8xuik=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-1.0.1.tgz",
+      "integrity": "sha1-gC+kIIQ03nEgUYKxWrfxNSCI5YA=",
       "optional": true,
       "requires": {
         "async": "1.5.2",
-        "minimist": "1.2.0"
+        "gar": "1.0.2"
       },
       "dependencies": {
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "optional": true
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "optional": true
         }
       }
@@ -8413,6 +8606,15 @@
           "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
           "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
         }
+      }
+    },
+    "global-dirs": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
+      "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
+      "requires": {
+        "ini": "1.3.4"
       }
     },
     "global-modules": {
@@ -9522,12 +9724,12 @@
       "dev": true
     },
     "is-ci": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
-      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
+      "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
       "dev": true,
       "requires": {
-        "ci-info": "1.1.1"
+        "ci-info": "1.1.2"
       }
     },
     "is-date-object": {
@@ -9609,6 +9811,16 @@
       "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
       "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM=",
       "dev": true
+    },
+    "is-installed-globally": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
+      "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
+      "requires": {
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-isodate": {
       "version": "0.0.1",
@@ -10371,6 +10583,12 @@
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "dev": true
     },
+    "lazy-val": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.3.tgz",
+      "integrity": "sha512-pjCf3BYk+uv3ZcPzEVM0BFvO9Uw58TmlrU0oG5tTrr9Kcid3+kdKxapH8CjdYmVa2nO5wOoZn2rdvZx2PKj/xg==",
+      "dev": true
+    },
     "lazystream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
@@ -11042,12 +11260,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-1.1.1.tgz",
       "integrity": "sha1-1vJPdcKMnsEjnKIGlSaJaW7BHmI="
-    },
-    "macaddress": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
-      "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
-      "dev": true
     },
     "magnet-uri": {
       "version": "5.1.7",
@@ -12142,12 +12354,6 @@
         "is-stream": "1.1.0"
       }
     },
-    "node-forge": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.1.tgz",
-      "integrity": "sha1-naYR6giYL0uUIGs760zJZl8gwwA=",
-      "dev": true
-    },
     "node-gyp": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
@@ -12425,6 +12631,7 @@
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
           "requires": {
             "ansi-styles": "2.2.1",
             "escape-string-regexp": "1.0.5",
@@ -12436,17 +12643,20 @@
             "ansi-styles": {
               "version": "2.2.1",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+              "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+              "dev": true
             },
             "escape-string-regexp": {
               "version": "1.0.5",
               "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+              "dev": true
             },
             "has-ansi": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
               "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+              "dev": true,
               "requires": {
                 "ansi-regex": "2.0.0"
               },
@@ -12454,7 +12664,8 @@
                 "ansi-regex": {
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                  "dev": true
                 }
               }
             },
@@ -12462,6 +12673,7 @@
               "version": "3.0.1",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
               "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
               "requires": {
                 "ansi-regex": "2.0.0"
               },
@@ -12469,14 +12681,16 @@
                 "ansi-regex": {
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
-                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
+                  "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc=",
+                  "dev": true
                 }
               }
             },
             "supports-color": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+              "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+              "dev": true
             }
           }
         },
@@ -12500,7 +12714,8 @@
         "cliclopts": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/cliclopts/-/cliclopts-1.1.1.tgz",
-          "integrity": "sha1-aUMcfLWvcjd0sNORG0w3USQxkQ8="
+          "integrity": "sha1-aUMcfLWvcjd0sNORG0w3USQxkQ8=",
+          "dev": true
         },
         "colors": {
           "version": "1.0.3",
@@ -12525,7 +12740,8 @@
         "deep-extend": {
           "version": "0.4.2",
           "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -12607,7 +12823,8 @@
         "ini": {
           "version": "1.3.4",
           "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+          "dev": true
         },
         "isemail": {
           "version": "1.2.0",
@@ -12668,7 +12885,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         },
         "nodesecurity-npm-utils": {
           "version": "5.0.0",
@@ -12690,7 +12908,16 @@
           "requires": {
             "deep-extend": "0.4.2",
             "ini": "1.3.4",
+            "minimist": "1.2.0",
             "strip-json-comments": "1.0.4"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
+            }
           }
         },
         "semver": {
@@ -12721,7 +12948,16 @@
           "requires": {
             "cliclopts": "1.1.1",
             "debug": "2.6.8",
+            "minimist": "1.2.0",
             "xtend": "4.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+              "dev": true
+            }
           }
         },
         "supports-color": {
@@ -12767,7 +13003,8 @@
         "xtend": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+          "dev": true
         }
       }
     },
@@ -13205,7 +13442,7 @@
       "dev": true,
       "requires": {
         "got": "6.7.1",
-        "registry-auth-token": "3.3.1",
+        "registry-auth-token": "3.3.2",
         "registry-url": "3.1.0",
         "semver": "5.4.1"
       }
@@ -14868,6 +15105,37 @@
       "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz",
       "integrity": "sha1-X2jKswfmY/GZk1J9m1icrORmEZQ="
     },
+    "read-config-file": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/read-config-file/-/read-config-file-2.1.1.tgz",
+      "integrity": "sha512-tzV5MRYA1OIbjy0ZC3cKlQZMLyRYMJ7k37Inff0CH0fQGXFP9p0s0eJ3bQxnnvQDhPSspnW9fw9v2K0b+6TODg==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.0",
+        "bluebird-lst": "1.0.5",
+        "dotenv": "4.0.0",
+        "dotenv-expand": "4.0.1",
+        "fs-extra-p": "4.5.0",
+        "js-yaml": "3.10.0",
+        "json5": "0.5.1",
+        "lazy-val": "1.0.3"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "4.6.0",
+            "fast-deep-equal": "1.0.0",
+            "fast-json-stable-stringify": "2.0.0",
+            "json-schema-traverse": "0.3.1"
+          }
+        }
+      }
+    },
     "read-file-stdin": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/read-file-stdin/-/read-file-stdin-0.2.1.tgz",
@@ -15125,9 +15393,9 @@
       }
     },
     "registry-auth-token": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.1.tgz",
-      "integrity": "sha1-+w0yie4Nmtosu1KvXf5mywcNMAY=",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
         "rc": "1.2.1",
@@ -17175,22 +17443,16 @@
         }
       }
     },
-    "tempfile": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-1.1.1.tgz",
-      "integrity": "sha1-W8xOrsxKsscH2LwR2ZzMmiyyh/I=",
+    "temp-file": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.1.1.tgz",
+      "integrity": "sha512-W/6SJgtg2SE/5rxgwUwoDhdSXrvUWQBpgKJglaAe6S7mk1kLkI+LUbY/jPZBu3UhydDJZstNNd7AJhnZ0UZHtw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "1.0.2",
-        "uuid": "2.0.3"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
-          "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-          "dev": true
-        }
+        "async-exit-hook": "2.0.1",
+        "bluebird-lst": "1.0.5",
+        "fs-extra-p": "4.5.0",
+        "lazy-val": "1.0.3"
       }
     },
     "term-size": {
@@ -17846,19 +18108,60 @@
       "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4="
     },
     "update-notifier": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.2.0.tgz",
-      "integrity": "sha1-G1g3z5DAc22IYncytmHBOPht5y8=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.3.0.tgz",
+      "integrity": "sha1-TognpruRUUCrCTVZ1wFOPruDdFE=",
       "dev": true,
       "requires": {
-        "boxen": "1.2.1",
-        "chalk": "1.1.3",
+        "boxen": "1.3.0",
+        "chalk": "2.3.0",
         "configstore": "3.1.1",
         "import-lazy": "2.1.0",
+        "is-installed-globally": "0.1.0",
         "is-npm": "1.0.0",
         "latest-version": "3.1.0",
         "semver-diff": "2.1.0",
         "xdg-basedir": "3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
       }
     },
     "urix": {
@@ -18009,15 +18312,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
       "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
-    },
-    "uuid-1345": {
-      "version": "0.99.6",
-      "resolved": "https://registry.npmjs.org/uuid-1345/-/uuid-1345-0.99.6.tgz",
-      "integrity": "sha1-sScK4BWnchx63sbEbsFpxgmK7UA=",
-      "dev": true,
-      "requires": {
-        "macaddress": "0.2.8"
-      }
     },
     "v8-compile-cache": {
       "version": "1.1.0",
@@ -19052,12 +19346,45 @@
       }
     },
     "widest-line": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
-      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
+      "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
       }
     },
     "wif": {

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "co-mocha": "^1.1.2",
     "cross-env": "^3.1.4",
     "css-loader": "~0.28.7",
-    "electron-builder": "^17.1.1",
+    "electron-builder": "^19.55.3",
     "electron-chromedriver": "^1.7.1",
     "electron-packager": "brave/electron-packager",
     "electron-prebuilt": "brave/electron-prebuilt",

--- a/res/dev/builderConfig.json
+++ b/res/dev/builderConfig.json
@@ -13,6 +13,7 @@
     ]
   },
   "pkg": {
+    "scripts": "pkg-scripts/",
     "installLocation": "/Applications",
     "allowAnywhere": false,
     "allowCurrentUserHome": false,

--- a/res/dev/builderConfig.json
+++ b/res/dev/builderConfig.json
@@ -3,7 +3,17 @@
   "productName": "Brave",
   "npmRebuild": false,
   "mac": {
-    "target": "dmg"
+    "target": [
+      {
+        "target": "pkg"
+      },
+      {
+        "target": "dmg"
+      }
+    ]
+  },
+  "pkg": {
+    "installLocation": "/Applications"
   },
   "dmg": {
     "title": "Brave",

--- a/res/dev/builderConfig.json
+++ b/res/dev/builderConfig.json
@@ -13,7 +13,10 @@
     ]
   },
   "pkg": {
-    "installLocation": "/Applications"
+    "installLocation": "/Applications",
+    "allowAnywhere": false,
+    "allowCurrentUserHome": false,
+    "allowRootDirectory": false
   },
   "dmg": {
     "title": "Brave",

--- a/tools/buildInstaller.js
+++ b/tools/buildInstaller.js
@@ -91,9 +91,11 @@ if (isDarwin) {
   const wvResources = wvContents + '/Resources'
   const wvBundleSig = wvResources + '/Brave Framework.sig'
   const wvPlugin = buildDir + `/${appName}.app/Contents/Frameworks/Brave Framework.framework/Libraries/WidevineCdm/_platform_specific/mac_x64/widevinecdmadapter.plugin`
+  // choose pkg or dmg based on channel
   cmds = [
     // Remove old
     'rm -f ' + outDir + `/${appName}.dmg`,
+    'rm -f ' + outDir + `/${appName}.pkg`,
 
     // sign for widevine
     'mkdir -p "' + wvResources + '"',
@@ -109,11 +111,10 @@ if (isDarwin) {
     'cd ../../..',
     `codesign --deep --force --strict --verbose --sign $IDENTIFIER ${appName}.app/`,
 
-    // Package it into a dmg
+    // Package it into a dmg or package
     'cd ..',
     'build ' +
       '--prepackaged="' + buildDir + `/${appName}.app" ` +
-      '--mac=dmg ' +
       ` --config=res/${channel}/builderConfig.json `,
 
     // Create an update zip
@@ -125,7 +126,7 @@ if (isDarwin) {
       return
     }
 
-    console.log.bind(null, 'done')
+    console.log('done')
   })
 } else if (isWindows) {
   // a cert file must be present to sign the created package


### PR DESCRIPTION
Bash script parses promocode e.g. pem001 from filename e.g. /path/to/Brave-Setup-v0.22-pem001.pkg

Fix #12786 

**Depends on #12946 (use pkg installer instead of dmg for macOS release channel)** ✅ now merged

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)


### Test plan
- Delete all Brave.app's everywhere (/Applications, browser-laptop/Brave*/, ...)
  - the .pkg installer will see these as existing (and moved installations), and upgrade them instead)
- Build package
- Build installer
- Rename installer with `-pem001` at end (before .pkg)
- Run installer

Observe:
- Brave still runs correctly after install
- `promoCode` file is created inside user-data dir with the contents: `pem001`

Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


