### PR TITLE
Fix URL bar

### DIFF
--- a/less/navigationBar.less
+++ b/less/navigationBar.less
@@ -583,7 +583,7 @@
   padding: 0 10px 0 3px;
   display: flex;
   flex-grow: 1;
-  min-width: 0%; // allow the navigator to shrink
+  min-width: 30px; // allow the navigator to shrink
  
   *:not(legend) {
     z-index: @zindexUrlbarNotLegend;


### PR DESCRIPTION
Set min-width of URL bar to 30px, so URL bar does not shrink too much and URL bar elements are not layered on each other when window width is reduced.

Fix #13773

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

1. Go to Preferences -> Advanced
2. Set "Toolbar and UI elements scale" to "Larger" or "Supersize"
3. Reduce the width of the window
4. URL bar elements are not layered on each other

Before:

![brave_1](https://user-images.githubusercontent.com/17289100/38479627-7bcb52d0-3b8e-11e8-88a4-514e7460b4ed.PNG)

After:

![brave-fixed-1](https://user-images.githubusercontent.com/17289100/38479635-839fe80e-3b8e-11e8-835f-d0ad2194b45b.PNG)
![brave-fixed-2](https://user-images.githubusercontent.com/17289100/38479632-81e4f428-3b8e-11e8-9622-8ac83e27b651.PNG)