### PR TITLE
Fix macOS builds

### DIFF
--- a/tools/buildInstaller.js
+++ b/tools/buildInstaller.js
@@ -128,7 +128,8 @@ if (isDarwin) {
     'cd ..',
     'build ' +
       `--prepackaged="${buildDir}/${appName}.app" ` +
-      `--config=res/${channel}/builderConfig.json `,
+      `--config=res/${channel}/builderConfig.json ` +
+      '--publish=never',
 
     // Create an update zip
     'ditto -c -k --sequesterRsrc --keepParent ' + buildDir + `/${appName}.app dist/${appName}-` + VersionInfo.braveVersion + '.zip'

--- a/tools/cibuild.py
+++ b/tools/cibuild.py
@@ -37,7 +37,12 @@ def run_script(script, args=[]):
   sys.stderr.write('\nRunning ' + script +'\n')
   sys.stderr.flush()
   script = os.path.join(SOURCE_ROOT, 'tools', script)
-  subprocess.check_call([sys.executable, script] + args)
+  try:
+    output = subprocess.check_output([sys.executable, script] + args, stderr=subprocess.STDOUT)
+    print output
+  except subprocess.CalledProcessError as e:
+    print e.output
+    raise e
 
 
 PLATFORM = {

--- a/tools/upload.py
+++ b/tools/upload.py
@@ -9,6 +9,7 @@ BROWSER_LAPTOP_REPO = 'brave/browser-laptop'
 TARGET_ARCH= os.environ['TARGET_ARCH'] if os.environ.has_key('TARGET_ARCH') else 'x64'
 
 def main():
+  print('Running upload...')
   github = GitHub(auth_token())
   releases = github.repos(BROWSER_LAPTOP_REPO).releases.get()
   tag = 'v' + json.load(open('package.json'))['version']
@@ -20,7 +21,7 @@ def main():
   release = create_or_get_release_draft(github, releases, tag,
                                         tag_exists)
   for f in get_files_to_upload():
-    upload_browser_laptop(github,release, f)
+    upload_browser_laptop(github, release, f)
 
 def get_channel_display_name():
   d = {'dev': 'Release', 'beta': 'Beta', 'developer': 'Developer', 'nightly': 'Nightly'}
@@ -36,6 +37,7 @@ def get_files_to_upload():
 
 def upload_browser_laptop(github, release, file_path):
   filename = os.path.basename(file_path)
+  print('upload_browser_laptop: ' + filename)
   try:
     for asset in release['assets']:
       if asset['name'] == filename:


### PR DESCRIPTION
- Add extra logging to upload.py
- Don't upload via electron-builder (macOS only - prevents double upload)
- update logging in cibuild for run_script (print details about error that happened)

Auditors: @petemill, @darkdh 

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Queue a new browser-laptop build from https://jenkins.brave.com
2. Verify macOS build finishes and is successful

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


