### PR TITLE
Release notes for 0.22.x Release 2 hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.22.22](https://github.com/brave/browser-laptop/releases/tag/v0.22.22dev)
+ - Fixes a missing static variable on macOS for first-run referral program installs ([#13853](https://github.com/brave/browser-laptop/issues/13853))
+
 ## [0.22.21](https://github.com/brave/browser-laptop/releases/tag/v0.22.21dev)
  - Improvements to the referral program. ([#13754](https://github.com/brave/browser-laptop/issues/13754))
  - Reverted quarantine feature for macOS. ([#13826](https://github.com/brave/browser-laptop/issues/13826))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [0.22.22](https://github.com/brave/browser-laptop/releases/tag/v0.22.22dev)
- - Fixes a missing static variable on macOS for first-run referral program installs ([#13853](https://github.com/brave/browser-laptop/issues/13853))
+ - Fixed missing static variable on macOS for first-run referral program installs. ([#13853](https://github.com/brave/browser-laptop/issues/13853))
 
 ## [0.22.21](https://github.com/brave/browser-laptop/releases/tag/v0.22.21dev)
  - Improvements to the referral program. ([#13754](https://github.com/brave/browser-laptop/issues/13754))


### PR DESCRIPTION
- Fixes a missing static variable on macOS for first-run referral program installs ([#13853](https://github.com/brave/browser-laptop/issues/13853))