### PR TITLE
Move webrtc options from advanced to security prefs

### DIFF
--- a/app/renderer/components/preferences/advancedTab.js
+++ b/app/renderer/components/preferences/advancedTab.js
@@ -11,7 +11,6 @@ const locale = require('../../../../js/l10n')
 
 // Actions
 const {getSetting} = require('../../../../js/settings')
-const aboutActions = require('../../../../js/about/aboutActions')
 
 // Components
 const {SettingsList, SettingItem, SettingCheckbox} = require('../common/settings')
@@ -20,7 +19,6 @@ const {DefaultSectionTitle} = require('../common/sectionTitle')
 
 // Constants
 const settings = require('../../../../js/constants/settings')
-const webrtcConstants = require('../../../../js/constants/webrtcConstants')
 const {scaleSize} = require('../../../common/constants/toolbarUserInterfaceScale')
 
 // Utils
@@ -155,30 +153,6 @@ class AdvancedTab extends ImmutableComponent {
           />
           {this.spellCheckLanguages}
         </SettingsList>
-        <DefaultSectionTitle data-l10n-id='webrtcPolicy' />
-        <SettingsList>
-          <SettingDropdown
-            value={(
-              getSetting(settings.WEBRTC_POLICY, this.props.settings)
-            )}
-            onChange={changeSetting.bind(
-              null,
-              this.props.onChangeSetting,
-              settings.WEBRTC_POLICY
-            )}>
-            {
-              Object.keys(webrtcConstants)
-                .map((policy) => <option data-l10n-id={policy} value={webrtcConstants[policy]} />)
-            }
-          </SettingDropdown>
-          <div
-            className={css(styles.link)}
-            data-l10n-id='webrtcPolicyExplanation'
-            onClick={aboutActions.createTabRequested.bind(null, {
-              url: 'https://cs.chromium.org/chromium/src/content/public/common/webrtc_ip_handling_policy.h'
-            })}
-          />
-        </SettingsList>
       </main>
       <footer className={css(styles.moreInfo)}>
         <div data-l10n-id='requiresRestart' className={css(commonStyles.requiresRestart)} />
@@ -203,13 +177,6 @@ const styles = StyleSheet.create({
 
   swipeNavigation__longLabel: {
     marginLeft: '5px'
-  },
-
-  link: {
-    cursor: 'pointer',
-    fontSize: '14px',
-    lineHeight: '3em',
-    textDecoration: 'underline'
   },
 
   moreInfo: {

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -35,6 +35,7 @@ const appConfig = require('../constants/appConfig')
 const preferenceTabs = require('../constants/preferenceTabs')
 const messages = require('../constants/messages')
 const settings = require('../constants/settings')
+const webrtcConstants = require('../constants/webrtcConstants')
 const {changeSetting} = require('../../app/renderer/lib/settingsUtil')
 const {passwordManagers, extensionIds} = require('../constants/passwordManagers')
 const {startsWithOption, newTabMode, bookmarksToolbarMode, fullscreenOption, autoplayOption} = require('../../app/common/constants/settingsEnums')
@@ -414,6 +415,30 @@ class SecurityTab extends ImmutableComponent {
       <SettingsList>
         <SettingCheckbox dataL10nId='useSiteIsolation' prefKey={settings.SITE_ISOLATION_ENABLED} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
       </SettingsList>
+      <DefaultSectionTitle data-l10n-id='webrtcPolicy' />
+      <SettingsList>
+        <SettingDropdown
+          value={(
+            getSetting(settings.WEBRTC_POLICY, this.props.settings)
+          )}
+          onChange={changeSetting.bind(
+            null,
+            this.props.onChangeSetting,
+            settings.WEBRTC_POLICY
+          )}>
+          {
+            Object.keys(webrtcConstants)
+              .map((policy) => <option data-l10n-id={policy} value={webrtcConstants[policy]} />)
+          }
+        </SettingDropdown>
+        <div
+          className={css(styles.link)}
+          data-l10n-id='webrtcPolicyExplanation'
+          onClick={aboutActions.createTabRequested.bind(null, {
+            url: 'https://cs.chromium.org/chromium/src/content/public/common/webrtc_ip_handling_policy.h'
+          })}
+        />
+      </SettingsList>
       <DefaultSectionTitle data-l10n-id='firewall' />
       <SettingsList>
         <SettingCheckbox dataL10nId='useFirewall' checked={this.props.braveryDefaults.get(firewall)} onChange={this.onToggleFirewall} />
@@ -765,6 +790,13 @@ const styles = StyleSheet.create({
 
   searchShortcutEntry: {
     fontSize: '1rem'
+  },
+
+  link: {
+    cursor: 'pointer',
+    fontSize: '14px',
+    lineHeight: '3em',
+    textDecoration: 'underline'
   }
 })
 


### PR DESCRIPTION
fix #13805

## Test Plan:
1. go to about:preferences > Advanced
2. you shouldn't see webrtc options there
3. go to about:preferences > security
4. you should see the webrtc options

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


