### PR TITLE
Increased a fond size for session tab indicator. Fixes #12349

### DIFF
--- a/app/renderer/components/tabs/content/tabIcon.js
+++ b/app/renderer/components/tabs/content/tabIcon.js
@@ -86,8 +86,9 @@ const styles = StyleSheet.create({
   },
 
   tabIcon_symbol_content: {
-    fontSize: '8px',
+    fontSize: '11px',
     fontWeight: 'bold',
+    marginLeft: '4px',
     justifyContent: 'flex-end',
     color: theme.tab.icon.symbol.color
   }


### PR DESCRIPTION
Increased the font for session tab indicator, also increased the distance between the icon and session indicator number. 
[Issue #12349 ](https://github.com/brave/browser-laptop/issues/12349)

Screencaptures:
Before:
![before](https://user-images.githubusercontent.com/15698572/38525959-545a45d2-3c22-11e8-931f-45e5b05ad2cb.png)

After:
![fix 2](https://user-images.githubusercontent.com/15698572/38525964-59c8f5a4-3c22-11e8-866d-343c0a7f661a.PNG)


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

cc @cezaraugusto Could you kindly review? 

## Test Plan:
1. Open a new session tab
2. Make sure that the partition number is readable

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


