### PR TITLE
Adds no thanks option to promo notification

### DIFF
--- a/app/browser/api/ledgerNotifications.js
+++ b/app/browser/api/ledgerNotifications.js
@@ -190,6 +190,11 @@ const onDynamicResponse = (message, actionId, activeWindow) => {
         appActions.onPromotionRemind()
         break
       }
+    case 'noThanks':
+      {
+        appActions.changeSetting(settings.PAYMENTS_ALLOW_PROMOTIONS, false)
+        break
+      }
   }
 
   appActions.hideNotification(message)
@@ -322,6 +327,13 @@ const showPromotionNotification = (state) => {
 
   const data = notification.toJS()
   data.position = 'global'
+
+  if (data.buttons) {
+    data.buttons.unshift({
+      text: locale.translation('noThanks'),
+      buttonActionId: 'noThanks'
+    })
+  }
 
   appActions.showNotification(data)
 }


### PR DESCRIPTION
Resolves #12758

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1) clean profile
2) run browser on ledger staging
3) wait for promo notification to show
4) Make sure that there is `No thanks` option
5) Click on this option
6) Go to advance settings and make sure that promotion notification toggle is set to off

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


