### PR TITLE
Adds context menu to edit bookmark dialog

### DIFF
--- a/app/renderer/components/bookmarks/addEditBookmarkForm.js
+++ b/app/renderer/components/bookmarks/addEditBookmarkForm.js
@@ -27,6 +27,7 @@ const settings = require('../../../../js/constants/settings')
 const UrlUtil = require('../../../../js/lib/urlutil')
 const {getSetting} = require('../../../../js/settings')
 const {isBookmarkNameValid} = require('../../../common/lib/bookmarkUtil')
+const contextMenus = require('../../../../js/contextMenus')
 
 // Styles
 const globalStyles = require('../styles/global')
@@ -42,6 +43,7 @@ class AddEditBookmarkForm extends React.Component {
     this.onClose = this.onClose.bind(this)
     this.onSave = this.onSave.bind(this)
     this.onRemoveBookmark = this.onRemoveBookmark.bind(this)
+    this.onContextMenu = this.onContextMenu.bind(this)
     this.state = {
       title: props.title,
       location: props.location,
@@ -65,6 +67,10 @@ class AddEditBookmarkForm extends React.Component {
         this.onClose()
         break
     }
+  }
+
+  onContextMenu (e) {
+    contextMenus.onEditBookmarkContextMenu(e)
   }
 
   onClose () {
@@ -173,6 +179,7 @@ class AddEditBookmarkForm extends React.Component {
                   commonStyles.textbox__outlineable,
                   commonFormStyles.input__box
                 )}
+                onContextMenu={this.onContextMenu}
                 data-test-id='bookmarkNameInput'
                 spellCheck='false'
                 onKeyDown={this.onKeyDown}
@@ -195,6 +202,7 @@ class AddEditBookmarkForm extends React.Component {
                     htmlFor='bookmarkLocation'
                   />
                   <CommonFormTextbox
+                    onContextMenu={this.onContextMenu}
                     data-test-id='bookmarkLocationInput'
                     spellCheck='false'
                     onKeyDown={this.onKeyDown}

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -119,6 +119,10 @@ function urlBarTemplateInit (searchDetail, activeFrame, e) {
   return items
 }
 
+function editBookmarkTemplateInit () {
+  return getEditableItems(window.getSelection().toString())
+}
+
 function findBarTemplateInit () {
   return getEditableItems(window.getSelection().toString())
 }
@@ -1375,6 +1379,12 @@ function onReloadContextMenu () {
   menu.popup(getCurrentWindow())
 }
 
+function onEditBookmarkContextMenu (e) {
+  e.stopPropagation()
+  const inputMenu = Menu.buildFromTemplate(editBookmarkTemplateInit())
+  inputMenu.popup(getCurrentWindow())
+}
+
 module.exports = {
   onHamburgerMenu,
   onMainContextMenu,
@@ -1386,5 +1396,6 @@ module.exports = {
   onFindBarContextMenu,
   onSiteDetailContextMenu,
   onShowAutofillMenu,
-  onReloadContextMenu
+  onReloadContextMenu,
+  onEditBookmarkContextMenu
 }


### PR DESCRIPTION
Fixes #10333

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

1. Bookmark a page
2. Click the star icon
3. Right click or equivalent on the title and location to trigger the context menu
4. Ensure that the cut, copy, and paste context menu items work as expected.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


The edit/add bookmark dialogues were missing a context menu for the title and location input fields. Per the issue, the expected result was the same context menu appears that does for the url bar. Cut, Copy, and Paste have been included, but Paste and Search/Go didn't make sense to place in this context menu to me. Let me know if more items need adding, thanks!