### PR TITLE
Fix bookmarking brave default top tile favicon issue.

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -167,7 +167,13 @@ let generateBraveManifest = () => {
       }
     ],
     web_accessible_resources: [
-      'img/favicon.ico'
+      'img/favicon.ico',
+      'img/newtab/defaultTopSitesIcon/appstore.png',
+      'img/newtab/defaultTopSitesIcon/brave.ico',
+      'img/newtab/defaultTopSitesIcon/facebook.png',
+      'img/newtab/defaultTopSitesIcon/playstore.png',
+      'img/newtab/defaultTopSitesIcon/twitter.png',
+      'img/newtab/defaultTopSitesIcon/youtube.png'
     ],
     permissions: [
       'externally_connectable.all_urls', 'tabs', '<all_urls>', 'contentSettings', 'idle'


### PR DESCRIPTION
Fix #9568 
@bsclifton 
## Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [X] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Clean Install brave
2. Set Bookmarks Bar to Text and Favicons
3. Bookmark brave default top tiles
4. Result

![bravebookmarkingtoptiles](https://user-images.githubusercontent.com/18662996/36112674-4618e74a-0fdf-11e8-8492-130a0e100977.png)


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


