### PR TITLE
Update pkg-installed app permissions to $USER:admin

### DIFF
--- a/build/pkg-scripts/postinstall
+++ b/build/pkg-scripts/postinstall
@@ -17,13 +17,15 @@ echo "Installer path is: $installerPath"
 echo "Username is: $userName"
 echo "Installation app path is: $installationAppPath"
 
-# Fix the permissions on installed .app so that updater has permissions to write new version
-# by default pkg with install the .app with root:wheel owner and 'drwxr-xr-x' permission.
+# Fix the permissions on installed .app so that updater has permissions to write new contents.
+# By default pkg with install the .app with root:wheel owner and 'drwxr-xr-x' permission.
 # Since the app is run by the user, and the updater built-in to electron does not successfully
 # escalate to root permissions, updating will fail.
-# We'll allow all standard users of the machine permissions to run and update the app.
+# We'll allow all admin users of the machine permissions to update the app, as well as the installing-user
+# (who may not be an admin).
 sudo chmod -R 775 "$installationAppPath"
-sudo chgrp -R staff "$installationAppPath"
+sudo chown -R $USER "$installationAppPath"
+sudo chgrp -R admin "$installationAppPath"
 
 # Detect if installer contained a referral promotion code within the filename
 if [[ $installerPath =~ $installerPathPromoCodeRegex ]]; then


### PR DESCRIPTION
Only the installing user, or any admin-user should be able to update the app.
Note that non-admin user will still not be able to update the app (as is currently the case with .dmg 'installer') due to #10100 (which I assume is `electron.autoUpdater` having trouble with permissions).

Fix #13130 

These permissions were discussed with myself, @diracdeltas and @jumde 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


