### PR TITLE
Fixes issue #12918, hides empty ad container on www.yahoo.com

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -53,7 +53,12 @@ let generateBraveManifest = () => {
       {
         run_at: 'document_start',
         all_frames: true,
-        matches: ['https://www.washingtonpost.com/*', 'https://www.youtube.com/*', 'https://coinmarketcap.com/*'],
+        matches: [
+          'https://www.washingtonpost.com/*',
+          'https://www.youtube.com/*',
+          'https://coinmarketcap.com/*',
+          'https://www.yahoo.com/*'
+        ],
         css: [
           'content/styles/removeEmptyElements.css'
         ]

--- a/app/extensions/brave/content/styles/removeEmptyElements.css
+++ b/app/extensions/brave/content/styles/removeEmptyElements.css
@@ -8,7 +8,8 @@
   .ytp-ad-progress-list,
   .ad-container,
   #video-masthead,
-  #watch-channel-brand-div {
+  #watch-channel-brand-div,
+  #Billboard-ad {
     display: none !important;
 }
 


### PR DESCRIPTION
Fixes #12918

This is a pretty straightforward fix, the container for the yahoo billboard ad is identifiable by the element Id Billboard-ad. This adds that container to removeEmptyElements.css, as well as adds www.yahoo.com to the sites that removeEmptyElements.css is loaded on.

I did make a slight stylistic change, I broke out the sites inside the matches[] array on to a new line, as it was getting pretty lengthy on one line (it's presumably going to get longer). Let me know if this isn't preferred and I can revert it :)

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

1. Navigate to https://www.yahoo.com/
2. Confirm that the display on the billboard ad (identified by Id: Billboard-ad) is set to none.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

