### PR TITLE
Fixed #2900 - Focusing address bar selects all text.

### DIFF
--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -52,6 +52,7 @@ class UrlBar extends React.Component {
     this.lastVal = ''
     this.lastSuffix = ''
     this.isOnComposition = false
+    this.inFocus = false
     this.onFocus = this.onFocus.bind(this)
     this.onBlur = this.onBlur.bind(this)
     this.onKeyDown = this.onKeyDown.bind(this)
@@ -208,6 +209,10 @@ class UrlBar extends React.Component {
   }
 
   onClick () {
+    if (!this.inFocus && this.urlInput.selectionEnd == this.urlInput.selectionStart){
+      this.inFocus = true;
+      this.select()
+    }
     if (this.props.isSelected) {
       windowActions.setUrlBarActive(true)
     }
@@ -218,6 +223,8 @@ class UrlBar extends React.Component {
   }
 
   onBlur (e) {
+    window.getSelection().empty()
+    this.inFocus = false
     windowActions.urlBarOnBlur(getCurrentWindowId(), e.target.value, this.props.urlbarLocation, eventElHasAncestorWithClasses(e, ['urlBarSuggestions', 'urlbarForm']))
   }
 
@@ -338,7 +345,6 @@ class UrlBar extends React.Component {
   }
 
   onFocus () {
-    this.select()
     windowActions.urlBarOnFocus(getCurrentWindowId())
   }
 
@@ -384,7 +390,6 @@ class UrlBar extends React.Component {
     }
 
     if (this.props.isSelected && !prevProps.isSelected) {
-      this.select()
       windowActions.urlBarSelected(false)
     }
 


### PR DESCRIPTION
Modified address bar so that mouse down will not select all. Instead, it'll only select all if the button is released and the mouse wasn't dragged/no text was highlighted. This will make Brave's address bar behave like other browsers. 

@diracdeltas


## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
Explained in issue #2900.

1. Open a page in Brave, or have some text in the address bar.
2. Click anywhere to lose focus on the address bar.
3. Click on the address bar OR click and drag the address bar.

All text will immediately be selected and dragged.


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header