### PR TITLE
Fixes Audio indicator if tab muted and video stops playing

### DIFF
--- a/app/common/state/tabContentState/audioState.js
+++ b/app/common/state/tabContentState/audioState.js
@@ -49,6 +49,10 @@ module.exports.showAudioTopBorder = (state, frameKey, isPinned) => {
     return false
   }
 
+  if (module.exports.isAudioMuted(state, frameKey)) {
+    return false
+  }
+
   return (
     module.exports.canPlayAudio(state, frameKey) &&
     (isEntryIntersected(state, 'tabs') || isPinned)

--- a/test/unit/app/common/state/tabContentStateTest/audioStateTest.js
+++ b/test/unit/app/common/state/tabContentStateTest/audioStateTest.js
@@ -160,5 +160,13 @@ describe('audioState unit tests', function () {
       const result = audioState.showAudioTopBorder(state, frameKey, false)
       assert.equal(result, false)
     })
+
+    it('return false if tab audio is mute and not pinned', function * () {
+      const state = defaultState
+        .setIn(['frames', index, 'audioPlayback'], true)
+        .setIn(['frames', index, 'audioMuted'], true)
+      const result = audioState.showAudioTopBorder(state, frameKey, false)
+      assert.equal(result, false)
+    })
   })
 })


### PR DESCRIPTION
Fix #12569

I have added something to check if the audio in the tab is muted or not within the audioState file. I have also made added a test for the new changes.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


