### PR TITLE
Fix restart notification bar when changing language setting.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -286,7 +286,7 @@ app.on('ready', () => {
             appActions.hideNotification(message)
           }
         }
-        if (prefsRestartLastValue[config] === undefined) {
+        if (prefsRestartLastValue[config] === undefined && typeof value === 'boolean') {
           prefsRestartLastValue[config] = value
         }
       }


### PR DESCRIPTION
Fix #6750 
@bsclifton 
## Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [X] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [X] Added/updated tests for this change (for new code or code which already has tests).
- [X] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Run webpack: npm run watch
2. Run Brave: npm run start
3. Open Brave settings: about:preferences  or about:preferences#advanced 
4. Change language: Choose a language from the Language menu
5. Choose another language
6. Result: Restart notification bar should always show when changing to another language


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


