### PR TITLE
Punycode bypass with `@`

### DIFF
--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -387,7 +387,9 @@ const UrlUtil = {
       parsed.hostname = punycode.toASCII(parsed.hostname)
       return urlFormat(parsed)
     } catch (e) {
-      return punycode.toASCII(url)
+      var splitUrl = url.split('@')
+      splitUrl = splitUrl.map(str => punycode.toASCII(str))
+      return splitUrl.join('@')
     }
   },
 

--- a/test/unit/lib/urlutilTest.js
+++ b/test/unit/lib/urlutilTest.js
@@ -299,6 +299,9 @@ describe('urlutil', function () {
     it('returns the punycode URL when given a valid URL', function () {
       assert.equal(urlUtil.getPunycodeUrl('http://brave:brave@ebаy.com:1234/brave#brave'), 'http://brave:brave@xn--eby-7cd.com:1234/brave#brave')
     })
+    it('returns the punycode URL when given a URL contains @', function () {
+      assert.equal(urlUtil.getPunycodeUrl('ebаy.com/@ebаy.com'), 'xn--eby-7cd.com/@xn--eby-7cd.com')
+    })
   })
 
   describe('isPotentialPhishingUrl', function () {


### PR DESCRIPTION
Strings with `@` are treated as email addresses, so the punycode conversion does not happen correctly. See: https://www.npmjs.com/package/punycode#punycodetoasciiinput

https://github.com/brave/browser-laptop/issues/13214