### PR TITLE
refactor isThirdPartyHost and block referer based on base domain

### DIFF
--- a/app/browser/isThirdPartyHost.js
+++ b/app/browser/isThirdPartyHost.js
@@ -3,22 +3,28 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const getBaseDomain = require('../../js/lib/baseDomain').getBaseDomain
+const ip = require('ip')
 
 /**
- * baseContextHost {string} - The base host to check against
- * testHost {string} - The host to check
+ * Checks if two hosts are third party. Subdomains count as first-party to the
+ * parent domain. Uses hostname (no port).
+ * @param {host1} string - First hostname to compare
+ * @param {host2} string - Second hostname to compare
  */
-const isThirdPartyHost = (baseContextHost, testHost) => {
-  // TODO: Always return true if these are IP addresses that aren't the same
-  if (!testHost || !baseContextHost) {
+const isThirdPartyHost = (host1, host2) => {
+  if (!host1 || !host2) {
     return true
   }
-  const documentDomain = getBaseDomain(baseContextHost)
-  if (testHost.length > documentDomain.length) {
-    return (testHost.substr(testHost.length - documentDomain.length - 1) !== '.' + documentDomain)
-  } else {
-    return (testHost !== documentDomain)
+  if (host1 === host2) {
+    return false
   }
+
+  if (ip.isV4Format(host1) || ip.isV4Format(host2)) {
+    // '127.0.0.1' and '::7f00:1' are actually equal, but ignore such cases for now
+    return host1 !== host2
+  }
+
+  return getBaseDomain(host1) !== getBaseDomain(host2)
 }
 
 module.exports = isThirdPartyHost

--- a/js/lib/baseDomain.js
+++ b/js/lib/baseDomain.js
@@ -25,7 +25,10 @@ const checkASCII = function (str) {
  * Returns base domain for specified host based on Public Suffix List.
  * Derived from Privacy Badger Chrome <https://github.com/EFForg/privacybadger>,
  * Copyright (C) 2015 Electronic Frontier Foundation and other contributors
- * @param {string} hostname The name of the host to get the base domain for
+ * TODO: Consider refactoring this into isThirdPartyHost since it's only used
+ *   for that.
+ * @param {string} hostname The name of the host to get the base domain for.
+ *   The caller must validate that this is a valid, non-IP hostname string!!
  */
 
 module.exports.getBaseDomain = function (hostname) {
@@ -42,6 +45,11 @@ module.exports.getBaseDomain = function (hostname) {
   let baseDomain = cachedBaseDomain.get(hostname)
   if (baseDomain) {
     return baseDomain
+  }
+
+  // If the hostname is a TLD, return '' for the base domain
+  if (hostname in publicSuffixes) {
+    return ''
   }
 
   // search through PSL

--- a/test/unit/app/browser/isThirdPartyhostTest.js
+++ b/test/unit/app/browser/isThirdPartyhostTest.js
@@ -12,11 +12,40 @@ describe('isThirdPartyHost test', function () {
   })
   it('A subdomain URL should not be third party', function () {
     assert.ok(!isThirdPartyHost(braveHost, 'ragu.brave.com'))
+    assert.ok(!isThirdPartyHost('ragu.brave.com', braveHost))
+  })
+  it('A 2nd level subdomain URL should not be third party', function () {
+    assert.ok(!isThirdPartyHost(braveHost, 'foo.bar.brave.com'))
+    assert.ok(!isThirdPartyHost('foo.bar.brave.com', braveHost))
   })
   it('Unrelated URLs should be third party', function () {
     assert.ok(isThirdPartyHost(braveHost, 'ragu.com'))
+    assert.ok(isThirdPartyHost('ragu.com', braveHost))
   })
   it('Checks subdomains properly', function () {
     assert.ok(isThirdPartyHost(braveHost, 'brave.ragu.com'))
+    assert.ok(isThirdPartyHost('brave.ragu.com', braveHost))
+  })
+  it('Handles multi-part TLDs', function () {
+    assert.ok(isThirdPartyHost('diracdeltas.github.io', 'brave.github.io'))
+    assert.ok(isThirdPartyHost('github.io', 'brave.github.io'))
+    assert.ok(!isThirdPartyHost('github.io', 'github.io'))
+    assert.ok(isThirdPartyHost('brave.github.io', 'github.io'))
+    assert.ok(isThirdPartyHost('brave.co.uk', 'example.co.uk'))
+  })
+  it('Handles IPv4', function () {
+    assert.ok(isThirdPartyHost('172.217.6.46', '173.217.6.46'))
+    assert.ok(!isThirdPartyHost('172.217.6.46', '172.217.6.46'))
+  })
+  it('Handles IPv6', function () {
+    assert.ok(!isThirdPartyHost('[2001:db8:85a3::8a2e:370:7334]', '[2001:db8:85a3::8a2e:370:7334]'))
+    assert.ok(!isThirdPartyHost('2001:db8:85a3::8a2e:370:7334', '2001:db8:85a3::8a2e:370:7334'))
+    assert.ok(isThirdPartyHost('[2001:db8:85a3::8a2e:370:7334]', '[2002:db8:85a3::8a2e:370:7334]'))
+    assert.ok(isThirdPartyHost('2001:db8:85a3::8a2e:370:7334', '2002:db8:85a3::8a2e:370:7334'))
+  })
+  it('Handles null', function () {
+    assert.ok(isThirdPartyHost('', ''))
+    assert.ok(isThirdPartyHost(null, null))
+    assert.ok(isThirdPartyHost('', null))
   })
 })

--- a/test/unit/js/lib/baseDomainTest.js
+++ b/test/unit/js/lib/baseDomainTest.js
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+/* global describe, it */
+
+const {getBaseDomain} = require('../../../../js/lib/baseDomain')
+const assert = require('assert')
+
+require('../../braveUnit')
+
+describe('getBaseDomain', function () {
+  it('regular domain and subdomains', function () {
+    const domain = 'brave.com'
+    assert.equal(domain, getBaseDomain('brave.com'))
+    assert.equal(domain, getBaseDomain('test.brave.com'))
+    assert.equal(domain, getBaseDomain('foo.test.brave.com'))
+  })
+  it('international domains', function () {
+    assert.equal('brave.comа', getBaseDomain('www.brave.xn--com-8cd'))
+    assert.equal('brave.\u9ce5\u53d6.jp', getBaseDomain('\u9ce5\u53d6.jp.brave.\u9ce5\u53d6.jp'))
+    assert.equal('ebаy.com', getBaseDomain('xn--eby-7cd.com'))
+  })
+  it('multi-part domains', function () {
+    assert.equal('diracdeltas.github.io', getBaseDomain('diracdeltas.github.io'))
+    assert.equal('diracdeltas.github.io', getBaseDomain('foo.diracdeltas.github.io'))
+    assert.equal('bar.ginoza.okinawa.jp', getBaseDomain('foo.bar.ginoza.okinawa.jp'))
+    assert.equal('brave.co.uk', 'brave.co.uk')
+  })
+  it('tlds', function () {
+    assert.equal('', getBaseDomain('github.io'))
+    assert.equal('', getBaseDomain('co.uk'))
+  })
+  it('non-hostname inputs', function () {
+    assert.equal('', getBaseDomain(''))
+    assert.equal('hello world', getBaseDomain('hello world'))
+    assert.equal('[2001:0db8:85a3:0000:0000:8a2e:0370:7334]', getBaseDomain('[2001:0db8:85a3:0000:0000:8a2e:0370:7334]'))
+    assert.equal('http://2001::7334', getBaseDomain('http://2001::7334'))
+  })
+})


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/13779
fix https://github.com/brave/browser-laptop/issues/11778
also removes TODO for isThirdPartyHost to handle IP addresses and adds more tests


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. unit tests pass
2. open Brave, make sure cookie setting is block all or block 3rd party
3. go to docs.google.com and login
4. documents should appear
5. open devtools and go to 'network' tab
6.  on requests to non-google.com domains like gstatic.com,  the referer
   header should be 'https://gstatic.com' or whatever the domain is, instead of
   'https://docs.google.com...'
7. turn cookie setting to 'allow all'
8. repeat step 6. now you should see some requests to third party domains where the referer header is 'https://docs.google.com...'

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


