### PR TITLE
Set DuckDuckGo as the default search engine

### DIFF
--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -150,7 +150,7 @@ module.exports = {
     'general.download-always-ask': true,
     'general.spellcheck-enabled': true,
     'general.spellcheck-languages': Immutable.fromJS(['en-US']),
-    'search.default-search-engine': 'Google',
+    'search.default-search-engine': 'DuckDuckGo',
     'search.offer-search-suggestions': false, // false by default for privacy reasons
     'search.use-alternate-private-search-engine': false, // use true for DDG search in Private Tab
     'tabs.switch-to-new-tabs': false,


### PR DESCRIPTION
Fixes brave/browser-laptop#9748

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

 - Start brave with a new profile
 - type a search query in the title bar --> should present results on duckduckgo

or

 - Start brave with a new profile
 - open preferences
 - check that the search engine is DuckDuckGo

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


