### PR TITLE
add WordCountTextArea component for ledger and sync

### DIFF
--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -391,3 +391,4 @@ visits=Visits
 wideURLbar=Use wide URL bar
 widevine=Run Google Widevine
 widevineSection=Google Widevine Support
+wordCount=Word Count:

--- a/app/extensions/brave/locales/en-US/styles.properties
+++ b/app/extensions/brave/locales/en-US/styles.properties
@@ -27,3 +27,5 @@ titles=Titles
 typography=Typography
 InfoBrowserButtonGrouped=To cancel the margin-left of the grouped buttons, they have to have a parent. Beginning with Selectors Level 4, it is no longer required.
 InfoCommonFormCustom=It is possible to customize the style of the components with <code>this.props.custom</code>. However, please consider to create a new component or enhance the existing one with <code>props</code> to maintain style consistency.
+wordCount=Word Count:
+copyToClipboard.title=Copy to clipboard

--- a/app/renderer/components/common/clipboardButton.js
+++ b/app/renderer/components/common/clipboardButton.js
@@ -51,6 +51,7 @@ class ClipboardButton extends React.Component {
       />
       <BrowserButton
         iconClass={globalStyles.appIcons.clipboard}
+        disabled={this.props.disabled}
         custom={styles.clipboardButton__browserButton}
         l10nId={this.props.dataL10nId ? this.props.dataL10nId : 'copyToClipboard'}
         testId={this.props.testId}

--- a/app/renderer/components/common/textbox.js
+++ b/app/renderer/components/common/textbox.js
@@ -6,6 +6,9 @@ const React = require('react')
 const ImmutableComponent = require('../immutableComponent')
 const {StyleSheet, css} = require('aphrodite/no-important')
 
+const ClipboardButton = require('../common/clipboardButton')
+const appActions = require('../../../../js/actions/appActions')
+
 const globalStyles = require('../styles/global')
 const commonStyles = require('../styles/commonStyles')
 
@@ -77,6 +80,65 @@ class DefaultTextArea extends ImmutableComponent {
   }
 }
 
+class WordCountTextArea extends React.Component {
+  constructor () {
+    super()
+    this.handleCopyToClipboard = this.handleCopyToClipboard.bind(this)
+    this.handleOnChange = this.handleOnChange.bind(this)
+    this.state = { wordCount: 0 }
+  }
+
+  handleOnChange (e) {
+    let wordCount = 0
+
+    if (e.target.value.length > 0) {
+      wordCount = e.target.value.trim().replace(/\s+/gi, ' ').split(' ').length
+    }
+
+    this.setState({wordCount})
+
+    if (this.props.onChangeText) {
+      this.props.onChangeText()
+    }
+  }
+
+  handleCopyToClipboard () {
+    if (!this.textAreaBox) {
+      return
+    }
+    appActions.clipboardTextCopied(this.textAreaBox.value)
+  }
+
+  render () {
+    return (
+      <div className={css(styles.wordCountTextArea__main)}>
+        <textarea className={css(
+          commonStyles.formControl,
+          commonStyles.textArea,
+          styles.wordCountTextArea__body
+        )}
+          spellCheck='false'
+          disabled={this.props.disabled}
+          autoFocus={this.props.autoFocus}
+          value={this.props.value}
+          ref={(node) => { this.textAreaBox = node }}
+          onChange={this.handleOnChange}
+        />
+        <div className={css(styles.wordCountTextArea__footer)}>
+          <div>
+            <span data-l10n-id='wordCount' />&nbsp;{this.state.wordCount}
+          </div>
+          <ClipboardButton
+            disabled={this.props.clipboardDisabled}
+            leftTooltip
+            copyAction={this.handleCopyToClipboard}
+          />
+        </div>
+      </div>
+    )
+  }
+}
+
 const styles = StyleSheet.create({
   // Textbox
   textbox: {
@@ -144,6 +206,36 @@ const styles = StyleSheet.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center'
+  },
+
+  wordCountTextArea__main: {
+    background: 'rgba(0, 0, 0, 0.1)',
+    border: '1px solid #000',
+    borderRadius: '4px',
+    padding: '2px',
+    width: '100%'
+  },
+
+  wordCountTextArea__body: {
+    width: '100%',
+    height: '120px',
+    borderTopLeftRadius: '4px',
+    borderTopRightRadius: '4px',
+    borderBottomLeftRadius: 0,
+    borderBottomRightRadius: 0,
+    resize: 'none',
+    fontSize: '18px'
+  },
+
+  wordCountTextArea__footer: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    borderBottomLeftRadius: '4px',
+    borderBottomRightRadius: '4px',
+    padding: '5px 10px',
+    fontSize: '13px',
+    fontWeight: 'bold'
   }
 })
 
@@ -153,5 +245,6 @@ module.exports = {
   GroupedFormTextbox,
   SettingTextbox,
   TextArea,
-  DefaultTextArea
+  DefaultTextArea,
+  WordCountTextArea
 }

--- a/js/about/styles.js
+++ b/js/about/styles.js
@@ -10,7 +10,12 @@ const globalStyles = require('../../app/renderer/components/styles/global')
 require('../../node_modules/font-awesome/css/font-awesome.css')
 
 const {Textbox, FormTextbox, SettingTextbox} = require('../../app/renderer/components/common/textbox')
-const {TextArea, DefaultTextArea} = require('../../app/renderer/components/common/textbox')
+
+const {
+  TextArea,
+  DefaultTextArea,
+  WordCountTextArea
+} = require('../../app/renderer/components/common/textbox')
 
 const {
   Dropdown,
@@ -171,6 +176,15 @@ class AboutStyle extends ImmutableComponent {
           <Pre><Code>
             const { '{DefaultTextArea}' } = require('../../app/renderer/components/common/textbox'){'\n'}
             &lt;DefaultTextArea />
+          </Code></Pre>
+        </Container>
+
+        <Container>
+          <h2>Word Count textarea</h2>
+          <WordCountTextArea onChangeText={() => console.log('changed!!')} />
+          <Pre><Code>
+            const { '{WordCountTextArea}' } = require('../../app/renderer/components/common/textbox'){'\n'}
+            &lt;WordCountTextArea />
           </Code></Pre>
         </Container>
 


### PR DESCRIPTION
screenshot from about:styles

<img width="850" alt="screen shot 2018-04-04 at 1 49 02 am" src="https://user-images.githubusercontent.com/4672033/38289156-28a6c152-37ab-11e8-8b2f-9dac8af1a25e.png">

Auditors: @NejcZdovc 
/cc @bsclifton as this can ease the task of bip39

Test Plan:

* Go to about:styles, search for "Word Count textarea"
* Ensure words are updated as you type
* Ensure words are updated when a word is removed
* Ensure you can copy content to clipboard without selecting any text
* Open console and check that at each new type there's a log called "changed!!" (`onChangeText` callback works)
* Ensure you can import the component to a preference page and keep the same styling

Default props:
* `clipboardDisabled` - disables copy to clipboard
* `autoFocus` - set immediate focus to the textarea
* `disabled` - disables the textarea (user can't type on it)
* `value` - the textarea's strings
* `onChangeText` - callback function that will be fired when text is changed