### PR TITLE
Put imported bookmarks under toolbar when there are no elements in it

### DIFF
--- a/app/importer.js
+++ b/app/importer.js
@@ -143,12 +143,26 @@ importer.on('add-bookmarks', (e, importedBookmarks, topLevelFolder) => {
     folders.push(folder)
   }
 
-  const importTopLevelFolder = {
-    title: bookmarkFoldersUtil.getNextFolderName(bookmarkFolders, topLevelFolder),
-    folderId: topLevelFolderId,
-    parentFolderId: 0
+  // If there are bookmarks or folders on bookmark toolbar, we will put imported
+  // bookmarks into "Imported from XXX" folder
+  if (bookmarksState.getBookmarksByParentId(state, 0).size > 0 ||
+      bookmarkFoldersState.getFoldersByParentId(state, 0).size > 0) {
+    const importTopLevelFolder = {
+      title: bookmarkFoldersUtil.getNextFolderName(bookmarkFolders, topLevelFolder),
+      folderId: topLevelFolderId,
+      parentFolderId: 0
+    }
+    bufferedAddFolder(importTopLevelFolder)
+  } else {
+    pathMap[topLevelFolder] = topLevelFolderId
+    pathMap['Bookmarks Toolbar'] = 0 // Firefox
+    pathMap['Bookmarks Bar'] = 0 // Chrome on mac
+    pathMap['Other Bookmarks'] = 1 // Chrome on mac
+    pathMap['Bookmarks bar'] = 0 // Chrome on win/linux
+    pathMap['Other bookmarks'] = 1 // Chrome on win/linux
+    pathMap['Bookmark Bar'] = 0 // Safari
+    pathMap['Links'] = 0 // Edge, IE
   }
-  bufferedAddFolder(importTopLevelFolder)
 
   for (let i = 0; i < importedBookmarks.length; ++i) {
     const importedBookmark = importedBookmarks[i]


### PR DESCRIPTION
bookmarks and folders under bookmark toolbar

Auditors: @bsclifton

Test Plan:
1. Make sure there are no bookmarks and folders under bookmark toolbar
2. Import bookmarks from other browsers or HTML
3. Imported bookmarks should be under bookmark toolbar
4. Import bookmarks from other browsers or HTML again
5. Import bookmarks will be put under "Imported from XXX" folder

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


