### PR TITLE
Ensure a window with no frames is not the last remembered window to restore on next startup

### DIFF
--- a/app/browser/windows.js
+++ b/app/browser/windows.js
@@ -341,7 +341,10 @@ const api = {
         // if we have a bufferWindow, the 'window-all-closed'
         // event will not fire once the last window is closed,
         // so close the buffer window if this is the last closed window
-        // apart from the buffer window
+        // apart from the buffer window.
+        // This would mean that the last window to close is the buffer window, but
+        // that will not get saved to state as the last-closed window which should be restored
+        // since we won't save state if there are no frames.
         if (!platformUtil.isDarwin() && api.getBufferWindow()) {
           const remainingWindows = api.getAllRendererWindows().filter(win => win !== api.getBufferWindow())
           if (!remainingWindows.length) {

--- a/app/browser/windows.js
+++ b/app/browser/windows.js
@@ -25,7 +25,7 @@ const browserWindowUtil = require('../common/lib/browserWindowUtil')
 const windowState = require('../common/state/windowState')
 const pinnedSitesState = require('../common/state/pinnedSitesState')
 const {zoomLevel} = require('../common/constants/toolbarUserInterfaceScale')
-const { shouldDebugWindowEvents } = require('../cmdLine')
+const { shouldDebugWindowEvents, disableBufferWindow } = require('../cmdLine')
 const activeTabHistory = require('./activeTabHistory')
 
 const isDarwin = platformUtil.isDarwin()
@@ -564,6 +564,12 @@ const api = {
   },
 
   getOrCreateBufferWindow: function (options = { }) {
+    if (disableBufferWindow) {
+      if (shouldDebugWindowEvents) {
+        console.log(`getOrCreateBufferWindow: buffer window disabled, not creating one.`)
+      }
+      return
+    }
     // only if we don't have one already
     let win = api.getBufferWindow()
     if (!win) {

--- a/app/cmdLine.js
+++ b/app/cmdLine.js
@@ -23,6 +23,7 @@ const debugTabEventsFlagName = '--debug-tab-events'
 let appInitialized = false
 let newWindowURL
 const debugWindowEventsFlagName = '--debug-window-events'
+const disableBufferWindowFlagName = '--disable-buffer-window'
 
 const focusOrOpenWindow = function (url) {
   // don't try to do anything if the app hasn't been initialized
@@ -172,5 +173,6 @@ const api = module.exports = {
   },
 
   shouldDebugTabEvents: process.argv.includes(debugTabEventsFlagName),
-  shouldDebugWindowEvents: process.argv.includes(debugWindowEventsFlagName)
+  shouldDebugWindowEvents: process.argv.includes(debugWindowEventsFlagName),
+  disableBufferWindow: process.argv.includes(disableBufferWindowFlagName)
 }

--- a/app/sessionStoreShutdown.js
+++ b/app/sessionStoreShutdown.js
@@ -218,7 +218,10 @@ ipcMain.on(messages.RESPONSE_WINDOW_STATE, (evt, mem) => {
 })
 
 ipcMain.on(messages.LAST_WINDOW_STATE, (evt, data) => {
-  if (data) {
+  // Remember last window (that was not buffer window, i.e. had frames).
+  // When the last tab of a window closes, the window is closed before the tab closes, so
+  // a used closing window will almost always have at least 1 frame.
+  if (data && data.frames && data.frames.length) {
     immutableLastWindowClosedState = Immutable.fromJS(data)
   }
 })


### PR DESCRIPTION
Fix #13278

Also introduces a new flag `--disable-buffer-window`, e.g. `npm start -- --disable-buffer-window` which can be useful for comparing any issues.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
On #13278 

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


