### PR TITLE
Adds confirmation dialog upon clicking the trash icon in the ledger table

### DIFF
--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -49,6 +49,7 @@ autoplay=Autoplay Media
 autoSuggestSites=auto-include
 backupLedger=Backup your wallet
 balanceRecovered={{balance}} was recovered and transferred to your Brave wallet.
+banSiteConfirmation=Are you sure you want to delete this site?
 beta=beta
 bitcoin=Bitcoin
 bitcoinBalance=Please transfer:&nbsp;

--- a/app/locale.js
+++ b/app/locale.js
@@ -233,6 +233,7 @@ var rendererIdentifiers = function () {
     'dappDetected',
     'dappDismiss',
     'dappEnableExtension',
+    'banSiteConfirmation',
     // other
     'passwordsManager',
     'extensionsManager',

--- a/app/renderer/components/preferences/payment/ledgerTable.js
+++ b/app/renderer/components/preferences/payment/ledgerTable.js
@@ -26,6 +26,7 @@ const getSetting = require('../../../../../js/settings').getSetting
 const aboutActions = require('../../../../../js/about/aboutActions')
 const urlUtil = require('../../../../../js/lib/urlutil')
 const {SettingCheckbox, SiteSettingCheckbox} = require('../../common/settings')
+const locale = require('../../../../../js/l10n')
 
 class LedgerTable extends ImmutableComponent {
   get synopsis () {
@@ -100,7 +101,10 @@ class LedgerTable extends ImmutableComponent {
   }
 
   banSite (hostPattern) {
-    aboutActions.changeSiteSetting(hostPattern, 'ledgerPaymentsShown', false)
+    const confMsg = locale.translation('banSiteConfirmation')
+    if (window.confirm(confMsg)) {
+      aboutActions.changeSiteSetting(hostPattern, 'ledgerPaymentsShown', false)
+    }
   }
 
   togglePinSite (hostPattern, pinned, percentage) {


### PR DESCRIPTION
Fixes Issue #11164

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

 1. Visit some sites
 2. Open about:payments
 3. Click a trash icon
 4. Ensure that the appearing confirmation dialogue, depending on the choice, allows the removal of the site or does nothing. 

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

Two translations added under the name: banSiteConfirmation. Mechanism for creating the confirmation dialogue mimics that shown in the syncTable component. Ref: [here](https://github.com/brave/browser-laptop/blob/master/app/renderer/components/preferences/syncTab.js#L392)
