### PR TITLE
Use translation for confirmation dialog for all password deletion

### DIFF
--- a/app/extensions/brave/locales/en-US/passwords.properties
+++ b/app/extensions/brave/locales/en-US/passwords.properties
@@ -1,5 +1,5 @@
 clearPasswords=Delete all saved passwords
-confirmClearPasswords=Are you sure you want to delete all passwords? This cannot be undone.
+confirmClearPasswords=Are you sure you want to delete all saved passwords? This cannot be undone.
 deletePassword=Delete
 hidePassword=Hide
 noPasswordsSaved=No passwords have been saved.

--- a/js/about/passwords.js
+++ b/js/about/passwords.js
@@ -161,8 +161,8 @@ class AboutPasswords extends React.Component {
   }
 
   onClear () {
-    const msg = 'Are you sure you want to delete all saved passwords? ' +
-      'This cannot be undone.'
+    const locale = require('../../js/l10n')
+    const msg = locale.translation('confirmClearPasswords')
     if (window.confirm(msg)) {
       aboutActions.clearPasswords()
     }


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/13181

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

**Additional infromation:**
We'll also have to update other translations if this passes