### PR TITLE
Fix window ReferenceError exceptions constantly thrown when browsing

### DIFF
--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -159,7 +159,7 @@ const UrlUtil = {
     }
 
     try {
-      return new window.URL(input).href
+      return (typeof window === 'undefined') ? input : new window.URL(input).href
     } catch (e) {
       return input
     }


### PR DESCRIPTION
Resolves #13336
Cancels PR #13337
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

@bsclifton This replaces PR #13337. I needed to free up my master to keep even
