### PR TITLE
Clean up upload/publish tools, add initial tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ dist: trusty
 sudo: required
 group: edge
 before_install:
+  - sudo apt-get install -y python
   - npm i -g npm@5.5.1
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
@@ -28,6 +29,7 @@ env:
     - TEST_DIR=lint
     - TEST_DIR=unit
     - TEST_DIR=codecov
+    - TEST_DIR=tools
     - TEST_DIR=security
     - TEST_DIR=about
     - TEST_DIR=app

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "start-brk": "node ./tools/start.js --debug-brk=5858 -enable-logging --v=0 --enable-dcheck --user-data-dir-name=brave-development",
     "test": "cross-env NODE_ENV=test mocha \"test/**/*Test.js\"",
     "testsuite": "node ./tools/test.js",
-    "unittest": "cross-env NODE_ENV=test mocha \"test/unit/**/*Test.js\" --globals chrome,DOMParser,XMLSerializer",
+    "unittest": "python tools/test && cross-env NODE_ENV=test mocha \"test/unit/**/*Test.js\" --globals chrome,DOMParser,XMLSerializer",
     "unittest-cov": "node --harmony node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha --globals chrome,DOMParser,XMLSerializer --report lcovonly --report html --report text -x \"test/unit/**/*Test.js\" -- \"test/unit/**/*Test.js\"",
     "update-pdfjs": "rm -r app/extensions/pdfjs/; cp -r ../pdf.js/build/chromium/ app/extensions/pdfjs/",
     "update-psl": "./tools/updatepsl.sh",

--- a/tools/cibuild.py
+++ b/tools/cibuild.py
@@ -87,4 +87,4 @@ if is_linux:
 execute([npm, 'run', 'build-package'])
 execute([npm, 'run', 'build-installer'])
 
-run_script('upload.py')
+run_script('upload.py', sys.argv[1:])

--- a/tools/lib/github.py
+++ b/tools/lib/github.py
@@ -40,7 +40,11 @@ class GitHub:
       if 'data' in kw:
         kw['data'] = json.dumps(kw['data'])
 
-    r = getattr(requests, method)(url, **kw).json()
+    try:
+      r = getattr(requests, method)(url, **kw).json()
+    except ValueError:
+      # Returned response may be empty in some cases
+      r = {}
     if 'message' in r:
       raise Exception(json.dumps(r, indent=2, separators=(',', ': ')))
     return r

--- a/tools/lib/helpers.py
+++ b/tools/lib/helpers.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import os
 import json
 

--- a/tools/lib/helpers.py
+++ b/tools/lib/helpers.py
@@ -10,33 +10,33 @@ BROWSER_LAPTOP_REPO = 'brave/browser-laptop'
 TARGET_ARCH= os.environ['TARGET_ARCH'] if os.environ.has_key('TARGET_ARCH') else 'x64'
 
 def get_env(env):
-    token = os.environ[env]
-    message = ('Error: Please set the ${} environment variable, which is your personal token'.format(env))
-    assert token, message
-    return token
+  token = os.environ[env]
+  message = ('Error: Please set the ${} environment variable, which is your personal token'.format(env))
+  assert token, message
+  return token
 
 def release_channel():
-    channel = os.environ['CHANNEL']
-    message = ('Error: Please set the $CHANNEL '
-                'environment variable, which is your release channel')
-    assert channel, message
-    return channel
+  channel = os.environ['CHANNEL']
+  message = ('Error: Please set the $CHANNEL '
+              'environment variable, which is your release channel')
+  assert channel, message
+  return channel
 
 def get_channel_display_name():
-    d = {'dev': 'Release', 'beta': 'Beta', 'developer': 'Developer', 'nightly': 'Nightly'}
-    return d[release_channel()]
+  d = {'dev': 'Release', 'beta': 'Beta', 'developer': 'Developer', 'nightly': 'Nightly'}
+  return d[release_channel()]
 
 def release_name():
-    return '{0} Channel'.format(get_channel_display_name())
+  return '{0} Channel'.format(get_channel_display_name())
 
 def get_tag():
-    return 'v' + get_version() + get_channel_display_name()
+  return 'v' + get_version() + get_channel_display_name()
 
 def get_version():
-    return json.load(open('package.json'))['version']
+  return json.load(open('package.json'))['version']
 
 def get_releases_by_tag(repo, tag_name, include_drafts=False):
-    if include_drafts:
-        return [r for r in repo.releases.get() if r['tag_name'] == tag_name]
-    else:
-        return [r for r in repo.releases.get() if r['tag_name'] == tag_name and not r['draft']]
+  if include_drafts:
+    return [r for r in repo.releases.get() if r['tag_name'] == tag_name]
+  else:
+    return [r for r in repo.releases.get() if r['tag_name'] == tag_name and not r['draft']]

--- a/tools/lib/helpers.py
+++ b/tools/lib/helpers.py
@@ -5,6 +5,7 @@
 
 import os
 import json
+import traceback
 
 BROWSER_LAPTOP_REPO = 'brave/browser-laptop'
 TARGET_ARCH= os.environ['TARGET_ARCH'] if os.environ.has_key('TARGET_ARCH') else 'x64'
@@ -40,3 +41,16 @@ def get_releases_by_tag(repo, tag_name, include_drafts=False):
     return [r for r in repo.releases.get() if r['tag_name'] == tag_name]
   else:
     return [r for r in repo.releases.get() if r['tag_name'] == tag_name and not r['draft']]
+
+def retry_func(try_func, catch, retries, catch_func=None):
+  for count in range(0, retries + 1):
+    try:
+      ret = try_func(count)
+      break
+    except catch as e:
+      print('[ERROR] Caught exception {}, {} retries left. {}'.format(catch, count, e.message))
+      if catch_func:
+        catch_func(count)
+      if count >= retries:
+        raise e
+  return ret

--- a/tools/lib/helpers.py
+++ b/tools/lib/helpers.py
@@ -1,0 +1,37 @@
+import os
+import json
+
+BROWSER_LAPTOP_REPO = 'brave/browser-laptop'
+TARGET_ARCH= os.environ['TARGET_ARCH'] if os.environ.has_key('TARGET_ARCH') else 'x64'
+
+def get_env(env):
+    token = os.environ[env]
+    message = ('Error: Please set the ${} environment variable, which is your personal token'.format(env))
+    assert token, message
+    return token
+
+def release_channel():
+    channel = os.environ['CHANNEL']
+    message = ('Error: Please set the $CHANNEL '
+                'environment variable, which is your release channel')
+    assert channel, message
+    return channel
+
+def get_channel_display_name():
+    d = {'dev': 'Release', 'beta': 'Beta', 'developer': 'Developer', 'nightly': 'Nightly'}
+    return d[release_channel()]
+
+def release_name():
+    return '{0} Channel'.format(get_channel_display_name())
+
+def get_tag():
+    return 'v' + get_version() + get_channel_display_name()
+
+def get_version():
+    return json.load(open('package.json'))['version']
+
+def get_releases_by_tag(repo, tag_name, include_drafts=False):
+    if include_drafts:
+        return [r for r in repo.releases.get() if r['tag_name'] == tag_name]
+    else:
+        return [r for r in repo.releases.get() if r['tag_name'] == tag_name and not r['draft']]

--- a/tools/lib/helpers.py
+++ b/tools/lib/helpers.py
@@ -31,7 +31,7 @@ def release_name():
   return '{0} Channel'.format(get_channel_display_name())
 
 def get_tag():
-  return 'v' + get_version() + get_channel_display_name()
+  return 'v' + get_version() + release_channel()
 
 def get_version():
   return json.load(open('package.json'))['version']

--- a/tools/lib/helpers.py
+++ b/tools/lib/helpers.py
@@ -33,6 +33,9 @@ def release_name():
 def get_tag():
   return 'v' + get_version() + release_channel()
 
+def get_tag_without_channel():
+  return 'v' + get_version()
+
 def get_version():
   return json.load(open('package.json'))['version']
 

--- a/tools/publish_release.py
+++ b/tools/publish_release.py
@@ -19,11 +19,6 @@ def main():
   release = get_draft(repo, get_tag())
   commit_tag = get_commit_tag(get_version())
 
-  print("Found draft {}, release this? [y/n]".format(release['tag_name']))
-  if raw_input() != 'y':
-    print("Ok, not releasing")
-    exit(1)
-
   print("[INFO] Releasing {}".format(release['tag_name']))
   publish_release(repo, release['id'], get_tag(), commit_tag)
 

--- a/tools/publish_release.py
+++ b/tools/publish_release.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python
-# for more info see https://developer.github.com/v3/repos/releases/
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import json
 import os
+import sys
+
 from lib.github import GitHub
 from lib.helpers import *
 import requests

--- a/tools/publish_release.py
+++ b/tools/publish_release.py
@@ -16,7 +16,7 @@ RELEASE_NAME = 'Dev Channel Beta'
 def main():
   repo = GitHub(get_env('GITHUB_TOKEN')).repos(BROWSER_LAPTOP_REPO)
 
-  release = get_draft(repo, get_tag())
+  release = get_draft(repo, get_tag_without_channel())
   commit_tag = get_commit_tag(get_version())
 
   print("[INFO] Releasing {}".format(release['tag_name']))

--- a/tools/publish_release.py
+++ b/tools/publish_release.py
@@ -4,73 +4,44 @@
 import json
 import os
 from lib.github import GitHub
+from lib.helpers import *
 import requests
 
-BROWSER_LAPTOP_REPO = 'brave/browser-laptop'
-TARGET_ARCH= os.environ['TARGET_ARCH'] if os.environ.has_key('TARGET_ARCH') else 'x64'
 RELEASE_NAME = 'Dev Channel Beta'
 
 def main():
-  github = GitHub(auth_token())
-  releases = github.repos(BROWSER_LAPTOP_REPO).releases.get()
-  version = json.load(open('package.json'))['version']
-  tag = ('v' + version + release_channel())
-  tag_exists = False
-  for release in releases:
-    if not release['draft'] and release['tag_name'] == tag:
-      tag_exists = True
-      break
-  release = create_or_get_release_draft(github, releases, tag,
-                                        tag_exists)
-  # match version to GitHub milestone
-  commit_tag = None
-  parts = version.split('.', 3)
+  repo = GitHub(get_env('GITHUB_TOKEN')).repos(BROWSER_LAPTOP_REPO)
+
+  release = get_draft(repo, get_tag())
+  commit_tag = get_commit_tag(get_version())
+
+  print("Found draft {}, release this? [y/n]".format(release['tag_name']))
+  if raw_input() != 'y':
+    print("Ok, not releasing")
+    exit(1)
+
+  print("[INFO] Releasing {}".format(release['tag_name']))
+  publish_release(repo, release['id'], get_tag(), commit_tag)
+
+def get_commit_tag(version):
+  parts = get_version().split('.', 3)
   if (len(parts) == 3):
     parts[2] = 'x'
-    commit_tag = '.'.join(parts)
+    return '.'.join(parts)
+  else:
+    raise(UserWarning("[ERROR] Invalid version name '%s'", get_version()))
 
-  # Press the publish button.
-  if not tag_exists and commit_tag:
-    publish_release(github, release['id'], tag, commit_tag)
+def get_draft(repo, tag):
+  releases = get_releases_by_tag(repo, tag, include_drafts=True)
+  if not releases:
+    raise(UserWarning("[ERROR]: No draft with tag '{}' found, may need to run the ./tools/upload.py script first".format(tag)))
+  elif len(releases) > 1 or not releases[0]['draft'] :
+    raise(UserWarning("[ERROR]: Release with tag {} already exists".format(tag)))
+  return releases[0]
 
-def create_release_draft(github, tag):
-  name = '{0} {1}'.format(RELEASE_NAME, tag)
-  # TODO: Parse release notes from CHANGELOG.md
-  body = '(placeholder)'
-  if body == '':
-    sys.stderr.write('Quit due to empty release note.\n')
-    sys.exit(1)
-  data = dict(tag_name=tag, name=name, body=body, draft=True, prerelease=True)
-  r = github.repos(BROWSER_LAPTOP_REPO).releases.post(data=data)
-  return r
-
-def create_or_get_release_draft(github, releases, tag, tag_exists):
-  # Search for existing draft.
-  for release in releases:
-    if release['draft']:
-      return release
-
-  if tag_exists:
-    tag = 'do-not-publish-me'
-  return create_release_draft(github, tag)
-
-def auth_token():
-  token = os.environ['GITHUB_TOKEN']
-  message = ('Error: Please set the $GITHUB_TOKEN '
-             'environment variable, which is your personal token')
-  assert token, message
-  return token
-
-def release_channel():
-  channel = os.environ['CHANNEL']
-  message = ('Error: Please set the $CHANNEL '
-             'environment variable, which is your release channel')
-  assert channel, message
-  return channel
-
-def publish_release(github, release_id, tag, commit_tag):
+def publish_release(repo, release_id, tag, commit_tag):
   data = dict(draft=False, prerelease=True, tag_name=tag, target_commitish=commit_tag)
-  github.repos(BROWSER_LAPTOP_REPO).releases(release_id).patch(data=data)
+  repo.releases(release_id).patch(data=data)
 
 if __name__ == '__main__':
   import sys

--- a/tools/test.js
+++ b/tools/test.js
@@ -15,6 +15,9 @@ switch (TEST_DIR) {
   case 'codecov':
     cmd.push('bash tools/codecov.sh')
     break
+  case 'tools':
+    cmd.push('python tools/test')
+    break
   case 'security':
     cmd.push('npm run check-security')
     break

--- a/tools/test/__main__.py
+++ b/tools/test/__main__.py
@@ -1,3 +1,8 @@
+#!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import unittest
 
 from test_publish import *

--- a/tools/test/__main__.py
+++ b/tools/test/__main__.py
@@ -5,6 +5,7 @@
 
 import unittest
 
+from test_helpers import *
 from test_publish import *
 from test_upload import *
 

--- a/tools/test/__main__.py
+++ b/tools/test/__main__.py
@@ -1,0 +1,6 @@
+import unittest
+
+from test_publish import *
+from test_upload import *
+
+print unittest.main()

--- a/tools/test/mock.py
+++ b/tools/test/mock.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class Repo():
     def __init__(self):

--- a/tools/test/mock.py
+++ b/tools/test/mock.py
@@ -4,11 +4,11 @@
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
 class Repo():
-    def __init__(self):
-        self.releases = self.Releases()
+  def __init__(self):
+    self.releases = self.Releases()
 
-    class Releases():
-        def __init__(self):
-            self._releases = []
-        def get(self):
-            return self._releases
+  class Releases():
+    def __init__(self):
+      self._releases = []
+    def get(self):
+      return self._releases

--- a/tools/test/mock.py
+++ b/tools/test/mock.py
@@ -1,0 +1,10 @@
+
+class Repo():
+    def __init__(self):
+        self.releases = self.Releases()
+
+    class Releases():
+        def __init__(self):
+            self._releases = []
+        def get(self):
+            return self._releases

--- a/tools/test/test_helpers.py
+++ b/tools/test/test_helpers.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import sys
+import unittest
+import os
+
+dirname = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(dirname, '..'))
+from lib.helpers import *
+
+class RetryFunc():
+  def __init__(self):
+    self.ran = 0
+    self.calls = []
+    self.err = UserWarning
+
+  def succeed(self, count):
+    self.ran = self.ran + 1
+    self.calls.append(count)
+
+  def fail(self, count):
+    self.ran = self.ran + 1
+    self.calls.append(count)
+    raise self.err
+
+class TestRetryFunc(unittest.TestCase):
+  def setUp(self):
+    self.retry_func = RetryFunc()
+    self.catch_func = RetryFunc()
+
+  def test_passes_retry_count(self):
+    self.assertRaises(
+      self.retry_func.err,
+      retry_func,
+      self.retry_func.fail,
+      catch=UserWarning, retries=3
+    )
+    self.assertEqual(self.retry_func.calls, [0, 1, 2, 3])
+
+  def test_retries_on_fail(self):
+    self.assertRaises(
+      self.retry_func.err,
+      retry_func,
+      self.retry_func.fail,
+      catch=UserWarning, retries=3
+    )
+    self.assertEqual(self.retry_func.ran, 4)
+
+  def test_run_catch_func_on_fail(self):
+    self.assertRaises(
+      self.retry_func.err,
+      retry_func,
+      self.retry_func.fail,
+      catch_func=self.catch_func.succeed,
+      catch=UserWarning, retries=3
+    )
+    self.assertEqual(self.catch_func.ran, 4)
+
+  def test_no_retry_on_success(self):
+    retry_func(
+      self.retry_func.succeed,
+      catch=UserWarning, retries=3
+    )
+    self.assertEqual(self.retry_func.ran, 1)
+
+  def test_no_run_catch_func_on_success(self):
+    retry_func(
+      self.retry_func.succeed,
+      catch_func=self.catch_func.succeed,
+      catch=UserWarning, retries=3
+    )
+    self.assertEqual(self.catch_func.ran, 0)
+
+if __name__ == '__main__':
+  print unittest.main()

--- a/tools/test/test_publish.py
+++ b/tools/test/test_publish.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import sys
 import unittest

--- a/tools/test/test_publish.py
+++ b/tools/test/test_publish.py
@@ -15,20 +15,20 @@ import publish_release
 from mock import Repo
 
 class TestPublishGetDraft(unittest.TestCase):
-    def setUp(self):
-        self.repo = Repo()
+  def setUp(self):
+    self.repo = Repo()
 
-    def test_fails_on_existing_release(self):
-        self.repo.releases._releases = [{'tag_name': 'test', 'draft': False}]
-        self.assertRaises(UserWarning, publish_release.get_draft, self.repo, 'test')
+  def test_fails_on_existing_release(self):
+    self.repo.releases._releases = [{'tag_name': 'test', 'draft': False}]
+    self.assertRaises(UserWarning, publish_release.get_draft, self.repo, 'test')
 
-    def test_fails_on_no_draft(self):
-        self.repo.releases._releases = [{'tag_name': 'old', 'draft': False}]
-        self.assertRaises(UserWarning, publish_release.get_draft, self.repo, 'new')
+  def test_fails_on_no_draft(self):
+    self.repo.releases._releases = [{'tag_name': 'old', 'draft': False}]
+    self.assertRaises(UserWarning, publish_release.get_draft, self.repo, 'new')
 
-    def test_succeeds_on_existing_draft(self):
-        self.repo.releases._releases = [{'tag_name': 'test', 'draft': True}]
-        publish_release.get_draft(self.repo, 'test')
+  def test_succeeds_on_existing_draft(self):
+    self.repo.releases._releases = [{'tag_name': 'test', 'draft': True}]
+    publish_release.get_draft(self.repo, 'test')
 
 if __name__ == '__main__':
-    print unittest.main()
+  print unittest.main()

--- a/tools/test/test_publish.py
+++ b/tools/test/test_publish.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import sys
+import unittest
+import os
+
+dirname = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(dirname, '..'))
+
+import publish_release
+
+from mock import Repo
+
+class TestPublishGetDraft(unittest.TestCase):
+    def setUp(self):
+        self.repo = Repo()
+
+    def test_fails_on_existing_release(self):
+        self.repo.releases._releases = [{'tag_name': 'test', 'draft': False}]
+        self.assertRaises(UserWarning, publish_release.get_draft, self.repo, 'test')
+
+    def test_fails_on_no_draft(self):
+        self.repo.releases._releases = [{'tag_name': 'old', 'draft': False}]
+        self.assertRaises(UserWarning, publish_release.get_draft, self.repo, 'new')
+
+    def test_succeeds_on_existing_draft(self):
+        self.repo.releases._releases = [{'tag_name': 'test', 'draft': True}]
+        publish_release.get_draft(self.repo, 'test')
+
+if __name__ == '__main__':
+    print unittest.main()

--- a/tools/test/test_upload.py
+++ b/tools/test/test_upload.py
@@ -15,21 +15,22 @@ import upload
 
 from mock import Repo
 
-class TestPublishSanityCheck(unittest.TestCase):
+class TestGetDraft(unittest.TestCase):
   def setUp(self):
     self.repo = Repo()
 
-  def test_fails_on_existing_draft(self):
+  def test_returns_existing_draft(self):
     self.repo.releases._releases = [{'tag_name': 'test', 'draft': True}]
-    self.assertRaises(UserWarning, upload.sanity_check, self.repo, 'test')
+    self.assertEquals(upload.get_draft(self.repo, 'test')['tag_name'], 'test')
 
   def test_fails_on_existing_release(self):
     self.repo.releases._releases = [{'tag_name': 'test', 'draft': False}]
-    self.assertRaises(UserWarning, upload.sanity_check, self.repo, 'test')
+    self.assertRaises(UserWarning, upload.get_draft, self.repo, 'test')
 
-  def test_succeeds_on_new_release(self):
+  def test_returns_none_on_new_draft(self):
     self.repo.releases._releases = [{'tag_name': 'old', 'draft': False}]
-    upload.sanity_check(self.repo, 'new')
+    upload.get_draft(self.repo, 'new')
+    self.assertEquals(upload.get_draft(self.repo, 'test'), None)
 
 if __name__ == '__main__':
   print unittest.main()

--- a/tools/test/test_upload.py
+++ b/tools/test/test_upload.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
 #!/usr/bin/env python
 
 import sys

--- a/tools/test/test_upload.py
+++ b/tools/test/test_upload.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+import sys
+import unittest
+import os
+
+dirname = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(dirname, '..'))
+
+import upload
+
+from mock import Repo
+
+class TestPublishSanityCheck(unittest.TestCase):
+    def setUp(self):
+        self.repo = Repo()
+
+    def test_fails_on_existing_draft(self):
+        self.repo.releases._releases = [{'tag_name': 'test', 'draft': True}]
+        self.assertRaises(UserWarning, upload.sanity_check, self.repo, 'test')
+
+    def test_fails_on_existing_release(self):
+        self.repo.releases._releases = [{'tag_name': 'test', 'draft': False}]
+        self.assertRaises(UserWarning, upload.sanity_check, self.repo, 'test')
+
+    def test_succeeds_on_new_release(self):
+        self.repo.releases._releases = [{'tag_name': 'old', 'draft': False}]
+        upload.sanity_check(self.repo, 'new')
+
+if __name__ == '__main__':
+    print unittest.main()

--- a/tools/test/test_upload.py
+++ b/tools/test/test_upload.py
@@ -1,8 +1,8 @@
+#!/usr/bin/env python
+
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
-
-#!/usr/bin/env python
 
 import sys
 import unittest

--- a/tools/test/test_upload.py
+++ b/tools/test/test_upload.py
@@ -16,20 +16,20 @@ import upload
 from mock import Repo
 
 class TestPublishSanityCheck(unittest.TestCase):
-    def setUp(self):
-        self.repo = Repo()
+  def setUp(self):
+    self.repo = Repo()
 
-    def test_fails_on_existing_draft(self):
-        self.repo.releases._releases = [{'tag_name': 'test', 'draft': True}]
-        self.assertRaises(UserWarning, upload.sanity_check, self.repo, 'test')
+  def test_fails_on_existing_draft(self):
+    self.repo.releases._releases = [{'tag_name': 'test', 'draft': True}]
+    self.assertRaises(UserWarning, upload.sanity_check, self.repo, 'test')
 
-    def test_fails_on_existing_release(self):
-        self.repo.releases._releases = [{'tag_name': 'test', 'draft': False}]
-        self.assertRaises(UserWarning, upload.sanity_check, self.repo, 'test')
+  def test_fails_on_existing_release(self):
+    self.repo.releases._releases = [{'tag_name': 'test', 'draft': False}]
+    self.assertRaises(UserWarning, upload.sanity_check, self.repo, 'test')
 
-    def test_succeeds_on_new_release(self):
-        self.repo.releases._releases = [{'tag_name': 'old', 'draft': False}]
-        upload.sanity_check(self.repo, 'new')
+  def test_succeeds_on_new_release(self):
+    self.repo.releases._releases = [{'tag_name': 'old', 'draft': False}]
+    upload.sanity_check(self.repo, 'new')
 
 if __name__ == '__main__':
-    print unittest.main()
+  print unittest.main()

--- a/tools/upload.py
+++ b/tools/upload.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import json
 import os

--- a/tools/upload.py
+++ b/tools/upload.py
@@ -16,15 +16,15 @@ def main(args):
   repo = GitHub(get_env('GITHUB_TOKEN')).repos(BROWSER_LAPTOP_REPO)
 
   try:
-    sanity_check(repo, get_tag())
+    sanity_check(repo, get_tag_without_channel())
   except UserWarning:
     if args.force:
-      delete_release(repo, get_tag())
+      delete_release(repo, get_tag_without_channel())
     else:
       raise
 
 
-  release = create_release_draft(repo, get_tag())
+  release = create_release_draft(repo, get_tag_without_channel())
   print('[INFO] Uploading release {}'.format(release['tag_name']))
   for f in get_files_to_upload():
     upload_browser_laptop(repo, release, f)

--- a/tools/upload.py
+++ b/tools/upload.py
@@ -30,35 +30,34 @@ def sanity_check(repo, tag):
     raise(UserWarning("Draft with tag {} already exists".format(tag)))
 
 def upload_browser_laptop(github, release, file_path):
-    filename = os.path.basename(file_path)
-    print('[INFO] Uploading: ' + filename)
+  filename = os.path.basename(file_path)
+  print('[INFO] Uploading: ' + filename)
 
-    # Upload the file.
-    with open(file_path, 'rb') as f:
-        if filename == 'RELEASES':
-          filename = 'RELEASES-{0}'.format(TARGET_ARCH)
-        upload_io_to_github(github, release,
-            filename, f, 'application/octet-stream')
+  # Upload the file.
+  with open(file_path, 'rb') as f:
+    if filename == 'RELEASES':
+      filename = 'RELEASES-{0}'.format(TARGET_ARCH)
+    upload_io_to_github(github, release,
+                        filename, f, 'application/octet-stream')
 
 def create_release_draft(repo, tag):
-    name = '{0} {1}'.format(release_name(), tag)
-    # TODO: Parse release notes from CHANGELOG.md
-    body = '(placeholder)'
-    data = dict(tag_name=tag, name=name, body=body, draft=True)
-    return repo.releases.post(data=data)
+  name = '{0} {1}'.format(release_name(), tag)
+  # TODO: Parse release notes from CHANGELOG.md
+  body = '(placeholder)'
+  data = dict(tag_name=tag, name=name, body=body, draft=True)
+  return repo.releases.post(data=data)
 
 def get_files_to_upload():
-    matches = []
-    for root, dirnames, filenames in os.walk('dist'):
-        for filename in filenames:
-          matches.append(os.path.join(root, filename))
-    return matches
+  matches = []
+  for root, dirnames, filenames in os.walk('dist'):
+    for filename in filenames:
+      matches.append(os.path.join(root, filename))
+  return matches
 
 def upload_io_to_github(github, release, name, io, content_type):
-    params = {'name': name}
-    headers = {'Content-Type': content_type}
-    github.releases(release['id']).assets.post(
-        params=params, headers=headers, data=io, verify=False)
+  params = {'name': name}
+  headers = {'Content-Type': content_type}
+  github.releases(release['id']).assets.post(params=params, headers=headers, data=io, verify=False)
 
 if __name__ == '__main__':
   import sys

--- a/tools/upload.py
+++ b/tools/upload.py
@@ -3,100 +3,59 @@
 import json
 import os
 from lib.github import GitHub
+from lib.helpers import *
 import requests
 
-BROWSER_LAPTOP_REPO = 'brave/browser-laptop'
 TARGET_ARCH= os.environ['TARGET_ARCH'] if os.environ.has_key('TARGET_ARCH') else 'x64'
 
 def main():
-  print('Running upload...')
-  github = GitHub(auth_token())
-  releases = github.repos(BROWSER_LAPTOP_REPO).releases.get()
-  tag = 'v' + json.load(open('package.json'))['version']
-  tag_exists = False
-  for release in releases:
-    if not release['draft'] and release['tag_name'] == tag:
-      tag_exists = True
-      break
-  release = create_or_get_release_draft(github, releases, tag,
-                                        tag_exists)
+  print('[INFO] Running upload...')
+  repo = GitHub(get_env('GITHUB_TOKEN')).repos(BROWSER_LAPTOP_REPO)
+
+  sanity_check(repo, get_tag())
+
+  release = create_release_draft(repo, get_tag())
+  print('[INFO] Uploading release {}'.format(release['tag_name']))
   for f in get_files_to_upload():
-    upload_browser_laptop(github, release, f)
+    upload_browser_laptop(repo, release, f)
+  print('[INFO] Finished upload')
 
-def get_channel_display_name():
-  d = {'dev': 'Release', 'beta': 'Beta', 'developer': 'Developer', 'nightly': 'Nightly'}
-  return d[release_channel()]
-
-def get_files_to_upload():
-  matches = []
-  for root, dirnames, filenames in os.walk('dist'):
-    for filename in filenames:
-      matches.append(os.path.join(root, filename))
-  return matches
-
+def sanity_check(repo, tag):
+  releases = get_releases_by_tag(repo, tag, include_drafts=True)
+  print('[INFO] Existing releases: {}'.format([x['tag_name'] for x in releases]))
+  if releases:
+    raise(UserWarning("Draft with tag {} already exists".format(tag)))
 
 def upload_browser_laptop(github, release, file_path):
-  filename = os.path.basename(file_path)
-  print('upload_browser_laptop: ' + filename)
-  try:
-    for asset in release['assets']:
-      if asset['name'] == filename:
-        github.repos(BROWSER_LAPTOP_REPO).releases.assets(asset['id']).delete()
-  except Exception:
-    pass
+    filename = os.path.basename(file_path)
+    print('[INFO] Uploading: ' + filename)
 
-  # Upload the file.
-  with open(file_path, 'rb') as f:
-    if filename == 'RELEASES':
-      filename = 'RELEASES-{0}'.format(TARGET_ARCH)
-    upload_io_to_github(github, release,
-        filename, f, 'application/octet-stream')
+    # Upload the file.
+    with open(file_path, 'rb') as f:
+        if filename == 'RELEASES':
+          filename = 'RELEASES-{0}'.format(TARGET_ARCH)
+        upload_io_to_github(github, release,
+            filename, f, 'application/octet-stream')
 
-def release_name():
-  return '{0} Channel'.format(get_channel_display_name())
+def create_release_draft(repo, tag):
+    name = '{0} {1}'.format(release_name(), tag)
+    # TODO: Parse release notes from CHANGELOG.md
+    body = '(placeholder)'
+    data = dict(tag_name=tag, name=name, body=body, draft=True)
+    return repo.releases.post(data=data)
 
-def create_release_draft(github, tag):
-  name = '{0} {1}'.format(release_name(), tag)
-  # TODO: Parse release notes from CHANGELOG.md
-  body = '(placeholder)'
-  if body == '':
-    sys.stderr.write('Quit due to empty release note.\n')
-    sys.exit(1)
-  data = dict(tag_name=tag, name=name, body=body, draft=True)
-  r = github.repos(BROWSER_LAPTOP_REPO).releases.post(data=data)
-  return r
-
-
-def create_or_get_release_draft(github, releases, tag, tag_exists):
-  # Search for existing draft.
-  for release in releases:
-    if release['draft']:
-      return release
-
-  if tag_exists:
-    tag = 'do-not-publish-me'
-  return create_release_draft(github, tag)
+def get_files_to_upload():
+    matches = []
+    for root, dirnames, filenames in os.walk('dist'):
+        for filename in filenames:
+          matches.append(os.path.join(root, filename))
+    return matches
 
 def upload_io_to_github(github, release, name, io, content_type):
-  params = {'name': name}
-  headers = {'Content-Type': content_type}
-  github.repos(BROWSER_LAPTOP_REPO).releases(release['id']).assets.post(
-      params=params, headers=headers, data=io, verify=False)
-
-
-def auth_token():
-  token = os.environ['GITHUB_TOKEN']
-  message = ('Error: Please set the $GITHUB_TOKEN '
-             'environment variable, which is your personal token')
-  assert token, message
-  return token
-
-def release_channel():
-  channel = os.environ['CHANNEL']
-  message = ('Error: Please set the $CHANNEL '
-             'environment variable, which is your release channel')
-  assert channel, message
-  return channel
+    params = {'name': name}
+    headers = {'Content-Type': content_type}
+    github.releases(release['id']).assets.post(
+        params=params, headers=headers, data=io, verify=False)
 
 if __name__ == '__main__':
   import sys


### PR DESCRIPTION
* upload.py now fails when an existing draft exists to avoid publishing the wrong version
* changed publish.py so it checks if tag is already released, asks for confirmation and doesn't upload draft when it doesn't currently exist
* moved duplicate functions to helper.py
* added initial python tests

Fixes: https://github.com/brave/browser-laptop/issues/13780

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
Started adding tests in tools/test but not enabled in CI yet. Tested manually on fork.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


