### PR TITLE
Fixes broken about page check in windowStore.js (#13450)

### DIFF
--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -18,7 +18,7 @@ const getSetting = require('../settings').getSetting
 const UrlUtil = require('../lib/urlutil')
 const {l10nErrorText} = require('../../app/common/lib/httpUtil')
 const { makeImmutable } = require('../../app/common/state/immutableUtil')
-const {aboutUrls, getTargetAboutUrl, newFrameUrl} = require('../lib/appUrlUtil')
+const {isSourceAboutUrl, getTargetAboutUrl, newFrameUrl} = require('../lib/appUrlUtil')
 const assert = require('assert')
 const contextMenuState = require('../../app/common/state/contextMenuState')
 const appStoreRenderer = require('./appStoreRenderer')
@@ -100,7 +100,7 @@ class WindowStore extends EventEmitter {
 
 const addToHistory = (frameProps) => {
   let history = frameProps.get('history') || Immutable.fromJS([])
-  if (!aboutUrls.get(frameProps.get('location'))) {
+  if (!isSourceAboutUrl(frameProps.get('location'))) {
     history = history.push(frameProps.get('location'))
   }
   return history.slice(-10)


### PR DESCRIPTION
Related to issue #13450

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
Confirm via logging that frameProp's history is not pushed to when navigating away from all of the following pages:
1. about:about
2. about:preferences
3. about:preferences#extensions
3. about:preferences#payments

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

I did a quick audit of the codebase, looking for uses of has() and get() against the aboutUrls map defined in the appUrlUtil that would give a faulty check. In windowStore inside the addToHistory function, no regard was paid to url fragments in the current about page check. This resolves that with the use of isSourceAboutUrl.
