### PR TITLE
Show intermediate errors in pinned tabs

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -862,9 +862,15 @@ const api = {
     if (tab && !tab.isDestroyed()) {
       let url = normalizeUrl(action.get('url'))
       // We only allow loading URLs explicitly when the origin is
-      // the same for pinned tabs.  This is to help preserve a users
-      // pins.
-      if (tab.pinned && getOrigin(tab.getURL()) !== getOrigin(url)) {
+      // the same for pinned tabs, or it's an intermediate error.
+      // This is to help preserve a users pins.
+      if (
+        tab.pinned &&
+        // is different origin
+        getOrigin(tab.getURL()) !== getOrigin(url) &&
+        // is not error page
+        !isIntermediateAboutPage(action.get('url'))
+      ) {
         api.create({
           url,
           partition: tab.session.partition


### PR DESCRIPTION
Fix #8639
If loading a pinned tab errors, the error is not shown in the pinned tab, but is shown in a new tab which does not show the url which errors. The pinned tab then shows a non-branded error page. This can be a confusing UX as we've seen here, as it's not clear where the error tab has come from.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
On #8639  but also:
### Steps to Reproduce

  1. Use borked profile from #13261 in which www.ebay.com cannot be loaded due to infinite redirects due to bad cookies
  2. Pin www.ebay.com
  3. Restart browser

**Actual result:**
2 additional tabs are created with errors that do not specify which url or tab caused those errors.
Pinned ebay.com tab shows unbranded error.

**Expected result:**
Error is shown in pinned ebay tab, and upon resolving of the error (clearing cookies), and restarting, ebay continues to load in a pinned tab.
**- verify that when the error is resolved, the pinned tab has remembered which url it is supposed to load**

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


