### PR TITLE
Fixing Brave Shield settings persisting from private to regular tabs.

### DIFF
--- a/app/renderer/components/navigation/navigator.js
+++ b/app/renderer/components/navigation/navigator.js
@@ -106,7 +106,7 @@ class Navigator extends React.Component {
     const activeTabId = activeFrame.get('tabId', tabState.TAB_ID_NONE)
     const activeTab = tabState.getByTabId(state, activeTabId) || Immutable.Map()
     const activeTabShowingMessageBox = !!(!activeTab.isEmpty() && tabState.isShowingMessageBox(state, activeTabId))
-    const allSiteSettings = siteSettingsState.getAllSiteSettings(state, activeFrame)
+    const allSiteSettings = siteSettingsState.getAllSiteSettings(state, activeFrame.get('isPrivate'))
     const activeSiteSettings = siteSettings.getSiteSettingsForURL(allSiteSettings, activeFrame.get('location'))
     const braverySettings = siteSettings.activeSettings(activeSiteSettings, state, appConfig)
     const enabledExtensions = extensionState.getEnabledExtensions(state)


### PR DESCRIPTION
Fixes #13467

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

   1. Visit zerohedge.com in a private tab.
   2. Disable the site shields and close the private tab.
   3. Open zerohedge.com in a regular, non private tab.
   4. Ensure that the Brave shield is orange, not greyed out.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


@kjozwiak @flamsmark this was a pretty simple fix:

`getAllSiteSettings` expects its second parameter to be a bool representing whether current frame is private or not so it can work with temporary site settings if needed. Just the frame was being passed in, so the shield state was partially persisting from private to regular tabs.