### PR TITLE
removed comments in menu.js

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -215,19 +215,6 @@ const createViewSubmenu = () => {
       }
     },
     CommonMenu.separatorMenuItem,
-    /*
-    {
-      label: locale.translation('toolbars'),
-      visible: false
-      submenu: [
-        {label: 'Favorites Bar', accelerator: 'Alt+CmdOrCtrl+B'},
-        {label: 'Tab Bar'},
-        {label: 'Address Bar', accelerator: 'Alt+CmdOrCtrl+A'},
-        {label: 'Tab Previews', accelerator: 'Alt+CmdOrCtrl+P'}
-      ]
-    },
-    CommonMenu.separatorMenuItem,
-    */
     {
       label: locale.translation('stop'),
       accelerator: isDarwin ? 'Cmd+.' : 'Esc',
@@ -238,31 +225,6 @@ const createViewSubmenu = () => {
     CommonMenu.reloadPageMenuItem(),
     CommonMenu.cleanReloadMenuItem(),
     CommonMenu.separatorMenuItem,
-    /*
-    {
-      label: locale.translation('readingView'),
-      visible: false,
-      accelerator: 'Alt+CmdOrCtrl+R'
-    }, {
-      label: locale.translation('tabManager'),
-      visible: false,
-      accelerator: 'Alt+CmdOrCtrl+M'
-    },
-    CommonMenu.separatorMenuItem,
-    {
-      label: locale.translation('textEncoding'),
-      visible: false
-      submenu: [
-        {label: 'Autodetect', submenu: []},
-        CommonMenu.separatorMenuItem,
-        {label: 'Unicode'},
-        {label: 'Western'},
-        CommonMenu.separatorMenuItem,
-        {label: 'etc...'}
-      ]
-    },
-    CommonMenu.separatorMenuItem,
-    */
     {
       label: locale.translation('toggleDeveloperTools'),
       accelerator: isDarwin ? 'Cmd+Alt+I' : 'Ctrl+Shift+I',


### PR DESCRIPTION
This pr fixes issue https://github.com/brave/browser-laptop/issues/13189.
I also found these lines in menu.js that look like dead code:
```
/*
{
  label: locale.translation('showAllHistory'),
  accelerator: 'CmdOrCtrl+Y',
  visible: false
},
CommonMenu.separatorMenuItem,
*/
```
Would it be ok to remove these lines too? 

Thanks for considering this request.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


