### PR TITLE
perf: log mergeProps 'wasted' time, total time and number of invocations

### DIFF
--- a/app/renderer/components/reduxComponent.js
+++ b/app/renderer/components/reduxComponent.js
@@ -1,8 +1,10 @@
+const ipc = require('electron').ipcRenderer
 const appStore = require('../../../js/stores/appStoreRenderer')
 const ImmutableComponent = require('./immutableComponent')
 const React = require('react')
 const windowStore = require('../../../js/stores/windowStore')
 const {isList, isSameHashCode} = require('../../common/state/immutableUtil')
+const messages = require('../../../js/constants/messages')
 
 const mergePropsImpl = (stateProps, ownProps) => {
   return Object.assign({}, stateProps, ownProps)
@@ -39,6 +41,57 @@ const didPropsChange = function (oldProps, newProps) {
   return false
 }
 
+let isProfiling = false
+let perfRunningIntervalWastedTime = null
+let perfRunningIntervalMergePropsHistory = null
+let mergePropsWasteMs = 0
+let mergePropsComponentHistory = { }
+ipc.on(messages.DEBUG_REACT_PROFILE, (e, args) => {
+  if (!isProfiling) {
+    isProfiling = true
+    let totalMergePropsWaste = 0
+
+    const logMergePropsWaste = function () {
+      const timeWasted = mergePropsWasteMs
+      if (timeWasted) {
+        mergePropsWasteMs = 0
+        totalMergePropsWaste += timeWasted
+        console.log(`wasted ${timeWasted}ms in the last 1 second performing mergeProps that did not change, now wasted a total of ${totalMergePropsWaste}ms`)
+      }
+    }
+    const logMergePropsHistory = function () {
+      let toLog = mergePropsComponentHistory
+      mergePropsComponentHistory = { }
+      // sort by time taken
+      let toLogArray = []
+      for (const componentName in toLog) {
+        const { totalTime, invocations } = toLog[componentName]
+        toLogArray.push({ componentName, totalTime, invocations })
+      }
+      toLogArray.sort((a, b) => b.totalTime - a.totalTime)
+      // get a pretty table in the format of: component-name : details
+      toLog = { }
+      for (const {componentName, totalTime, invocations} of toLogArray) {
+        toLog[componentName] = { totalTime, invocations }
+      }
+      const totalBlockingTime = toLogArray.reduce((total, current) => total + current.totalTime, 0)
+      // Log time spent, but only if there was time spent in mergeProps.
+      // App may have been inactive and we don't want to log '0' every 10 seconds, if so.
+      if (totalBlockingTime) {
+        console.log(`MergeProps history over the last 10 seconds (total UI blocking time = ${totalBlockingTime}ms): `)
+        console.table(toLog)
+      }
+    }
+    perfRunningIntervalWastedTime = setInterval(logMergePropsWaste, 1000)
+    perfRunningIntervalMergePropsHistory = setInterval(logMergePropsHistory, 10000)
+  } else {
+    window.clearInterval(perfRunningIntervalWastedTime)
+    window.clearInterval(perfRunningIntervalMergePropsHistory)
+    isProfiling = false
+    mergePropsWasteMs = null
+  }
+})
+
 class ReduxComponent extends ImmutableComponent {
   constructor (componentType, mergeStateToProps, props) {
     super(props)
@@ -51,9 +104,27 @@ class ReduxComponent extends ImmutableComponent {
 
   checkForUpdates () {
     if (!this.dontCheck) {
+      const t0 = isProfiling && window.performance.now()
       const newState = this.buildProps(this.props)
+      const t1 = isProfiling && window.performance.now()
       if (didPropsChange(this.state, newState)) {
         this.setState(newState)
+      } else if (isProfiling) {
+        // log time used up in mergeProps where nothing changed
+        const timeTaken = t1 - t0
+        mergePropsWasteMs += timeTaken
+      }
+      // log how much total time was taken, whether something changed or not,
+      // so we can asses which Components mergeProps functions are taking the most time
+      if (isProfiling) {
+        const componentName = this.componentType.name
+        let componentMergePropsHistory = mergePropsComponentHistory[componentName]
+        if (!componentMergePropsHistory) {
+          componentMergePropsHistory = { totalTime: 0, invocations: 0 }
+          mergePropsComponentHistory[componentName] = componentMergePropsHistory
+        }
+        componentMergePropsHistory.invocations++
+        componentMergePropsHistory.totalTime += (t1 - t0)
       }
     }
   }


### PR DESCRIPTION
When choosing the existing 'Debug' --> 'Toggle react profiling' menu option, also include the following:
- all time that is spent in all component mergeProps functions that results in no properties actually changing (and therefore no render), every 1 second. This is an important metric to improve since this is blocking the renderer window UI thread, and the time is likely spent re-computing functions even though the state input to those functions has not changed.
- total time for each Component-type spent in mergeProps, output every 10 seconds
- number of invocations for each Component-type mergeProps, output every 10 seconds

This measures the issue described by #11515, and allows us to compare the before and after compared to the solution proposed in #12105.

Using these features I found that:
- with about 10 tabs open and switching between them, we're **wasting** about a second of unnecessary blocking UI thread time, every 10 seconds (time taken in mergeProps that resulted in no changes to props).
- when typing in the url bar, we're blocking for a total of about 330ms every 10 seconds, and 90% of that is time wasted (resulted in no changed to component props.

![image](https://user-images.githubusercontent.com/741836/36240276-7d686440-11c5-11e8-97e2-f67977e41460.png)


## Test Plan:
- Ensure that **no** extra logging is showing in the console without choosing the 'Debug' --> 'Toggle react profiling' and also when toggling it on and off again.
- Ensure that the extra logging **is** showing in the console without choosing the 'Debug' --> 'Toggle react profiling' and also when toggling it off and on again.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


