### PR TITLE
When no frame index is provided for a new tab, insert at the end of the frame list

### DIFF
--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -118,11 +118,10 @@ const newFrame = (state, frameOpts) => {
     console.debug('newFrame', frameOpts)
   }
   // Ensure valid index
-  let insertionIndex = frameOpts.index != null
-    ? frameOpts.index
-    : 0
+  let insertionIndex = frameOpts.index
   const highestFrameIndex = (state.get('frames') || Immutable.List()).count()
-  if (insertionIndex === -1 || insertionIndex > highestFrameIndex) {
+  const insertionIndexIsInvalid = (insertionIndex == null || insertionIndex < 0 || insertionIndex > highestFrameIndex)
+  if (insertionIndexIsInvalid) {
     if (shouldLogDebug) {
       console.debug(`newFrame: invalid insertionIndex of ${insertionIndex} so using max index of ${highestFrameIndex}`)
     }


### PR DESCRIPTION
Fix #14101
Whilst we do not display a tab until it has received tab-inserted-at and therefore has an index, we do switch the active Tab Page to the index of the new tab (if it is active), which would be the index of the tab page at tab index 0.

A better fix would be to not add the frame to the window state until tab-inserted-at has been received and we have the actual index, but that is a larger (high-risk) change that I'll contribute separately . This could also help performance, especially if batched.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
On #14101

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


