### PR TITLE
Fixes width of the balance input

### DIFF
--- a/app/renderer/components/common/textbox.js
+++ b/app/renderer/components/common/textbox.js
@@ -17,10 +17,14 @@ class Textbox extends ImmutableComponent {
       styles.textbox,
       (this.props.readonly || this.props.readOnly) ? styles.readOnly : styles.outlineable,
       this.props['data-isCommonForm'] && commonStyles.isCommonForm,
-      this.props['data-isSettings'] && styles.isSettings
+      this.props['data-isSettings'] && styles.isSettings,
+      this.props.customClass && this.props.customClass
     )
 
-    return <input type='text' className={className} {...this.props} />
+    const props = Object.assign({}, this.props)
+    delete props.customClass
+
+    return <input type='text' className={className} {...props} />
   }
 }
 

--- a/app/renderer/components/preferences/payment/enabledContent.js
+++ b/app/renderer/components/preferences/payment/enabledContent.js
@@ -130,11 +130,14 @@ class EnabledContent extends ImmutableComponent {
 
   fundsAmount () {
     const ledgerData = this.props.ledgerData
+    const val = formatCurrentBalance(ledgerData) || ''
+    const big = val.length > 23
 
     return <FormTextbox
       readOnly
       data-test-id='fundsAmount'
-      value={formatCurrentBalance(ledgerData)}
+      value={val}
+      customClass={big && styles.width_input}
     />
   }
 
@@ -491,6 +494,10 @@ const gridStyles = StyleSheet.create({
 const styles = StyleSheet.create({
   claimButton: {
     marginTop: '10px'
+  },
+
+  width_input: {
+    width: '195px'
   },
 
   iconLink: {


### PR DESCRIPTION
Resolves #12220

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
- enable brave payments
- add a lot of BAT's into your wallet (1000+ BAT)
make sure that input is width enough

Normal input
![image](https://user-images.githubusercontent.com/9574457/38362007-a272b46c-38cf-11e8-8fbd-a424fc68f500.png)

Big input
![image](https://user-images.githubusercontent.com/9574457/38362046-c10c6058-38cf-11e8-8e9c-69747e184261.png)


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


