### PR TITLE
About brave clipboard copy now starts at top line - fixes issue #13355

### DIFF
--- a/js/about/brave.js
+++ b/js/about/brave.js
@@ -25,7 +25,7 @@ require('../../node_modules/font-awesome/css/font-awesome.css')
 
 const tranformVersionInfoToString = (versionInformation) =>
   versionInformation
-    .reduce((coll, version, name) => `${coll} \n${name}: ${version}`, '')
+  .reduce((coll, version, name) => `${coll}${name}: ${version}\n`, '')
 
 class AboutBrave extends React.Component {
   constructor (props) {


### PR DESCRIPTION
…issue #13355 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Go to about:brave
2. Click "copy to clipboard" to get the version information
3. Paste the copied text in a text editor
4. Ensure the pasted text starts at the top line vice leaving a blank line at the top

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


