### PR TITLE
Tabs are always autoDiscardable

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -1009,11 +1009,10 @@ const api = {
       if (preventLazyLoad) {
         createProperties.discarded = false
       }
-      // Similarly, autoDiscardable will happen for regular tabs (not about: tabs)
-      const preventAutoDiscard = createProperties.pinned || !isRegularContent
-      if (preventAutoDiscard) {
-        createProperties.autoDiscardable = false
-      }
+      // autoDiscardable can happen for all tabs
+      // TODO(petemill): if there are schemes / Urls that should not be autodiscarded
+      // then the flag should be exposed from muon and set on each URL change for a tab
+      createProperties.autoDiscardable = true
 
       const doCreate = () => {
         if (shouldDebugTabEvents) {


### PR DESCRIPTION
Fix faulty logic that would almost never have a tab become discarded automatically.
Fix #13547

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


