### PR TITLE
Change webrtc info link to be friendlier

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -436,7 +436,7 @@ class SecurityTab extends ImmutableComponent {
           className={css(styles.link)}
           data-l10n-id='webrtcPolicyExplanation'
           onClick={aboutActions.createTabRequested.bind(null, {
-            url: 'https://cs.chromium.org/chromium/src/content/public/common/webrtc_ip_handling_policy.h'
+            url: 'https://github.com/brave/browser-laptop/wiki/WebRTC-Custom-Settings'
           })}
         />
       </SettingsList>


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/14015

Test Plan:
1. go to about:preferences#security
2. scroll to 'what do these policies mean'
3. it should open a brave wiki page

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


