### PR TITLE
Prevent borkiness when session-store file is missing perWindowState[].closedFrames

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -246,6 +246,7 @@ module.exports.cleanPerWindowData = (immutablePerWindowData, isShutdown) => {
     }
     return immutableFrame
   }
+
   const clearHistory = isShutdown && getSetting(settings.SHUTDOWN_CLEAR_HISTORY) === true
   if (clearHistory) {
     immutablePerWindowData = immutablePerWindowData.set('closedFrames', Immutable.List())

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -328,41 +328,48 @@ const handleAppAction = (action) => {
         break
       }
     case appConstants.APP_SHOW_NOTIFICATION:
-      let notifications = appState.get('notifications', Immutable.List())
-      notifications = notifications.filterNot((notification) => {
-        let message = notification.get('message')
-        // action.detail is a regular mutable object only when running tests
-        return action.detail.get
-          ? message === action.detail.get('message')
-          : message === action.detail['message']
-      })
-
-      // Insert notification next to those with the same style, or at the end
-      let insertIndex = notifications.size
-      const style = action.detail.get
-        ? action.detail.get('options').get('style')
-        : action.detail['options']['style']
-      if (style) {
-        const styleIndex = notifications.findLastIndex((notification) => {
-          return notification.get('options').get('style') === style
+      {
+        let notifications = appState.get('notifications', Immutable.List()) || Immutable.List()
+        notifications = notifications.filterNot((notification) => {
+          let message = notification.get('message')
+          // action.detail is a regular mutable object only when running tests
+          return action.detail.get
+            ? message === action.detail.get('message')
+            : message === action.detail['message']
         })
-        if (styleIndex > -1) {
-          insertIndex = styleIndex
-        } else {
-          // Insert after the last notification with a style
-          insertIndex = notifications.findLastIndex((notification) => {
-            return typeof notification.get('options').get('style') === 'string'
-          }) + 1
+
+        // Insert notification next to those with the same style, or at the end
+        let insertIndex = notifications.size
+        const style = action.detail
+          ? action.detail.get
+            ? action.detail.get('options').get('style')
+            : action.detail['options']['style']
+          : undefined
+        if (style) {
+          const styleIndex = notifications.findLastIndex((notification) => {
+            return notification.get('options').get('style') === style
+          })
+          if (styleIndex > -1) {
+            insertIndex = styleIndex
+          } else {
+            // Insert after the last notification with a style
+            insertIndex = notifications.findLastIndex((notification) => {
+              return typeof notification.get('options').get('style') === 'string'
+            }) + 1
+          }
         }
+        notifications = notifications.insert(insertIndex, Immutable.fromJS(action.detail))
+        appState = appState.set('notifications', notifications)
+        break
       }
-      notifications = notifications.insert(insertIndex, Immutable.fromJS(action.detail))
-      appState = appState.set('notifications', notifications)
-      break
     case appConstants.APP_HIDE_NOTIFICATION:
-      appState = appState.set('notifications', appState.get('notifications', Immutable.List()).filterNot((notification) => {
-        return notification.get('message') === action.message
-      }))
-      break
+      {
+        const notifications = appState.get('notifications', Immutable.List()) || Immutable.List()
+        appState = appState.set('notifications', notifications.filterNot((notification) => {
+          return notification.get('message') === action.message
+        }))
+        break
+      }
     case appConstants.APP_TAB_CLOSE_REQUESTED:
       const tabValue = tabState.getByTabId(appState, immutableAction.get('tabId'))
       if (!tabValue) {
@@ -374,7 +381,8 @@ const handleAppAction = (action) => {
         const tabsInOrigin = tabState.getTabs(appState).find((tabValue) =>
           urlUtil.getOrigin(tabValue.get('url')) === origin && tabValue.get('tabId') !== immutableAction.get('tabId'))
         if (!tabsInOrigin) {
-          appState = appState.set('notifications', appState.get('notifications', Immutable.List()).filterNot((notification) => {
+          const notifications = appState.get('notifications', Immutable.List()) || Immutable.List()
+          appState = appState.set('notifications', notifications.filterNot((notification) => {
             return notification.get('frameOrigin') === origin
           }))
         }

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -328,7 +328,7 @@ const handleAppAction = (action) => {
         break
       }
     case appConstants.APP_SHOW_NOTIFICATION:
-      let notifications = appState.get('notifications')
+      let notifications = appState.get('notifications', Immutable.List())
       notifications = notifications.filterNot((notification) => {
         let message = notification.get('message')
         // action.detail is a regular mutable object only when running tests
@@ -359,7 +359,7 @@ const handleAppAction = (action) => {
       appState = appState.set('notifications', notifications)
       break
     case appConstants.APP_HIDE_NOTIFICATION:
-      appState = appState.set('notifications', appState.get('notifications').filterNot((notification) => {
+      appState = appState.set('notifications', appState.get('notifications', Immutable.List()).filterNot((notification) => {
         return notification.get('message') === action.message
       }))
       break
@@ -374,7 +374,7 @@ const handleAppAction = (action) => {
         const tabsInOrigin = tabState.getTabs(appState).find((tabValue) =>
           urlUtil.getOrigin(tabValue.get('url')) === origin && tabValue.get('tabId') !== immutableAction.get('tabId'))
         if (!tabsInOrigin) {
-          appState = appState.set('notifications', appState.get('notifications').filterNot((notification) => {
+          appState = appState.set('notifications', appState.get('notifications', Immutable.List()).filterNot((notification) => {
             return notification.get('frameOrigin') === origin
           }))
         }

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -354,8 +354,10 @@ const doAction = (action) => {
       if (!action.location) {
         windowState = windowState.set('closedFrames', new Immutable.List())
       } else {
+        const closedFrames = windowState.get('closedFrames', Immutable.List()) || Immutable.List()
         windowState = windowState.set('closedFrames',
-          windowState.get('closedFrames', Immutable.List()).filterNot((frame) => frame.get('location') === action.location))
+          closedFrames.filterNot((frame) => frame.get('location') === action.location)
+        )
       }
       break
     case windowConstants.WINDOW_SET_PREVIEW_TAB_PAGE_INDEX:

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -355,7 +355,7 @@ const doAction = (action) => {
         windowState = windowState.set('closedFrames', new Immutable.List())
       } else {
         windowState = windowState.set('closedFrames',
-          windowState.get('closedFrames').filterNot((frame) => frame.get('location') === action.location))
+          windowState.get('closedFrames', Immutable.List()).filterNot((frame) => frame.get('location') === action.location))
       }
       break
     case windowConstants.WINDOW_SET_PREVIEW_TAB_PAGE_INDEX:

--- a/test/unit/js/stores/appStoreTest.js
+++ b/test/unit/js/stores/appStoreTest.js
@@ -1,0 +1,151 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* global describe, before, after, afterEach, it */
+
+const mockery = require('mockery')
+// const assert = require('assert')
+// const sinon = require('sinon')
+const Immutable = require('immutable')
+const fakeElectron = require('../../lib/fakeElectron')
+// const windowConstants = require('../../../../js/constants/windowConstants')
+const appConstants = require('../../../../js/constants/appConstants')
+let doAction
+// let appStore
+let appActions
+require('../../braveUnit')
+
+describe('App store unit tests', function () {
+  const fakeDispatcher = {
+    register: (actionHandler) => {
+      doAction = actionHandler
+    },
+    registerLocalCallback: (actionHandler) => {
+      doAction = actionHandler
+    }
+  }
+
+  const reducers = [
+    '../../app/browser/reducers/downloadsReducer',
+    '../../app/browser/reducers/flashReducer',
+    '../../app/browser/reducers/dappReducer',
+    '../../app/browser/reducers/autoplayReducer',
+    '../../app/browser/reducers/tabsReducer',
+    '../../app/browser/reducers/urlBarSuggestionsReducer',
+    '../../app/browser/reducers/bookmarksReducer',
+    '../../app/browser/reducers/bookmarkFoldersReducer',
+    '../../app/browser/reducers/historyReducer',
+    '../../app/browser/reducers/pinnedSitesReducer',
+    '../../app/browser/reducers/windowsReducer',
+    '../../app/browser/reducers/syncReducer',
+    '../../app/browser/reducers/clipboardReducer',
+    '../../app/browser/reducers/passwordManagerReducer',
+    '../../app/browser/reducers/spellCheckerReducer',
+    '../../app/browser/reducers/tabMessageBoxReducer',
+    '../../app/browser/reducers/dragDropReducer',
+    '../../app/browser/reducers/extensionsReducer',
+    '../../app/browser/reducers/shareReducer',
+    '../../app/browser/reducers/updatesReducer',
+    '../../app/browser/reducers/aboutNewTabReducer',
+    '../../app/browser/reducers/braverySettingsReducer',
+    '../../app/browser/reducers/bookmarkToolbarReducer',
+    '../../app/browser/reducers/siteSettingsReducer',
+    '../../app/browser/reducers/pageDataReducer',
+    '../../app/browser/reducers/ledgerReducer',
+    '../../app/browser/menu'
+  ]
+
+  before(function () {
+    appActions = require('../../../../js/actions/appActions.js')
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    })
+    mockery.registerMock('electron', fakeElectron)
+    mockery.registerMock('../dispatcher/appDispatcher', fakeDispatcher)
+    mockery.registerMock('../actions/appActions', appActions)
+    mockery.registerMock('ad-block', require('../../lib/fakeAdBlock'))
+    mockery.registerMock('leveldown', {})
+    mockery.registerMock('../../app/browser/api/topSites', {
+      calculateTopSites: () => {}
+    })
+
+    const modulesNeedingInit = [
+      '../../app/filtering',
+      '../../app/browser/basicAuth',
+      '../../app/browser/webtorrent',
+      '../../app/browser/profiles',
+      '../../app/sync'
+    ]
+    modulesNeedingInit.forEach((moduleNeedingInit) => {
+      mockery.registerMock(moduleNeedingInit, {
+        init: (appState, action, appStore) => {}
+      })
+    })
+
+    require('../../../../js/stores/appStore.js')
+  })
+
+  after(function () {
+    mockery.disable()
+  })
+
+  const callWithMissingValues = (labelForUnitTest, fieldName, demoAction) => {
+    describe(labelForUnitTest, function () {
+      afterEach(function () {
+        reducers.forEach((reducer) => {
+          mockery.deregisterMock(reducer)
+        })
+      })
+
+      const performCall = (field) => {
+        const fakeReducer = (state, action, immutableAction) => {
+          return Immutable.fromJS(field)
+        }
+        reducers.forEach((reducer) => {
+          mockery.registerMock(reducer, fakeReducer)
+        })
+        require('../../../../js/stores/appStore.js')
+        doAction({actionType: appConstants.APP_SET_STATE})
+        doAction(demoAction)
+      }
+
+      it(`does not throw exception when \`${fieldName}\` is missing from appState`, function () {
+        performCall({})
+      })
+
+      it(`does not throw exception when \`${fieldName}\` is undefined`, function () {
+        const field = {}
+        field[fieldName] = undefined
+        performCall(field)
+      })
+
+      it(`does not throw exception when \`${fieldName}\` is null`, function () {
+        const field = {}
+        field[fieldName] = null
+        performCall(field)
+      })
+    })
+  }
+
+  describe('doAction', function () {
+    callWithMissingValues(
+      'APP_SHOW_NOTIFICATION',
+      'notifications',
+      {
+        actionType: appConstants.APP_SHOW_NOTIFICATION
+      }
+    )
+
+    callWithMissingValues(
+      'APP_HIDE_NOTIFICATION',
+      'notifications',
+      {
+        actionType: appConstants.APP_HIDE_NOTIFICATION
+      }
+    )
+
+    // TODO: add your tests if you modify appStore.js :)
+  })
+})

--- a/test/unit/js/stores/windowStoreTest.js
+++ b/test/unit/js/stores/windowStoreTest.js
@@ -295,6 +295,64 @@ describe('Window store unit tests', function () {
       })
     })
 
+    describe('WINDOW_CLEAR_CLOSED_FRAMES', function () {
+      const demoAction = {
+        actionType: windowConstants.WINDOW_CLEAR_CLOSED_FRAMES,
+        location: 'https://brave.com'
+      }
+
+      it('does not throw exception when `closedFrames` is missing from windowState', function () {
+        const fakeReducer = (state, action) => {
+          return Immutable.fromJS({})
+        }
+        reducers.forEach((reducer) => {
+          mockery.registerMock(reducer, fakeReducer)
+        })
+        doAction(demoAction)
+      })
+
+      it('does not throw exception when `closedFrames` is undefined', function () {
+        const fakeReducer = (state, action) => {
+          return Immutable.fromJS({closedFrames: undefined})
+        }
+        reducers.forEach((reducer) => {
+          mockery.registerMock(reducer, fakeReducer)
+        })
+        doAction(demoAction)
+      })
+
+      it('does not throw exception when `closedFrames` is null', function () {
+        const fakeReducer = (state, action) => {
+          return Immutable.fromJS({closedFrames: null})
+        }
+        reducers.forEach((reducer) => {
+          mockery.registerMock(reducer, fakeReducer)
+        })
+        doAction(demoAction)
+      })
+
+      it('removes the specified location from closedFrames', function () {
+        const fakeReducer = (state, action) => {
+          return Immutable.fromJS({
+            closedFrames: [{
+              location: 'https://example.com'
+            }, {
+              location: 'https://brave.com'
+            }]
+          })
+        }
+        reducers.forEach((reducer) => {
+          mockery.registerMock(reducer, fakeReducer)
+        })
+        doAction(demoAction)
+
+        // get the updated windowState (AFTER doAction runs)
+        windowStore = require('../../../../js/stores/windowStore.js')
+        const windowState = windowStore.getState()
+        assert.equal(windowState.get('closedFrames').size, 1)
+      })
+    })
+
     // TODO: add your tests if you modify windowStore.js :)
   })
 })

--- a/test/unit/js/stores/windowStoreTest.js
+++ b/test/unit/js/stores/windowStoreTest.js
@@ -301,6 +301,12 @@ describe('Window store unit tests', function () {
         location: 'https://brave.com'
       }
 
+      afterEach(function () {
+        reducers.forEach((reducer) => {
+          mockery.deregisterMock(reducer)
+        })
+      })
+
       it('does not throw exception when `closedFrames` is missing from windowState', function () {
         const fakeReducer = (state, action) => {
           return Immutable.fromJS({})


### PR DESCRIPTION
This would then cause the app never recover, even after restart. Especially with an `about:error` tab in the session-store, which would immediately cause `appActions.removeHistorySite` to fire when it fails to load. The reducer of that action relied on `windowState.closedFrames` being there. This changes it to not rely on that.

Fix #13261, although since that's not reproducible I'm not sure the moving-tab keyboard shortcut necessarily caused it, but something did, and this will allow recovery in that situation.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


