### PR TITLE
fix: Ensure that only "What do these policies mean" is clickable and the entire row

### DIFF
--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -432,7 +432,7 @@ class SecurityTab extends ImmutableComponent {
               .map((policy) => <option data-l10n-id={policy} value={webrtcConstants[policy]} />)
           }
         </SettingDropdown>
-        <div
+        <label
           className={css(styles.link)}
           data-l10n-id='webrtcPolicyExplanation'
           onClick={aboutActions.createTabRequested.bind(null, {


### PR DESCRIPTION
Fixes: #14059

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

![x1](https://user-images.githubusercontent.com/5358146/39949923-a10c6b52-559b-11e8-9b7c-9ae0f2bbc024.gif)

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

@jonathansampson decided to open up a PR post the gitcoin call ^_^
