### PR TITLE
Fixes disabled torrent viewer torrent download

### DIFF
--- a/app/common/state/extensionState.js
+++ b/app/common/state/extensionState.js
@@ -2,9 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-const { makeImmutable } = require('./immutableUtil')
 const Immutable = require('immutable')
+
+// Constants
+const config = require('../../../js/constants/config')
+const settings = require('../../../js/constants/settings')
+
+// Utils
+const { makeImmutable } = require('./immutableUtil')
 const platformUtil = require('../lib/platformUtil')
+const getSetting = require('../../../js/settings').getSetting
 const {chromeUrl} = require('../../../js/lib/appUrlUtil')
 
 const browserActionDefaults = Immutable.fromJS({
@@ -205,6 +212,18 @@ const extensionState = {
       })
     })
     return allProperties
+  },
+
+  isWebTorrentEnabled: (state) => {
+    if (state == null) {
+      return false
+    }
+
+    const settingsState = state.get('settings')
+    const extension = extensionState.getExtensionById(state, config.torrentExtensionId)
+    const extensionEnabled = extension != null ? extension.get('enabled') : false
+    const torrentEnabled = getSetting(settings.TORRENT_VIEWER_ENABLED, settingsState)
+    return extensionEnabled && torrentEnabled
   }
 }
 

--- a/app/filtering.js
+++ b/app/filtering.js
@@ -786,10 +786,7 @@ module.exports.isResourceEnabled = (resourceName, url, isPrivate) => {
   }
 
   if (resourceName === 'webtorrent') {
-    const extension = extensionState.getExtensionById(appState, config.torrentExtensionId)
-    const torrentEnabled = getSetting(settings.TORRENT_VIEWER_ENABLED, settingsState)
-    const extensionEnabled = extension !== undefined ? extension.get('enabled') : false
-    return extensionEnabled && torrentEnabled
+    return extensionState.isWebTorrentEnabled(appState)
   }
 
   if (resourceName === 'ledger') {

--- a/js/stores/appStore.js
+++ b/js/stores/appStore.js
@@ -271,7 +271,9 @@ const handleAppAction = (action) => {
       // TODO(bridiver) - these should be refactored into reducers
       appState = filtering.init(appState, action, appStore)
       appState = basicAuth.init(appState, action, appStore)
-      appState = webtorrent.init(appState, action, appStore)
+      if (extensionState.isWebTorrentEnabled(appState)) {
+        appState = webtorrent.init(appState, action, appStore)
+      }
       appState = profiles.init(appState, action, appStore)
       appState = require('../../app/sync').init(appState, action, appStore)
       calculateTopSites(true, true)

--- a/test/unit/app/common/state/extensionStateTest.js
+++ b/test/unit/app/common/state/extensionStateTest.js
@@ -1,5 +1,7 @@
 /* global describe, it, before */
 const extensionState = require('../../../../../app/common/state/extensionState')
+const config = require('../../../../../js/constants/config')
+const settings = require('../../../../../js/constants/settings')
 const Immutable = require('immutable')
 const assert = require('assert')
 
@@ -680,6 +682,50 @@ describe('extensionState', function () {
       })
 
       commonTests()
+    })
+  })
+
+  describe('isWebTorrentEnabled', function () {
+    const torrentId = config.torrentExtensionId
+
+    it('null case', function () {
+      const result = extensionState.isWebTorrentEnabled()
+      assert.equal(result, false)
+    })
+
+    it('empty state', function () {
+      const result = extensionState.isWebTorrentEnabled(defaultAppState)
+      assert.equal(result, false)
+    })
+
+    it('extension is disabled', function () {
+      const state = defaultAppState
+        .setIn(['extensions', torrentId], Immutable.fromJS({
+          enabled: false
+        }))
+        .setIn(['settings', settings.TORRENT_VIEWER_ENABLED], true)
+      const result = extensionState.isWebTorrentEnabled(state)
+      assert.equal(result, false)
+    })
+
+    it('torrent is disabled', function () {
+      const state = defaultAppState
+        .setIn(['extensions', torrentId], Immutable.fromJS({
+          enabled: true
+        }))
+        .setIn(['settings', settings.TORRENT_VIEWER_ENABLED], false)
+      const result = extensionState.isWebTorrentEnabled(state)
+      assert.equal(result, false)
+    })
+
+    it('everything is enabled', function () {
+      const state = defaultAppState
+        .setIn(['extensions', torrentId], Immutable.fromJS({
+          enabled: true
+        }))
+        .setIn(['settings', settings.TORRENT_VIEWER_ENABLED], true)
+      const result = extensionState.isWebTorrentEnabled(state)
+      assert.equal(result, true)
     })
   })
 })


### PR DESCRIPTION
Resolves #10767

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

1. disable Torrent Viewer in preferences
2. go to https://webtorrent.io/free-torrents/
3. download Big Buck Bunny torrent file
4. make sure that save dialog is opened

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


