### PR TITLE
Fixing recovery progress indicator showing before a recovery file has been loaded.

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -1135,6 +1135,7 @@ const fileRecoveryKeys = (state, recoveryKeyFile) => {
     return state
   }
 
+  state = aboutPreferencesState.setRecoveryInProgress(state, true)
   const result = loadKeysFromBackupFile(state, recoveryKeyFile)
   const recoveryKey = result.recoveryKey || ''
   state = result.state

--- a/app/browser/reducers/ledgerReducer.js
+++ b/app/browser/reducers/ledgerReducer.js
@@ -53,16 +53,14 @@ const ledgerReducer = (state, action, immutableAction) => {
       }
     case appConstants.APP_RECOVER_WALLET:
       {
-        state = aboutPreferencesState.setPreferencesProp(
-          state,
-          'recoveryInProgress',
-          true
-        )
-        state = ledgerApi.recoverKeys(
-          state,
-          action.get('useRecoveryKeyFile'),
-          action.get('recoveryKey')
-        )
+        const recoveryKey = action.get('recoveryKey')
+        const useRecoveryKeyFile = action.get('useRecoveryKeyFile')
+
+        if (!useRecoveryKeyFile) {
+          state = aboutPreferencesState.setRecoveryInProgress(state, true)
+        }
+
+        state = ledgerApi.recoverKeys(state, useRecoveryKeyFile, recoveryKey)
         break
       }
     case appConstants.APP_ON_FILE_RECOVERY_KEYS:

--- a/app/common/state/aboutPreferencesState.js
+++ b/app/common/state/aboutPreferencesState.js
@@ -45,10 +45,15 @@ const aboutPreferencesState = {
     return state.setIn(['about', 'preferences', key], value)
   },
 
+  setRecoveryInProgress: (state, inProgress) => {
+    state = validateState(state)
+    return aboutPreferencesState.setPreferencesProp(state, 'recoveryInProgress', inProgress)
+  },
+
   setRecoveryStatus: (state, status) => {
     state = validateState(state)
     const date = new Date().getTime()
-    state = aboutPreferencesState.setPreferencesProp(state, 'recoveryInProgress', false)
+    state = aboutPreferencesState.setRecoveryInProgress(state, false)
     state = aboutPreferencesState.setPreferencesProp(state, 'recoverySucceeded', status)
     return aboutPreferencesState.setPreferencesProp(state, 'updatedStamp', date)
   }

--- a/test/unit/app/common/state/aboutPreferencesStateTest.js
+++ b/test/unit/app/common/state/aboutPreferencesStateTest.js
@@ -65,15 +65,25 @@ describe('aboutPreferencesState unit test', function () {
   describe('setRecoveryStatus', function () {
     it('updates recoverySucceeded', function () {
       const result = aboutPreferencesState.setRecoveryStatus(defaultState, true)
-      assert.equal(result.getIn(['about', 'preferences', 'recoverySucceeded']), true)
+      assert.equal(aboutPreferencesState.getPreferencesProp(result, 'recoverySucceeded'), true)
     })
     it('recoveryInProgress is false when recovery is successful', function () {
       const result = aboutPreferencesState.setRecoveryStatus(defaultState, true)
-      assert.equal(result.getIn(['about', 'preferences', 'recoveryInProgress']), false)
+      assert.equal(aboutPreferencesState.getPreferencesProp(result, 'recoveryInProgress'), false)
     })
     it('recoveryInProgress is false when recovery is not successful', function () {
       const result = aboutPreferencesState.setRecoveryStatus(defaultState, false)
-      assert.equal(result.getIn(['about', 'preferences', 'recoveryInProgress']), false)
+      assert.equal(aboutPreferencesState.getPreferencesProp(result, 'recoveryInProgress'), false)
+    })
+  })
+
+  describe('setRecoveryInProgress', function () {
+    it('updates recoveryInProgress', function () {
+      const result = aboutPreferencesState.setRecoveryInProgress(defaultState, true)
+      assert.equal(aboutPreferencesState.getPreferencesProp(result, 'recoveryInProgress'), true)
+
+      const nextResult = aboutPreferencesState.setRecoveryInProgress(defaultState, false)
+      assert.equal(aboutPreferencesState.getPreferencesProp(nextResult, 'recoveryInProgress'), false)
     })
   })
 })


### PR DESCRIPTION
Fixes: #14014 

The in progress overlay now waits for:
A recovery file to have been loaded
A recovery to then start off of the loaded file

This PR also includes some refactoring by way of adding `setRecoveryInProgress` to `aboutPreferencesState`. Tests have been updated to reflect both the refactoring and the fix.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
  1. Enable payments
  2. Go to advance settings, recover your wallet
  3. Click import recovery keys, confirm recovery progress message does not show.
  4. Exit Brave. Corrupt your wallet by removing seeds 20 and 21 from `ledger-state.json`
  5. Restart brave, recover your wallet by clicking `import recovery key` but then hit cancel as opposed to choosing a file.
  6. Confirm recovery progress message does not show
  7. Load in an actual recovery file.
  8. Confirm recovery progress messages shows for the duration of the recovery
  9. [Regression testing via pasting in a recovery key]

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


