### PR TITLE
Adding re-inclusion for deleted publishers via context menu.

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -708,9 +708,9 @@ const addSiteVisit = (state, timestamp, location, tabId, manualAdd = false) => {
 
   location = pageDataUtil.getInfoKey(location)
 
-  const locationData = ledgerState.getLocation(state, location)
   const minimumVisitTime = getSetting(settings.PAYMENTS_MINIMUM_VISIT_TIME)
   const duration = manualAdd ? parseInt(minimumVisitTime) : new Date().getTime() - timestamp
+  const locationData = manualAdd ? Immutable.fromJS({ publisher: tldjs.getDomain(location) }) : ledgerState.getLocation(state, location)
 
   if (_internal.verboseP) {
     console.log(

--- a/app/common/lib/ledgerUtil.js
+++ b/app/common/lib/ledgerUtil.js
@@ -139,15 +139,17 @@ const shouldShowMenuOption = (state, location) => {
     return false
   }
 
-  const publisherKey = tldjs.getDomain(location)
+  const publisherKey = tldjs.tldExists(location) && tldjs.getDomain(location)
   const validUrl = urlUtil.isURL(location) && urlParse(location).protocol !== undefined
-  const isVisible = visibleP(state, publisherKey)
 
-  return (
-    validUrl &&
-    !isVisible &&
-    publisherKey != null
-  )
+  if (!publisherKey || !validUrl) {
+    return false
+  }
+
+  const isVisible = visibleP(state, publisherKey)
+  const isBlocked = blockedP(state, publisherKey)
+
+  return (!isVisible && !isBlocked)
 }
 
 // TODO rename function

--- a/test/unit/app/browser/api/ledgerTest.js
+++ b/test/unit/app/browser/api/ledgerTest.js
@@ -1090,6 +1090,26 @@ describe('ledger api unit tests', function () {
 
         assert.equal(false, calledRevisited)
       })
+      it('saves the visit with a valid publisherKey under a manual addition', function () {
+        const location = 'https://brave.com'
+        const expectedPublisherKey = 'brave.com'
+        const state = ledgerApi.initialize(stateWithLocationTwo, true)
+
+        ledgerApi.addSiteVisit(state, 0, location, tabIdNone, manualAdd)
+        const passedPublisherKey = saveVisitSpy.getCall(0).args[1]
+
+        assert.equal(expectedPublisherKey, passedPublisherKey)
+      })
+      it('saves the visit with a valid publisherKey under a non-manual addition', function () {
+        const location = 'https://brave.com'
+        const expectedPublisherKey = 'brave.com'
+        const state = ledgerApi.initialize(stateWithLocationTwo, true)
+
+        ledgerApi.addSiteVisit(state, 0, location, fakeTabId)
+        const passedPublisherKey = saveVisitSpy.getCall(0).args[1]
+
+        assert.equal(expectedPublisherKey, passedPublisherKey)
+      })
       it('state is not modified on a null location under a manual addition', function () {
         const location = null
         const result = ledgerApi.addSiteVisit(defaultAppState, 0, location, tabIdNone, manualAdd)


### PR DESCRIPTION
Fixes #13994

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

  1. Clean install Brave
  2. Enable payments, visit some sites to add in ledger table
  3. Delete one of the publisher from the list
  4. Open about:history and right click on the publisher deleted
  5. Ensure that that the `Include this publisher` option is not present.
  6. Clear the above site out of deleted sites in `about:preferences#payments`
  7. Go back to about:history, ensure that the entry now has the `Include this publisher option`
  8. Click the option, ensure that it is again present in the ledger.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


