### PR TITLE
Adds s-s to the referral code

### DIFF
--- a/app/cmdLine.js
+++ b/app/cmdLine.js
@@ -17,7 +17,6 @@ const fs = require('fs')
 const path = require('path')
 
 const isDarwin = process.platform === 'darwin'
-const promoCodeFilenameRegex = /-([a-zA-Z\d]{3}\d{3})\s?(?:\(\d+\))?$/g
 const debugTabEventsFlagName = '--debug-tab-events'
 
 let appInitialized = false
@@ -166,8 +165,9 @@ const api = module.exports = {
     // parse promo code from installer path
     // first, get filename
     const fileName = path.win32.parse(installerPath).name
+    const promoCodeFilenameRegex = /-(([a-zA-Z\d]{3}\d{3})|([a-zA-Z]{1,}-[a-zA-Z]{1,}))\s?(?:\(\d+\))?$/g
     const matches = promoCodeFilenameRegex.exec(fileName)
-    if (matches && matches.length === 2) {
+    if (matches && matches.length > 1) {
       return matches[1]
     }
     return null

--- a/build/pkg-scripts/postinstall
+++ b/build/pkg-scripts/postinstall
@@ -8,7 +8,7 @@ installationPath=$2
 # TODO: ugly to assume the name of the app, especially with multi-channel.
 # Luckily for now, release channel is the only channel with a pkg installer.
 installationAppPath="$installationPath/Brave.app"
-installerPathPromoCodeRegex='.+-([a-zA-Z0-9]{3}[0-9]{3})([[:blank:]]?\([0-9]+\))?\.pkg$'
+installerPathPromoCodeRegex='.+-(([a-zA-Z0-9]{3}[0-9]{3})|([a-zA-Z]{1,}-[a-zA-Z]{1,}))([[:blank:]]?\([0-9]+\))?\.pkg$'
 userDataDir="$HOME/Library/Application Support/brave"
 promoCodePath="$userDataDir/promoCode"
 # pkg runs this script as root so we need to get current username

--- a/build/pkg-scripts/postinstall-test.sh
+++ b/build/pkg-scripts/postinstall-test.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+installerPath=$1
+installerPathPromoCodeRegex='.+-(([a-zA-Z0-9]{3}[0-9]{3})|([a-zA-Z]{1,}-[a-zA-Z]{1,}))([[:blank:]]?\([0-9]+\))?\.pkg$'
+echo "Installer path is: $installerPath"
+
+if [[ $installerPath =~ $installerPathPromoCodeRegex ]]; then
+  echo "Installer path matched for promo code"
+  n=${#BASH_REMATCH[*]}
+  if [ $n -ge 1 ]; then
+    promoCode=${BASH_REMATCH[1]}
+    echo "Got promo code: $promoCode"
+  fi
+else
+  echo "Installer path did not match for promo code"
+fi
+
+exit 0

--- a/test/unit/app/cmdLineTest.js
+++ b/test/unit/app/cmdLineTest.js
@@ -52,6 +52,31 @@ describe('cmdLine', function () {
       const result = this.cmdLine.getFirstRunPromoCode(args)
       assert.equal(result, promoCode)
     })
+
+    it('finds and parses promo code when we have multiple downloads', function () {
+      const promoCode = 'pem001 (1)'
+      const validPromoCodeInstallerPath = `d:\\my\\location\\on-disk\\in-a-folder-tes301\\Setup-Brave-x64-${promoCode}.exe`
+      const args = [...initialArgs, key, validPromoCodeInstallerPath, '--other', 'arg', '--and-another']
+      const result = this.cmdLine.getFirstRunPromoCode(args)
+      assert.equal(result, 'pem001')
+    })
+
+    it('finds and parses promo code 2', function () {
+      const promoCode = 'org-name'
+      const validPromoCodeInstallerPath = `d:\\my\\location\\on-disk\\in-a-folder-tes301\\Setup-Brave-x64-${promoCode}.exe`
+      const args = [...initialArgs, key, validPromoCodeInstallerPath, '--other', 'arg', '--and-another']
+      const result = this.cmdLine.getFirstRunPromoCode(args)
+      assert.equal(result, promoCode)
+    })
+
+    it('finds and parses promo code 2 when we have multiple downloads', function () {
+      const promoCode = 'org-name (1)'
+      const validPromoCodeInstallerPath = `d:\\my\\location\\on-disk\\in-a-folder-tes301\\Setup-Brave-x64-${promoCode}.exe`
+      const args = [...initialArgs, key, validPromoCodeInstallerPath, '--other', 'arg', '--and-another']
+      const result = this.cmdLine.getFirstRunPromoCode(args)
+      assert.equal(result, 'org-name')
+    })
+
     it(`does not find promo code when there isn't one`, function () {
       const noPromoCodeInstallerPath = `d:\\my\\location\\on-disk\\in-a-folder-tes301\\Setup-Brave-x64.exe`
       const args = [...initialArgs, key, noPromoCodeInstallerPath, '--other', 'arg', '--and-another']


### PR DESCRIPTION
Resolves #13754

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
Instead of just supporting `pem001` (3 letters and 3 numbers) we need to support `org-name` (at least 1 letter, dash and at least 1 letter) as well.

Copied test script from https://github.com/brave/browser-laptop/pull/13113

Mac OS
```
~/Development/tmp
❯ ./postinstall-test.sh "hi-pem001.pkg"
Installer path is: hi-pem001.pkg
Installer path matched for promo code
Got promo code: pem001

~/Development/tmp
❯ ./postinstall-test.sh "hi-pem001(1).pkg"
Installer path is: hi-pem001(1).pkg
Installer path matched for promo code
Got promo code: pem001

~/Development/tmp
❯ ./postinstall-test.sh "hi-pem001 (1).pkg"
Installer path is: hi-pem001 (1).pkg
Installer path matched for promo code
Got promo code: pem001

~/Development/tmp
❯ ./postinstall-test.sh "hi-pem001 (12).pkg"
Installer path is: hi-pem001 (12).pkg
Installer path matched for promo code
Got promo code: pem001

~/Development/tmp
❯ ./postinstall-test.sh "hi-pem001(12).pkg"
Installer path is: hi-pem001(12).pkg
Installer path matched for promo code
Got promo code: pem001

~/Development/tmp
❯ ./postinstall-test.sh "hi-pemf001(12).pkg"
Installer path is: hi-pemf001(12).pkg
Installer path did not match for promo code

~/Development/tmp
❯ ./postinstall-test.sh "hi-org-name.pkg"
Installer path is: hi-org-name.pkg
Installer path matched for promo code
Got promo code: org-name

~/Development/tmp
❯ ./postinstall-test.sh "hi-org-name(1).pkg"
Installer path is: hi-org-name(1).pkg
Installer path matched for promo code
Got promo code: org-name

~/Development/tmp
❯ ./postinstall-test.sh "hi-org-name (1).pkg"
Installer path is: hi-org-name (1).pkg
Installer path matched for promo code
Got promo code: org-name
```

Windows:
- covered with automated tests

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


