### PR TITLE
Ensuring that pinned publishers are not unpinned when decimal values are entered for the pin percentage

### DIFF
--- a/app/renderer/components/preferences/payment/pinnedInput.js
+++ b/app/renderer/components/preferences/payment/pinnedInput.js
@@ -28,7 +28,7 @@ class PinnedInput extends ImmutableComponent {
   pinPercentage (hostPattern, event) {
     let value = parseInt(event.target.value)
 
-    if (value < 1) {
+    if (value < 1 || !value) {
       value = 1
       this.textInput.value = 1
     }


### PR DESCRIPTION
Fixes #12001 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

    1. Enable payments, visit few sites to add it to ledger
    2. Pin 3-4 sites in the ledger table
    3. Change one of the pinned site value to random decimal value
    4. Ensure site value changes to 1 and stays pinned.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

This is a very simple fix for the issues of decimal values unpinning a pinned publisher.

Inside the PinnedInput component, the callback for onBlur was interpreting decimal values less than 1 as falsey, causing them to be unpinned. This performs an additional check ensuring those cases are accounted for.

cc: @NejcZdovc 