### PR TITLE
Cleanup of the eopkg commands on Solus for more simplicity

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,7 @@ dnf group install "Development Tools" "C Development Tools and Libraries"
 #### On Solus
 
 ````
-sudo eopkg install -c system.devel
-sudo eopkg install gconf
+sudo eopkg it -c system.devel gconf
 ````
 
 


### PR DESCRIPTION
Just some simple cleanup of the command for installing dependencys when building Brave under [Solus](https://solus-project.com). I later learned that there is no reason to use two separate commands because it can be compacted down to one command with "it" instead of "install".

This should be safe for merging pretty quickly 👍 
