### PR TITLE
Open new window from command line

### DIFF
--- a/app/cmdLine.js
+++ b/app/cmdLine.js
@@ -51,6 +51,14 @@ const focusOrOpenWindow = function (url) {
   return true
 }
 
+const openNewWindow = function (argv) {
+  if (!appInitialized) {
+    return false
+  }
+  appActions.newWindow()
+  return true
+}
+
 // Checks an array of arguments if it can find a url
 const getUrlFromCommandLine = (argv) => {
   if (argv) {
@@ -78,6 +86,27 @@ const getUrlFromCommandLine = (argv) => {
   }
   return undefined
 }
+
+app.on('ready', () => {
+  if (process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test') {
+    const appAlreadyStartedShouldQuit = app.makeSingleInstance((argv, workingDirectory) => {
+      //If trying to open a new window
+      if(argv.indexOf("--new-window")!=-1){
+        openNewWindow()
+      }else{
+        // Someone tried to run a second instance, we should focus our window.
+        if (isDarwin) {
+          focusOrOpenWindow()
+        } else {
+          focusOrOpenWindow(getUrlFromCommandLine(argv))
+        }
+      }
+    })
+    if (appAlreadyStartedShouldQuit) {
+      app.exit(0)
+    }
+  }
+})
 
 app.on('ready', () => {
   if (process.env.NODE_ENV !== 'development' && process.env.NODE_ENV !== 'test') {


### PR DESCRIPTION
Added the functionality to open a new window from command line by using `./brave --new-window`.
Done as a first part of solving issue #6094 with help from @bsclifton 

## Submitter Checklist:

- [X] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests). _(Do I need to provide tests for this?)_
- [X] Ran `git rebase -i` to squash commits (if needed).
- [X] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

- Run the program from command line.
- When open, run it with `--new-window` as argument, it will open a new window.
- You can check that running it with the argument again opens a new window once more, and running it without it, focuses on one of the windows instead.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


