### PR TITLE
Fixed netflix video resizing bug

### DIFF
--- a/app/renderer/components/main/main.js
+++ b/app/renderer/components/main/main.js
@@ -281,7 +281,6 @@ class Main extends React.Component {
     if (this.lastLoadedSearchProviders === undefined || engine !== this.lastLoadedSearchProviders) {
       entries.forEach((entry) => {
         if (entry.name === engine) {
-        if (entry.name === engine) {
           appActions.defaultSearchEngineLoaded(Immutable.fromJS({
             searchURL: entry.search,
             privateSearchURL: entry.privateSearch,
@@ -321,7 +320,7 @@ class Main extends React.Component {
     // picture of what's happening.
 	//This has been disabled as it appears to mess around with how videos on netflix resize themself (https://github.com/brave/browser-laptop/issues/12870)
     /*if (prevProps.tabId !== this.props.tabId && this.props.isFullScreen) {
-      windowActions.setFullScreen(this.props.tabId, false)
+     // windowActions.setFullScreen(this.props.tabId, false)
     }*/
   }
 

--- a/app/renderer/components/main/main.js
+++ b/app/renderer/components/main/main.js
@@ -281,6 +281,7 @@ class Main extends React.Component {
     if (this.lastLoadedSearchProviders === undefined || engine !== this.lastLoadedSearchProviders) {
       entries.forEach((entry) => {
         if (entry.name === engine) {
+        if (entry.name === engine) {
           appActions.defaultSearchEngineLoaded(Immutable.fromJS({
             searchURL: entry.search,
             privateSearchURL: entry.privateSearch,
@@ -318,9 +319,10 @@ class Main extends React.Component {
 
     // If the tab changes or was closed, exit out of full screen to give a better
     // picture of what's happening.
-    if (prevProps.tabId !== this.props.tabId && this.props.isFullScreen) {
+	//This has been disabled as it appears to mess around with how videos on netflix resize themself (https://github.com/brave/browser-laptop/issues/12870)
+    /*if (prevProps.tabId !== this.props.tabId && this.props.isFullScreen) {
       windowActions.setFullScreen(this.props.tabId, false)
-    }
+    }*/
   }
 
   componentDidMount () {


### PR DESCRIPTION
Removal of the forcible re-size of a tab seems to have fixed this issue https://github.com/brave/browser-laptop/issues/12870 . I have been looking into this for a while, and it appears that by not forcing a resize of the tab, the video size does not overlap.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

@srirambv
