### PR TITLE
When closing last window, make sure buffer window is closed so that app exits

### DIFF
--- a/app/browser/windows.js
+++ b/app/browser/windows.js
@@ -334,6 +334,16 @@ const api = {
       win.once('closed', () => {
         appActions.windowClosed(windowId)
         cleanupWindow(windowId)
+        // if we have a bufferWindow, the 'window-all-closed'
+        // event will not fire once the last window is closed,
+        // so close the buffer window if this is the last closed window
+        // apart from the buffer window
+        if (!platformUtil.isDarwin() && api.getBufferWindow()) {
+          const remainingWindows = api.getAllRendererWindows().filter(win => win !== api.getBufferWindow())
+          if (!remainingWindows.length) {
+            api.closeBufferWindow()
+          }
+        }
       })
       win.on('blur', () => {
         appActions.windowBlurred(windowId)


### PR DESCRIPTION
Only on win/linux, since we only handle 'window-all-closed' on those platforms.
Fix #13233

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
Specified on #13233

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


