### PR TITLE
Fixes broken seed overlay trigger

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -1688,6 +1688,7 @@ const getStateInfo = (state, parsedData) => {
     }
   } catch (e) {
     console.error(e)
+    state = ledgerState.setAboutProp(state, 'status', ledgerStatuses.CORRUPTED_SEED)
   }
 
   state = ledgerState.mergeInfoProp(state, newInfo)


### PR DESCRIPTION
Resolves #14001

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

1. Enable payments and close browser after wallet is created
2. Edit ledger-state.json file and change the keyinfo section to look like this per #13424 (comment):
"keyinfo": {
"seed": {
"0": 0,
"1": 0
}
3. Relaunch browser go to payments
4. Make sure that broken seed overlay is shown

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


