### PR TITLE
Revert "Add accelerator keys to create new session tabs"

### DIFF
--- a/app/common/commonMenu.js
+++ b/app/common/commonMenu.js
@@ -93,7 +93,6 @@ module.exports.newPrivateTabMenuItem = () => {
 module.exports.newPartitionedTabMenuItem = () => {
   const newPartitionedMenuItem = (partitionNumber) => ({
     label: `${locale.translation('newSessionTab')} ${partitionNumber}`,
-    accelerator: 'CmdOrCtrl+Alt+' + partitionNumber,
     click: (item, focusedWindow) => {
       ensureAtLeastOneWindow({
         partitionNumber


### PR DESCRIPTION
Reverts brave/browser-laptop#10364

Fix #12956

test plan (Windows):
- visit site with an input box (duckduckgo.com)
- Attempt to insert special character (<kbd>altgr</kbd>+<kbd>3</kbd>)
- Observe character is inserted and new session tab is not opened
