### PR TITLE
Do not show a window inactive if there is not another focused window

### DIFF
--- a/app/browser/windows.js
+++ b/app/browser/windows.js
@@ -490,6 +490,9 @@ const api = {
     renderedWindows.add(win)
     setImmediate(() => {
       if (win && win.__showWhenRendered && !win.isDestroyed() && !win.isVisible()) {
+        if (shouldDebugWindowEvents) {
+          console.log('rendered window so showing window')
+        }
         // window is hidden by default until we receive 'ready' message,
         // so show it now
         showDeferredShowWindow(win)
@@ -705,6 +708,7 @@ const api = {
 
     if (shouldDebugWindowEvents) {
       markWindowCreationTime(win.id)
+      console.log(`createWindow: new BrowserWindow with ID ${win.id} created with options`, windowOptions)
     }
     // TODO: pass UUID
     publicEvents.emit('new-window-state', win.id, immutableState)
@@ -720,6 +724,9 @@ const api = {
       // in those cases, we want to still show it, so that the user can find the error message
       setTimeout(() => {
         if (win && !win.isDestroyed() && !win.isVisible()) {
+          if (shouldDebugWindowEvents) {
+            console.log('deferred-show window passed timeout, so showing deferred')
+          }
           showDeferredShowWindow(win)
         }
       }, config.windows.timeoutToShowWindowMs)

--- a/app/browser/windows.js
+++ b/app/browser/windows.js
@@ -25,7 +25,7 @@ const browserWindowUtil = require('../common/lib/browserWindowUtil')
 const windowState = require('../common/state/windowState')
 const pinnedSitesState = require('../common/state/pinnedSitesState')
 const {zoomLevel} = require('../common/constants/toolbarUserInterfaceScale')
-const { shouldDebugWindowEvents, disableBufferWindow } = require('../cmdLine')
+const { shouldDebugWindowEvents, disableBufferWindow, disableDeferredWindowLoad } = require('../cmdLine')
 const activeTabHistory = require('./activeTabHistory')
 
 const isDarwin = platformUtil.isDarwin()
@@ -591,6 +591,9 @@ const api = {
   },
 
   createWindow: function (windowOptionsIn, parentWindow, maximized, frames, immutableState = Immutable.Map(), hideUntilRendered = true, cb = null) {
+    if (disableDeferredWindowLoad) {
+      hideUntilRendered = false
+    }
     const defaultOptions = {
       // hide the window until the window reports that it is rendered
       show: true,

--- a/app/browser/windows.js
+++ b/app/browser/windows.js
@@ -163,7 +163,9 @@ function refocusFocusedWindow () {
 
 function showDeferredShowWindow (win) {
   // were we asked to make the window active / foreground?
-  const shouldShowInactive = win.webContents.browserWindowOptions.inactive
+  // note: do not call win.showInactive if there is no other active window, otherwise this window will
+  // never get an entry in taskbar on Windows
+  const shouldShowInactive = win.webContents.browserWindowOptions.inactive && BrowserWindow.getFocusedWindow()
   if (shouldShowInactive) {
     // we were asked NOT to show the window active.
     // we should maintain focus on the window which already has it

--- a/app/cmdLine.js
+++ b/app/cmdLine.js
@@ -24,6 +24,7 @@ let appInitialized = false
 let newWindowURL
 const debugWindowEventsFlagName = '--debug-window-events'
 const disableBufferWindowFlagName = '--disable-buffer-window'
+const disableDeferredWindowLoadFlagName = '--show-windows-immediately'
 
 const focusOrOpenWindow = function (url) {
   // don't try to do anything if the app hasn't been initialized
@@ -174,5 +175,6 @@ const api = module.exports = {
 
   shouldDebugTabEvents: process.argv.includes(debugTabEventsFlagName),
   shouldDebugWindowEvents: process.argv.includes(debugWindowEventsFlagName),
-  disableBufferWindow: process.argv.includes(disableBufferWindowFlagName)
+  disableBufferWindow: process.argv.includes(disableBufferWindowFlagName),
+  disableDeferredWindowLoad: process.argv.includes(disableDeferredWindowLoadFlagName)
 }


### PR DESCRIPTION
Otherwise the window will not get a taskbar entry on Windows.
Fix #13659 

Also adds some features I used for debugging:
- Log window creation options when the existing `--debug-window-events` flag is specified
- Introduce new `--show-windows-immediately` flag which shows windows as soon as they are created, instead of waiting for rendering, in which this issue did not present because the code path which caused #13659 is not needed in that scenario.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
- on Windows:
- Create two windows
- Quit the app from the 'kebab' menu
- Start the app again

Both windows should be created and have taskbar entries

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


