### PR TITLE
Returning to the recovery modal after a wallet recovery failure

### DIFF
--- a/app/renderer/components/preferences/payment/ledgerRecovery.js
+++ b/app/renderer/components/preferences/payment/ledgerRecovery.js
@@ -31,8 +31,10 @@ class LedgerRecoveryContent extends ImmutableComponent {
     this.props.handleRecoveryKeyChange(e.target.value)
   }
 
-  clearRecoveryStatus () {
-    this.props.hideAdvancedOverlays()
+  clearRecoveryStatus (success) {
+    if (success) {
+      this.props.hideAdvancedOverlays()
+    }
     appActions.resetRecoverStatus()
   }
 
@@ -57,7 +59,7 @@ class LedgerRecoveryContent extends ImmutableComponent {
             <BrowserButton secondaryColor
               l10nId='ok'
               testId='recoveryOverlayOkButton'
-              onClick={this.clearRecoveryStatus.bind(this)}
+              onClick={this.clearRecoveryStatus.bind(this, true)}
             />
           </section>
           : null
@@ -73,7 +75,7 @@ class LedgerRecoveryContent extends ImmutableComponent {
             <BrowserButton secondaryColor
               l10nId='ok'
               testId='recoveryOverlayErrorButton'
-              onClick={this.clearRecoveryStatus.bind(this)}
+              onClick={this.clearRecoveryStatus.bind(this, false)}
             />
           </section>
           : null
@@ -89,7 +91,7 @@ class LedgerRecoveryContent extends ImmutableComponent {
             <BrowserButton secondaryColor
               l10nId='ok'
               testId='recoveryOverlayErrorButton'
-              onClick={this.clearRecoveryStatus.bind(this)}
+              onClick={this.clearRecoveryStatus.bind(this, false)}
             />
           </section>
           : null

--- a/test/about/ledgerPanelAdvancedPanelTest.js
+++ b/test/about/ledgerPanelAdvancedPanelTest.js
@@ -1,7 +1,7 @@
 /* global describe, it, beforeEach */
 
 const Brave = require('../lib/brave')
-const {urlInput, paymentsWelcomePage, paymentsTab, walletSwitch, backupWallet, recoverWallet, saveWalletFile, advancedSettingsButton, recoverWalletFromFileButton, balanceRecovered, balanceNotRecovered, recoveryOverlayOkButton} = require('../lib/selectors')
+const {urlInput, paymentsWelcomePage, paymentsTab, walletSwitch, backupWallet, recoverWallet, saveWalletFile, advancedSettingsButton, recoverWalletFromFileButton, balanceRecovered, balanceNotRecovered, recoveryOverlayOkButton, modalOverlay, recoveryOverlayErrorButton} = require('../lib/selectors')
 const messages = require('../../js/constants/messages')
 
 const assert = require('assert')
@@ -185,5 +185,15 @@ describe.skip('Advanced payment panel tests', function () {
     context.cleanSessionStoreAfterEach = true
     yield this.app.client
       .waitForVisible(balanceNotRecovered, ledgerAPIWaitTimeout)
+  })
+
+  it('keeps ledger recovery modal open if there was a recovery error', function * () {
+    generateAndSaveRecoveryFile(context.recoveryFilePathname, '')
+    yield recoverWalletFromFile(this.app.client)
+    yield this.app.client
+      .waitForVisible(balanceNotRecovered, ledgerAPIWaitTimeout)
+      .click(recoveryOverlayErrorButton)
+      .pause(1000)
+      .waitForVisible(modalOverlay, ledgerAPIWaitTimeout)
   })
 })

--- a/test/lib/selectors.js
+++ b/test/lib/selectors.js
@@ -109,6 +109,7 @@ module.exports = {
   recoverWallet: '[data-test-id="recoverLedgerButton"]',
   recoverWalletFromFileButton: '[data-test-id="recoverFromFileButton"]',
   recoveryOverlayOkButton: '[data-test-id="recoveryOverlayOkButton"]',
+  recoveryOverlayErrorButton: '[data-test-id="recoveryOverlayErrorButton"]',
   saveWalletFile: '[data-test-id="saveRecoveryFileButton"]',
   balanceRecovered: '[data-test-id="balanceRecoveredMessage"]',
   balanceNotRecovered: '[data-test-id="ledgerRecoveryFailedMessage"]',


### PR DESCRIPTION
Fixes #11422

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

    1. Visit about:preferences#payments and create a wallet
    2. Select "Advanced Settings" -> "Recover your wallet"
    3. Select "Recover" and press "OK" on the "Recovery Failed" message
    4. Ensure that the Recover Your Brave Wallet modal stays open

    [Regression]
    1. Visit about:preferences#payments and create a wallet
    2. Select "Advanced Settings" -> "Recover your wallet"
    3. Enter in a valid recovery key and select "Recover"
    4. Hit "OK" on the success message
    5. Ensure that the Recovery Your Brave Wallet modal dissapears

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

clearRecoveryStatus() inside the LedgerRecoveryContent component would hide all the advanced overlays no matter the outcome. This binds a success variable (bool) and only hides the advanced overlays on success.

An automated test was added for this. Additionally, recoveryOverlayErrorButton was added to the test selectors.
