### PR TITLE
Adjust some colors to completement new tab / top nav colors 

### DIFF
--- a/app/renderer/components/bookmarks/addEditBookmarkHanger.js
+++ b/app/renderer/components/bookmarks/addEditBookmarkHanger.js
@@ -169,7 +169,7 @@ const styles = StyleSheet.create({
       position: 'absolute',
       width: 0,
       height: 0,
-      border: `8px solid ${globalStyles.color.commonFormBackgroundColor}`,
+      border: `8px solid ${globalStyles.color.modalVeryLightGray}`,
       boxShadow: globalStyles.shadow.bookmarkHangerArrowUpShadow,
       transformOrigin: '0 0',
       transform: 'rotate(135deg)'

--- a/app/renderer/components/common/commonForm.js
+++ b/app/renderer/components/common/commonForm.js
@@ -89,7 +89,7 @@ class CommonFormClickable extends ImmutableComponent {
 
 const styles = StyleSheet.create({
   commonForm: {
-    background: globalStyles.color.commonFormBackgroundColor,
+    background: globalStyles.color.modalVeryLightGray,
     color: globalStyles.color.commonTextColor,
     padding: 0,
     top: '40px',

--- a/app/renderer/components/common/settings.js
+++ b/app/renderer/components/common/settings.js
@@ -178,7 +178,7 @@ class SettingItemIcon extends ImmutableComponent {
 
 const styles = StyleSheet.create({
   icon: {
-    backgroundColor: '#5a5a5a',
+    backgroundColor: 'rgb(90, 90, 98)',
     height: '16px',
     width: '16px',
     display: 'inline-block',

--- a/app/renderer/components/preferences/preferenceNavigation.js
+++ b/app/renderer/components/preferences/preferenceNavigation.js
@@ -5,6 +5,7 @@ const HelpfulHints = require('./helpfulHints')
 
 const {StyleSheet, css} = require('aphrodite')
 const globalStyles = require('../styles/global')
+const { theme } = require('../styles/theme')
 
 // Icons
 const iconGeneral = require('../../../extensions/brave/img/preferences/browser_prefs_general.svg')
@@ -89,7 +90,7 @@ class PreferenceNavigation extends ImmutableComponent {
 const navIcon = icon => ({WebkitMask: `url(${icon}) no-repeat 0 0`})
 const styles = StyleSheet.create({
   prefAside: {
-    background: `linear-gradient(${globalStyles.color.gray}, ${globalStyles.color.mediumGray})`,
+    background: theme.preferences.navigationBackground,
     boxShadow: globalStyles.shadow.insetShadow,
     position: 'fixed',
     zIndex: '600',

--- a/app/renderer/components/styles/global.js
+++ b/app/renderer/components/styles/global.js
@@ -39,7 +39,7 @@ const globalStyles = {
     at12: 0.125
   },
   color: {
-    commonTextColor: '#3b3b3b',
+    commonTextColor: 'rgb(59, 59, 62)',
     linkColor: '#0099CC',
     highlightBlue: '#37A9FD',
     privateTabBackground: '#665296',
@@ -61,18 +61,18 @@ const globalStyles = {
     progressBarColor: '#3498DB',
     siteInsecureColor: '#C63626',
     siteEVColor: 'green',
-    buttonColor: '#5a5a5a',
+    buttonColor: 'rgb(90, 90, 98)',
     braveOrange: 'rgb(255, 80, 0)',
     braveLightOrange: '#FF7A1D',
     braveMediumOrange: 'rgb(232, 72, 0)',
     braveDarkOrange: '#D44600',
-    veryLightGray: 'rgb(250, 250, 250)',
-    lightGray: 'rgb(236, 236, 236)',
-    gray: 'rgb(153, 153, 153)',
-    mediumGray: 'rgb(101, 101, 101)',
-    darkGray: 'rgb(68, 68, 68)',
-    modalVeryLightGray: 'rgb(247, 247, 247)',
-    modalLightGray: 'rgb(231, 231, 231)',
+    veryLightGray: 'rgb(250, 250, 251)',
+    lightGray: 'rgb(236, 236, 239)',
+    gray: 'rgb(153, 153, 157)',
+    mediumGray: 'rgb(101, 101, 107)',
+    darkGray: 'rgb(68, 68, 72)',
+    modalVeryLightGray: 'rgb(247, 247, 249)',
+    modalLightGray: 'rgb(231, 231, 234)',
     white25: 'rgba(255, 255, 255, 0.25)',
     white50: 'rgba(255, 255, 255, 0.5)',
     white100: 'rgba(255, 255, 255, 1)',
@@ -93,7 +93,7 @@ const globalStyles = {
     notificationItemColor: '#f1e9e5',
     notificationBottomBorderColor: '#ff5500',
     almostInvisible: 'rgba(255,255,255,0.01)',
-    urlBarOutline: '#bbb',
+    urlBarOutline: 'rgb(187, 187, 191)',
     alphaWhite: 'rgba(255,255,255,0.8)'
   },
   typography: {
@@ -303,7 +303,7 @@ const globalStyles = {
   },
 
   button: {
-    color: '#5a5a5a',
+    color: 'rgb(90, 90, 98)',
 
     default: {
       color: '#fff',
@@ -322,11 +322,11 @@ const globalStyles = {
 
     secondary: {
       gradientColor1: '#fff',
-      gradientColor2: '#ececec',
-      background: 'linear-gradient(#fff, #ececec)',
-      color: '#666',
-      hoverColor: '#444',
-      borderHoverColor: 'rgb(153, 153, 153)'
+      gradientColor2: 'rgb(236, 236, 239)',
+      background: 'linear-gradient(#fff, rgb(236, 236, 239))',
+      color: 'rgb(101, 101, 107)',
+      hoverColor: 'rgb(68, 68, 72)',
+      borderHoverColor: 'rgb(153, 153, 157)'
     },
 
     subtle: {
@@ -345,11 +345,11 @@ const globalStyles = {
   },
 
   braveryPanel: {
-    color: '#3b3b3b',
+    color: 'rgb(59, 59, 62)',
 
     header: {
-      color: '#fafafa',
-      background: '#808080',
+      color: '#fff',
+      background: 'rgb(128, 128, 133)',
       switchControlTopTextColor: '#d3d3d3',
       border: '1px solid #aaa'
     },
@@ -359,10 +359,10 @@ const globalStyles = {
     },
 
     body: {
-      background: '#eee',
+      background: 'rgb(239, 239, 241)',
 
       hr: {
-        background: '#ccc'
+        background: 'rgb(204, 204, 214)'
       }
     }
   },

--- a/app/renderer/components/styles/theme.js
+++ b/app/renderer/components/styles/theme.js
@@ -51,7 +51,7 @@
       backgroundColor: '#CDD1D5',
 
       border: {
-        color: '#bbb'
+        color: 'rgb(187, 187, 191)'
       },
 
       button: {
@@ -64,14 +64,14 @@
 
       tabs: {
         navigation: {
-          borderColor: '#bbb'
+          borderColor: 'rgb(187, 187, 191)'
         }
       }
     },
 
     tabPage: {
       backgroundColor: '#fff',
-      borderColor: '#bbb',
+      borderColor: 'rgb(187, 187, 191)',
 
       hover: {
         backgroundColor: globalStyles.color.braveOrange,
@@ -99,7 +99,7 @@
       item: {
         separator: {
           hr: {
-            backgroundColor: '#bbb'
+            backgroundColor: 'rgb(187, 187, 191)'
           }
         },
 
@@ -109,7 +109,7 @@
         },
 
         disabled: {
-          color: '#bbb'
+          color: 'rgb(187, 187, 191)'
         },
 
         icon: {
@@ -130,7 +130,7 @@
       },
 
       single: {
-        backgroundColor: 'rgba(238, 238, 238, 1)',
+        backgroundColor: 'rgba(238, 238, 240, 1)',
         borderColor: 'rgba(204, 204, 204, 0.54)',
         boxShadowColor: 'rgba(0, 0, 0, 0.5)'
       }
@@ -142,7 +142,7 @@
       transitionEasingOut: 'ease-in',
       transitionEasingIn: 'ease-out',
       background: 'rgb(205,209,213)',
-      borderColor: '#bbb',
+      borderColor: 'rgb(187, 187, 191)',
       borderWidth: 1,
       color: '#222',
       identityHeight: globalStyles.spacing.iconSize,
@@ -223,7 +223,7 @@
     },
 
     findBar: {
-      backgroundColor: '#F7F7F7',
+      backgroundColor: globalStyles.color.modalVeryLightGray,
       color: globalStyles.color.highlightBlue,
 
       border: {
@@ -239,7 +239,7 @@
       },
 
       find: {
-        color: '#555'
+        color: 'rgb(85, 85, 90)'
       },
 
       close: {
@@ -259,7 +259,7 @@
     switchControl: {
       label: {
         top: {
-          color: '#bbb'
+          color: 'rgb(187, 187, 190)'
         }
       },
 
@@ -280,5 +280,13 @@
           backgroundColor: '#fff'
         }
       }
+    },
+
+    preferences: {
+      navigationBackground: `linear-gradient(
+        rgb(164, 167, 171),
+        rgb(94, 96, 99)
+      )`,
+      navigationSectionSelectedColor: 'rgb(101, 101, 107)'
     }
   }

--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -837,8 +837,8 @@
         &.fa-search {
           position: relative;
           bottom: 0;
-          // 50% of #5a5a5a
-          color: rgba(90, 90, 90, 0.5);
+          // 50% of rgb(90, 90, 98)
+          color: rgba(90, 90, 98, 0.5);
         }
 
         &.fa-lock,

--- a/less/variables.less
+++ b/less/variables.less
@@ -45,7 +45,7 @@
 @siteEVColor: green;
 @loadTimeColor: @highlightBlue;
 @activeTabDefaultColor: @chromePrimary;
-@buttonColor: #5a5a5a;
+@buttonColor: rgb(90, 90, 98);
 @braveOrange: rgb(255, 85, 0);
 @braveLightOrange: #FF7A1D;
 @braveMediumOrange: rgb(232, 72, 0);

--- a/less/window.less
+++ b/less/window.less
@@ -66,7 +66,7 @@ html,
       background: linear-gradient(to top, rgb(28, 27, 27) 0%, rgba(255, 255, 255, .3) 60%);
       display: block;
       opacity: 0;
-      transition: opacity .4s ease-in; // TODO: get from theme.tab
+      transition: opacity .2s ease-in; // TODO: get from theme.tab
       pointer-events: none;
       will-change: opacity;
       z-index: 1100;

--- a/less/window.less
+++ b/less/window.less
@@ -50,7 +50,7 @@ html,
   display: flex;
   flex-direction: row;
   flex-grow: 1;
-  box-shadow: 0 -1px 0 #bbb;
+  box-shadow: 0 -1px 0 rgb(187, 187, 191);
   width: 100%;
   z-index: 1;
   .tabContainer {


### PR DESCRIPTION
By request of @bradleyrichter 

New tab colors were introduced with #12565
 - additional complementing colors contained in this PR
New preview style/animation was introduced also with #12565 
 - timing adjustment for animation

Whilst the colors will be further polished, along with new icons, in upcoming versions, this PR ensures that the grays do not clash with the new grays in use for tab chrome.

Fix #13537
See issue for details

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


