### PR TITLE
Made urlBarIconContainer clickable to display connection info

### DIFF
--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -213,6 +213,10 @@ class UrlBar extends React.Component {
     }
   }
 
+  onUrlBarIconContainerClick () {
+    windowActions.setSiteInfoVisible(true)
+  }
+
   onBlur (e) {
     windowActions.urlBarOnBlur(getCurrentWindowId(), e.target.value, this.props.urlbarLocation, eventElHasAncestorWithClasses(e, ['urlBarSuggestions', 'urlbarForm']))
   }
@@ -497,13 +501,13 @@ class UrlBar extends React.Component {
 
   render () {
     const urlbarIconContainer = this.props.evCert
-    ? (<div className='urlbarIconContainer'>
+    ? (<div onClick={this.onUrlBarIconContainerClick} className='urlbarIconContainer'>
       <UrlBarIcon
         titleMode={this.props.titleMode}
       />
       {this.showEvCert}
     </div>)
-    : (<div className='urlbarIconContainer'>
+    : (<div onClick={this.onUrlBarIconContainerClick} className='urlbarIconContainer'>
       <UrlBarIcon
         titleMode={this.props.titleMode}
       />
@@ -513,13 +517,13 @@ class UrlBar extends React.Component {
         urlbarForm: true,
         [css(styles.urlbarForm_wide)]: this.props.isWideURLbarEnabled,
         noBorderRadius: this.props.publisherButtonVisible
-      })}
+      })} 
       id='urlbar'
     >
       {urlbarIconContainer}
       {
         this.props.titleMode
-        ? <div id='titleBar' data-test-id='titleBar'>
+        ? <div id='titleBar' data-test-id='titleBar' >
           <span><strong>{this.props.hostValue}</strong></span>
           <span>{this.props.hostValue && this.titleValue ? ' | ' : ''}</span>
           <span>{this.titleValue}</span>

--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -517,13 +517,13 @@ class UrlBar extends React.Component {
         urlbarForm: true,
         [css(styles.urlbarForm_wide)]: this.props.isWideURLbarEnabled,
         noBorderRadius: this.props.publisherButtonVisible
-      })} 
+      })}
       id='urlbar'
     >
       {urlbarIconContainer}
       {
         this.props.titleMode
-        ? <div id='titleBar' data-test-id='titleBar' >
+        ? <div id='titleBar' data-test-id='titleBar'>
           <span><strong>{this.props.hostValue}</strong></span>
           <span>{this.props.hostValue && this.titleValue ? ' | ' : ''}</span>
           <span>{this.titleValue}</span>

--- a/app/renderer/components/styles/global.js
+++ b/app/renderer/components/styles/global.js
@@ -391,7 +391,6 @@ globalStyles.color.chromeBorderColor = globalStyles.color.chromePrimary
 globalStyles.color.chromeControlsWarningBackground = globalStyles.color.chromePrimary
 globalStyles.color.audioColor = globalStyles.color.highlightBlue
 globalStyles.color.focusUrlbarOutline = globalStyles.color.highlightBlue
-globalStyles.color.siteSecureColor = globalStyles.color.buttonColor
 globalStyles.color.loadTimeColor = globalStyles.color.highlightBlue
 globalStyles.color.activeTabDefaultColor = globalStyles.color.chromePrimary
 

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -574,8 +574,6 @@
   }
 }
 
-@urlbarFormHeight: 25px;
-
 .urlbarForm {
   position: relative; // PR #6485
   width: 0; // Fixes #4298
@@ -619,8 +617,7 @@
     color: @chromeText;
 
     // #4922
-    // TODO: replace this value with a CSS variable to add a dark UI.
-    background: #fff;
+    background: @chromeControlsBackground2;
   }
 
   @media (max-width: @breakpointNarrowViewport) {
@@ -825,7 +822,7 @@
       justify-content: center;
       height: @urlbarFormHeight;
       min-height: @urlbarFormHeight;
-      margin: 0 5px;
+      margin-right: 5px;
       max-width: 40%;
 
       .urlbarIcon {
@@ -835,7 +832,7 @@
         background-position: center;
         position: relative;
         bottom: -1px;
-        margin-left: 3px;
+        padding: 5px 7px 5px 7px;
 
         // about:newtab
         &.fa-search {
@@ -863,8 +860,9 @@
 
       .evCert {
         font-size: 12px;
-        color: forestgreen;
-        padding: 5px;
+        font-weight: 500;
+        color: @siteEVColor;
+        padding-right: 5px;
         border-right: 1px solid #ccc;
         overflow: hidden;
         text-overflow: ellipsis;

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -832,7 +832,7 @@
         background-position: center;
         position: relative;
         bottom: -1px;
-        padding: 5px 7px 5px 7px;
+        padding: 5px 0px 5px 5px;
 
         // about:newtab
         &.fa-search {
@@ -862,6 +862,7 @@
         font-size: 12px;
         font-weight: 500;
         color: @siteEVColor;
+        padding-left: 5px;
         padding-right: 5px;
         border-right: 1px solid #ccc;
         overflow: hidden;

--- a/less/variables.less
+++ b/less/variables.less
@@ -40,7 +40,7 @@
 @settingItemSubtextFontSize: 0.95rem;
 @audioColor: @highlightBlue;
 @focusUrlbarOutline: rgba(55, 169, 253, 0.4);
-@siteSecureColor: @buttonColor;
+@siteSecureColor: green;
 @siteInsecureColor: #C63626;
 @siteEVColor: green;
 @loadTimeColor: @highlightBlue;
@@ -52,6 +52,7 @@
 @braveDarkOrange: #D44600;
 @dragSpacing: 50px;
 @urlBarOutline: #bbb;
+@urlbarFormHeight: 25px; // added
 
 @navbarHeight: 36px;
 @downloadsBarHeight: 60px;

--- a/less/variables.less
+++ b/less/variables.less
@@ -40,7 +40,7 @@
 @settingItemSubtextFontSize: 0.95rem;
 @audioColor: @highlightBlue;
 @focusUrlbarOutline: rgba(55, 169, 253, 0.4);
-@siteSecureColor: green;
+@siteSecureColor: @buttonColor;
 @siteInsecureColor: #C63626;
 @siteEVColor: green;
 @loadTimeColor: @highlightBlue;
@@ -52,7 +52,7 @@
 @braveDarkOrange: #D44600;
 @dragSpacing: 50px;
 @urlBarOutline: #bbb;
-@urlbarFormHeight: 25px; // added
+@urlbarFormHeight: 25px;
 
 @navbarHeight: 36px;
 @downloadsBarHeight: 60px;


### PR DESCRIPTION
Fixes #7888 

Redo of https://github.com/brave/browser-laptop/pull/13147 (which unintentionally introduced #13163)
- original commit was reverted in master with https://github.com/brave/browser-laptop/commit/49a9b7379bbaf03d48bb1438512195fd6b3fdb66
- commit re-added here (first commit in this PR)
- second commit fixes the issue discovered

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Visit https;//github.com, connection info icon should be grey and EVC should be in green
2. Visit http;//pdf995.com, connection info icon should be red
3. Visit https://https-everywhere.badssl.com, connection info icon should be gery
4. Visit https://mixed-script.badssl.com, connection icon should be grey, click and load unsafe script, connection info icon should be red

![connection1](https://user-images.githubusercontent.com/17010094/36299228-1bc9f47a-1322-11e8-9882-c303bf70fae5.gif)

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


