### PR TITLE
Fixing server error overlay falling short [WIP]

### DIFF
--- a/app/renderer/components/preferences/payment/enabledContent.js
+++ b/app/renderer/components/preferences/payment/enabledContent.js
@@ -562,7 +562,7 @@ const styles = StyleSheet.create({
     top: 0,
     left: 0,
     width: '100%',
-    minHeight: '159px',
+    minHeight: '188px',
     background: '#f3f3f3',
     borderRadius: '8px',
     padding: '27px 50px 17px',


### PR DESCRIPTION
Related to: #14062 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

Current fix:

Before:
![39782942-90013408-52e1-11e8-8f38-44d0891d452b](https://user-images.githubusercontent.com/8732757/39785288-7279cbc2-52d0-11e8-8038-9258963b3c7a.png)

After:
<img width="899" alt="screen shot 2018-05-08 at 2 59 28 pm" src="https://user-images.githubusercontent.com/8732757/39785309-87447c6e-52d0-11e8-8438-d07707892dc6.png">

This PR is marked as a work in progress while we decide whether or not to show the `Show only included sites` switch control