### PR TITLE
Prevent null key in historySites state

### DIFF
--- a/app/common/lib/historyUtil.js
+++ b/app/common/lib/historyUtil.js
@@ -160,8 +160,8 @@ const mergeSiteDetails = (oldDetail, newDetail) => {
 }
 
 const getDetailFromFrame = (frame) => {
-  if (frame == null) {
-    return Immutable.Map()
+  if (frame == null || !frame.has('location')) {
+    return null
   }
 
   return makeImmutable({

--- a/app/common/state/historyState.js
+++ b/app/common/state/historyState.js
@@ -8,6 +8,7 @@ const {STATE_SITES} = require('../../../js/constants/stateConstants')
 const historyUtil = require('../lib/historyUtil')
 const urlUtil = require('../../../js/lib/urlutil')
 const {makeImmutable, isMap} = require('./immutableUtil')
+const shouldLogWarnings = process.env.NODE_ENV !== 'production'
 
 const validateState = function (state) {
   state = makeImmutable(state)
@@ -33,8 +34,20 @@ const historyState = {
   },
 
   addSite: (state, siteDetail) => {
+    if (!siteDetail) {
+      if (shouldLogWarnings) {
+        console.error('historyState:addSite siteDetail was null')
+      }
+      return state
+    }
     let sites = historyState.getSites(state)
     let siteKey = historyUtil.getKey(siteDetail)
+    if (!siteKey) {
+      if (shouldLogWarnings) {
+        console.log('historyState:addSite siteKey was null for siteDetail:', (siteDetail && siteDetail.toJS) ? siteDetail.toJS() : siteDetail)
+      }
+      return state
+    }
     siteDetail = makeImmutable(siteDetail)
 
     const oldSite = sites.get(siteKey)

--- a/app/renderer/components/frame/frame.js
+++ b/app/renderer/components/frame/frame.js
@@ -620,8 +620,17 @@ class Frame extends React.Component {
         // calling with setTimeout is an ugly hack for a race condition
         // with setTitle. We either need to delay this call until the title is
         // or add a way to update it
+        // However, it's possible that the frame could be destroyed, or in a bad
+        // way by then, so make sure we do a null check.
         setTimeout(() => {
-          appActions.addHistorySite(historyUtil.getDetailFromFrame(this.frame))
+          const siteDetail = historyUtil.getDetailFromFrame(this.frame)
+          if (siteDetail) {
+            appActions.addHistorySite(siteDetail)
+          } else if (process.env.NODE_ENV !== 'production') {
+            // log, in case we decide we want these entries to go in to the history
+            // but do not send a null entry to history as it will be rejected
+            console.error('frame: siteDetail was null when calling addHistorySite')
+          }
         }, 250)
       }
 

--- a/test/unit/app/common/lib/historyUtilTest.js
+++ b/test/unit/app/common/lib/historyUtilTest.js
@@ -297,7 +297,13 @@ describe('historyUtil unit tests', function () {
   describe('getDetailFromFrame', function () {
     it('null case', function () {
       const result = historyUtil.getDetailFromFrame()
-      assert.deepEqual(result, Immutable.Map())
+      assert.deepEqual(result, null)
+    })
+
+    it('no location case', function () {
+      const badFrame = Immutable.Map().set('partitionNumber', 0)
+      const result = historyUtil.getDetailFromFrame(badFrame)
+      assert.deepEqual(result, null)
     })
 
     it('returns details', function () {


### PR DESCRIPTION
This was causing an error to be thrown for every subsequent action, and no more state updates to be sent to windows, resulting in multiple issues.
It was also causing an error dump to be generated upon every action, thus halting the browser at those times, including any audio/video (and creating stutters).

Fix #13079 (main test case with STR)
Fix #12333
Fix #12828
Fix #13157
Address #13087 but this is a broad issue - this change will fix a hard issue, whereas that refers to general slowness.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
On #13079 

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


