### PR TITLE
Fixed recovery overlay showing invalid amount before completion

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -1162,6 +1162,7 @@ const recoverKeys = (state, useRecoveryKeyFile, key) => {
     return state
   }
 
+  state = aboutPreferencesState.setRecoveryBalanceRecalculated(state, false)
   client.recoverWallet(null, recoveryKey, (err, result) => {
     appActions.onWalletRecovery(err, result)
     appActions.onPromotionRemoval()
@@ -1919,7 +1920,9 @@ const onWalletProperties = (state, body) => {
   }
 
   state = module.exports.generatePaymentData(state)
-
+  if (state.getIn(['about', 'preferences']) != null && aboutPreferencesState.getRecoveryBalanceRecalulated(state) === false) {
+    state = aboutPreferencesState.setRecoveryBalanceRecalculated(state, true)
+  }
   return state
 }
 

--- a/app/common/state/aboutPreferencesState.js
+++ b/app/common/state/aboutPreferencesState.js
@@ -50,6 +50,16 @@ const aboutPreferencesState = {
     return aboutPreferencesState.setPreferencesProp(state, 'recoveryInProgress', inProgress)
   },
 
+  setRecoveryBalanceRecalculated: (state, hasRecalculated) => {
+    state = validateState(state)
+    return aboutPreferencesState.setPreferencesProp(state, 'recoveryBalanceRecalculated', hasRecalculated)
+  },
+
+  getRecoveryBalanceRecalulated: (state) => {
+    state = validateState(state)
+    return aboutPreferencesState.getPreferencesProp(state, 'recoveryBalanceRecalculated') || false
+  },
+
   setRecoveryStatus: (state, status) => {
     state = validateState(state)
     const date = new Date().getTime()

--- a/app/extensions/brave/locales/en-US/preferences.properties
+++ b/app/extensions/brave/locales/en-US/preferences.properties
@@ -272,6 +272,7 @@ publisher=Site
 publisherMediaName={{publisherName}} on {{provider}}
 publishers=Publishers
 rank=Rank
+recalculatingBalance=Calculating balance...
 receiptLink=Receipt Link
 recover=Recover
 recoverFromFile=Import recovery key

--- a/app/renderer/components/preferences/payment/ledgerRecovery.js
+++ b/app/renderer/components/preferences/payment/ledgerRecovery.js
@@ -65,11 +65,29 @@ class LedgerRecoveryContent extends ImmutableComponent {
     const recoverySucceeded = this.props.ledgerData.get('recoverySucceeded')
     const recoveryError = this.props.ledgerData.getIn(['error', 'error'])
     const recoveryInProgress = this.props.ledgerData.get('recoveryInProgress')
+    const recoveryBalanceRecalculated = this.props.ledgerData.get('recoveryBalanceRecalculated') || false
     const isNetworkError = typeof recoveryError === 'object'
 
     return <section>
       {
-        recoverySucceeded === true
+        recoverySucceeded === true && recoveryBalanceRecalculated === false
+          ? <section className={css(styles.recoveryOverlay)} onKeyDown={(e) => this.onEscape(e, true)} ref='ledgerRecoveryOverlay' tabIndex='0'>
+            <h1 className={css(styles.recoveryOverlay__textColor)} data-l10n-id='ledgerRecoverySucceeded' />
+            <p className={css(styles.recoveryOverlay__textColor, styles.recoveryOverlay__spaceAround)}
+              data-l10n-id='recalculatingBalance'
+              data-test-id='recalculatingBalance'
+              data-l10n-args={JSON.stringify({balance: batToCurrencyString(this.props.ledgerData.get('balance'), this.props.ledgerData)})}
+            />
+            <BrowserButton secondaryColor
+              l10nId='ok'
+              testId='recoveryOverlayOkButton'
+              onClick={this.onRecoveryOverlay.bind(this, true)}
+            />
+          </section>
+          : null
+      }
+      {
+        recoverySucceeded === true && recoveryBalanceRecalculated === true
           ? <section className={css(styles.recoveryOverlay)} onKeyDown={(e) => this.onEscape(e, true)} ref='ledgerRecoveryOverlay' tabIndex='0'>
             <h1 className={css(styles.recoveryOverlay__textColor)} data-l10n-id='ledgerRecoverySucceeded' />
             <p className={css(styles.recoveryOverlay__textColor, styles.recoveryOverlay__spaceAround)}

--- a/docs/state.md
+++ b/docs/state.md
@@ -39,6 +39,7 @@ AppStore
       backupNotifyCount: number, // number of times user has been reminded to backup wallet
       backupNotifyTimestamp: number, // number of milliseconds from the last reminder until the next
       backupSucceeded: (boolean|undefined), // was last backup successful?
+      recoveryBalanceRecalculated: (boolean|undefined),
       recoverySucceeded: (boolean|undefined),
       updatedStamp: number
     }

--- a/test/unit/app/browser/api/ledgerTest.js
+++ b/test/unit/app/browser/api/ledgerTest.js
@@ -2374,6 +2374,35 @@ describe('ledger api unit tests', function () {
     })
   })
 
+  describe('recoverKeys', function () {
+    it('sets recoveryBalanceRecalculated to false when a recovery is started', function () {
+      ledgerApi.setClient(ledgerClientObject)
+      const state = ledgerApi.recoverKeys(defaultAppState
+        .setIn(['about'], Immutable.fromJS({
+          preferences: {}
+        })), false, 'fakeKey')
+      assert.equal(aboutPreferencesState.getPreferencesProp(state, 'recoveryBalanceRecalculated'), false)
+    })
+
+    it('set recoveryBalanceRecalculated to true when balance has been retrieved', function () {
+      const state = ledgerApi.onWalletProperties(defaultAppState
+        .setIn(['about'], Immutable.fromJS({
+          preferences: {
+            recoveryBalanceRecalculated: true
+          }
+        })))
+      assert.equal(aboutPreferencesState.getPreferencesProp(state, 'recoveryBalanceRecalculated'), true)
+    })
+
+    it('skips over setting recoveryBalanceRecalculated if it hasnt been set', function () {
+      const state = ledgerApi.onWalletProperties(defaultAppState
+        .setIn(['about'], Immutable.fromJS({
+          preferences: {}
+        })))
+      assert.equal(aboutPreferencesState.getPreferencesProp(state, 'recoveryBalanceRecalculated'), null)
+    })
+  })
+
   describe('checkReferralActivity', function () {
     let checkForUpdateSpy, roundtripSpy, fakeClock
 

--- a/test/unit/app/common/state/aboutPreferencesStateTest.js
+++ b/test/unit/app/common/state/aboutPreferencesStateTest.js
@@ -62,6 +62,43 @@ describe('aboutPreferencesState unit test', function () {
     })
   })
 
+  describe('setRecoveryBalanceRecalculated', function () {
+    it('null case', function () {
+      const state = aboutPreferencesState.setRecoveryBalanceRecalculated(defaultState, null)
+      assert.equal(aboutPreferencesState.getPreferencesProp(state, 'recoveryBalanceRecalculated'), null)
+    })
+
+    it('sets true', function () {
+      const state = aboutPreferencesState.setRecoveryBalanceRecalculated(defaultState, true)
+      assert.equal(aboutPreferencesState.getPreferencesProp(state, 'recoveryBalanceRecalculated'), true)
+    })
+
+    it('sets false', function () {
+      const state = aboutPreferencesState.setRecoveryBalanceRecalculated(defaultState, false)
+      assert.equal(aboutPreferencesState.getPreferencesProp(state, 'recoveryBalanceRecalculated'), false)
+    })
+  })
+
+  describe('getRecoveryBalanceRecalculated', function () {
+    it('null case returns false', function () {
+      const state = aboutPreferencesState.setRecoveryBalanceRecalculated(defaultState, null)
+      const result = aboutPreferencesState.getRecoveryBalanceRecalulated(state)
+      assert.equal(result, false)
+    })
+
+    it('returns false', function () {
+      const state = aboutPreferencesState.setRecoveryBalanceRecalculated(defaultState, false)
+      const result = aboutPreferencesState.getRecoveryBalanceRecalulated(state)
+      assert.equal(result, false)
+    })
+
+    it('returns true', function () {
+      const state = aboutPreferencesState.setRecoveryBalanceRecalculated(defaultState, true)
+      const result = aboutPreferencesState.getRecoveryBalanceRecalulated(state)
+      assert.equal(result, true)
+    })
+  })
+
   describe('setRecoveryStatus', function () {
     it('updates recoverySucceeded', function () {
       const result = aboutPreferencesState.setRecoveryStatus(defaultState, true)


### PR DESCRIPTION
Fixes #11790 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

1. Run Brave -> preferences -> payments -> advanced settings
2. Use a recovery file with funds attached to it to recover wallet.
3. If recovery is delayed, overlay will display 'Calculating balance...' where the recovery amount would display

@bradleyrichter for 'Calculating balance...' text

NOTE: Newly made recovery keys may not show the delay that would have shown the incorrect balance. ping @jasonrsadler for keys that can be used to demonstrate.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


