### PR TITLE
Pinned donations are always shown

### DIFF
--- a/app/common/lib/ledgerUtil.js
+++ b/app/common/lib/ledgerUtil.js
@@ -153,6 +153,7 @@ const visibleP = (state, publisherKey) => {
     state = ledgerState.setSynopsisOption(state, 'showOnlyVerified', showOnlyVerified)
   }
 
+  const pinPercentage = publisher.get('pinPercentage')
   const publisherOptions = publisher.get('options', Immutable.Map())
   const onlyVerified = !showOnlyVerified
 
@@ -160,15 +161,17 @@ const visibleP = (state, publisherKey) => {
   const deletedByUser = blockedP(state, publisherKey)
   const eligibleByStats = eligibleP(state, publisherKey) // num of visits and time spent
   const verifiedPublisher = publisherOptions.get('verified')
+  const isPinned = pinPercentage && pinPercentage > 0
 
-  return (
+  return ((
       eligibleByStats &&
       (
         (onlyVerified && verifiedPublisher) ||
         !onlyVerified
       )
     ) &&
-    !deletedByUser
+    !deletedByUser) ||
+    isPinned
 }
 
 // TODO rename function


### PR DESCRIPTION
Resolves issue #12584

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

Test plan is reflected in the issue:

1. Set the threshold to 5 visits, and quality a few domains
2. Pin one of the domains
3. Increase the threshold to 10 visits

Ensure the pinned domain is present. Note: Use either the time spent or visit no. criteria.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header

This is a pretty straightforward fix for the pinned donations disappearing depending on threshold specs. An override is added to visibleP() inside the ledgerUtil module if a site is pinned. 
