### PR TITLE
Mac - installer has valid regex for detecting promoCode when duplicate files have been downloaded

### DIFF
--- a/build/pkg-scripts/postinstall
+++ b/build/pkg-scripts/postinstall
@@ -8,7 +8,7 @@ installationPath=$2
 # TODO: ugly to assume the name of the app, especially with multi-channel.
 # Luckily for now, release channel is the only channel with a pkg installer.
 installationAppPath="$installationPath/Brave.app"
-installerPathPromoCodeRegex='.+-([a-zA-Z0-9]{3}[0-9]{3})\s?(?:\([0-9]+\))?\.pkg$'
+installerPathPromoCodeRegex='.+-([a-zA-Z0-9]{3}[0-9]{3})([[:blank:]]?\([0-9]+\))?\.pkg$'
 userDataDir="$HOME/Library/Application Support/brave"
 promoCodePath="$userDataDir/promoCode"
 # pkg runs this script as root so we need to get current username


### PR DESCRIPTION
E.g. Brave-Setup-rom033.pkg
E.g. Brave-Setup-rom033(1).pkg
E.g. Brave-Setup-rom033 (1).pkg
E.g. Brave-Setup-rom033 (21).pkg

Fix #13112

I tested this by creating a reduced script:
```
#!/bin/sh
installerPath=$1
installerPathPromoCodeRegex='.+-([a-zA-Z0-9]{3}[0-9]{3})([[:blank:]]?\([0-9]+\))?\.pkg$'
echo "Installer path is: $installerPath"

if [[ $installerPath =~ $installerPathPromoCodeRegex ]]; then
  echo "Installer path matched for promo code"
  n=${#BASH_REMATCH[*]}
  if [ $n -ge 1 ]; then
    promoCode=${BASH_REMATCH[1]}
    echo "Got promo code: $promoCode"
  fi
else
  echo "Installer path did not match for promo code"
fi

exit 0
```

and running:
```
~/Development/tmp
❯ ./postinstall-test.sh "hi-pem001.pkg"
Installer path is: hi-pem001.pkg
Installer path matched for promo code
Got promo code: pem001

~/Development/tmp
❯ ./postinstall-test.sh "hi-pem001(1).pkg"
Installer path is: hi-pem001(1).pkg
Installer path matched for promo code
Got promo code: pem001

~/Development/tmp
❯ ./postinstall-test.sh "hi-pem001 (1).pkg"
Installer path is: hi-pem001 (1).pkg
Installer path matched for promo code
Got promo code: pem001

~/Development/tmp
❯ ./postinstall-test.sh "hi-pem001 (12).pkg"
Installer path is: hi-pem001 (12).pkg
Installer path matched for promo code
Got promo code: pem001

~/Development/tmp
❯ ./postinstall-test.sh "hi-pem001(12).pkg"
Installer path is: hi-pem001(12).pkg
Installer path matched for promo code
Got promo code: pem001

~/Development/tmp
❯ ./postinstall-test.sh "hi-pemf001(12).pkg"
Installer path is: hi-pemf001(12).pkg
Installer path did not match for promo code
```


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


