### PR TITLE
disable webusb and bluetooth API explicitly

### DIFF
--- a/app/extensions/brave/content/scripts/navigator.js
+++ b/app/extensions/brave/content/scripts/navigator.js
@@ -12,6 +12,11 @@ chrome.webFrame.setGlobal("navigator.getBattery", function () {
   return new Promise((resolve, reject) => { reject(new Error('navigator.getBattery not supported.')) })
 })
 
+// bluetooth is not currently supported
+executeScript("window.Navigator.prototype.__defineGetter__('bluetooth', () => { return undefined })")
+// webusb also not supported yet
+executeScript("window.Navigator.prototype.__defineGetter__('usb', () => { return undefined })")
+
 if (chrome.contentSettings.doNotTrack == 'allow') {
   executeScript("window.Navigator.prototype.__defineGetter__('doNotTrack', () => { return 1 })")
 }

--- a/test/contents/contentLoadingTest.js
+++ b/test/contents/contentLoadingTest.js
@@ -51,4 +51,20 @@ describe('content loading', function () {
       .windowByUrl(Brave.browserWindowUrl)
       .waitForTextValue('[data-test-id="tabTitle"]', 'fail')
   })
+
+  it('does not support bluetooth API', function * () {
+    const page1 = Brave.fixtureUrl('navigator.html')
+    yield this.app.client
+      .tabByIndex(0)
+      .url(page1)
+      .waitForTextValue('#bluetooth', 'undefined')
+  })
+
+  it('does not support webusb API', function * () {
+    const page1 = Brave.fixtureUrl('navigator.html')
+    yield this.app.client
+      .tabByIndex(0)
+      .url(page1)
+      .waitForTextValue('#webusb', 'undefined')
+  })
 })

--- a/test/fixtures/navigator.html
+++ b/test/fixtures/navigator.html
@@ -1,0 +1,12 @@
+<html>
+	<div id='bluetooth'>
+	testing...
+	</div>
+	<div id='webusb'>
+	testing...
+	</div>
+    <script>
+		bluetooth.innerText = navigator.bluetooth
+		webusb.innerText = navigator.usb
+    </script>
+</html>


### PR DESCRIPTION
    disable webusb and bluetooth API

    neither are supported, but this will cause sites that check whether
    they're supported to know more reliably that they aren't supproted.

    fix https://github.com/brave/browser-laptop/issues/13374

    Test Plan:
    1. go to any site and open page console.
    2. navigator.usb should be undefined
    3. navigator.bluetooth should be undefined

fix https://github.com/brave/browser-laptop/issues/13374


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


