### PR TITLE
Fix lock/unlock icon from disappearing when downloading from a site

### DIFF
--- a/app/renderer/components/frame/frame.js
+++ b/app/renderer/components/frame/frame.js
@@ -591,6 +591,10 @@ class Frame extends React.Component {
           // update the load state; otherwise it will not show the security
           // icon.
           return
+        } else if (!(getBaseUrl === getTargetAboutUrl('about:newtab'))) {
+          // If on the same page, don't reset the state
+          // Fixes a security icon when downloading an item
+          return
         }
         windowActions.onWebviewLoadStart(this.frame, e.url)
       }

--- a/app/renderer/components/frame/frame.js
+++ b/app/renderer/components/frame/frame.js
@@ -584,18 +584,12 @@ class Frame extends React.Component {
       if (this.frame.isEmpty()) {
         return
       }
-    
-      const isNewPage = getBaseUrl(e.url) === getTargetAboutUrl('about:newtab')
       if (e.isMainFrame && !e.isErrorPage && !e.isFrameSrcDoc) {
         if (e.url && e.url.startsWith(appConfig.noScript.twitterRedirectUrl) &&
           this.props.noScript === true) {
           // This result will be canceled immediately by sitehacks, so don't
           // update the load state; otherwise it will not show the security
           // icon.
-          return
-        } else if (!isNewPage) {
-          // If not new page, don't reset the state
-          // Fixes a security icon when downloading an item
           return
         }
         windowActions.onWebviewLoadStart(this.frame, e.url)

--- a/app/renderer/components/frame/frame.js
+++ b/app/renderer/components/frame/frame.js
@@ -584,6 +584,8 @@ class Frame extends React.Component {
       if (this.frame.isEmpty()) {
         return
       }
+    
+      const isNewPage = getBaseUrl(e.url) === getTargetAboutUrl('about:newtab')
       if (e.isMainFrame && !e.isErrorPage && !e.isFrameSrcDoc) {
         if (e.url && e.url.startsWith(appConfig.noScript.twitterRedirectUrl) &&
           this.props.noScript === true) {
@@ -591,8 +593,8 @@ class Frame extends React.Component {
           // update the load state; otherwise it will not show the security
           // icon.
           return
-        } else if (!(getBaseUrl === getTargetAboutUrl('about:newtab'))) {
-          // If on the same page, don't reset the state
+        } else if (!isNewPage) {
+          // If not new page, don't reset the state
           // Fixes a security icon when downloading an item
           return
         }

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -306,14 +306,16 @@ const doAction = (action) => {
         const statePath = path =>
           [path, frameStateUtil.getFrameIndex(windowState, action.frameProps.get('key'))]
 
-        // Reset security state
-        windowState =
-          windowState.deleteIn(statePath('frames').concat(['security', 'blockedRunInsecureContent']))
-        windowState = windowState.mergeIn(statePath('frames').concat(['security']), {
-          isSecure: null,
-          evCert: undefined,
-          runInsecureContent: false
-        })
+        if (!appConstants.APP_DOWNLOAD_ACTION_PERFORMED) {
+          // Reset security state
+          windowState =
+            windowState.deleteIn(statePath('frames').concat(['security', 'blockedRunInsecureContent']))
+          windowState = windowState.mergeIn(statePath('frames').concat(['security']), {
+            isSecure: null,
+            evCert: undefined,
+            runInsecureContent: false
+          })
+        }
         // Update loading UI
         windowState = windowState.mergeIn(statePath('frames'), {
           loading: true,


### PR DESCRIPTION
Fixes [issue #12248](https://github.com/brave/browser-laptop/issues/12248)

Before:
![before](https://user-images.githubusercontent.com/15698572/37692934-73c1851a-2c92-11e8-94f4-2f1dd8c70772.gif)

After:
![fix 3-1](https://user-images.githubusercontent.com/15698572/37692942-7a167128-2c92-11e8-8c92-1ad06b843d82.gif)

Tested on:
- Secure websites with secure downloads
- Secure websites with insecure downloads
- Insecure websites
- PDF downloads
- Twitter ( made sure to not cause [this issue](https://github.com/brave/browser-laptop/issues/8403))


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


