### PR TITLE
Allow 'self' CSP connect-src by default

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -206,7 +206,8 @@ let generateBraveManifest = () => {
     // allow access to webpack dev server resources
     let devServer = 'localhost:' + process.env.npm_package_config_port
     cspDirectives['default-src'] = '\'self\' http://' + devServer
-    cspDirectives['connect-src'] = cspDirectives['connect-src'] + [
+    cspDirectives['connect-src'] = [
+      cspDirectives['connect-src'],
       'http://' + devServer,
       'ws://' + devServer
     ].join(' ')

--- a/app/extensions.js
+++ b/app/extensions.js
@@ -198,7 +198,7 @@ let generateBraveManifest = () => {
     'style-src': '\'self\' \'unsafe-inline\'',
     'font-src': '\'self\' data:',
     'img-src': '* data: file://*',
-    'connect-src': 'https://www.youtube.com',
+    'connect-src': '\'self\' https://www.youtube.com',
     'frame-src': '\'self\' https://brave.com'
   }
 
@@ -207,7 +207,6 @@ let generateBraveManifest = () => {
     let devServer = 'localhost:' + process.env.npm_package_config_port
     cspDirectives['default-src'] = '\'self\' http://' + devServer
     cspDirectives['connect-src'] = cspDirectives['connect-src'] + [
-      ' \'self\'',
       'http://' + devServer,
       'ws://' + devServer
     ].join(' ')


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/13499

test plan:
1. do a packaged build
2. translations should work in it
3. translations should also work in development mode

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


