### PR TITLE
Fixes long publisher titles breaking the ledger table.

### DIFF
--- a/app/renderer/components/preferences/payment/ledgerTable.js
+++ b/app/renderer/components/preferences/payment/ledgerTable.js
@@ -183,7 +183,7 @@ class LedgerTable extends ImmutableComponent {
                 ? <img className={css(styles.siteData__anchor__icon_favicon)} src={faviconURL} alt='' onError={this.onFaviconError.bind(null, faviconURL, publisherKey)} />
                 : <span className={css(styles.siteData__anchor__icon_default)}><span className={globalStyles.appIcons.defaultIcon} /></span>
             }
-            <span className={css(styles.siteData__anchor__url)} data-test-id='siteName'>{siteName}</span>
+            <span className={css(styles.siteData__anchor__url)} title={siteName} data-test-id='siteName'>{siteName}</span>
           </a>
         </div>,
         value: publisherKey
@@ -410,6 +410,13 @@ const styles = StyleSheet.create({
     display: 'flex',
     flex: '1',
     alignItems: 'center'
+  },
+
+  siteData__anchor: {
+    width: '430px',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap'
   },
 
   siteData__anchor__icon_favicon: {


### PR DESCRIPTION
Fixes #13195

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
 1. Visit long domains or creators with large titles, such as: 
   * http://www.thelongestdomainnameintheworldandthensomeandthensomemoreandmore.com/
   * https://www.youtube.com/user/yohvh/featured
 2. When they meet payment criteria, ensure the titles truncate with an ellipsis and do not break the ledger table. 
 3. Ensure that the title attribute on hover shows the full name. 

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

(Taken on with @NejcZdovc 's blessing)

This fix restricts the site name to a width of 430px and uses an ellipsis via css to truncate the text overflow. This width allows for the most use of the cell without stretching the table beyond view/under-using whitespace. A title attribute is added to the <span> containing the sitename, which will show the entire site name. This allows a user to see the full text when it is truncated by hovering over it.
