### PR TITLE
#12770 - Improved styling on promotion component

### DIFF
--- a/app/renderer/components/preferences/payment/enabledContent.js
+++ b/app/renderer/components/preferences/payment/enabledContent.js
@@ -506,8 +506,10 @@ const styles = StyleSheet.create({
 
   enabledContent__grant_text: {
     fontSize: '16px',
-    color: '#9b9b9b',
-    maxWidth: '600px'
+    color: '#828282',
+    maxWidth: '700px',
+    lineHeight: '25px',
+    padding: '5px'
   },
 
   enabledContent__grant_button: {


### PR DESCRIPTION
Fixed a bit of the styling on promotion component in payments preferences tab. Texts are now on 2 lines, rather than 3, spacing, colour, and padding applied for hopefully better look and feel. 

Before:
![image](https://user-images.githubusercontent.com/5307218/36940868-b961352c-1f1b-11e8-99f5-bccd7c973fb1.png)

After:
![image](https://user-images.githubusercontent.com/5307218/36940870-c0ba85da-1f1b-11e8-9d6b-718ba375f414.png)

@NejcZdovc Let me know your thoughts!

Cheers.

- [ X] Ran `git rebase -i` to squash commits (if needed).
- [ X] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

Resolves #12770