### PR TITLE
Fixes URL Parsing failing for query string and file name with space

### DIFF
--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -5,10 +5,11 @@
 'use strict'
 
 // characters, then : with optional //
-const rscheme = /^(?:[a-z\u00a1-\uffff0-9-+]+)(?::(\/\/)?)(?!\d)/i
+const rscheme = /^(?:[a-z\u00a1-\uffff0-9-+]{2,})(?::(\/\/)?)(?!\d)/i
 const httpScheme = 'http://'
 const httpsScheme = 'https://'
 const fileScheme = 'file://'
+const windowsFileScheme = /[a-z]:\\/i
 const defaultScheme = httpScheme
 const os = require('os')
 const punycode = require('punycode/')
@@ -67,6 +68,11 @@ const UrlUtil = {
       input = fileScheme + input
     }
 
+    if (windowsFileScheme.test(input)) {
+      input = input.replace(/\\/g, '/')
+      input = `${fileScheme}/${input}`
+    }
+
     // If there's no scheme, prepend the default scheme
     if (!UrlUtil.hasScheme(input)) {
       input = defaultScheme + input
@@ -111,12 +117,13 @@ const UrlUtil = {
     // - starts with "?" or "."
     // - contains "? "
     // - ends with "." (and was not preceded by a domain or /)
-    const case2Reg = /(^\?)|(\?.+\s)|(^\.)|(^[^.+]*[^/]*\.$)/
+    const case2Reg = /(^\?)|(\?\s+)|(^\.)|(^[^.+]*[^/]*\.$)/
     // for cases, pure string
     const case3Reg = /[?./\s:]/
     // for cases, data:uri, view-source:uri and about
     const case4Reg = /^(data|view-source|mailto|about|chrome-extension|chrome-devtools|magnet|chrome):.*/
-
+    // for Windows and unix file paths
+    const case5Reg = /(?:^\/)|(?:^[a-zA-Z]:\\)/
     let str = input.trim()
     const scheme = UrlUtil.getScheme(str)
 
@@ -127,7 +134,7 @@ const UrlUtil = {
       return true
     }
     if (case2Reg.test(str) || !case3Reg.test(str) ||
-        (scheme === undefined && /\s/g.test(str))) {
+    (scheme === undefined && /\s/g.test(str) && !case5Reg.test(str))) {
       return true
     }
     if (case4Reg.test(str)) {

--- a/test/unit/lib/urlutilTestComponents.js
+++ b/test/unit/lib/urlutilTestComponents.js
@@ -46,6 +46,9 @@ module.exports = {
       'is an absolute file path without scheme': (test) => {
         test.equal(urlUtil().isNotURL('/file/path/to/file'), false)
       },
+      'is an absolute file path without scheme with space in name': (test) => {
+        test.equal(urlUtil().isNotURL('/path/to/file/with space'), false)
+      },
       'is an absolute file path with scheme': (test) => {
         test.equal(urlUtil().isNotURL('file:///file/path/to/file'), false)
       },
@@ -97,6 +100,15 @@ module.exports = {
       },
       'has custom protocol': (test) => {
         test.equal(urlUtil().isNotURL('brave://test'), false)
+      },
+      'returns url with encoded space character in the query string': (test) => {
+        test.equal(urlUtil().isNotURL('https://www.google.ca/search?q=dog cat'), false)
+      },
+      'is a Windows file path without scheme': (test) => {
+        test.equal(urlUtil().isNotURL('C:\\Path\to\\file'), false)
+      },
+      'is a Windows file path without scheme with space in file name': (test) => {
+        test.equal(urlUtil().isNotURL('C:\\Path\\with\\some space'), false)
       }
     },
 
@@ -121,6 +133,9 @@ module.exports = {
         },
         'has a question mark followed by a space': (test) => {
           test.equal(urlUtil().isNotURL('? brave'), true)
+        },
+        'is a pure query string without domain name': (test) => {
+          test.equal(urlUtil().isNotURL('?query=hello'), true)
         },
         'starts with period': (test) => {
           test.equal(urlUtil().isNotURL('.brave'), true)
@@ -160,6 +175,12 @@ module.exports = {
     },
     'calls prependScheme': (test) => {
       test.equal(urlUtil().getUrlFromInput('/file/path/to/file'), 'file:///file/path/to/file')
+    },
+    'returns URL with file schema for Windows': (test) => {
+      test.equal(urlUtil().getUrlFromInput('C:\\path\\to\\file'), 'file:///C:/path/to/file')
+    },
+    'returns url with file schema for Windows with space character encoded': (test) => {
+      test.equal(urlUtil().getUrlFromInput('C:\\path\\to\\file name'), 'file:///C:/path/to/file%20name')
     }
   },
 


### PR DESCRIPTION
Fixes #13897 

## Screenshots of fixes
1. Resolving google search URL with query string with space

![google_search_fix](https://user-images.githubusercontent.com/13398997/39109589-847823dc-469b-11e8-8a7b-9041a5d68c54.gif)

2. Resolving windows path with space in file name

![path_windows_fix](https://user-images.githubusercontent.com/13398997/39109597-8e11900e-469b-11e8-9927-4fc9474fc2c7.gif)

3. Resolving Mac/Linux absolute path with space in file name

![path_mac_fix](https://user-images.githubusercontent.com/13398997/39109600-9540b24c-469b-11e8-8263-13db9738d91c.gif)

## Submitter Checklist:
- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:<br>
- [ ] run test on urlutil by executing: npm test -- --grep="urlutil"

- [ ] Type in address bar: `C:\path\to\file should` show `file:///c:/path/to/file`

- [ ] Type in address bar `C:\path\to\file\with space` should show `file:///C:/path/to/file/with%20space`

- [ ] Type in address bar `http://www.google.ca/search?q=dog cat` should result in a google search of "dog cat"

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


