### PR TITLE
Fix discrepancy between node url.parse and muon.url.parse

### DIFF
--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -481,11 +481,12 @@ const UrlUtil = {
     // parsed.origin is specific to muon.url.parse
     if (parsed.origin !== undefined) {
       if (parsed.protocol === 'about:') {
-        return [parsed.protocol, parsed.path].join('')
+        return [parsed.protocol, parsed.path.replace(/\/.*/, '')].join('')
       }
       return parsed.origin.replace(/\/+$/, '')
     }
     if (parsed.host && parsed.protocol) {
+      // parsed.slashes is specific to node's url.parse
       return parsed.slashes ? [parsed.protocol, parsed.host].join('//') : [parsed.protocol, parsed.host].join('')
     }
     return null

--- a/test/unit/lib/urlutilTestComponents.js
+++ b/test/unit/lib/urlutilTestComponents.js
@@ -173,10 +173,10 @@ module.exports = {
 
   'isFileType': {
     'relative file': (test) => {
-      test.equal(urlUtil().isFileType('/file/abc/test.pdf', 'pdf'), true)
+      test.equal(urlUtil().isFileType('file:///file/abc/test.pdf', 'pdf'), true)
     },
     'relative path': (test) => {
-      test.equal(urlUtil().isFileType('/file/abc/test', 'pdf'), false)
+      test.equal(urlUtil().isFileType('file:///file/abc/test', 'pdf'), false)
     },
     'JPG URL': (test) => {
       test.equal(urlUtil().isFileType('http://example.com/test/ABC.JPG?a=b#test', 'jpg'), true)
@@ -365,7 +365,7 @@ module.exports = {
       test.strictEqual(urlUtil().getOrigin('https://abc.bing.com'), 'https://abc.bing.com')
     },
     'gets URL origin for url with port': (test) => {
-      test.strictEqual(urlUtil().getOrigin('https://bing.com:443/?test=1#abc'), 'https://bing.com:443')
+      test.strictEqual(urlUtil().getOrigin('https://bing.com:8000/?test=1#abc'), 'https://bing.com:8000')
     },
     'gets URL origin for IP host': (test) => {
       test.strictEqual(urlUtil().getOrigin('http://127.0.0.1:443/?test=1#abc'), 'http://127.0.0.1:443')
@@ -374,7 +374,11 @@ module.exports = {
       test.strictEqual(urlUtil().getOrigin('about:preferences#abc'), 'about:preferences')
     },
     'gets URL origin for slashless protocol URL': (test) => {
+      test.strictEqual(urlUtil().getOrigin('about:test'), 'about:test')
+      test.strictEqual(urlUtil().getOrigin('about:test/'), 'about:test')
       test.strictEqual(urlUtil().getOrigin('about:test/foo'), 'about:test')
+      test.strictEqual(urlUtil().getOrigin('about:test/foo/bar'), 'about:test')
+      test.strictEqual(urlUtil().getOrigin('about:test/foo/bar#baz'), 'about:test')
     },
     'returns null for invalid URL': (test) => {
       test.strictEqual(urlUtil().getOrigin('abc'), null)


### PR DESCRIPTION
fix #13906 

Test Plan:
1. npm run test -- --grep='muon tests'

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


