### PR TITLE
Download bar can now be closed when download is in progress

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -566,6 +566,7 @@ function updateDownloadState (win, downloadId, item, state) {
 }
 
 function registerForDownloadListener (session) {
+  var repaint = false
   session.on('default-download-directory-changed', (e, newPath) => {
     if (newPath !== getSetting(settings.DOWNLOAD_DEFAULT_PATH)) {
       appActions.changeSetting(settings.DOWNLOAD_DEFAULT_PATH, newPath)
@@ -590,14 +591,16 @@ function registerForDownloadListener (session) {
     item.setPrompt(getSetting(settings.DOWNLOAD_ALWAYS_ASK) || false)
 
     const downloadId = item.getGuid()
+    repaint = true
     item.on('updated', function (e, st) {
       if (!item.getSavePath()) {
         return
       }
       const state = item.isPaused() ? downloadStates.PAUSED : downloadStates.IN_PROGRESS
       updateDownloadState(win, downloadId, item, state)
-      if (win && !win.isDestroyed() && !win.webContents.isDestroyed()) {
+      if (win && !win.isDestroyed() && !win.webContents.isDestroyed() && repaint) {
         win.webContents.send(messages.SHOW_DOWNLOADS_TOOLBAR)
+        repaint = false
       }
       item.on('removed', function () {
         updateElectronDownloadItem(downloadId, item, downloadStates.CANCELLED)


### PR DESCRIPTION
Fixes : #11923

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Launch Browser
2. Open https://download.fedoraproject.org/pub/fedora/linux/releases/27/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-27-1.6.iso
3. Choose save location as desktop
4. Verify download bar shows
5. Close download bar
6. Verify download bar does not re-open

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


