### PR TITLE
increase version range for pinnedTopSites cleanup

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -845,11 +845,17 @@ module.exports.runPreMigrations = (data) => {
       if (data.cache) {
         delete data.cache.bookmarkLocation
       }
+    }
 
-      // pinned top sites were stored in the wrong position in 0.19.x
-      // allowing duplicated items. See #12941
-      // in this case eliminate pinned items so they can be properly
-      // populated in their own indexes
+    // pinned top sites were stored in the wrong position in 0.19.x
+    // and on some updates ranging from 0.20.x/0.21.x
+    // allowing duplicated items. See #12941
+    let pinnedTopSitesCleanup = false
+    try {
+      pinnedTopSitesCleanup = compareVersions(data.lastAppVersion, '0.22.00') < 1
+    } catch (e) {}
+
+    if (pinnedTopSitesCleanup) {
       if (data.about.newtab.pinnedTopSites) {
         // Empty array is currently set to include default pinned sites
         // which we avoid given the user already have a profile


### PR DESCRIPTION
Different fixes were tried for this but all needed to iterate over the list to check for duplicates and ended bulking startup time.

This fix is the same take as previous with a wider range of versions. This is better for performance as it does not iterate over the list on startup/every pin interaction but instead cleans the state at update time so no user-space affected.

fix #12941

## Test Plan:

1. Hack your session-store-1 adding a few duplicated objects inside pinnedTopSites list.
2. Run Brave
3. Quit
4. Check session-store-1 file again. There should be no duplicates
5. Run Brave again. There should be no pinned top sites

## Test Plan (QA specific):

1. Install 0.19.x - have a bunch of top sites
2. Upgrade to 0.20.30 which doesn't have the fix. Verify still broken
3. Update to this release (0.22.x) and verify issue is now fixed