### PR TITLE
Update OpenSUSE install instructions

### DIFF
--- a/docs/linuxInstall.md
+++ b/docs/linuxInstall.md
@@ -159,7 +159,7 @@ To install Brave using zypper:
 ```
 sudo rpmkeys --import https://s3-us-west-2.amazonaws.com/brave-rpm-release/keys.asc
 sudo zypper install lsb
-sudo zypper addrepo https://s3-us-west-2.amazonaws.com/brave-rpm-release/x86_64/ brave-rpm-release
+sudo zypper addrepo --type yast2 https://s3-us-west-2.amazonaws.com/brave-rpm-release/x86_64/ brave-rpm-release
 sudo zypper ref
 sudo zypper install brave
 ```
@@ -169,6 +169,14 @@ To update Brave using zypper:
 sudo zypper ref
 sudo zypper update brave
 ```
+
+If zypper throws an error similar to
+```
+Problem: nothing provides GConf2 needed by brave-*
+ Solution 1: do not install brave-*
+ Solution 2: break brave-* by ignoring some of its dependencies
+```
+Choose solution 2 and install gconf2 just to be safe. (`sudo zypper in gconf2`)
 
 Alternatively you can install the rpm directly, but then you won't get automatic upgrades:
 ```


### PR DESCRIPTION
Closes #10894
Sets the openSUSE repository type to `yast2` which fixes some refresh errors.
Add instructions to get around GConf2 vs gconf2.

## Submitter Checklist
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


