### PR TITLE
Prevent cmd-w or ctrl-w closing a pinned tab.

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -85,7 +85,12 @@ const createFileSubmenu = () => {
       label: locale.translation('closeTab'),
       accelerator: 'CmdOrCtrl+W',
       click: function () {
-        appActions.tabCloseRequested(tabState.TAB_ID_ACTIVE)
+        const tabId = tabState.TAB_ID_ACTIVE
+        // Do not allow closing a pinned tab.
+        const isPinned = tabState.isTabPinned(state, tabId)
+        if (!isPinned) {
+          appActions.tabCloseRequested(tabId)
+        }
       }
     }, {
       // This should be disabled when no windows are active.


### PR DESCRIPTION
Change the `CmdOrCtrl+w` accelerator to check whether a tab is pinned before sending `tabCloseRequested`, and do nothing otherwise.

This will allow closing a pinned tab via any other method to continue to work normally.

Fixes #1563.

Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

Test Plan:
Still unsure!

Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


