### PR TITLE
Some verified publishers no longer remove green tick at sublevels - Fixes issue #10484

### DIFF
--- a/app/common/state/ledgerState.js
+++ b/app/common/state/ledgerState.js
@@ -17,6 +17,8 @@ const settings = require('../../../js/constants/settings')
 // Utils
 const getSetting = require('../../../js/settings').getSetting
 const {makeImmutable, isMap} = require('../../common/state/immutableUtil')
+const urlParse = require('../../common/urlParse')
+const getBaseDomain = require('../../../js/lib/baseDomain').getBaseDomain
 
 const validateState = function (state) {
   state = makeImmutable(state)
@@ -65,12 +67,28 @@ const ledgerState = {
     return state.setIn(['ledger', 'locations', url, prop], value)
   },
 
+  getVerifiedPublisherLocation: (state, url) => {
+    state = validateState(state)
+    if (url == null) {
+      return null
+    }
+
+    let publisherKey = state.getIn(['ledger', 'locations', url, 'publisher'])
+
+    if (!publisherKey) {
+      const parsedUrl = urlParse(url) || {}
+      if (parsedUrl.hostname != null) {
+        publisherKey = getBaseDomain(parsedUrl.hostname)
+      }
+    }
+    return publisherKey
+  },
+
   getLocationProp: (state, url, prop) => {
     state = validateState(state)
     if (url == null || prop == null) {
       return null
     }
-
     return state.getIn(['ledger', 'locations', url, prop])
   },
 

--- a/app/renderer/components/navigation/publisherToggle.js
+++ b/app/renderer/components/navigation/publisherToggle.js
@@ -59,7 +59,7 @@ class PublisherToggle extends React.Component {
     const activeFrame = frameStateUtil.getActiveFrame(currentWindow) || Immutable.Map()
     const location = activeFrame.get('location', '')
     const locationId = getBaseUrl(location)
-    const publisherKey = ledgerState.getLocationProp(state, locationId, 'publisher')
+    const publisherKey = ledgerState.getVerifiedPublisherLocation(state, locationId)
 
     const props = {}
     // used in renderer

--- a/package-lock.json
+++ b/package-lock.json
@@ -1908,6 +1908,11 @@
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.0.4.tgz",
           "integrity": "sha512-LDXpJKVzEx2/OqNbG9mXBNvHuiRL4PzHCGfnANHMJ+fv68Ads3exDVJeGDJws+AoNEuca93bU3q+S0woeUaCdg=="
         },
+        "extend": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+        },
         "lodash": {
           "version": "4.13.1",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
@@ -1917,6 +1922,23 @@
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
           "integrity": "sha1-Tf/lJdriuGTGbC4jxicdev3s784="
+        },
+        "superagent": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.5.2.tgz",
+          "integrity": "sha1-M2GjlxVnUEw1EGOr6q4PqiPb8/g=",
+          "requires": {
+            "component-emitter": "1.2.1",
+            "cookiejar": "2.1.1",
+            "debug": "2.6.9",
+            "extend": "3.0.1",
+            "form-data": "2.3.2",
+            "formidable": "1.2.1",
+            "methods": "1.1.2",
+            "mime": "1.6.0",
+            "qs": "6.5.1",
+            "readable-stream": "2.3.5"
+          }
         },
         "underscore.string": {
           "version": "2.4.0",
@@ -17585,30 +17607,6 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9"
-      }
-    },
-    "superagent": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.5.2.tgz",
-      "integrity": "sha1-M2GjlxVnUEw1EGOr6q4PqiPb8/g=",
-      "requires": {
-        "component-emitter": "1.2.1",
-        "cookiejar": "2.1.1",
-        "debug": "2.6.9",
-        "extend": "3.0.1",
-        "form-data": "2.3.2",
-        "formidable": "1.2.1",
-        "methods": "1.1.2",
-        "mime": "1.6.0",
-        "qs": "6.5.1",
-        "readable-stream": "2.3.5"
-      },
-      "dependencies": {
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-        }
       }
     },
     "superagent-proxy": {

--- a/test/unit/app/common/state/ledgerStateTest.js
+++ b/test/unit/app/common/state/ledgerStateTest.js
@@ -622,4 +622,71 @@ describe('ledgerState unit test', function () {
       assert.equal(result, 'corrupted')
     })
   })
+
+  describe('getVerifiedPublisherLocation', function () {
+    it('null case', function () {
+      const result = ledgerState.getVerifiedPublisherLocation(defaultState)
+      assert.equal(result, null)
+    })
+    it('empty string', function () {
+      const url = ''
+      const result = ledgerState.getVerifiedPublisherLocation(defaultState, url)
+      assert.equal(result, null)
+    })
+    it('url shortener', function () {
+      const url = 'https://www.duckduckgo.com'
+      const result = ledgerState.getVerifiedPublisherLocation(defaultState, url)
+      assert.equal(result, 'duckduckgo.com')
+    })
+    it('url shortner with sub levels', function () {
+      const url = 'https://brianbondywww.com/projects/'
+      const result = ledgerState.getVerifiedPublisherLocation(defaultState, url)
+      assert.equal(result, 'brianbondywww.com')
+    })
+    it('url shortner with sub levels', function () {
+      const url = 'https://www.brianbondywww.com/projects/'
+      const result = ledgerState.getVerifiedPublisherLocation(defaultState, url)
+      assert.equal(result, 'brianbondywww.com')
+    })
+    it('url shortner with sub levels', function () {
+      const url = 'https://www2.brianbondy.com/projects/'
+      const result = ledgerState.getVerifiedPublisherLocation(defaultState, url)
+      assert.equal(result, 'brianbondy.com')
+    })
+    it('url shortner with sub levels', function () {
+      const url = 'https://subdomain.brianbondy.com/projects/'
+      const result = ledgerState.getVerifiedPublisherLocation(defaultState, url)
+      assert.equal(result, 'brianbondy.com')
+    })
+    it('url shortener with multi sublevels', function () {
+      const url = 'https://www.coindesk.com/market-center/ethereum'
+      const result = ledgerState.getVerifiedPublisherLocation(defaultState, url)
+      assert.equal(result, 'coindesk.com')
+    })
+    it('url shortener with any protocol', function () {
+      const url = 'anything://www.this.any.site.com'
+      const result = ledgerState.getVerifiedPublisherLocation(defaultState, url)
+      assert.equal(result, 'site.com')
+    })
+    it('url shortener with any protocol [ccTLD]', function () {
+      const url = 'anything://www.this.any.site.co.jp'
+      const result = ledgerState.getVerifiedPublisherLocation(defaultState, url)
+      assert.equal(result, 'site.co.jp')
+    })
+    it('url shortener with any protocol with sublevels', function () {
+      const url = 'anything://www.this.any.site.co.jp/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v'
+      const result = ledgerState.getVerifiedPublisherLocation(defaultState, url)
+      assert.equal(result, 'site.co.jp')
+    })
+    it('url shortener with any protocol with sublevels ultra log', function () {
+      const url = 'anything://www.this.any.site.co.jp/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q/r/s/.com/r/s/t/u/v'
+      const result = ledgerState.getVerifiedPublisherLocation(defaultState, url)
+      assert.equal(result, 'site.co.jp')
+    })
+    it('url shortener with any protocol confusion', function () {
+      const url = 'anything://www.2.www.ww.www.this.any.site.com.org.com'
+      const result = ledgerState.getVerifiedPublisherLocation(defaultState, url)
+      assert.equal(result, 'org.com')
+    })
+  })
 })


### PR DESCRIPTION
Fixes #10484

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

I could only get this to repro on the brianbondy site. All other verified pubs didn't have this problem. 

Regardless the addition allows the brianbondy sub levels to show green tick

Review Requested @bsclifton 
Security Review Requested @diracdeltas 