### PR TITLE
Fix promoCode Regex to include valid suffix

### DIFF
--- a/app/cmdLine.js
+++ b/app/cmdLine.js
@@ -17,7 +17,7 @@ const fs = require('fs')
 const path = require('path')
 
 const isDarwin = process.platform === 'darwin'
-const promoCodeFilenameRegex = /-([a-zA-Z\d]{3}\d{3})$/g
+const promoCodeFilenameRegex = /-([a-zA-Z\d]{3}\d{3})\s?(?:\(\d+\))?$/g
 const debugTabEventsFlagName = '--debug-tab-events'
 
 let appInitialized = false

--- a/build/pkg-scripts/postinstall
+++ b/build/pkg-scripts/postinstall
@@ -4,7 +4,7 @@
 # Extract a referral / promo code from the installer path of the format /dir/path/Setup-Brave-Anything-xxx001.pkg
 # where the promo code would be xxx001
 installerPath=$1
-installerPathPromoCodeRegex='.+-([a-zA-Z0-9]{3}[0-9]{3})\.pkg$'
+installerPathPromoCodeRegex='.+-([a-zA-Z0-9]{3}[0-9]{3})\s?(?:\([0-9]+\))?\.pkg$'
 userDataDir="$HOME/Library/Application Support/brave"
 promoCodePath="$userDataDir/promoCode"
 # pkg runs this script as root so we need to get current username


### PR DESCRIPTION
Fix #13089

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Open Firefox
2. Download Brave from https://staging.brave.com/ABC-123
3. Download again Brave from https://staging.brave.com/ABC-123
4. Run downloaded file from 3.

Expected Result:
promoCode file is created inside user-data dir with the contents: ABC123

Repeat for Chrome and Safari

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests
https://regex101.com/r/1ymYY3/3/
https://regex101.com/r/ehl7rC/1

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


