### PR TITLE
Fix automated tests post-0.22.x

### DIFF
--- a/app/cmdLine.js
+++ b/app/cmdLine.js
@@ -175,6 +175,6 @@ const api = module.exports = {
 
   shouldDebugTabEvents: process.argv.includes(debugTabEventsFlagName),
   shouldDebugWindowEvents: process.argv.includes(debugWindowEventsFlagName),
-  disableBufferWindow: process.argv.includes(disableBufferWindowFlagName),
+  disableBufferWindow: process.env.NODE_ENV === 'test' || process.argv.includes(disableBufferWindowFlagName),
   disableDeferredWindowLoad: process.argv.includes(disableDeferredWindowLoadFlagName)
 }


### PR DESCRIPTION
Fix #13611
Do not use buffer window in automated test environment.
This seems to confuse looking up windows and querying elements inside them.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
`npm run test -- --grep "^Performance startup"`

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


