### PR TITLE
Making address bar aware of dates/division

### DIFF
--- a/test/unit/lib/urlutilTestComponents.js
+++ b/test/unit/lib/urlutilTestComponents.js
@@ -45,9 +45,11 @@ module.exports = {
       },
       'is an absolute file path without scheme': (test) => {
         test.equal(urlUtil().isNotURL('/file/path/to/file'), false)
+        test.equal(urlUtil().isNotURL('/3/25/25'), false)
       },
       'is an absolute file path with scheme': (test) => {
         test.equal(urlUtil().isNotURL('file:///file/path/to/file'), false)
+        test.equal(urlUtil().isNotURL('file:///3/25/25'), false)
       },
       'for special pages': {
         'is a data URI': (test) => {
@@ -147,6 +149,35 @@ module.exports = {
       },
       'has space in schema': (test) => {
         test.equal(urlUtil().isNotURL('https ://brave.com'), true)
+      },
+      'slashes and numbers': {
+        'forward-slashes and numbers in an arbitrary order': (test) => {
+          test.equal(urlUtil().isNotURL('3//'), true)
+          test.equal(urlUtil().isNotURL('64//8'), true)
+          test.equal(urlUtil().isNotURL('25/5/2//'), true)
+        },
+        'division-like expression containing no spaces': (test) => {
+          test.equal(urlUtil().isNotURL('4/2'), true)
+          test.equal(urlUtil().isNotURL('8/2/4'), true)
+          test.equal(urlUtil().isNotURL('100/25'), true)
+        }
+      },
+      // This set of tests confirm that isDate works as a test case inside isNotURL
+      // to determine that valid dates are not interpreted as URLs.
+      'dates': {
+        'forward-slash delimited date': (test) => {
+          test.equal(urlUtil().isNotURL('03/26'), true)
+          test.equal(urlUtil().isNotURL('01/01/1970'), true)
+          test.equal(urlUtil().isNotURL('03/26/2017'), true)
+          test.equal(urlUtil().isNotURL('1995/05/12'), true)
+        },
+        'dot-delimited date': (test) => {
+          test.equal(urlUtil().isNotURL('01.01.1970'), true)
+          test.equal(urlUtil().isNotURL('12.25.2000'), true)
+          test.equal(urlUtil().isNotURL('25.12.2000'), true)
+          test.equal(urlUtil().isNotURL('03.26'), true)
+          test.equal(urlUtil().isNotURL('1977.03.25'), true)
+        }
       }
     }
   },
@@ -561,6 +592,22 @@ module.exports = {
     'url is pdf': (test) => {
       const result = urlUtil().getUrlFromPDFUrl('chrome-extension://jdbefljfgobbmcidnmpjamcbhnbphjnb/http://www.test.com/test.pdf')
       test.equal(result, 'http://www.test.com/test.pdf')
+    }
+  },
+
+  'isDate': {
+    'forward-slash delimited date': (test) => {
+      test.equal(urlUtil().isDate('03/26'), true)
+      test.equal(urlUtil().isDate('01/01/1970'), true)
+      test.equal(urlUtil().isDate('03/26/2017'), true)
+      test.equal(urlUtil().isDate('1995/05/12'), true)
+    },
+    'dot-delimited date': (test) => {
+      test.equal(urlUtil().isDate('01.01.1970'), true)
+      test.equal(urlUtil().isDate('12.25.2000'), true)
+      test.equal(urlUtil().isDate('25.12.2000'), true)
+      test.equal(urlUtil().isDate('03.26'), true)
+      test.equal(urlUtil().isDate('1977.03.25'), true)
     }
   }
 }


### PR DESCRIPTION
Fixes #11316

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

1. Enter a forward slash delimited datestamp, such as `03/27/2018` in the address bar
2. Confirm that it resolves as a search query against the default search engine, not as a url
3. Enter other division-like expressions/combinations of numbers and slashes such as `03/27`, `55//55` and `5555/2` in the address bar
4. Confirm that they resolves as a search query against the default search engine, not as a url
5. [Regression testing] Enter a valid file path, such as `/35/5` or `//3/` in to the address bar
6. Confirm that Brave attempts to resolve it as a local file

## Reviewer Checklist:

- [] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

@jonathansampson 

Overall this adds an additional check in the UrlUtil's `isNotURL` function to check for slash delimited dates and other combinations of forward slashes and numbers.

In Chrome and Firefox, the following entries default to a search query (Where Brave without this PR attempts to resolve them as a URL)

- `03/28/2013`
- `15/3`
- `234/25/235/235`

This was not allowing a user to search for a date or enter a division expression using the address bar.

This PR does not conflict with Brave's current handling of valid local file paths (ex `/34/2` or `//3`). Tests have been added to show case all a-formentioned scenarios.