### PR TITLE
Remove quarantine attribute from binary (updates from 0.22.13 unintentionally add this)

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -19,6 +19,7 @@ const Immutable = require('immutable')
 const app = electron.app
 const compareVersions = require('compare-versions')
 const merge = require('deepmerge')
+const {execSync} = require('child_process')
 
 // Constants
 const UpdateStatus = require('../js/constants/updateStatus')
@@ -823,6 +824,30 @@ module.exports.runPreMigrations = (data) => {
   }
 
   if (data.lastAppVersion) {
+    try {
+      // with version 0.22.13, any file downloaded (including the update itself) would get
+      // quarantined on macOS (per work done with https://github.com/brave/muon/pull/484)
+      // this functionality was then reverted with https://github.com/brave/muon/pull/570
+      //
+      // To fix the executable, we need to manually un-quarantine the Brave executable so that it works as expected
+      if (process.platform === 'darwin' && compareVersions(data.lastAppVersion, '0.22.13') === 0) {
+        let runningAppPath
+        const appDirectories = app.getPath('exe').split(path.sep)
+        // Remove the `Contents`/`MacOS`/`Brave` parts from path
+        if (appDirectories.length > 3) {
+          runningAppPath = path.join(...appDirectories.slice(0, appDirectories.length - 3))
+        }
+
+        execSync('xattr -d com.apple.quarantine /Applications/Brave.app || true')
+        if (runningAppPath) {
+          execSync(`xattr -d com.apple.quarantine ${runningAppPath} || true`)
+        }
+        console.log('Update was downloaded from 0.22.13; Quarantine attribute has been removed')
+      }
+    } catch (e) {
+      console.error('Update was downloaded from 0.22.13; failed to remove quarantine attribute: ', e)
+    }
+
     let runHSTSCleanup = false
     try { runHSTSCleanup = compareVersions(data.lastAppVersion, '0.22.13') < 1 } catch (e) {}
 


### PR DESCRIPTION
Part 2 of 2 for fixing brave/browser-laptop#13817

NOTE: when building binaries for release, we'll need to:
- kick off regular CI process
- cancel the macOS build
- on my machine, prep the macOS release
- after `npm run build-package`, the plist will need to be edited to remove https://github.com/brave/muon/pull/570/commits/02bf2e0c578cb5ca836d9bcf3852c435247414cc
- `build-installer` and upload can then take place for macOS
- CI can finish the rest of the process

Auditors: @bridiver, @jumde

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


