### PR TITLE
Localize multi-selection bookmarks

### DIFF
--- a/app/extensions/brave/locales/en-US/bookmarks.properties
+++ b/app/extensions/brave/locales/en-US/bookmarks.properties
@@ -12,3 +12,4 @@ lastVisited=Last Visited
 otherBookmarks=Other Bookmarks
 partitionNumber=Session {{partitionNumber}}
 title=Title
+multiSelectionBookmarks=Multi-selection ({{count}} bookmarks)

--- a/app/locale.js
+++ b/app/locale.js
@@ -256,6 +256,7 @@ var rendererIdentifiers = function () {
     'downloadPaused',
     'noDownloads',
     'torrentDesc',
+    'multiSelectionBookmarks',
     // Caption buttons in titlebar (min/max/close - Windows only)
     'windowCaptionButtonMinimize',
     'windowCaptionButtonMaximize',
@@ -415,7 +416,8 @@ exports.init = function (language) {
       path.join(__dirname, 'extensions', 'brave', 'locales', lang, 'countries.properties'),
       path.join(__dirname, 'extensions', 'brave', 'locales', lang, 'locales.properties'),
       path.join(__dirname, 'extensions', 'brave', 'locales', lang, 'preferences.properties'),
-      path.join(__dirname, 'extensions', 'brave', 'locales', lang, 'downloads.properties')
+      path.join(__dirname, 'extensions', 'brave', 'locales', lang, 'downloads.properties'),
+      path.join(__dirname, 'extensions', 'brave', 'locales', lang, 'bookmarks.properties')
       )
   }
 

--- a/app/renderer/about/bookmarks/bookmarksList.js
+++ b/app/renderer/about/bookmarks/bookmarksList.js
@@ -20,6 +20,7 @@ const appActions = require('../../../../js/actions/appActions')
 
 // Utils
 const dndData = require('../../../../js/dndData')
+const locale = require('../../../../js/l10n')
 
 class BookmarksList extends ImmutableComponent {
   onDoubleClick (entry, e) {
@@ -42,8 +43,9 @@ class BookmarksList extends ImmutableComponent {
     e.dataTransfer.effectAllowed = 'all'
     dndData.setupDataTransferBraveData(e.dataTransfer, dragTypes.BOOKMARK, siteDetail)
     // TODO: Pass the location here when content scripts are fixed
+    const count = siteDetail.size
     dndData.setupDataTransferURL(e.dataTransfer, '', isList
-      ? 'Multi-selection (' + siteDetail.size + ' bookmarks)'
+      ? locale.translation('multiSelectionBookmarks', {count})
       : siteDetail.get('title'))
   }
   /**


### PR DESCRIPTION
Fixes #10105

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

On macOS:
1. Open about:bookmarks (Bookmarks > Bookmarks...)
2. Make sure there are at least two bookmarks. Create some if needed.
3. Open TextEdit and place the TextEdit window beside the Brave window (Brave on the left half of screen, TextEdit on the right half).
4. Select two bookmarks.
5. Drag the bookmarks to the TextEdit window.
6. The text in the TextEdit window should say `Multi-selection (2 bookmarks)`.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


