### PR TITLE
Set correct widevine resource ID

### DIFF
--- a/js/state/contentSettings.js
+++ b/js/state/contentSettings.js
@@ -19,6 +19,9 @@ const {getSetting} = require('../settings')
 const {autoplayOption} = require('../../app/common/constants/settingsEnums')
 const {getFlashResourceId} = require('../flash')
 
+// Widevine not supported yet on linux
+const widevineResourceId = `widevinecdmadapter.${process.platform === 'darwin' ? 'plugin' : 'dll'}`
+
 // backward compatibility with appState siteSettings
 const parseSiteSettingsPattern = (pattern) => {
   if (pattern === 'file:///') {
@@ -152,7 +155,7 @@ const getDefaultPluginSettings = (braveryDefaults, appSettings, appConfig) => {
     },
     {
       setting: 'block',
-      resourceId: appConfig.widevine.resourceId,
+      resourceId: widevineResourceId,
       primaryPattern: '*'
     },
     // allow autodetction of flash install by adobe
@@ -317,7 +320,7 @@ const siteSettingsToContentSettings = (currentSiteSettings, defaultContentSettin
       contentSettings = addContentSettings(contentSettings, 'flashAllowed', primaryPattern, '*', 'allow', getFlashResourceId())
     }
     if (typeof siteSetting.get('widevine') === 'number' && braveryDefaults.get('widevine')) {
-      contentSettings = addContentSettings(contentSettings, 'plugins', primaryPattern, '*', 'allow', appConfig.widevine.resourceId)
+      contentSettings = addContentSettings(contentSettings, 'plugins', primaryPattern, '*', 'allow', widevineResourceId)
     }
     if (typeof siteSetting.get('autoplay') === 'boolean') {
       contentSettings = addContentSettings(contentSettings, 'autoplay', primaryPattern, '*', siteSetting.get('autoplay') ? 'allow' : 'block')


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/11430

Test Plan:
1. on a windows machine/VM, go to https://shaka-player-demo.appspot.com/demo/#asset=//media.axprod.net/TestVectors/v7-MultiDRM-SingleKey/Manifest.mpd;lang=en-US;build=uncompiled and click 'load'
2. the video should show a DRM error
3. go to about:preferences#plugins and enable Widevine
4. repeat step 1
5. the video should now load

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


