### PR TITLE
fix path issue preventing u2f support from working on mac

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -4,7 +4,7 @@ const extensionActions = require('./common/actions/extensionActions')
 const config = require('../js/constants/config')
 const appConfig = require('../js/constants/appConfig')
 const {fileUrl} = require('../js/lib/appUrlUtil')
-const {getExtensionsPath, getBraveExtUrl, getBraveExtIndexHTML} = require('../js/lib/appUrlUtil')
+const {getComponentExtensionsPath, getExtensionsPath, getBraveExtUrl, getBraveExtIndexHTML} = require('../js/lib/appUrlUtil')
 const {getSetting} = require('../js/settings')
 const settings = require('../js/constants/settings')
 const extensionStates = require('../js/constants/extensionStates')
@@ -527,7 +527,7 @@ module.exports.init = () => {
   loadExtension(config.braveExtensionId, getExtensionsPath('brave'), generateBraveManifest(), 'component')
   // Cryptotoken extension is loaded from electron_resources.pak
   extensionInfo.setState(config.cryptoTokenExtensionId, extensionStates.REGISTERED)
-  loadExtension(config.cryptoTokenExtensionId, path.join(process.resourcesPath, 'cryptotoken'), {}, 'component')
+  loadExtension(config.cryptoTokenExtensionId, getComponentExtensionsPath('cryptotoken'), {}, 'component')
   extensionInfo.setState(config.syncExtensionId, extensionStates.REGISTERED)
   loadExtension(config.syncExtensionId, getExtensionsPath('brave'), generateSyncManifest(), 'unpacked')
 

--- a/js/lib/appUrlUtil.js
+++ b/js/lib/appUrlUtil.js
@@ -6,6 +6,7 @@ const Immutable = require('immutable')
 const path = require('path')
 const UrlUtil = require('./urlutil')
 const config = require('../constants/config')
+const isDarwin = require('../../app/common/lib/platformUtil').isDarwin()
 
 module.exports.fileUrl = (filePath) => {
   // It's preferrable to call path.resolve but it's not available
@@ -60,6 +61,14 @@ module.exports.getExtensionsPath = function (extensionDir) {
     // the path is different for release builds because extensions are not in the asar file
     ? path.join(__dirname, '..', '..', '..', 'extensions', extensionDir)
     : path.join(__dirname, '..', '..', 'app', 'extensions', extensionDir)
+}
+
+module.exports.getComponentExtensionsPath = function (extensionDir) {
+  if (isDarwin) {
+    return path.join(process.resourcesPath, '../Frameworks/Brave Framework.framework/Resources/', extensionDir)
+  } else {
+    return path.join(process.resourcesPath, extensionDir)
+  }
 }
 
 module.exports.getGenDir = function (url) {


### PR DESCRIPTION
Fixes #13344

The cryptotoken extension (used for u2f support) is bundled into `electron_resources.pak` as part of the muon build. There is muon code which attempts to fetch extension resources from the pak if the path passed during extension load is a subdirectory of `chrome::DIR_RESOURCES`.  Currently we use `process.resourcesPath` on the browser-laptop side to get the path to the `chome::DIR_RESOURCES` directory.

There's an issue with this on mac though, in that `process.resourcesPath` returns `Brave.app/Contents/Resources` while inside muon `chome::DIR_RESOURCES` actually refers to `Brave.app/Contents/Frameworks/Brave Framework.framework/Resources`.

This PR adds a helper function to retrieve the correct path for all platforms.

I've tested this PR on mac in dev mode as well as with a packaged build and also on linux to ensure u2f support is still working there.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

# Test plan
1. Go to https://demo.yubico.com/u2f?tab=register
2. Make up a username and password and click next
3. You should be prompted to plug in your u2f key
4. You will be prompted to touch the sensor on your u2f key
5. On success you can attempt login using the same username and password
6. You will be prompted to again plug in / touch the sensor on your u2f key

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


