### PR TITLE
Fix pinned tab drag size and pinned preview z-index

### DIFF
--- a/app/renderer/components/tabs/pinnedTabs.js
+++ b/app/renderer/components/tabs/pinnedTabs.js
@@ -20,6 +20,7 @@ const windowStore = require('../../../../js/stores/windowStore')
 
 // Constants
 const dragTypes = require('../../../../js/constants/dragTypes')
+const globalStyles = require('../styles/global')
 
 // Utils
 const dnd = require('../../../../js/dnd')
@@ -71,18 +72,22 @@ class PinnedTabs extends React.Component {
   mergeProps (state, ownProps) {
     const currentWindow = state.get('currentWindow')
     const pinnedFrames = frameStateUtil.getPinnedFrames(currentWindow) || Immutable.List()
+    const previewFrameKey = frameStateUtil.getPreviewFrameKey(currentWindow)
 
     const props = {}
     // used in renderer
     props.pinnedTabs = pinnedFrames.map((frame) => frame.get('key'))
-
+    props.isPreviewingPinnedTab = previewFrameKey && props.pinnedTabs.some(key => key === previewFrameKey)
     return props
   }
 
   render () {
     this.tabRefs = []
     return <div
-      className={css(styles.pinnedTabs)}
+      className={css(
+        styles.pinnedTabs,
+        this.props.isPreviewingPinnedTab && styles.pinnedTabs_previewing
+      )}
       data-test-id='pinnedTabs'
       onDragOver={this.onDragOver}
       onDrop={this.onDrop}
@@ -110,6 +115,10 @@ const styles = StyleSheet.create({
     position: 'relative',
     marginLeft: 0,
     marginTop: 0
+  },
+
+  pinnedTabs_previewing: {
+    zIndex: globalStyles.zindex.zindexTabs + 1
   }
 })
 

--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -616,7 +616,7 @@ const styles = StyleSheet.create({
       left: 'var(--tab-mouse-x)',
       top: 0,
       bottom: 0,
-      width: 'calc(190px * var(--tab-mouse-opacity, 0))',
+      width: 'calc(100% * var(--tab-mouse-opacity, 0))',
       background: `radial-gradient(
         circle farthest-corner,
         var(--tab-background-hover),


### PR DESCRIPTION
'Tab Mouse' gradient scales to tab size
Never wider than the size of the tab, so it does not affect drag bounds.
Fix #13566 

Previewing pinned tab should have higher z-index than other tab
Fix #13606

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


