### PR TITLE
Adds progress text for a contribution

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -263,7 +263,7 @@ const updateAboutDetails = (tabId) => {
   if (location === 'about:contributions' || onPaymentsPage) {
     const ledgerInfo = ledgerState.getInfoProps(appState)
     const preferencesData = appState.getIn(['about', 'preferences'], Immutable.Map())
-    const synopsis = appState.getIn(['ledger', 'about'])
+    const synopsis = ledgerState.getAboutData(appState)
     const migration = appState.get('migrations')
     const wizardData = ledgerState.geWizardData(appState)
     const ledgerData = ledgerInfo

--- a/app/common/state/ledgerState.js
+++ b/app/common/state/ledgerState.js
@@ -513,15 +513,15 @@ const ledgerState = {
   // TODO (optimization) don't have two almost identical object in state (synopsi->publishers and about->synopsis)
   saveAboutSynopsis: (state, publishers) => {
     state = validateState(state)
+    state = ledgerState.setAboutProp(state, 'synopsis', publishers)
+    state = ledgerState.setAboutProp(state, 'synopsisOptions', ledgerState.getSynopsisOptions(state))
+
     return state
-      .setIn(['ledger', 'about', 'synopsis'], publishers)
-      .setIn(['ledger', 'about', 'synopsisOptions'], ledgerState.getSynopsisOptions(state))
   },
 
   setAboutSynopsisOptions: (state) => {
     state = validateState(state)
-    return state
-      .setIn(['ledger', 'about', 'synopsisOptions'], ledgerState.getSynopsisOptions(state))
+    return ledgerState.setAboutProp(state, 'synopsisOptions', ledgerState.getSynopsisOptions(state))
   },
 
   getAboutData: (state) => {
@@ -555,6 +555,16 @@ const ledgerState = {
     }
 
     return promotion
+  },
+
+  setAboutProp: (state, prop, value) => {
+    state = validateState(state)
+
+    if (prop == null) {
+      return state
+    }
+
+    return state.setIn(['ledger', 'about', prop], value)
   }
 }
 

--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -224,6 +224,7 @@ paymentHistoryOKText=OK
 paymentHistoryOverdueFooterText=Your contribution is overdue.
 paymentHistoryTitle=Your Payment History
 paymentHistoryTitle=Your Payment History
+paymentInProgress=Currently processing
 payments=Payments
 paymentsFAQLink.title=View the FAQ
 paymentsSidebarText1=Our Partners

--- a/app/renderer/components/preferences/payment/enabledContent.js
+++ b/app/renderer/components/preferences/payment/enabledContent.js
@@ -139,7 +139,9 @@ class EnabledContent extends ImmutableComponent {
     let prevReconcileDateValue
     let text
 
-    if (!walletCreated || !walletHasReconcile || !walletHasTransactions) {
+    if (ledgerData.get('status') === 'contributionInProgress') {
+      text = 'paymentInProgress'
+    } else if (!walletCreated || !walletHasReconcile || !walletHasTransactions) {
       text = 'noPaymentHistory'
     } else {
       text = 'viewPaymentHistory'

--- a/docs/state.md
+++ b/docs/state.md
@@ -330,6 +330,7 @@ AppStore
       }
     }
     publisherTimestamp: number, // timestamp of last publisher update in the database
+    status: string, // ledger status
     synopsis: {
       options: {
         emptyScores: {

--- a/test/unit/app/common/state/ledgerStateTest.js
+++ b/test/unit/app/common/state/ledgerStateTest.js
@@ -586,4 +586,17 @@ describe('ledgerState unit test', function () {
       })
     })
   })
+
+  describe('setAboutProp', function () {
+    it('null case', function () {
+      const result = ledgerState.setAboutProp(defaultState)
+      assert.deepEqual(result.toJS(), defaultState.toJS())
+    })
+
+    it('prop is set', function () {
+      const result = ledgerState.setAboutProp(defaultState, 'status', 'ok')
+      const expectedState = defaultState.setIn(['ledger', 'about', 'status'], 'ok')
+      assert.deepEqual(result.toJS(), expectedState.toJS())
+    })
+  })
 })


### PR DESCRIPTION
Resolves #13423

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

1. clean profile
2. enable payments and add some funds (on staging)
3. add some sites
4. change reconcileStamp under ledger-state.json so Next Contribution is Overdue
5. run browser with `LEDGER_NO_DELAY=true LEDGER_NO_FUZZING=true LEDGER_VERBOSE=true LEDGER_ENVIRONMENT=staging`
6. Make sure that you see in progress after amount is substracted
7. There should be date after contribution is done in the first section

Step 5
![image](https://user-images.githubusercontent.com/9574457/37432627-3a169360-2796-11e8-8d0f-de82f06900e2.png)

Step 6
![image](https://user-images.githubusercontent.com/9574457/37433980-3d66f320-279b-11e8-9b62-8494d61b024a.png)


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


