### PR TITLE
Hide bookmark bar when removing last item

### DIFF
--- a/app/browser/reducers/bookmarkFoldersReducer.js
+++ b/app/browser/reducers/bookmarkFoldersReducer.js
@@ -11,11 +11,16 @@ const bookmarkFoldersState = require('../../common/state/bookmarkFoldersState')
 // Constants
 const appConstants = require('../../../js/constants/appConstants')
 const {STATE_SITES} = require('../../../js/constants/stateConstants')
+const settings = require('../../../js/constants/settings')
+
+// Actions
+const appActions = require('../../../js/actions/appActions')
 
 // Utils
 const {makeImmutable} = require('../../common/state/immutableUtil')
 const syncUtil = require('../../../js/state/syncUtil')
 const bookmarkFolderUtil = require('../../common/lib/bookmarkFoldersUtil')
+const {getSetting} = require('../../../js/settings')
 
 const bookmarkFoldersReducer = (state, action, immutableAction) => {
   action = immutableAction || makeImmutable(action)
@@ -82,6 +87,12 @@ const bookmarkFoldersReducer = (state, action, immutableAction) => {
 
         const destinationDetail = bookmarksState.findBookmark(state, action.get('destinationKey'))
         state = syncUtil.updateObjectCache(state, destinationDetail, STATE_SITES.BOOKMARK_FOLDERS)
+
+        // close bookmark bar when going to 0
+        const bookmarkBarItemCount = bookmarksState.getBookmarksWithFolders(state, 0).size
+        if (bookmarkBarItemCount === 0 && getSetting(settings.SHOW_BOOKMARKS_TOOLBAR, state.get('settings'))) {
+          appActions.changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, false)
+        }
         break
       }
     case appConstants.APP_REMOVE_BOOKMARK_FOLDER:
@@ -102,6 +113,12 @@ const bookmarkFoldersReducer = (state, action, immutableAction) => {
           const folder = bookmarkFoldersState.getFolder(state, folderKey)
           state = bookmarkFoldersState.removeFolder(state, folderKey)
           state = syncUtil.updateObjectCache(state, folder, STATE_SITES.BOOKMARK_FOLDERS)
+        }
+
+        // close bookmark bar when going to 0
+        const bookmarkBarItemCount = bookmarksState.getBookmarksWithFolders(state, 0).size
+        if (bookmarkBarItemCount === 0 && getSetting(settings.SHOW_BOOKMARKS_TOOLBAR, state.get('settings'))) {
+          appActions.changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, false)
         }
         break
       }

--- a/app/browser/reducers/bookmarkFoldersReducer.js
+++ b/app/browser/reducers/bookmarkFoldersReducer.js
@@ -11,16 +11,12 @@ const bookmarkFoldersState = require('../../common/state/bookmarkFoldersState')
 // Constants
 const appConstants = require('../../../js/constants/appConstants')
 const {STATE_SITES} = require('../../../js/constants/stateConstants')
-const settings = require('../../../js/constants/settings')
-
-// Actions
-const appActions = require('../../../js/actions/appActions')
 
 // Utils
 const {makeImmutable} = require('../../common/state/immutableUtil')
 const syncUtil = require('../../../js/state/syncUtil')
+const bookmarkUtil = require('../../common/lib/bookmarkUtil')
 const bookmarkFolderUtil = require('../../common/lib/bookmarkFoldersUtil')
-const {getSetting} = require('../../../js/settings')
 
 const bookmarkFoldersReducer = (state, action, immutableAction) => {
   action = immutableAction || makeImmutable(action)
@@ -87,12 +83,7 @@ const bookmarkFoldersReducer = (state, action, immutableAction) => {
 
         const destinationDetail = bookmarksState.findBookmark(state, action.get('destinationKey'))
         state = syncUtil.updateObjectCache(state, destinationDetail, STATE_SITES.BOOKMARK_FOLDERS)
-
-        // close bookmark bar when going to 0
-        const bookmarkBarItemCount = bookmarksState.getBookmarksWithFolders(state, 0).size
-        if (bookmarkBarItemCount === 0 && getSetting(settings.SHOW_BOOKMARKS_TOOLBAR, state.get('settings'))) {
-          appActions.changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, false)
-        }
+        bookmarkUtil.closeToolbarIfEmpty(state)
         break
       }
     case appConstants.APP_REMOVE_BOOKMARK_FOLDER:
@@ -114,12 +105,7 @@ const bookmarkFoldersReducer = (state, action, immutableAction) => {
           state = bookmarkFoldersState.removeFolder(state, folderKey)
           state = syncUtil.updateObjectCache(state, folder, STATE_SITES.BOOKMARK_FOLDERS)
         }
-
-        // close bookmark bar when going to 0
-        const bookmarkBarItemCount = bookmarksState.getBookmarksWithFolders(state, 0).size
-        if (bookmarkBarItemCount === 0 && getSetting(settings.SHOW_BOOKMARKS_TOOLBAR, state.get('settings'))) {
-          appActions.changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, false)
-        }
+        bookmarkUtil.closeToolbarIfEmpty(state)
         break
       }
   }

--- a/app/browser/reducers/bookmarksReducer.js
+++ b/app/browser/reducers/bookmarksReducer.js
@@ -10,17 +10,12 @@ const bookmarksState = require('../../common/state/bookmarksState')
 // Constants
 const appConstants = require('../../../js/constants/appConstants')
 const {STATE_SITES} = require('../../../js/constants/stateConstants')
-const settings = require('../../../js/constants/settings')
-
-// Actions
-const appActions = require('../../../js/actions/appActions')
 
 // Utils
 const {makeImmutable} = require('../../common/state/immutableUtil')
 const syncUtil = require('../../../js/state/syncUtil')
 const bookmarkUtil = require('../../common/lib/bookmarkUtil')
 const bookmarkLocationCache = require('../../common/cache/bookmarkLocationCache')
-const {getSetting} = require('../../../js/settings')
 
 const bookmarksReducer = (state, action, immutableAction) => {
   action = immutableAction || makeImmutable(action)
@@ -94,12 +89,7 @@ const bookmarksReducer = (state, action, immutableAction) => {
 
         const destinationDetail = bookmarksState.findBookmark(state, action.get('destinationKey'))
         state = syncUtil.updateObjectCache(state, destinationDetail, STATE_SITES.BOOKMARKS)
-
-        // close bookmark bar when going to 0
-        const bookmarkBarItemCount = bookmarksState.getBookmarksWithFolders(state, 0).size
-        if (bookmarkBarItemCount === 0 && getSetting(settings.SHOW_BOOKMARKS_TOOLBAR, state.get('settings'))) {
-          appActions.changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, false)
-        }
+        bookmarkUtil.closeToolbarIfEmpty(state)
         break
       }
     case appConstants.APP_REMOVE_BOOKMARK:
@@ -117,11 +107,7 @@ const bookmarksReducer = (state, action, immutableAction) => {
           state = bookmarksState.removeBookmark(state, bookmarkKey)
         }
         state = bookmarkUtil.updateActiveTabBookmarked(state)
-        // close bookmark bar when going to 0
-        const bookmarkBarItemCount = bookmarksState.getBookmarksWithFolders(state, 0).size
-        if (bookmarkBarItemCount === 0 && getSetting(settings.SHOW_BOOKMARKS_TOOLBAR, state.get('settings'))) {
-          appActions.changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, false)
-        }
+        bookmarkUtil.closeToolbarIfEmpty(state)
         break
       }
   }

--- a/app/browser/reducers/bookmarksReducer.js
+++ b/app/browser/reducers/bookmarksReducer.js
@@ -10,12 +10,17 @@ const bookmarksState = require('../../common/state/bookmarksState')
 // Constants
 const appConstants = require('../../../js/constants/appConstants')
 const {STATE_SITES} = require('../../../js/constants/stateConstants')
+const settings = require('../../../js/constants/settings')
+
+// Actions
+const appActions = require('../../../js/actions/appActions')
 
 // Utils
 const {makeImmutable} = require('../../common/state/immutableUtil')
 const syncUtil = require('../../../js/state/syncUtil')
 const bookmarkUtil = require('../../common/lib/bookmarkUtil')
 const bookmarkLocationCache = require('../../common/cache/bookmarkLocationCache')
+const {getSetting} = require('../../../js/settings')
 
 const bookmarksReducer = (state, action, immutableAction) => {
   action = immutableAction || makeImmutable(action)
@@ -89,6 +94,12 @@ const bookmarksReducer = (state, action, immutableAction) => {
 
         const destinationDetail = bookmarksState.findBookmark(state, action.get('destinationKey'))
         state = syncUtil.updateObjectCache(state, destinationDetail, STATE_SITES.BOOKMARKS)
+
+        // close bookmark bar when going to 0
+        const bookmarkBarItemCount = bookmarksState.getBookmarksWithFolders(state, 0).size
+        if (bookmarkBarItemCount === 0 && getSetting(settings.SHOW_BOOKMARKS_TOOLBAR, state.get('settings'))) {
+          appActions.changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, false)
+        }
         break
       }
     case appConstants.APP_REMOVE_BOOKMARK:
@@ -106,6 +117,11 @@ const bookmarksReducer = (state, action, immutableAction) => {
           state = bookmarksState.removeBookmark(state, bookmarkKey)
         }
         state = bookmarkUtil.updateActiveTabBookmarked(state)
+        // close bookmark bar when going to 0
+        const bookmarkBarItemCount = bookmarksState.getBookmarksWithFolders(state, 0).size
+        if (bookmarkBarItemCount === 0 && getSetting(settings.SHOW_BOOKMARKS_TOOLBAR, state.get('settings'))) {
+          appActions.changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, false)
+        }
         break
       }
   }

--- a/app/common/lib/bookmarkUtil.js
+++ b/app/common/lib/bookmarkUtil.js
@@ -22,6 +22,9 @@ const {getSetting} = require('../../../js/settings')
 const UrlUtil = require('../../../js/lib/urlutil')
 const {makeImmutable} = require('../state/immutableUtil')
 
+// Actions
+const appActions = require('../../../js/actions/appActions')
+
 const bookmarkHangerHeading = (editMode, isAdded) => {
   if (isAdded) {
     return 'bookmarkAdded'
@@ -206,6 +209,13 @@ const buildEditBookmark = (oldBookmark, bookmarkDetail) => {
   return newBookmark.set('key', newKey)
 }
 
+const closeToolbarIfEmpty = (state) => {
+  const bookmarkBarItemCount = bookmarksState.getBookmarksWithFolders(state, 0).size
+  if (bookmarkBarItemCount === 0 && getSetting(settings.SHOW_BOOKMARKS_TOOLBAR, state.get('settings'))) {
+    appActions.changeSetting(settings.SHOW_BOOKMARKS_TOOLBAR, false)
+  }
+}
+
 module.exports = {
   bookmarkHangerHeading,
   isBookmarkNameValid,
@@ -220,5 +230,6 @@ module.exports = {
   getKey,
   getBookmarksToolbarMode,
   buildBookmark,
-  buildEditBookmark
+  buildEditBookmark,
+  closeToolbarIfEmpty
 }

--- a/js/settings.js
+++ b/js/settings.js
@@ -61,7 +61,7 @@ const getDefaultSetting = (settingKey, settingsCollection) => {
 }
 
 const resolveValue = (settingKey, settingsCollection) => {
-  if (settingsCollection && settingsCollection.constructor === Immutable.Map &&
+  if (settingsCollection && Immutable.Map.isMap(settingsCollection) &&
     settingsCollection.get(settingKey) !== undefined) {
     return settingsCollection.get(settingKey)
   }

--- a/test/unit/app/browser/reducers/bookmarkFoldersReducerTest.js
+++ b/test/unit/app/browser/reducers/bookmarkFoldersReducerTest.js
@@ -13,6 +13,7 @@ const fakeAdBlock = require('../../../lib/fakeAdBlock')
 const appConstants = require('../../../../../js/constants/appConstants')
 const siteTags = require('../../../../../js/constants/siteTags')
 const {STATE_SITES} = require('../../../../../js/constants/stateConstants')
+const bookmarkUtil = require('../../../../../app/common/lib/bookmarkUtil')
 require('../../../braveUnit')
 
 describe('bookmarkFoldersReducer unit test', function () {
@@ -126,6 +127,7 @@ describe('bookmarkFoldersReducer unit test', function () {
     })
     mockery.registerMock('electron', fakeElectron)
     mockery.registerMock('ad-block', fakeAdBlock)
+    mockery.registerMock('../../common/lib/bookmarkUtil', bookmarkUtil)
     bookmarkFoldersReducer = require('../../../../../app/browser/reducers/bookmarkFoldersReducer')
     bookmarkFoldersState = require('../../../../../app/common/state/bookmarkFoldersState')
   })
@@ -406,6 +408,15 @@ describe('bookmarkFoldersReducer unit test', function () {
         .deleteIn([STATE_SITES.BOOKMARK_FOLDERS, '81'])
       assert.equal(spy.calledTwice, true)
       assert.deepEqual(newState.toJS(), expectedState.toJS())
+    })
+
+    it('calls bookmarkUtil.closeToolbarIfEmpty', function () {
+      spy = sinon.spy(bookmarkUtil, 'closeToolbarIfEmpty')
+      bookmarkFoldersReducer(stateWithData, {
+        actionType: appConstants.APP_REMOVE_BOOKMARK_FOLDER,
+        folderKey: '1'
+      })
+      assert.equal(spy.calledOnce, true)
     })
   })
 })

--- a/test/unit/app/browser/reducers/bookmarksReducerTest.js
+++ b/test/unit/app/browser/reducers/bookmarksReducerTest.js
@@ -12,8 +12,8 @@ const fakeAdBlock = require('../../../lib/fakeAdBlock')
 
 const appConstants = require('../../../../../js/constants/appConstants')
 const appActions = require('../../../../../js/actions/appActions')
-const settingsConstants = require('../../../../../js/constants/settings')
 const siteTags = require('../../../../../js/constants/siteTags')
+const bookmarkUtil = require('../../../../../app/common/lib/bookmarkUtil')
 require('../../../braveUnit')
 
 describe('bookmarksReducer unit test', function () {
@@ -33,8 +33,7 @@ describe('bookmarksReducer unit test', function () {
       bookmarkLocation: {}
     },
     historySites: {},
-    tabs: [],
-    settings: {}
+    tabs: []
   })
 
   const stateWithData = Immutable.fromJS({
@@ -136,10 +135,7 @@ describe('bookmarksReducer unit test', function () {
       }
     },
     historySites: {},
-    tabs: [],
-    settings: {
-      [settingsConstants.SHOW_BOOKMARKS_TOOLBAR]: true
-    }
+    tabs: []
   })
 
   before(function () {
@@ -151,6 +147,7 @@ describe('bookmarksReducer unit test', function () {
     mockery.registerMock('electron', fakeElectron)
     mockery.registerMock('ad-block', fakeAdBlock)
     mockery.registerMock('../../../js/actions/appActions', appActions)
+    mockery.registerMock('../../common/lib/bookmarkUtil', bookmarkUtil)
     bookmarksReducer = require('../../../../../app/browser/reducers/bookmarksReducer')
     bookmarksState = require('../../../../../app/common/state/bookmarksState')
     bookmarkLocationCache = require('../../../../../app/common/cache/bookmarkLocationCache')
@@ -522,28 +519,45 @@ describe('bookmarksReducer unit test', function () {
   })
 
   describe('APP_REMOVE_BOOKMARK', function () {
-    let spy
-    let onChangeSettingSpy
+    let removeBookmarkSpy
+    let updateActiveTabBookmarkedSpy
+    let closeToolbarIfEmptySpy
 
     beforeEach(function () {
-      spy = sinon.spy(bookmarksState, 'removeBookmark')
-      onChangeSettingSpy = sinon.spy(appActions, 'changeSetting')
+      removeBookmarkSpy = sinon.spy(bookmarksState, 'removeBookmark')
+      updateActiveTabBookmarkedSpy = sinon.spy(bookmarkUtil, 'updateActiveTabBookmarked')
+      closeToolbarIfEmptySpy = sinon.spy(bookmarkUtil, 'closeToolbarIfEmpty')
     })
 
     afterEach(function () {
-      spy.restore()
-      onChangeSettingSpy.restore()
+      removeBookmarkSpy.restore()
+      updateActiveTabBookmarkedSpy.restore()
+      closeToolbarIfEmptySpy.restore()
     })
 
-    it('null case', function () {
-      const newState = bookmarksReducer(state, {
-        actionType: appConstants.APP_REMOVE_BOOKMARK
+    describe('when bookmarkKey is null', function () {
+      it('does not call removeBookmark', function () {
+        const newState = bookmarksReducer(state, {
+          actionType: appConstants.APP_REMOVE_BOOKMARK
+        })
+        assert.equal(removeBookmarkSpy.notCalled, true)
+        assert.deepEqual(state, newState)
       })
-      assert.equal(spy.notCalled, true)
-      assert.deepEqual(state, newState)
     })
 
-    it('check if delete is working', function () {
+    describe('when bookmarkKey is a list', function () {
+      // TODO: test that removeBookmark is called multiple times
+    })
+
+    it('calls bookmarksState.removeBookmark', function () {
+      bookmarksReducer(stateWithData, {
+        actionType: appConstants.APP_REMOVE_BOOKMARK,
+        bookmarkKey: 'https://clifton.io/|0|0'
+      })
+      assert.equal(removeBookmarkSpy.calledOnce, true)
+    })
+
+    it('deletes the entry from bookmarks and cache', function () {
       const newState = bookmarksReducer(stateWithData, {
         actionType: appConstants.APP_REMOVE_BOOKMARK,
         bookmarkKey: 'https://clifton.io/|0|0'
@@ -558,21 +572,23 @@ describe('bookmarksReducer unit test', function () {
         ]))
         .deleteIn(['bookmarks', 'https://clifton.io/|0|0'])
         .deleteIn(['cache', 'bookmarkLocation', 'https://clifton.io/'])
-      assert.equal(spy.calledOnce, true)
       assert.deepEqual(newState.toJS(), expectedState.toJS())
-      console.log('settings', newState.get('settings').toJS(), newState.getIn(['settings', settingsConstants.SHOW_BOOKMARKS_TOOLBAR]))
-      assert.ok(onChangeSettingSpy.neverCalledWith(settingsConstants.SHOW_BOOKMARKS_TOOLBAR, false), 'bookmarks toolbar enabled setting is unaffected by removing 1 bookmark')
     })
 
-    it('hides bookmarks toolbar when all toolbar bookmarks are removed', function () {
-      let newState = stateWithData
-      for (const bookmarkKey of stateWithData.get('bookmarks').keys()) {
-        newState = bookmarksReducer(newState, {
-          actionType: appConstants.APP_REMOVE_BOOKMARK,
-          bookmarkKey
-        })
-      }
-      assert.ok(onChangeSettingSpy.calledWith(settingsConstants.SHOW_BOOKMARKS_TOOLBAR, false))
+    it('calls bookmarkUtil.updateActiveTabBookmarked', function () {
+      bookmarksReducer(stateWithData, {
+        actionType: appConstants.APP_REMOVE_BOOKMARK,
+        bookmarkKey: 'https://clifton.io/|0|0'
+      })
+      assert.equal(updateActiveTabBookmarkedSpy.calledOnce, true)
+    })
+
+    it('calls bookmarkUtil.closeToolbarIfEmpty', function () {
+      bookmarksReducer(stateWithData, {
+        actionType: appConstants.APP_REMOVE_BOOKMARK,
+        bookmarkKey: 'https://clifton.io/|0|0'
+      })
+      assert.equal(closeToolbarIfEmptySpy.calledOnce, true)
     })
   })
 })


### PR DESCRIPTION
Fix #14047
The bookmark bar has always remained 'visible' when removing the last item. It just happened to be reduced to a few pixels tall. This was a defect as it affected the vertical rhythm of the UI. With #13758, the toolbar always remains the set height. With this change, the toolbar is hidden automatically when the last item is removed, just like it already automatically shows when the first item is added.

Also fixes `getSetting` so check for whether an object is `Immutable.Map` correctly, so that it can be used in tests.

## Test Plan:
### Automated
- `npm run unittest -- --grep 'bookmarksReducer'`

### Manual
- Add several bookmark items, including folders
- Remove some items
  - observe the toolbar is still shown
- Move some items
  - observe the toolbar is still shown
- Delete all items
  - observe the toolbar is not shown anymore
- Recreate items, and use 'move' to put all items in a folder that is not on the bookmark bar
  - observe the toolbar is not shown anymore

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


