### PR TITLE
Opens add funds overlay when clicking on it in the notification

### DIFF
--- a/app/browser/api/ledgerNotifications.js
+++ b/app/browser/api/ledgerNotifications.js
@@ -106,7 +106,7 @@ const onResponse = (message, buttonIndex, activeWindow) => {
       } else if (buttonIndex === 2 && activeWindow) {
         // Add funds: Open payments panel
         appActions.createTabRequested({
-          url: 'about:preferences#payments',
+          url: 'about:preferences#payments?addFundsOverlayVisible',
           windowId: activeWindow.id
         })
       }


### PR DESCRIPTION
Resolves #4310

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
- clean profile
- enable payments
- change timestamp to be less then a day of now (`now - timestamp < day`)
- wait for add funds notification to be shown
- click on `Add funds` which should open add funds overlay


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header