### PR TITLE
Made urlBarIconContainer clickable to display connection info. Fix #7888

### DIFF
--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -213,6 +213,10 @@ class UrlBar extends React.Component {
     }
   }
 
+  onUrlBarIconContainerClick () {
+    windowActions.setSiteInfoVisible(true)
+  }
+
   onBlur (e) {
     windowActions.urlBarOnBlur(getCurrentWindowId(), e.target.value, this.props.urlbarLocation, eventElHasAncestorWithClasses(e, ['urlBarSuggestions', 'urlbarForm']))
   }
@@ -497,13 +501,13 @@ class UrlBar extends React.Component {
 
   render () {
     const urlbarIconContainer = this.props.evCert
-    ? (<div className='urlbarIconContainer'>
+    ? (<div onClick={this.onUrlBarIconContainerClick} className='urlbarIconContainer'>
       <UrlBarIcon
         titleMode={this.props.titleMode}
       />
       {this.showEvCert}
     </div>)
-    : (<div className='urlbarIconContainer'>
+    : (<div onClick={this.onUrlBarIconContainerClick} className='urlbarIconContainer'>
       <UrlBarIcon
         titleMode={this.props.titleMode}
       />
@@ -513,13 +517,13 @@ class UrlBar extends React.Component {
         urlbarForm: true,
         [css(styles.urlbarForm_wide)]: this.props.isWideURLbarEnabled,
         noBorderRadius: this.props.publisherButtonVisible
-      })}
+      })} 
       id='urlbar'
     >
       {urlbarIconContainer}
       {
         this.props.titleMode
-        ? <div id='titleBar' data-test-id='titleBar'>
+        ? <div id='titleBar' data-test-id='titleBar' >
           <span><strong>{this.props.hostValue}</strong></span>
           <span>{this.props.hostValue && this.titleValue ? ' | ' : ''}</span>
           <span>{this.titleValue}</span>

--- a/app/renderer/components/styles/global.js
+++ b/app/renderer/components/styles/global.js
@@ -391,7 +391,6 @@ globalStyles.color.chromeBorderColor = globalStyles.color.chromePrimary
 globalStyles.color.chromeControlsWarningBackground = globalStyles.color.chromePrimary
 globalStyles.color.audioColor = globalStyles.color.highlightBlue
 globalStyles.color.focusUrlbarOutline = globalStyles.color.highlightBlue
-globalStyles.color.siteSecureColor = globalStyles.color.buttonColor
 globalStyles.color.loadTimeColor = globalStyles.color.highlightBlue
 globalStyles.color.activeTabDefaultColor = globalStyles.color.chromePrimary
 

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -574,8 +574,6 @@
   }
 }
 
-@urlbarFormHeight: 25px;
-
 .urlbarForm {
   position: relative; // PR #6485
   width: 0; // Fixes #4298
@@ -619,8 +617,7 @@
     color: @chromeText;
 
     // #4922
-    // TODO: replace this value with a CSS variable to add a dark UI.
-    background: #fff;
+    background: @chromeControlsBackground2;
   }
 
   @media (max-width: @breakpointNarrowViewport) {
@@ -825,7 +822,7 @@
       justify-content: center;
       height: @urlbarFormHeight;
       min-height: @urlbarFormHeight;
-      margin: 0 5px;
+      margin-right: 5px;
       max-width: 40%;
 
       .urlbarIcon {
@@ -835,7 +832,7 @@
         background-position: center;
         position: relative;
         bottom: -1px;
-        margin-left: 3px;
+        padding: 5px 7px 5px 7px;
 
         // about:newtab
         &.fa-search {
@@ -863,8 +860,9 @@
 
       .evCert {
         font-size: 12px;
-        color: forestgreen;
-        padding: 5px;
+        font-weight: 500;
+        color: @siteEVColor;
+        padding-right: 5px;
         border-right: 1px solid #ccc;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/less/variables.less
+++ b/less/variables.less
@@ -40,7 +40,7 @@
 @settingItemSubtextFontSize: 0.95rem;
 @audioColor: @highlightBlue;
 @focusUrlbarOutline: rgba(55, 169, 253, 0.4);
-@siteSecureColor: @buttonColor;
+@siteSecureColor: green;
 @siteInsecureColor: #C63626;
 @siteEVColor: green;
 @loadTimeColor: @highlightBlue;
@@ -52,6 +52,7 @@
 @braveDarkOrange: #D44600;
 @dragSpacing: 50px;
 @urlBarOutline: #bbb;
+@urlbarFormHeight: 25px; // added
 
 @navbarHeight: 36px;
 @downloadsBarHeight: 60px;


### PR DESCRIPTION
Fixed issue #7888 and issue #13011.
Before:
![before](https://user-images.githubusercontent.com/15698572/36239879-276f8e72-11db-11e8-9e42-8090ad254127.gif)
After:
![after](https://user-images.githubusercontent.com/15698572/36239880-2c1aecdc-11db-11e8-8096-37522624eaf2.gif)

I also touched some css, changed few things that had a TODO. In addition to changing a little bit of styling. 
Also, I am not sure if I need to update and/or add new tests for this fix. Please let me know if so :)

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Navigate to wikipedia.org
2. Put mouse in URL bar and try clicking around the lock icon
3. `Secure connection` modal should come up (even near the edges)
4. Verify you can still drag and drop the lock icon to bookmarks toolbar
5. Navigate to github.com
6. Put mouse in URL bar and try clicking around the lock icon
7. Verify secure modal is shown when clicking everything left of where you type (ex: the EV info bar and the lock icon, including the edges)

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


