### PR TITLE
Bring back ability for menu items to focus or create window without creating a tab

### DIFF
--- a/app/common/commonMenu.js
+++ b/app/common/commonMenu.js
@@ -15,11 +15,18 @@ const isDarwin = process.platform === 'darwin'
 const electron = require('electron')
 
 const ensureAtLeastOneWindow = (frameOpts) => {
-  // If this action is dispatched from a renderer window (windows)
-  // it will create the tab in the current window
-  // If it was dispatched by the browser (mac / linux)
+  // Handle no new tab requested, but need a window
+  // and possibly there is no window.
+  if (!frameOpts && process.type === 'browser') {
+    // focus active window, or create a new one if there are none
+    appActions.focusOrCreateWindow()
+    return
+  }
+  // If this action is dispatched from a renderer window (Windows OS),
+  // it will create the tab in the current window since the action originates from it.
+  // If it was dispatched by the browser (macOS / Linux),
   // then it will create the tab in the active window
-  // or a new window if there is no active window
+  // or a new window if there is no active window.
   appActions.createTabRequested(frameOpts, false, false, true)
 }
 


### PR DESCRIPTION
This affects `Help -> Check For Updates`, especially on Windows.
Fix #13876

#### Should be merged to:
- [ ] master
- [ ] 0.23.x
- [ ] 0.22.x (for 0.22.x Release 3)
- [ ] 0.22.x-c66

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
### Primary fix:
- Ensure Help -> Check for Updates does not error, and produces update notification bar
### Secondary regression checks:
- Ensure all menu items open new tab in currently active window
- Ensure all menu items open new tab in currently active window, when app is not focused
- Ensure all menu items open new tab in new window if there is no visible window

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


