### PR TITLE
mac - set file mode and group owner for pkg-installed Brave.app

### DIFF
--- a/build/pkg-scripts/postinstall
+++ b/build/pkg-scripts/postinstall
@@ -4,6 +4,10 @@
 # Extract a referral / promo code from the installer path of the format /dir/path/Setup-Brave-Anything-xxx001.pkg
 # where the promo code would be xxx001
 installerPath=$1
+installationPath=$2
+# TODO: ugly to assume the name of the app, especially with multi-channel.
+# Luckily for now, release channel is the only channel with a pkg installer.
+installationAppPath="$installationPath/Brave.app"
 installerPathPromoCodeRegex='.+-([a-zA-Z0-9]{3}[0-9]{3})\s?(?:\([0-9]+\))?\.pkg$'
 userDataDir="$HOME/Library/Application Support/brave"
 promoCodePath="$userDataDir/promoCode"
@@ -11,7 +15,17 @@ promoCodePath="$userDataDir/promoCode"
 userName="$USER"
 echo "Installer path is: $installerPath"
 echo "Username is: $userName"
+echo "Installation app path is: $installationAppPath"
 
+# Fix the permissions on installed .app so that updater has permissions to write new version
+# by default pkg with install the .app with root:wheel owner and 'drwxr-xr-x' permission.
+# Since the app is run by the user, and the updater built-in to electron does not successfully
+# escalate to root permissions, updating will fail.
+# We'll allow all standard users of the machine permissions to run and update the app.
+sudo chmod -R 775 "$installationAppPath"
+sudo chgrp -R staff "$installationAppPath"
+
+# Detect if installer contained a referral promotion code within the filename
 if [[ $installerPath =~ $installerPathPromoCodeRegex ]]; then
   echo "Installer path matched for promo code"
   n=${#BASH_REMATCH[*]}


### PR DESCRIPTION
…appropriate to app update feature

Fix #13109
Fix #13106

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


