### PR TITLE
Fix regression for default favicon color on tab hover

### DIFF
--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -185,7 +185,7 @@ class Tab extends React.Component {
       },
       getSetting(settings.TAB_PREVIEW_TIMING))
     // fancy radial gradient mouse tracker
-    if (this.elementRef) {
+    if (this.elementRef && !this.props.isActive) {
       // only update position once per render frame
       if (!this.nextFrameSetTabMouseX) {
         var x = e.pageX - this.tabOffsetLeft
@@ -576,18 +576,20 @@ const styles = StyleSheet.create({
 
   tabArea_private_active: {
     '--tab-background': theme.tab.active.private.background,
-    '--tab-color': theme.tab.active.private.color,
     '--tab-background-hover': theme.tab.active.private.background,
+    '--tab-color': theme.tab.active.private.color,
     '--tab-color-hover': theme.tab.active.private.color,
-    '--tab-default-icon-color': theme.tab.active.private.defaultFaviconColor
+    '--tab-default-icon-color': theme.tab.active.private.defaultFaviconColor,
+    '--tab-default-icon-color-hover': theme.tab.active.private.defaultFaviconColor
   },
 
   tabArea_themed: {
-    '--tab-color': `var(--theme-color-fg)`,
     '--tab-background': `var(--theme-color-bg)`,
     '--tab-background-hover': 'var(--theme-color-bg)',
+    '--tab-color': `var(--theme-color-fg)`,
     '--tab-color-hover': 'var(--theme-color-fg)',
-    '--tab-default-icon-color': 'var(--theme-color-default-icon)'
+    '--tab-default-icon-color': 'var(--theme-color-default-icon)',
+    '--tab-default-icon-color-hover': 'var(--theme-color-default-icon)'
   },
 
   tabArea__tab: {


### PR DESCRIPTION
Fix #13524

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
See https://github.com/brave/browser-laptop/issues/13524

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


