### PR TITLE
clear old pinned items stored in wrong position

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -847,6 +847,16 @@ module.exports.runPreMigrations = (data) => {
       if (data.cache) {
         delete data.cache.bookmarkLocation
       }
+
+      // pinned top sites were stored in the wrong position in 0.19.x
+      // allowing duplicated items. See #12941
+      // in this case eliminate pinned items so they can be properly
+      // populated in their own indexes
+      if (data.about.newtab.pinnedTopSites) {
+        // Empty array is currently set to include default pinned sites
+        // which we avoid given the user already have a profile
+        data.about.newtab.pinnedTopSites = [null]
+      }
     }
   }
 


### PR DESCRIPTION
fix #12941 

TL;DR: The bug is caused because pinned top sites were stored in a wrong position -- instead of own index they were pushed to the first index, causing duplicates. Since duplicated keys are hidden you ended up having only one tile.

The fix cleans pinned top sites from the previous version.

Test Plan:

1. checkout 0.19.x
2. Visit some websites, restart browser a couple times until some tiles start disappearing, you'll reach a point where only twitter is shown
3. Switch to 0.20.x  
4. Top sites should be populated with sites you visited in step 1