### PR TITLE
Add Other Bookmarks to bookmarks menu.

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -414,6 +414,15 @@ const createBookmarksSubmenu = (state) => {
     submenu = submenu.concat(bookmarks)
   }
 
+  const otherBookmarks = menuUtil.createOtherBookmarkTemplateItems(state)
+  if (otherBookmarks.length > 0) {
+    submenu.push(CommonMenu.separatorMenuItem)
+    submenu.push({
+      label: locale.translation('otherBookmarks'),
+      submenu: otherBookmarks
+    })
+  }
+
   return submenu
 }
 

--- a/app/common/lib/menuUtil.js
+++ b/app/common/lib/menuUtil.js
@@ -130,6 +130,15 @@ module.exports.createBookmarkTemplateItems = (state) => {
 }
 
 /**
+ * Used to create bookmarks and bookmark folder entries for "Other Bookamrks" in the "Bookmarks" menu
+ *
+ * @param state The application state
+ */
+module.exports.createOtherBookmarkTemplateItems = (state) => {
+  return createBookmarkTemplateItems(state, -1)
+}
+
+/**
  * @param {string} key within closedFrames, i.e. a URL
  * @return {string}
  */

--- a/app/extensions/brave/locales/en-US/menu.properties
+++ b/app/extensions/brave/locales/en-US/menu.properties
@@ -114,6 +114,7 @@ openInNewTabs=Open Links in New Tabs
 openInNewWindow=Open Link in New Window
 openLocation=Open Location…
 openSearch=Search for "{{selectedVariable}}"
+otherBookmarks=Other Bookmarks
 passwordsManager=Passwords…
 paste=Paste
 pasteAndGo=Paste and Go

--- a/app/locale.js
+++ b/app/locale.js
@@ -133,6 +133,7 @@ var rendererIdentifiers = function () {
     'recentlyClosed',
     'recentlyVisited',
     'bookmarks',
+    'otherBookmarks',
     'addToFavoritesBar',
     'window',
     'minimize',

--- a/test/unit/app/browser/menuTest.js
+++ b/test/unit/app/browser/menuTest.js
@@ -30,6 +30,9 @@ describe('menu reducer unit tests', function () {
       createBookmarkTemplateItems: (sites) => {
         return []
       },
+      createOtherBookmarkTemplateItems: (sites) => {
+        return []
+      },
       getMenuItem: (menu, label) => {
         return {
           click: () => {}


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.

Partially fixes https://github.com/brave/browser-laptop/issues/6607. This PR handled the bookmarks menu, but not the toolbar. I couldn't figure out how to get the "other bookmarks" into a dedicated "other bookmarks" folder on the bookmarks toolbar. Someone can help add that to this PR or it can be a separate effort. At least, with this PR, we'll have access to "other bookmarks" through the menu.

- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.

This doesn't really close the related issue, though. It only fixes half of request (menu, but not toolbar, as explained above).

- [ ] Added/updated tests for this change (for new code or code which already has tests).

I couldn't figure out how to add tests for this change.

- [x] Ran `git rebase -i` to squash commits (if needed).

- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

I don't know who to tag. I'll just tag @jonathansampson I guess.

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

I don't know what this security/privacy review is all about. @jonathansampson?

## Test Plan:

TBD

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

Screenshot:

<img width="1131" alt="screen shot 2018-02-19 at 10 01 38 pm" src="https://user-images.githubusercontent.com/133786/36517178-f5d0bcda-1746-11e8-9805-d6ad08adabdb.png">
