### PR TITLE
Disables Action column header in ledger payments table

### DIFF
--- a/app/renderer/components/common/sortableTable.js
+++ b/app/renderer/components/common/sortableTable.js
@@ -479,7 +479,8 @@ class SortableTable extends React.Component {
               [css(styles.table__th, this.props.smallRow && styles.table__th_smallRow)]: true
             }
             const isString = typeof heading === 'string'
-            const sortMethod = this.sortingDisabled ? 'none' : (dataType === 'number' ? 'number' : undefined)
+            const nonSortableColumns = this.props.nonSortableColumns ? this.props.nonSortableColumns : []
+            const sortMethod = (this.sortingDisabled || nonSortableColumns.includes(heading)) ? 'none' : (dataType === 'number' ? 'number' : undefined)
             if (isString) headerClasses['heading-' + heading] = true
 
             return <th className={cx(headerClasses)}

--- a/app/renderer/components/preferences/payment/ledgerTable.js
+++ b/app/renderer/components/preferences/payment/ledgerTable.js
@@ -297,6 +297,7 @@ class LedgerTable extends ImmutableComponent {
         fillAvailable
         smallRow
         headings={['', 'publisher', 'include', 'views', 'timeSpent', 'percentage', 'actions']}
+        nonSortableColumns={['actions']}
         defaultHeading='percentage'
         defaultHeadingSortOrder='desc'
         headerStyles={styles.header}


### PR DESCRIPTION
Resolves #13074

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

Ensure that the Actions column on the ledger table in about:preferences#payments is neither clickable nor sortable.

Ensure that other implementations of the SortableTable such as on about:history work as expected without error.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

As opposed to hard coding in something to exclude the Actions column from being clickable/sortable, I thought it would be helpful to have a nonSortableColumns property on the <SortableTable> component for future column exclusions as more tables may be added. It is implemented in such away that not having the property does not break anything or produce any unexpected behavior. 
