### PR TITLE
Using dialog.showSaveDialog instead of webContents.downloadURL

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -1069,7 +1069,14 @@ const backupKeys = (state, backupAction) => {
         if (backupAction === 'print') {
           webContents.print({silent: false, printBackground: false})
         } else {
-          webContents.downloadURL(fileUrl(filePath), true)
+          const dialog = electron.dialog
+          dialog.showSaveDialog({
+            defaultPath: filePath,
+            filters: [{
+              name: 'TXT files',
+              extensions: ['txt']
+            }]
+          })
         }
       })
     }


### PR DESCRIPTION
fix #13510

Auditors: @bsclifton, @bridiver

Test Plan:

1. enable payments
2. once the wallet has been created, click on Advanced Settings -> Backup your wallet
3. click on Save recovery file
4. Should be able to save or cancel in a file dialog

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


