### PR TITLE
fallback to frame location if originating script URL is not found

### DIFF
--- a/app/extensions/brave/content/scripts/blockCanvasFingerprinting.js
+++ b/app/extensions/brave/content/scripts/blockCanvasFingerprinting.js
@@ -144,7 +144,7 @@ if (chrome.contentSettings.canvasFingerprinting == 'block') {
   })
 
   function reportBlock (type) {
-    var script_url = getOriginatingScriptUrl()
+    var script_url = getOriginatingScriptUrl() || window.location.href
     var msg = {
       type,
       scriptUrl: stripLineAndColumnNumbers(script_url)


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/13360

Test Plan:
clean session store
go to https://browserleaks.com/canvas and open shields
note that canvas fingerprinting is blocked from about:blank

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


