### PR TITLE
Fixes recover flow when seed is corrupted

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -1160,6 +1160,12 @@ const onWalletRecovery = (state, error, result) => {
     state = ledgerState.setInfoProp(state, 'walletQR', Immutable.Map())
     state = ledgerState.setInfoProp(state, 'addresses', Immutable.Map())
 
+    const status = ledgerState.getAboutProp(state, 'status')
+
+    if (status === ledgerStatuses.CORRUPTED_SEED) {
+      state = ledgerState.setAboutProp(state, 'status', '')
+    }
+
     callback(error, result)
 
     if (balanceTimeoutId) {
@@ -1647,9 +1653,13 @@ const getStateInfo = (state, parsedData) => {
     state = ledgerState.setAboutProp(state, 'status', ledgerStatuses.IN_PROGRESS)
   }
 
-  let passphrase = ledgerClient.prototype.getWalletPassphrase(parsedData)
-  if (passphrase) {
-    newInfo.passphrase = passphrase.join(' ')
+  try {
+    let passphrase = ledgerClient.prototype.getWalletPassphrase(parsedData)
+    if (passphrase) {
+      newInfo.passphrase = passphrase.join(' ')
+    }
+  } catch (e) {
+    console.error(e)
   }
 
   state = ledgerState.mergeInfoProp(state, newInfo)

--- a/app/common/state/ledgerState.js
+++ b/app/common/state/ledgerState.js
@@ -570,6 +570,16 @@ const ledgerState = {
     }
 
     return state.setIn(['ledger', 'about', prop], value)
+  },
+
+  getAboutProp: (state, prop) => {
+    state = validateState(state)
+
+    if (prop == null) {
+      return null
+    }
+
+    return state.getIn(['ledger', 'about', prop])
   }
 }
 

--- a/test/unit/app/common/state/ledgerStateTest.js
+++ b/test/unit/app/common/state/ledgerStateTest.js
@@ -609,4 +609,17 @@ describe('ledgerState unit test', function () {
       assert.deepEqual(result.toJS(), expectedState.toJS())
     })
   })
+
+  describe('getAboutProp', function () {
+    it('null case', function () {
+      const result = ledgerState.getAboutProp(defaultState)
+      assert.equal(result, null)
+    })
+
+    it('prop is set', function () {
+      const state = defaultState.setIn(['ledger', 'about', 'status'], 'corrupted')
+      const result = ledgerState.getAboutProp(state, 'status')
+      assert.equal(result, 'corrupted')
+    })
+  })
 })


### PR DESCRIPTION
Resolves #13583

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

1. Launch brave with LEDGER_ENVIRONMENT=staging and LEDGER_VERBOSE=true with a clean profile
2. Enable payments
3. Save recovery key
4. Close Brave
5. Open ledger-state.json and modify seed (remove some of them)
6. Launch Brave with same parameters from step 1
7. Navigate to Payments, overlay is shown.
8. Click on recover button
9. Copy/Paste words or import them.
10. Successful wallet recovery, close popup
11. Corrupt message is not displayed

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


