### PR TITLE
Add new `BRAVE_USE_STAGING_DATA_FILES` environment variable to allow …

### DIFF
--- a/app/dataFile.js
+++ b/app/dataFile.js
@@ -87,7 +87,7 @@ module.exports.init = (resourceName, version, startExtension, onInitDone, forceD
 
   let versionFolder = version
   const hasStagedDatFile = [appConfig.resourceNames.ADBLOCK, appConfig.resourceNames.SAFE_BROWSING].includes(resourceName)
-  if (process.env.NODE_ENV === 'development' && hasStagedDatFile) {
+  if (hasStagedDatFile && (process.env.NODE_ENV === 'development' || process.env.BRAVE_USE_STAGING_DATA_FILES !== undefined)) {
     versionFolder = `test/${versionFolder}`
   }
   const url = appConfig[resourceName].url.replace('{version}', versionFolder)


### PR DESCRIPTION
…testing of STAGING ad-block definitions

Fixes https://github.com/brave/browser-laptop/issues/13909

Auditors: @bbondy

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


