### PR TITLE
Fixing File and Open Location options when there are no rendered windows

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -7,7 +7,6 @@
 const Immutable = require('immutable')
 const electron = require('electron')
 const Menu = electron.Menu
-const dialog = electron.dialog
 const app = electron.app
 const BrowserWindow = electron.BrowserWindow
 
@@ -29,7 +28,6 @@ const appActions = require('../../js/actions/appActions')
 // Util
 const CommonMenu = require('../common/commonMenu')
 const {makeImmutable} = require('../common/state/immutableUtil')
-const {fileUrl} = require('../../js/lib/appUrlUtil')
 const frameStateUtil = require('../../js/state/frameStateUtil')
 const menuUtil = require('../common/lib/menuUtil')
 const {getSetting} = require('../../js/settings')
@@ -40,7 +38,7 @@ const isDarwin = platformUtil.isDarwin()
 const isLinux = platformUtil.isLinux()
 const isWindows = platformUtil.isWindows()
 const {templateUrls} = require('./share')
-const {getAllRendererWindows} = require('./windows')
+const windows = require('./windows')
 
 let appMenu = null
 let closedFrames = new Immutable.OrderedMap()
@@ -59,23 +57,21 @@ const createFileSubmenu = () => {
       label: locale.translation('openFile'),
       accelerator: 'CmdOrCtrl+O',
       click: (item, focusedWindow) => {
-        dialog.showDialog(focusedWindow, {
-          type: 'select-open-multi-file'
-        }, (paths) => {
-          if (paths) {
-            paths.forEach((path) => {
-              appActions.createTabRequested({
-                url: fileUrl(path),
-                windowId: focusedWindow.id
-              })
-            })
-          }
-        })
+        if (focusedWindow) {
+          CommonMenu.openFileDialog(focusedWindow)
+        } else {
+          focusedWindow = windows.getWindowForFileAction(appStore.getState())
+          focusedWindow.webContents.on('did-finish-load', () => {
+            focusedWindow.show()
+            CommonMenu.openFileDialog(focusedWindow)
+          })
+        }
       }
     }, {
       label: locale.translation('openLocation'),
       accelerator: 'CmdOrCtrl+L',
       click: function (item, focusedWindow) {
+        focusedWindow = focusedWindow || windows.getWindowForFileAction(appStore.getState(), true)
         CommonMenu.sendToFocusedWindow(focusedWindow, [messages.SHORTCUT_FOCUS_URL])
       }
     },
@@ -646,7 +642,7 @@ const doAction = (state, action) => {
     case appConstants.APP_WINDOW_CLOSED:
     case appConstants.APP_WINDOW_CREATED:
       {
-        const windowCount = getAllRendererWindows().length
+        const windowCount = windows.getAllRendererWindows().length
         if (action.actionType === appConstants.APP_WINDOW_CLOSED && windowCount === 0) {
           updateShareMenuItems(state, false)
         } else if (action.actionType === appConstants.APP_WINDOW_CREATED && windowCount === 1) {

--- a/app/browser/windows.js
+++ b/app/browser/windows.js
@@ -873,6 +873,44 @@ const api = {
       )
   },
 
+  /**
+   * Determine the frame(s) to be loaded in a new window
+   * based on user preferences
+   */
+  getFramesForNewWindow: () => {
+    const startupSetting = getSetting(settings.STARTUP_MODE)
+    const homepageSetting = getSetting(settings.HOMEPAGE)
+    if (startupSetting === 'homePage' && homepageSetting) {
+      return homepageSetting
+        .split('|')
+        .map((homepage) => ({
+          location: homepage
+        }))
+    }
+    return [ { } ]
+  },
+
+  windowDefaults: (state) => {
+    return {
+      width: state.getIn(['defaultWindowParams', 'width']) || state.get('defaultWindowWidth'),
+      height: state.getIn(['defaultWindowParams', 'height']) || state.get('defaultWindowHeight'),
+      x: state.getIn(['defaultWindowParams', 'x']) || undefined,
+      y: state.getIn(['defaultWindowParams', 'y']) || undefined,
+      minWidth: 480,
+      minHeight: 300,
+      minModalHeight: 100,
+      minModalWidth: 100,
+      windowOffset: 20
+    }
+  },
+
+  getWindowForFileAction: (state, show = false) => {
+    const frames = api.getFramesForNewWindow()
+    const defaults = api.windowDefaults(state)
+    const options = Object.assign({ fullscreen: false, show: show }, defaults)
+    return api.createWindow(options, null, false, frames)
+  },
+
   notifyWindowWebContentsAdded (windowId, frame, tabValue) {
     const win = api.getWindow(windowId)
     if (!win || win.isDestroyed()) {

--- a/app/common/commonMenu.js
+++ b/app/common/commonMenu.js
@@ -13,7 +13,9 @@ const getSetting = require('../../js/settings').getSetting
 const communityURL = 'https://community.brave.com/'
 const isDarwin = process.platform === 'darwin'
 const electron = require('electron')
+const dialog = electron.dialog
 const menuUtil = require('./lib/menuUtil')
+const {fileUrl} = require('../../js/lib/appUrlUtil')
 
 const ensureAtLeastOneWindow = (frameOpts) => {
   // Handle no new tab requested, but need a window
@@ -29,6 +31,19 @@ const ensureAtLeastOneWindow = (frameOpts) => {
   // then it will create the tab in the active window
   // or a new window if there is no active window.
   appActions.createTabRequested(frameOpts, false, false, true)
+}
+
+module.exports.openFileDialog = (focusedWindow) => {
+  dialog.showDialog(focusedWindow, { type: 'select-open-multi-file' }, (paths) => {
+    if (paths) {
+      paths.forEach((path) => {
+        appActions.createTabRequested({
+          url: fileUrl(path),
+          windowId: focusedWindow.id
+        })
+      })
+    }
+  })
 }
 
 /**

--- a/test/unit/app/browser/reducers/windowsReducerTest.js
+++ b/test/unit/app/browser/reducers/windowsReducerTest.js
@@ -22,7 +22,21 @@ describe('windowsReducer unit test', function () {
   }
 
   const fakeWindowApi = {
-    createWindow: () => {}
+    createWindow: () => {},
+    getFramesForNewWindow: () => {},
+    windowDefaults: (state) => {
+      return {
+        width: state.getIn(['defaultWindowParams', 'width']) || state.get('defaultWindowWidth'),
+        height: state.getIn(['defaultWindowParams', 'height']) || state.get('defaultWindowHeight'),
+        x: state.getIn(['defaultWindowParams', 'x']) || undefined,
+        y: state.getIn(['defaultWindowParams', 'y']) || undefined,
+        minWidth: 480,
+        minHeight: 300,
+        minModalHeight: 100,
+        minModalWidth: 100,
+        windowOffset: 20
+      }
+    }
   }
 
   const fakePlatformUtil = {

--- a/test/unit/app/browser/windowsTest.js
+++ b/test/unit/app/browser/windowsTest.js
@@ -289,5 +289,25 @@ describe('window API unit tests', function () {
         assert.propertyVal(maximizeSpy, 'callCount', 1)
       })
     })
+
+    describe('getWindowForFileAction', function () {
+      it('returns a window object', function () {
+        const newWindow = windows.getWindowForFileAction(defaultState)
+        assert.equal(browserWindowSpy.callCount, 1)
+        assert.equal('object', typeof newWindow)
+      })
+
+      it('sets fullscreen to false', function () {
+        windows.getWindowForFileAction(defaultState)
+        const windowOptions = browserWindowSpy.args[0][0]
+        assert.isFalse(windowOptions.fullscreen)
+      })
+
+      it('does not show window by default', function () {
+        windows.getWindowForFileAction(defaultState)
+        const windowOptions = browserWindowSpy.args[0][0]
+        assert.isFalse(windowOptions.show)
+      })
+    })
   })
 })


### PR DESCRIPTION
Fixes: #13927

This PR includes some refactoring: 
- Some valuable functions were nested in the `windowsReducer`. Exporting utility functions from a reducer usually isn't the best approach so they were move to the windows api inside `windows.js`
- The action to open the file dialog was moved to `commonMenu.js`

`windowDefaults` are used to construct the new window, let me know if this isn't the best. 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Start Brave
2. Close all windows, keep Brave in focus
3. Select `File > Open Location`
4. Ensure that a new window is opened with focus on the URL bar
5. Close the new window
6. Select `File > Open File`
7. Ensure that a new window is opened, then a file dialog is opened. Test that the dialog displays the chosen file in the new window as expected.
8. Ensure that regressions don't exist with either operation when windows already exist.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


