### PR TITLE
Implemented fix to show publisher toggle for PDFs

### DIFF
--- a/app/common/lib/publisherUtil.js
+++ b/app/common/lib/publisherUtil.js
@@ -8,17 +8,17 @@ const settings = require('../../../js/constants/settings')
 // Utils
 const ledgerUtil = require('./ledgerUtil')
 const {getSetting} = require('../../../js/settings')
-const {isHttpOrHttps} = require('../../../js/lib/urlutil')
+const {isHttpOrHttps, getUrlFromPDFUrl} = require('../../../js/lib/urlutil')
 const {isSourceAboutUrl} = require('../../../js/lib/appUrlUtil')
 
-const publisherState = {
+const publisherUtil = {
   shouldShowAddPublisherButton: (state, location, publisherKey) => {
     return location &&
       !isSourceAboutUrl(location) &&
       getSetting(settings.PAYMENTS_ENABLED) &&
-      isHttpOrHttps(location) &&
+      isHttpOrHttps(getUrlFromPDFUrl(location)) &&
       !ledgerUtil.blockedP(state, publisherKey)
   }
 }
 
-module.exports = publisherState
+module.exports = publisherUtil

--- a/app/renderer/components/navigation/publisherToggle.js
+++ b/app/renderer/components/navigation/publisherToggle.js
@@ -18,7 +18,7 @@ const tabState = require('../../../common/state/tabState')
 const ledgerState = require('../../../common/state/ledgerState')
 
 // Utils
-const {getHostPattern} = require('../../../../js/lib/urlutil')
+const {getHostPattern, getUrlFromPDFUrl} = require('../../../../js/lib/urlutil')
 const {getBaseUrl} = require('../../../../js/lib/appUrlUtil')
 const frameStateUtil = require('../../../../js/state/frameStateUtil')
 const ledgerUtil = require('../../../common/lib/ledgerUtil')
@@ -107,7 +107,7 @@ class PublisherToggle extends React.Component {
     const currentWindow = state.get('currentWindow')
     const activeFrame = frameStateUtil.getActiveFrame(currentWindow) || Immutable.Map()
     const tabId = activeFrame.get('tabId', tabState.TAB_ID_NONE)
-    const location = activeFrame.get('location', '')
+    const location = getUrlFromPDFUrl(activeFrame.get('location', ''))
     const locationId = getBaseUrl(location)
     const publisherKey = ledgerState.getVerifiedPublisherLocation(state, locationId)
 


### PR DESCRIPTION
Fixes #14025 

Payment button is still not being enabled after time requirements satisified.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

1. Clear profile, start browser, and enable payments.
2. Visit orimi.com/pdf-test.pdf and verify that publisher toggle button renders.
3. Wait the minimum amount of time and verify that publisher toggle becomes enabled.
4. Verify that the publisher toggle includes and excludes from the ledger table appropriately. 


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


