### PR TITLE
Add support for deploying to Ubuntu 18 LTS compatible repositories

### DIFF
--- a/tools/upload_to_aptly
+++ b/tools/upload_to_aptly
@@ -7,7 +7,7 @@ GPG_KEY=${2:-4A1B4360}
 KEY_NAME=keys.asc
 KEY_FILE=/tmp/${KEY_NAME}
 SNAP_TAG=`date +'%s'`
-DIST='artful zesty yakkety xenial jessie trusty serena stretch'
+DIST='artful zesty yakkety xenial jessie trusty serena stretch bionic'
 
 cat <<EOF > $HOME/.aptly.conf
 { "rootDir": "$HOME/.aptly",


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/13861

Auditors: @evq, @bbondy

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Have a channel ready for build (ex: beta)
2. Connect to our signator box and unlock the GPG key
3. Login to Jenkins and run the `browser-laptop-release-linux` job
  - if we wanted to test before accepting this PR, we can modify that job to checkout from this branch
4. After it finishes, have an Ubuntu 18 LTS VM ready
5. [Follow instructions here](https://github.com/brave/browser-laptop/blob/master/docs/linuxInstall.md)
6. Brave should install

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


