### PR TITLE
Ensure type-safety with tab audio muting

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -877,11 +877,17 @@ const api = {
   setAudioMuted: (action) => {
     action = makeImmutable(action)
     const muted = action.get('muted')
+    // We're crossing into type-safe muon code so make sure args
+    // are of correct type
+    if (typeof muted !== 'boolean') {
+      return
+    }
     const tabId = action.get('tabId')
     const tab = webContentsCache.getWebContents(tabId)
-    if (tab && !tab.isDestroyed()) {
-      tab.setAudioMuted(muted)
+    if (!tab || tab.isDestroyed()) {
+      return
     }
+    tab.setAudioMuted(muted)
   },
 
   clone: (action) => {

--- a/app/renderer/reducers/contextMenuReducer.js
+++ b/app/renderer/reducers/contextMenuReducer.js
@@ -55,14 +55,20 @@ const validateState = function (state) {
   return state
 }
 
-function generateMuteFrameList (framePropsList, muted) {
-  return framePropsList.map((frameProp) => {
-    return {
-      frameKey: frameProp.get('key'),
-      tabId: frameProp.get('tabId'),
-      muted: muted && frameProp.get('audioPlaybackActive') && !frameProp.get('audioMuted')
+function generateMuteFrameActions (framePropsList, mute) {
+  return framePropsList.filter(frame => {
+    if (mute) {
+      // only frames which are playing audio and haven't been asked to be muted
+      return frame.get('audioPlaybackActive') && !frame.get('audioMuted')
     }
+    // only frames which are not playing audio or have been asked to be muted
+    return frame.get('audioMuted')
   })
+  .map(frame => ({
+    tabId: frame.get('tabId'),
+    frameKey: frame.get('key'),
+    muted: mute
+  }))
 }
 
 const onTabPageMenu = function (state, action) {
@@ -85,12 +91,12 @@ const onTabPageMenu = function (state, action) {
   const template = [{
     label: locale.translation('unmuteTabs'),
     click: () => {
-      windowActions.muteAllAudio(generateMuteFrameList(tabPageFrames, false))
+      windowActions.muteAllAudio(generateMuteFrameActions(tabPageFrames, false))
     }
   }, {
     label: locale.translation('muteTabs'),
     click: () => {
-      windowActions.muteAllAudio(generateMuteFrameList(tabPageFrames, true))
+      windowActions.muteAllAudio(generateMuteFrameActions(tabPageFrames, true))
     }
   }, {
     label: locale.translation('closeTabPage'),

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -508,20 +508,21 @@ function tabTemplateInit (frameProps) {
   //   }
   // })
 
-  const frameToSkip = frameProps.get('key')
-  const frameList = frames.map((frame) => {
-    return {
-      frameKey: frame.get('key'),
-      tabId: frame.get('tabId'),
-      muted: frame.get('key') !== frameToSkip && frame.get('audioPlaybackActive')
-    }
-  })
-
   template.push(CommonMenu.separatorMenuItem,
     {
       label: locale.translation('muteOtherTabs'),
       click: () => {
-        windowActions.muteAllAudio(frameList)
+        // only select frames which are not the current frame and are not muted
+        const otherFrames = frames.filter(frame =>
+          frame.get('key') !== frameProps.get('key') &&
+          frame.get('audioPlaybackActive') === true
+        )
+        const actionCommands = otherFrames.map(frame => ({
+          tabId: frame.get('tabId'),
+          frameKey: frame.get('key'),
+          muted: true
+        }))
+        windowActions.muteAllAudio(actionCommands)
       }
     })
 


### PR DESCRIPTION
Fix #14058

Muon will error if receiving a value that is not of the expected type, including `undefined`.
Optimize which frames are sent from window to browser for muting.

## Test plan:

Directly affected by code changes:
- Tab's context-menu: mute all tabs
- Tab Page Indicator context menu: mute all tabs
- Tab Page Indicator context menu: unmute all tabs

Regression tests:
- Tab audio indicator: mute
- Tab audio indicator: unmute

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


