### PR TITLE
Fix unittest error on MacOS due to invalid semver

### DIFF
--- a/test/unit/app/sessionStoreTest.js
+++ b/test/unit/app/sessionStoreTest.js
@@ -1118,7 +1118,7 @@ describe('sessionStore unit tests', function () {
         before(function () {
           readFileSyncStub = sinon.stub(fakeFileSystem, 'readFileSync').returns(JSON.stringify({
             cleanedOnShutdown: true,
-            lastAppVersion: 'NOT A REAL VERSION'
+            lastAppVersion: '0.0.1'
           }))
         })
         after(function () {


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/13907
caused by
https://github.com/brave/browser-laptop/pull/13830/files#diff-9e0c81a9a3f51c8a895685e3183a1452R832
- compareVersions requires a valid semver version or else it throws an
error, causing the unit test to fail

test plan:
1. `npm run unittest` on MacOS
2. all tests should pass

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


