### PR TITLE
Handle failure in creating a state diff by logging (and crash-reporting) the full path of any keys that are null

### DIFF
--- a/app/common/state/immutableUtil.js
+++ b/app/common/state/immutableUtil.js
@@ -45,6 +45,22 @@ const api = {
       return defaultValue
     }
     return api.isImmutable(obj) ? obj.toJS() : obj
+  },
+
+  findNullKeyPaths (state, pathToState = []) {
+    let nullKeys = [ ]
+    if (!Immutable.Map.isMap(state) && !Immutable.List.isList(state)) {
+      return nullKeys
+    }
+    for (const key of state.keySeq()) {
+      const keyPath = [...pathToState, key]
+      if (key === null) {
+        nullKeys.push(keyPath)
+      }
+      // recursive, to find deep keys
+      nullKeys.push(...api.findNullKeyPaths(state.get(key), keyPath))
+    }
+    return nullKeys
   }
 }
 

--- a/test/unit/app/common/state/immutableUtilTest.js
+++ b/test/unit/app/common/state/immutableUtilTest.js
@@ -148,4 +148,32 @@ describe('immutableUtil unit test', function () {
       assert.deepEqual(immutableUtil.deleteImmutablePaths(data, [['a', 'a1'], 'c']).toJS(), {a: {a2: 8}, d: 5})
     })
   })
+  describe('findNullKeyPaths', function () {
+    it('finds maps which have a null key', function () {
+      const data = Immutable.fromJS({
+        normal: {
+          key1: 'value'
+        },
+        bad: { },
+        anotherBad: {
+          deeper: { }
+        },
+        null: {
+          badParent: 'value4'
+        },
+        nullValue: null
+      })
+      .setIn(['bad', null], 'value2')
+      .setIn(['anotherBad', 'deeper', null], 'value3')
+      .set(null, Immutable.fromJS({badParent: 'value4'}))
+
+      const expectedNullPaths = [
+        ['bad', null],
+        ['anotherBad', 'deeper', null],
+        [null]
+      ]
+      const actualNullPaths = immutableUtil.findNullKeyPaths(data)
+      assert.deepEqual(actualNullPaths, expectedNullPaths)
+    })
+  })
 })


### PR DESCRIPTION
A null key path was fixed in #13234, but there may be other cases, so we should add better logging to the console and for the crash reports.

Performance should be unaffected since v8 can now optimize functions which contain a try...catch block.

Fix #13239

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
This should cause no change in functionality, or extra log lines.
If a dev really wants to check the output in error conditions, they can force a null key path in the state, for example in appStore.js at the top of the `emitChanges` function:
`appState = appState.setIn(['historySites', null], Immutable.fromJS({ hello: 'a' }))`

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


