### PR TITLE
Removing download percentage from downloadItem tooltip

### DIFF
--- a/app/renderer/components/download/downloadItem.js
+++ b/app/renderer/components/download/downloadItem.js
@@ -12,7 +12,6 @@ const Button = require('../common/button')
 // Constants
 const downloadStates = require('../../../../js/constants/downloadStates')
 const {PAUSE, RESUME, CANCEL} = require('../../../common/constants/electronDownloadItemActions')
-const locale = require('../../../../js/l10n')
 
 // Actions
 const appActions = require('../../../../js/actions/appActions')
@@ -258,7 +257,7 @@ class DownloadItem extends React.Component {
       }
       <div className='downloadInfo'>
         <span>
-          <div data-test-id='downloadFilename' className='downloadFilename' title={this.props.fileName + '\n' + locale.translation(this.props.statel10n)}>
+          <div data-test-id='downloadFilename' className='downloadFilename' title={this.props.fileName}>
             {this.props.fileName}
           </div>
           {
@@ -269,7 +268,7 @@ class DownloadItem extends React.Component {
                     ? <span className='fa fa-unlock isInsecure' />
                     : null
                 }
-                <span data-l10n-id={this.props.isLocalFile ? 'downloadLocalFile' : null} title={this.props.origin + '\n' + locale.translation(this.props.statel10n)}>
+                <span data-l10n-id={this.props.isLocalFile ? 'downloadLocalFile' : null} title={this.props.origin}>
                   {this.props.isLocalFile ? null : this.props.origin}
                 </span>
               </div>


### PR DESCRIPTION
Fixes #13920

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

  1. Go to http://releases.ubuntu.com/14.04/
  2. Click `64-bit PC (AMD64) desktop image`
  3. Start download
  4. Move mouse to downloading item and wait
  5. Confirm that the {{ downloadPercent }} template is no longer visible for both the origin and file name tooltips.

Ex: 

<img width="254" alt="screen shot 2018-04-24 at 12 25 28 pm" src="https://user-images.githubusercontent.com/8732757/39209490-c2467630-47ba-11e8-83d7-a20c4af09b52.png">
<img width="287" alt="screen shot 2018-04-24 at 12 25 13 pm" src="https://user-images.githubusercontent.com/8732757/39209484-bf5dfc40-47ba-11e8-94dd-c02a110145f8.png">


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

## Additional Info
The problem was the downloadProgress locale was not set to render with the download percentage in the tooltip. Rendering it revealed a latency issue in the DOM updating the tooltip text very quickly (Tooltip would not show up while the download progressed for smaller/quicker to download files). The decision was made to remove the progress from the tooltip all together, as the percentage isn't going to overflow out of the item.

cc: @AlexeyBarabash 


