### PR TITLE
Scope openExternal permissions by scheme instead of href

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -446,33 +446,26 @@ function registerPermissionHandler (session, partition) {
       const isOpenExternal = permission === 'openExternal'
 
       let requestingOrigin
-      let settings
-      let tempSettings
 
       if (requestingUrl === appUrlUtil.getBraveExtIndexHTML() || isPDFOrigin || isBraveOrigin) {
         // lookup, display and store site settings by the origin alias
         requestingOrigin = isPDFOrigin ? 'PDF Viewer' : 'Brave Browser'
         // display on all tabs
         mainFrameOrigin = null
-        // Lookup by exact host pattern match since 'Brave Browser' is not
-        // a parseable URL
-        settings = siteSettings.getSiteSettingsForHostPattern(appState.get('siteSettings'), requestingOrigin)
-        tempSettings = siteSettings.getSiteSettingsForHostPattern(appState.get('temporarySiteSettings'), requestingOrigin)
       } else if (isOpenExternal) {
         // Open external is a special case since we want to apply the permission
         // for the entire scheme to avoid cluttering the saved permissions. See
         // https://github.com/brave/browser-laptop/issues/13642
         const protocol = urlParse(requestingUrl).protocol
         requestingOrigin = protocol ? `${protocol} URLs` : requestingUrl
-        // Lookup by exact host pattern match since getSiteSettingsForURL
-        // does not correctly handle protocols without slashes like mailto:
-        settings = siteSettings.getSiteSettingsForHostPattern(appState.get('siteSettings'), requestingOrigin)
-        tempSettings = siteSettings.getSiteSettingsForHostPattern(appState.get('temporarySiteSettings'), requestingOrigin)
       } else {
         requestingOrigin = getOrigin(requestingUrl) || requestingUrl
-        settings = siteSettings.getSiteSettingsForURL(appState.get('siteSettings'), requestingOrigin)
-        tempSettings = siteSettings.getSiteSettingsForURL(appState.get('temporarySiteSettings'), requestingOrigin)
       }
+
+      // Look up by host pattern since requestingOrigin is not necessarily
+      // a parseable URL
+      const settings = siteSettings.getSiteSettingsForHostPattern(appState.get('siteSettings'), requestingOrigin)
+      const tempSettings = siteSettings.getSiteSettingsForHostPattern(appState.get('temporarySiteSettings'), requestingOrigin)
 
       if (!permissions[permission]) {
         console.warn('WARNING: got unregistered permission request', permission)


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/13643
fix https://github.com/brave/browser-laptop/issues/13642

Test Plan:
1. Open a zoom link
2. Select 'remember this decision' and 'allow' when it asks you if you would like it to open
   an external application
3. Open more zoom links
4. Go to about:preferences#security. You should only see one entry for
   zoom.
5. Go to some website, then open sms://test in URL field
6. Select 'remember this decision' and 'deny'
7. Open sms://test in URL field
8. No prompt should appear
9. Go to about:preferences#security. You should only see one entry for
   sms.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


