### PR TITLE
Talk to the control socket using my old draft tor daemon manager.

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -748,6 +748,7 @@ function setupTor () {
     torDaemon.on('launch', (socksAddr) => {
       console.log(`tor: daemon listens on ${socksAddr}`)
       const bootstrapped = (err, progress) => {
+        // TODO(riastradh): Visually update a progress bar!
         if (err) {
           console.log(`tor: bootstrap error: ${err}`)
           return

--- a/app/filtering.js
+++ b/app/filtering.js
@@ -48,8 +48,6 @@ const headersReceivedFilteringFns = []
 let partitionsToInitialize = ['default', appConfig.tor.partition]
 let initializedPartitions = {}
 
-let torDaemon = new tor.TorDaemon()
-
 const transparent1pxGif = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
 const pdfjsOrigin = `chrome-extension://${config.PDFJSExtensionId}`
 
@@ -740,6 +738,7 @@ function setupTor () {
   // Set up the tor daemon watcher.  (NOTE: We don't actually start
   // the tor daemon here; that happens in C++ code.  But we do talk to
   // its control socket.)
+  const torDaemon = new tor.TorDaemon()
   torDaemon.setup((err) => {
     if (err) {
       console.log(`tor: failed to make directories: ${err}`)

--- a/app/filtering.js
+++ b/app/filtering.js
@@ -754,10 +754,22 @@ function setupTor () {
         }
         console.log(`tor: bootstrapped ${progress}%`)
       }
+      const circuitEstablished = (err, ok) => {
+        if (ok) {
+          console.log(`tor: ready`)
+        } else {
+          console.log(err ? `tor: not ready: ${err}` : `tor: not ready`)
+        }
+      }
       torDaemon.onBootstrap(bootstrapped, (err) => {
         if (err) {
           console.log(`tor: error subscribing to bootstrap: ${err}`)
         }
+        torDaemon.onCircuitEstablished(circuitEstablished, (err) => {
+          if (err) {
+            console.log(`tor: error subscribing to circuit ready: ${err}`)
+          }
+        })
       })
     })
     torDaemon.start()

--- a/app/tor.js
+++ b/app/tor.js
@@ -547,7 +547,8 @@ class TorDaemon extends EventEmitter {
    */
   _torStatus (event, keys, info, statusHandler, infoHandler, callback) {
     const control = this._control
-    const handleStatus = (data, extra) => {
+    // Subscribe to events.
+    const statusListener = (data, extra) => {
       const args = data.split(' ') // TODO(riastradh): better parsing
       if (args.length < 2) {
         console.log(`tor: warning: truncated ${event}`)
@@ -563,12 +564,10 @@ class TorDaemon extends EventEmitter {
       }
       statusHandler(err, data)
     }
-    // Subscribe to events.
-    const statusListener = (data, extra) => handleStatus(data)
     control.on(`async-${event}`, statusListener)
     control.subscribe(event, (err) => {
       if (err) {
-        control.removeListener(`async-$[event}`, statusListener)
+        control.removeListener(`async-${event}`, statusListener)
         return callback(err)
       }
       // Run `GETINFO ${info}' to kick us off, in case it's a long

--- a/app/tor.js
+++ b/app/tor.js
@@ -544,7 +544,7 @@ class TorDaemon extends EventEmitter {
    */
   onBootstrap (handler, callback) {
     const control = this._control
-    const onStatusClient = (event, extra) => {
+    const handleStatusClient = (event, extra) => {
       const args = event.split(' ') // TODO(riastradh): better parsing
       if (args[1] !== 'BOOTSTRAP') {
         // Not for us!
@@ -569,10 +569,11 @@ class TorDaemon extends EventEmitter {
       handler(err, null)
     }
     // Subscribe to STATUS_CLIENT events.
-    control.on('async-STATUS_CLIENT', (event, extra) => onStatusClient(event))
+    const statusClientListener = (event, extra) => handleStatusClient(event)
+    control.on('async-STATUS_CLIENT', statusClientListener)
     control.subscribe('STATUS_CLIENT', (err) => {
       if (err) {
-        control.removeListener('async-STATUS_CLIENT', onStatusClient)
+        control.removeListener('async-STATUS_CLIENT', statusClientListener)
         return callback(err)
       }
       // Run `GETINFO status/bootstrap-phase' to kick us off, in case
@@ -589,7 +590,7 @@ class TorDaemon extends EventEmitter {
           return handler(err, null)
         }
         const event = reply.slice(prefix.length)
-        return onStatusClient(event)
+        return handleStatusClient(event)
       }
       control.cmd(`GETINFO ${info}`, getinfoLine, (err, status, reply) => {
         if (!err) {

--- a/app/tor.js
+++ b/app/tor.js
@@ -949,7 +949,7 @@ class TorControl extends EventEmitter {
       return process.nextTick(() => callback(err))
     }
     if (!(event in this._tor_events)) {
-      return
+      return process.nextTick(() => callback(null))
     }
     if (this._tor_events[event]-- === 0) {
       delete this._tor_events[event]

--- a/app/tor.js
+++ b/app/tor.js
@@ -135,6 +135,7 @@ class TorDaemon extends EventEmitter {
       return
     }
     this._control.close()
+    this.emit('exit')
   }
 
   // _watchEvent(event, filename)

--- a/app/tor.js
+++ b/app/tor.js
@@ -422,7 +422,7 @@ class TorDaemon extends EventEmitter {
 
     // Create a socket and arrange provisional close/error listeners.
     const controlSocket = new net.Socket()
-    const closeMethod = () => console.log('tor: control socket closed')
+    const closeMethod = () => console.log('tor: control socket closed early')
     const errorMethod = (err) => {
       console.log(`tor: control socket error: ${err}`)
       controlSocket.destroy(err)

--- a/app/tor.js
+++ b/app/tor.js
@@ -131,10 +131,14 @@ class TorDaemon extends EventEmitter {
   kill () {
     if (!this._process) {
       assert(this._process === null)
+      assert(this._control === null)
       console.log("tor: not running, can't kill")
       return
     }
-    this._control.close()
+    if (this._control) {
+      this._control.close()
+      this._control = null
+    }
     this.emit('exit')
   }
 

--- a/app/tor.js
+++ b/app/tor.js
@@ -4,11 +4,15 @@
 
 'use strict'
 
-// Tor daemon management.
-//
-// This doesn't actually manage the tor daemon: the parts that did are
-// commented out.  Rather it just watches the tor daemon's control
-// port file for activity and connects to its control socket.
+/**
+ * Tor daemon management.
+ *
+ * This doesn't actually manage the tor daemon: the parts that did are
+ * commented out.  Rather it just watches the tor daemon's control
+ * port file for activity and connects to its control socket.
+ *
+ * @module tor
+ */
 
 const EventEmitter = require('events')
 const assert = require('assert')

--- a/app/tor.js
+++ b/app/tor.js
@@ -1,0 +1,1253 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+'use strict'
+
+// Tor daemon management.
+//
+// This doesn't actually manage the tor daemon: the parts that did are
+// commented out.  Rather it just watches the tor daemon's control
+// port file for activity and connects to its control socket.
+
+const EventEmitter = require('events')
+const assert = require('assert')
+const electron = require('electron')
+const fs = require('fs')
+const net = require('net')
+const path = require('path')
+const stream = require('stream')
+
+// torBravePath()
+//
+//      Return the path to the directory where we store tor-related
+//      files.
+//
+function torBravePath () {
+  const bravePath = electron.app.getPath('userData')
+  return path.join(bravePath, 'tor')
+}
+
+// torDataDirPath()
+//
+//      Return the path to the data directory that we use for our tor
+//      daemon.
+//
+function torDataDirPath () {
+  return path.join(torBravePath(), 'data')
+}
+
+// torWatchDirPath()
+//
+//      Return the path to the directory we watch for changes as tor
+//      starts up.
+//
+function torWatchDirPath () {
+  return path.join(torBravePath(), 'watch')
+}
+
+// torControlPortPath()
+//
+//      Return the path to the file containing the port number for the
+//      control channel that our tor daemon is listening on.
+//
+function torControlPortPath () {
+  return path.join(torWatchDirPath(), 'controlport')
+}
+
+// torControlCookiePath()
+//
+//      Return the path to the file containing the control connection
+//      authentication cookie.
+//
+function torControlCookiePath () {
+  return path.join(torDataDirPath(), 'control_auth_cookie')
+}
+
+// TorDaemon
+//
+//      State for a tor daemon subprocess.
+//
+class TorDaemon extends EventEmitter {
+  constructor () {
+    super()
+    this._process = null        // child process
+    this._watcher = null        // fs watcher
+    this._polling = false       // true if we are polling for start
+    this._retry_poll = null     // set if polling, true if should retry on fail
+    this._control = null        // TorControl instance
+    this._socks_addresses = null // array of tor's socks addresses
+  }
+
+  // setup(callback)
+  //
+  //    Create the necessary directories and invoke callback when
+  //    done.  We assume the parent of torBravePath exists; we create
+  //    it and everything we need underneath it.  On failure other
+  //    than EEXIST, may leave directories partially created.
+  //
+  setup (callback) {
+    const directories = [
+      torBravePath(),
+      torWatchDirPath()
+    ]
+    const loop = (i) => {
+      if (i === directories.length) {
+        return callback(null)
+      }
+      assert(i >= 0)
+      assert(i < directories.length)
+      fs.mkdir(directories[i], 0o700, (err) => {
+        if (err && err.code !== 'EEXIST') {
+          return callback(err)
+        }
+        loop(i + 1)
+      })
+    }
+    loop(0)
+  }
+
+  // start()
+  //
+  //    Start the tor daemon.  Caller must ensure that the necessary
+  //    directories have been created.
+  //
+  start () {
+    // Begin watching for the control port file to be written.
+    const watchDir = torWatchDirPath()
+    const watchOpts = {persistent: false}
+    this._watcher = fs.watch(watchDir, watchOpts, (event, filename) => {
+      this._watchEvent(event, filename)
+    })
+
+    this._process = 'i am the very seeming of a child process daemon'
+    this._poll()
+  }
+
+  // kill()
+  //
+  //    Kill the tor daemon.
+  //
+  kill () {
+    if (!this._process) {
+      assert(this._process === null)
+      console.log("tor: not running, can't kill")
+      return
+    }
+    this._control.close()
+  }
+
+  // _watchEvent(event, filename)
+  //
+  //    Called by fs.watch when the tor watch directory is changed.
+  //    If the control port file is newly written, then the control
+  //    socket should be available now.
+  //
+  //    Note: filename is documented to be unreliable, so we don't use
+  //    it.  Instead we just check whether the control port file is
+  //    written and matches.
+  //
+  _watchEvent (event, filename) {
+    assert(this._watcher)
+
+    // If the process died in the interim, give up.
+    if (!this._process) {
+      console.log('tor: process dead, ignoring watch event')
+      return
+    }
+
+    if (this._control) {
+      console.log('tor: ignoring watch event, control already open')
+      return
+    }
+    this._poll()
+  }
+
+  // _poll()
+  //
+  //    Poll for whether tor has started yet, or if there is a poll
+  //    already pending, tell it to retry in case it fails.
+  //
+  _poll () {
+    assert(this._process)
+    assert(this._control === null)
+
+    if (this._polling) {
+      console.log('tor: already polling, will retry if it fails')
+      this._retry_poll = true
+      return
+    } else {
+      assert(this._retry_poll === null)
+    }
+    this._polling = true
+    this._retry_poll = false
+    this._doPoll()
+  }
+
+  // _doPoll()
+  //
+  //    Actually poll for whether tor has started yet.
+  //
+  _doPoll () {
+    assert(this._process)
+    assert(this._control === null)
+    assert(this._polling)
+
+    this._readControlPort((err, portno) => {
+      if (err) {
+        // If there's an error, don't worry: the file may have been
+        // written incompletely, and we will, with any luck, be notified
+        // again when it has been written completely and renamed to its
+        // permanent location.
+        console.log(`tor: failed to read control port: ${err}`)
+        return this._polled()
+      }
+
+      // If the process died in the interim, give up.
+      if (!this._process) {
+        return this._polled()
+      }
+
+      // Assert we're in a sane state: we have a process, we have no
+      // control, and we're polling.
+      assert(this._process)
+      assert(this._control === null)
+      assert(this._polling)
+
+      this._readControlCookie((err, cookie) => {
+        if (err) {
+          console.log(`tor: failed to read control cookie: ${err}`)
+          return this._polled()
+        }
+
+        // If the process died in the interim, give up.
+        if (!this._process) {
+          return this._polled()
+        }
+
+        // Assert we're in a sane state: we have a process, we have no
+        // control, and we're polling.
+        assert(this._process)
+        assert(this._control === null)
+        assert(this._polling)
+
+        this._openControl(portno, cookie)
+      })
+    })
+  }
+
+  // _polled()
+  //
+  //    Called when done polling.  If no control socket but asked to
+  //    retry, arrange to poll again; otherwise, restore state.
+  //
+  _polled () {
+    assert(this._polling)
+    if (this._retry_polling && this._control === null) {
+      return process.nextTick(() => this._doPoll())
+    }
+    this._polling = false
+    this._retry_poll = null
+  }
+
+  // _readControlPort(callback)
+  //
+  //    Read the control port.
+  //
+  _readControlPort (callback) {
+    // First, open the control port file.
+    fs.open(torControlPortPath(), 'r', (err, fd) => {
+      if (err) {
+        return callback(err)
+      }
+
+      // Read up to 27 octets, the maximum we will ever need.
+      const readlen = 'PORT=255.255.255.255:65535\n'.length
+      const buf = Buffer.alloc(readlen)
+      fs.read(fd, buf, 0, readlen, null, (err, nread, buf) => {
+        let portno = null
+        do {                    // break for cleanup
+          if (err) {
+            break
+          }
+
+          // Make sure the line looks sensible.
+          const line = buf.slice(0, nread).toString('utf8')
+          if (!line.startsWith('PORT=') || !line.endsWith('\n')) {
+            err = new Error(`invalid control port file`)
+            break
+          }
+          if (!line.startsWith('PORT=127.0.0.1:')) {
+            err = new Error(`control port has non-local address`)
+            break
+          }
+
+          // Parse the port number.
+          const portstr = line.slice('PORT=127.0.0.1:'.length, line.length - 1)
+          const portno0 = parseInt(portstr, 10)
+          if (isNaN(portno) || portno === 0) {
+            err = new Error(`invalid control port number`)
+            break
+          }
+
+          // We'll take it!
+          assert(!err)
+          portno = portno0
+        } while (0)
+
+        // We're done with the control port file; close it.
+        fs.close(fd, (err) => {
+          if (err) {
+            console.log(`tor: close pidfile failed: ${err}`)
+          }
+        })
+
+        // And call back.
+        callback(err, portno)
+      })
+    })
+  }
+
+  // _readControlCookie(callback)
+  //
+  //    Read the control cookie.
+  //
+  _readControlCookie (callback) {
+    // First, open the control cookie file.
+    fs.open(torControlCookiePath(), 'r', (err, fd) => {
+      if (err) {
+        return callback(err, null)
+      }
+
+      // Read up to 33 octets.  We should need no more than 32, so 33
+      // will indicate the file is abnormally large.
+      const readlen = 33
+      const buf = Buffer.alloc(readlen)
+      fs.read(fd, buf, 0, readlen, null, (err, nread, buf) => {
+        let cookie = null
+        do {                    // break for cleanup
+          if (err) {
+            break
+          }
+
+          // Check for probable truncation.
+          if (nread === readlen) {
+            err = new Error('control cookie too long')
+            break
+          }
+
+          // We'll take it!
+          assert(!err)
+          cookie = buf.slice(0, nread)
+        } while (0)
+        callback(err, cookie)
+      })
+    })
+  }
+
+  // _openControl(portno, cookie)
+  //
+  //    Open a control socket, arrange to set up a TorControl to
+  //    manage it, and authenticate to it with a null authentication
+  //    cookie.
+  //
+  _openControl (portno, cookie) {
+    assert(this._process)
+    assert(this._control === null)
+
+    // Create a socket and arrange provisional close/error listeners.
+    const controlSocket = new net.Socket()
+    const closeMethod = () => console.log('tor: control socket closed')
+    const errorMethod = (err) => {
+      console.log(`tor: control socket error: ${err}`)
+      controlSocket.destroy(err)
+    }
+    controlSocket.on('close', closeMethod)
+    controlSocket.on('error', errorMethod)
+
+    // Now connect the socket.
+    controlSocket.connect({port: portno}, () => {
+      // If the process died in the interim, give up.
+      if (!this._process) {
+        console.log('tor: process died, closing control')
+        controlSocket.close((err) => {
+          if (err) {
+            console.log(`tor: close control socket failed: ${err}`)
+          }
+        })
+        return
+      }
+
+      // Assert we are in a sane state: we have a process, but we have
+      // no control yet.
+      assert(this._process)
+      assert(this._control === null)
+
+      // Remove our provisional listeners and hand ownership to
+      // TorControl.
+      controlSocket.removeListener('close', closeMethod)
+      controlSocket.removeListener('error', errorMethod)
+
+      const readable = controlSocket
+      const writable = controlSocket
+      this._control = new TorControl(readable, writable)
+      this._control.on('error', (err) => this._controlError(err))
+      this._control.on('end', (err) => this._controlClosed(err))
+      const hexCookie = cookie.toString('hex')
+      this._control.cmd1(`AUTHENTICATE ${hexCookie}`, (err, status, reply) => {
+        if (!err) {
+          if (status !== '250' || reply !== 'OK') {
+            err = new Error(`Tor error ${status}: ${reply}`)
+          }
+        }
+        if (err) {
+          console.log(`tor: authentication failure: ${err}`)
+          this.kill()
+          return
+        }
+        this._control.getSOCKSListeners((err, listeners) => {
+          if (err) {
+            console.log(`tor: failed to get socks addresses: ${err}`)
+            this.kill()
+            return
+          }
+          this._socks_addresses = listeners
+          this.emit('launch', this.getSOCKSAddress())
+        })
+      })
+    })
+  }
+
+  // _controlError(err)
+  //
+  //    Callback for any errors on the control socket.  If we get
+  //    anything, close it and kill the process.
+  //
+  //    TODO(riastradh): Also try to restart tor or anything?
+  //
+  _controlError (err) {
+    assert(this._control)
+    console.log(`tor: control socket error: ${err}`)
+    this.kill()
+  }
+
+  // _controlClosed()
+  //
+  //    Callback for when the control socket has been closed.  Just
+  //    clear it.
+  //
+  //    TODO(riastradh): Also try to restart tor or anything?
+  //
+  _controlClosed () {
+    assert(this._control)
+    // TODO(riastradh): Attempt to reopen it?
+    console.log('tor: control socket closed')
+    this._control = null
+  }
+
+  // getSOCKSAddress()
+  //
+  //    Returns the current SOCKS address: a string of the form
+  //    `<IPv4>:<portno>', `[<IPv6>]:<portno>', or `unix:<pathname>'.
+  //    If tor is not initialized yet, or is dead, this returns null
+  //    instead.
+  //
+  getSOCKSAddress () {
+    if (!this._socks_addresses) {
+      return null
+    }
+    return this._socks_addresses[0]
+  }
+
+  // getControl()
+  //
+  //    Returns the control socket.
+  //
+  getControl () {
+    return this._control
+  }
+}
+
+const TOR_ASYNC_EVENTS = {
+  ADDRMAP: 1,
+  AUTHDIR_NEWDESCS: 1,
+  BUILDTIMEOUT_SET: 1,
+  BW: 1,
+  CELL_STATS: 1,
+  CIRC: 1,
+  CIRC_BW: 1,
+  CIRC_MINOR: 1,
+  CLIENTS_SEEN: 1,
+  CONF_CHANGED: 1,
+  CONN_BW: 1,
+  DEBUG: 1,
+  DESCCHANGED: 1,
+  ERR: 1,
+  GUARD: 1,
+  HS_DESC: 1,
+  // HS_DESC_CONTENT: 1, // omitted because uses data replies
+  INFO: 1,
+  NETWORK_LIVENESS: 1,
+  // NEWCONSENSUS: 1    // omitted because uses data replies
+  NEWDESC: 1,
+  NOTICE: 1,
+  // NS: 1,             // omitted because uses data replies
+  ORCONN: 1,
+  SIGNAL: 1,
+  STATUS_CLIENT: 1,
+  STATUS_GENERAL: 1,
+  STATUS_SERVER: 1,
+  STREAM: 1,
+  STREAM_BW: 1,
+  TB_EMPTY: 1,
+  TRANSPORT_LAUNCHED: 1,
+  WARN: 1
+}
+
+// TorControl(readable, writable)
+//
+//      State for a tor control socket interface.
+//
+//      TODO(riastradh): register close event listeners on readable/writable?
+//
+class TorControl extends EventEmitter {
+  constructor (readable, writable) {
+    assert(readable instanceof stream.Readable)
+    assert(!readable.isPaused())
+
+    super()
+
+    this._readable = new LineReadable(readable, 4096)
+    this._readable_on_line = this._onLine.bind(this)
+    this._readable_on_end = this._onEnd.bind(this)
+    this._readable_on_error = this._onError.bind(this)
+    this._readable.on('line', this._readable_on_line)
+    this._readable.on('end', this._readable_on_end)
+    this._readable.on('error', this._readable_on_error)
+
+    this._writable = writable
+    this._writable_on_error = this._onError.bind(this)
+    this._writable.on('error', this._writable_on_error)
+
+    this._cmdq = []
+
+    this._async_keyword = null
+    this._async_initial = null
+    this._async_extra = null
+    this._async_skip = null
+
+    this._tor_events = {}
+  }
+
+  close () {
+    this._tidy()
+    const err = new Error('tor control connection closed')
+    while (this._cmdq.length > 0) {
+      const [, callback] = this._cmdq.shift()
+      callback(err, null, null)
+    }
+  }
+
+  _tidy () {
+    this._readable.removeListener('line', this._readable_on_line)
+    this._readable.removeListener('end', this._readable_on_end)
+    this._readable.removeListener('error', this._readable_on_error)
+    this._writable.removeListener('error', this._writable_on_error)
+  }
+
+  _onError (err) {
+    console.log(`tor control error: ${err}`)
+    this._tidy()
+    this.emit('error', err)
+    while (this._cmdq.length > 0) {
+      const [, callback] = this._cmdq.shift()
+      callback(err, null, null)
+    }
+  }
+
+  _onLine (linebuf, trunc) {
+    assert(linebuf instanceof Buffer)
+
+    // Check for line-too-long or line-too-short.
+    if (trunc) {
+      return this._error('truncated line from tor')
+    }
+    if (linebuf.length < 4) {
+      return this._error('malformed line from tor')
+    }
+
+    // Get the line as US-ASCII, and confirm it is only US-ASCII by
+    // confirming it survives a decoding/encoding round-trip.
+    const line = linebuf.toString('ascii')
+    if (!linebuf.equals(Buffer.from(line, 'ascii'))) {
+      return this._error('non-US-ASCII in line from tor')
+    }
+
+    // Parse out the line into status, position in reply stream, and
+    // content.
+    //
+    // TODO(riastradh): parse or check syntax of status
+    const status = line.slice(0, 3)
+    const position = line.slice(3, 4)
+    const reply = line.slice(4)
+
+    // If it's an asynchronous reply (status 6yz), pass it on
+    // asynchronously.
+    if (status[0] === '6') {
+      assert(this._async_keyword || this._async_keyword === null)
+      assert((this._async_keyword === null) === (this._async_extra === null))
+      assert((this._async_keyword === null) === (this._async_skip === null))
+
+      if (this._async_keyword === null && position === ' ') {
+        // Single-line async reply.
+        const sp = reply.indexOf(' ')
+        const keyword = (sp === -1 ? reply : reply.slice(0, sp))
+        const initial = (sp === -1 ? null : reply.slice(sp + 1))
+        if (!(keyword in TOR_ASYNC_EVENTS)) {
+          console.log(`ignoring unknown event: ${JSON.stringify(keyword)}`)
+          return
+        }
+        this.emit(`async-${keyword}`, initial, {})
+        return
+      } else if (this._async_keyword === null && position === '-') {
+        // Start a fresh async reply.
+        const sp = reply.indexOf(' ')
+        const keyword = (sp === -1 ? reply : reply.slice(0, sp))
+        const skip = !(keyword in TOR_ASYNC_EVENTS)
+        this._async_keyword = keyword
+        this._async_initial = (sp === -1 ? null : reply.slice(sp + 1))
+        this._async_extra = {}
+        this._async_skip = skip
+        return
+      } else if (this._async_keyword !== null && position === '-') {
+        // Contribute to an async reply, unless we're skipping it.
+        if (this._async_skip) {
+          return
+        }
+        const [key, value, end] = torControlParseKV(reply, 0, reply.length)
+        if (key === null || value === null || end !== reply.length) {
+          return this._error('invalid async reply line')
+        }
+        assert(key)
+        assert(value)
+        if (key in this._async_extra) {
+          return this._error('duplicate key in async reply')
+        }
+        this._async_extra[key] = value
+        return
+      } else if (this._async_keyword !== null && position === ' ') {
+        // Finish an async reply, unless we're skipping it.
+        if (!this._async_skip) {
+          const [key, value, end] = torControlParseKV(reply, 0, reply.length)
+          if (key === null || value === null || end !== reply.length) {
+            return this._error('invalid async reply line')
+          }
+          assert(key)
+          assert(value)
+          const keyword = this._async_keyword
+          const initial = this._async_initial
+          const extra = this._async_extra
+          if (key in extra) {
+            return this._error('duplicate key in async reply')
+          }
+          extra[key] = value
+          this.emit(`async-${keyword}`, initial, extra)
+        }
+        this._async_keyword = null
+        this._async_initial = null
+        this._async_extra = null
+        this._async_skip = null
+        return
+      } else {
+        return this._error('invalid async reply line')
+      }
+      // not reached
+    }
+
+    // Synchronous reply.  Return it to the next command callback in
+    // the queue.
+    switch (position) {
+      case '-':
+        this.emit('midReply', status, reply)
+        if (this._cmdq.length > 0) {
+          const [perline] = this._cmdq[0]
+          perline(status, reply)
+        }
+        return
+      case '+':
+        return this._error('NYI: data reply from tor')
+      case ' ':
+        this.emit('endReply', status, reply)
+        if (this._cmdq.length > 0) {
+          const [, callback] = this._cmdq.shift()
+          callback(null, status, reply)
+        }
+        return
+      default:
+        return this._error('unknown line type from tor')
+    }
+  }
+
+  _onEnd () {
+    if (this._cmdq.length > 0) {
+      this._error('Tor control connection closed')
+    } else {
+      this._tidy()
+    }
+    this.emit('end')
+  }
+
+  _error (msg) {
+    this._onError(new Error(msg))
+  }
+
+  cmd (cmdline, perline, callback) {
+    this._cmdq.push([perline, callback])
+    this._writable.cork()
+    this._writable.write(cmdline, 'ascii')
+    this._writable.write('\r\n')
+    process.nextTick(() => this._writable.uncork())
+  }
+
+  cmd1 (cmdline, callback) {
+    this.cmd(cmdline, (status, reply) => {}, callback)
+  }
+
+  newnym (callback) {
+    this.cmd1('SIGNAL NEWNYM', (err, status, reply) => {
+      if (err) {
+        return callback(err)
+      } else if (status !== '250') {
+        return callback(new Error(`Tor error ${status}: ${reply}`))
+      } else {
+        return callback(null)
+      }
+    })
+  }
+
+  subscribe (event, callback) {
+    if (!(event in TOR_ASYNC_EVENTS)) {
+      const err = new Error('invalid tor controller event')
+      return process.nextTick(() => callback(err))
+    }
+    if (event in this._tor_events) {
+      this._tor_events[event]++
+      return process.nextTick(() => callback(null))
+    }
+    this._tor_events[event] = 1
+    const eventList = Object.keys(this._tor_events).sort().join(' ')
+    this.cmd1(`SETEVENTS ${eventList}`, (err, status, reply) => {
+      if (!err) {
+        if (status !== '250') {
+          err = new Error(`tor: ${status} ${reply}`)
+        }
+      }
+      if (err) {
+        delete this._tor_events[event]
+        return callback(err)
+      }
+      return callback(null)
+    })
+  }
+
+  unsubscribe (event, callback) {
+    if (!(event in TOR_ASYNC_EVENTS)) {
+      const err = new Error('invalid tor controller event')
+      return process.nextTick(() => callback(err))
+    }
+    if (!(event in this._tor_events)) {
+      return
+    }
+    if (this._tor_events[event]-- === 0) {
+      delete this._tor_events[event]
+      const eventList = Object.keys(this._tor_events).sort().join(' ')
+      this.cmd1(`SETEVENTS ${eventList}`, (err, status, reply) => {
+        if (!err) {
+          if (status !== '250') {
+            err = new Error(`tor: ${status} ${reply}`)
+          }
+        }
+        if (err) {
+          return callback(err)
+        }
+        return callback(null)
+      })
+    }
+  }
+
+  _getListeners (purpose, callback) {
+    const keyword = `net/listeners/${purpose}`
+    let listeners = null
+    const perline = (status, reply) => {
+      if (status !== '250' || !reply.startsWith(`${keyword}=`) || listeners) {
+        console.log(`unexpected GETINFO ${keyword} reply`)
+        return
+      }
+      listeners = []
+      const string = reply.slice(`${keyword}=`.length)
+      for (let i = 0, j; i < string.length; i = j) {
+        let listener
+        [listener, j] = torControlParseQuoted(string, i, string.length)
+        if (listener === null) {
+          // Malformed garbage from Tor.  Give up.
+          listeners = null
+          return
+        }
+        listeners.push(listener)
+      }
+    }
+    this.cmd(`GETINFO ${keyword}`, perline, (err, status, reply) => {
+      if (err) {
+        return callback(err, null)
+      } else if (status !== '250' || reply !== 'OK') {
+        return callback(new Error(`Tor error ${status}: ${reply}`), null)
+      } else if (listeners === null) {
+        return callback(new Error('Malformed listeners from Tor'), null)
+      } else {
+        return callback(null, listeners)
+      }
+    })
+  }
+
+  getSOCKSListeners (callback) {
+    return this._getListeners('socks', callback)
+  }
+
+  getControlListeners (callback) {
+    return this._getListeners('control', callback)
+  }
+}
+
+// torrcEscapeBuffer(buf)
+//
+//      Escape a Buffer buf in torrc's format, and return a
+//      US-ASCII-only string of it.
+//
+//      - We must escape leading SPC and TAB because tor will
+//        interpret them as the separator between config name and
+//        value.
+//
+//      - We must escape the sequence `\' LF because tor will
+//        interpret that as a continuation line.
+//
+//      To keep it safe, we choose to escape _all_ nonprintable
+//      characters, SPC, `\', `#' (comment), and `"'.
+//
+function torrcEscapeBuffer (buf) {
+  assert(buf instanceof Buffer)
+
+  const setbit = (a, b) => { a[b >> 5] |= 1 << (b & 0x1f) }
+  const testbit = (a, b) => !!(a[b >> 5] & (1 << (b & 0x1f)))
+
+  // Bit map from octet to true if we must escape the octet.
+  const escapeBitmap = new Uint32Array(8)
+  for (let i = 0; i < 0x20; i++) { // control characters
+    setbit(escapeBitmap, i)
+  }
+  setbit(escapeBitmap, 0x20)           // SPC
+  setbit(escapeBitmap, 0x22)           // `"'
+  setbit(escapeBitmap, 0x23)           // `#'
+  setbit(escapeBitmap, 0x5c)           // `\'
+  for (let i = 0x7f; i < 0x100; i++) { // DEL and 8-bit
+    setbit(escapeBitmap, i)
+  }
+
+  // Table mapping octet to string notation for that octet, if it must
+  // be escaped.
+  const escapeString = {
+    0x20: ' ',
+    0x22: '\\"',
+    0x23: '#',
+    0x5c: '\\\\'
+  }
+
+  const hex = '0123456789abcdef'
+
+  // If it's empty, use double-quotes for clarity.
+  if (buf.length === 0) {
+    return '""'
+  }
+
+  // Find the first character needing escaping, or the end of the
+  // string.
+  let i
+  for (i = 0; i < buf.length; i++) {
+    if (testbit(escapeBitmap, buf[i])) {
+      break
+    }
+  }
+  let result = buf.toString('ascii', 0, i)
+  if (i === buf.length) {
+    // No need to quote or escape anything.
+    return result
+  }
+
+  do {
+    // Escape all the characters that need it.
+    do {
+      if (buf[i] in escapeString) {
+        result += escapeString[buf[i]]
+      } else {
+        let h0 = hex[buf[i] >> 4]
+        let h1 = hex[buf[i] & 0xf]
+        result += '\\x' + h0 + h1
+      }
+      i++
+    } while (i < buf.length && testbit(escapeBitmap, buf[i]))
+
+    // Break off as large a US-ASCII chunk as we can.
+    let start = i
+    for (; i < buf.length; i++) {
+      if (testbit(escapeBitmap, buf[i])) {
+        break
+      }
+    }
+    result += buf.toString('ascii', start, i)
+  } while (i < buf.length)
+
+  return '"' + result + '"'
+}
+
+// torrcEscapeString(str)
+//
+//      Escape the UTF-8 encoding of the string str in torrc's format,
+//      and return a US-ASCII-only string of it.
+//
+function torrcEscapeString (str) {
+  return torrcEscapeBuffer(Buffer.from(str, 'utf8'))
+}
+
+// torrcEscapeString(path)
+//
+//      Escape a path in torrc's format, encoded as UTF-8, and return
+//      a US-ASCII-only string of it.
+//
+//      Paths are represented by strings, so this is the same as
+//      torrcEscapeString, and we cannot handle (e.g.) Unix paths that
+//      do not consist of a UTF-8 octet sequence.
+//
+function torrcEscapePath (path) {
+  return torrcEscapeString(path)
+}
+
+// torControlParseQuoted(string, start, end)
+//
+//      Try to parse a quoted string, in the tor control connection's
+//      C-style notation, from the given string, in the slice [start,
+//      end).
+//
+//      => On success, return [body, i], where body is the body of the
+//         quoted string and i is the first index after the closing
+//         quotation mark.
+//
+//      => On failure, return [null, i], where i is the first index
+//         where something went wrong, possibly equal to end if the
+//         string lacked a closing quote mark.
+//
+function torControlParseQuoted (string, start, end) {
+  const buf = Buffer.alloc(string.length)
+  let pos = 0                   // position in buffer
+  let octal = null              // accumulated octet for octal notation
+  const S = {
+    REJECT: -2,
+    ACCEPT: -1,
+    START: 1,
+    BODY: 2,
+    BACKSLASH: 3,
+    OCTAL1: 4,
+    OCTAL2: 5
+  }
+  /* eslint-disable no-multi-spaces, indent */
+  const transition = (state, c, cp) => {
+    switch (state) {
+      case S.REJECT:    assert(false); return S.REJECT
+      case S.ACCEPT:    assert(false); return S.REJECT
+      case S.START:     return c === '"' ? S.BODY : S.REJECT
+      case S.BODY:
+        switch (c) {
+          case '\\':    return S.BACKSLASH
+          case '"':     return S.ACCEPT
+          default:      buf[pos++] = cp; return S.BODY
+        }
+      case S.BACKSLASH:
+        switch (c) {
+          case '0': case '1': case '2': case '3':
+          case '4': case '5': case '6': case '7':
+            assert(octal === null)
+            octal = (cp - '0'.codePointAt(0)) << 6
+            return S.OCTAL1
+          case 'n':     buf[pos++] = 0x0a;      return S.BODY
+          case 'r':     buf[pos++] = 0x0d;      return S.BODY
+          case 't':     buf[pos++] = 0x09;      return S.BODY
+          case '\\': case '"': case "'":
+                        buf[pos++] = cp;        return S.BODY
+          default:                              return S.REJECT
+        }
+      case S.OCTAL1:
+        assert(octal !== null)
+        switch (c) {
+          case '0': case '1': case '2': case '3':
+          case '4': case '5': case '6': case '7':
+            octal |= (cp - '0'.codePointAt(0)) << 3
+            return S.OCTAL2
+          default:
+            return S.REJECT
+        }
+      case S.OCTAL2:
+        assert(octal !== null)
+        switch (c) {
+          case '0': case '1': case '2': case '3':
+          case '4': case '5': case '6': case '7':
+            octal |= cp - '0'.codePointAt(0)
+            buf[pos++] = octal
+            octal = null
+            return S.BODY
+          default:
+            return S.REJECT
+        }
+      default:
+        return S.REJECT
+    }
+  }
+  /* eslint-enable no-multi-spaces, indent */
+  let state = S.START
+  for (let i = start; i < end; i++) {
+    assert(state)
+    const next = transition(state, string[i], string.codePointAt(i))
+    assert(next)
+    switch (next) {
+      case S.REJECT:
+        return [null, i]
+      case S.ACCEPT:
+        const result =
+          (pos === end - start ? buf : Buffer.from(buf.slice(0, pos)))
+        return [result, i + 1]
+      default:
+        break
+    }
+    state = next
+  }
+  return [null, end]
+}
+
+// torControlParseKV(string, start, end)
+//
+//      Try to parse the value of a keyword=value pair in the tor
+//      control connection's optionally-quoted notation.  Return a
+//      list [keyword, value, i], where the keyword is returned as a
+//      US-ASCII string, the value is returned as a buffer that
+//      may contain arbitrary octets, and i is the index of the first
+//      position not consumed by torControlParseKV, either end or one
+//      position past the space that terminated.
+//
+//      The string in [start, end) should contain no CR or LF.
+//
+function torControlParseKV (string, start, end) {
+  const eq = string.indexOf('=', start)
+  if (eq === -1 || end <= eq) {
+    return [null, null, end]
+  }
+  const keyword = string.slice(start, eq)
+  const vstart = eq + 1
+  if (vstart === end) {
+    return [keyword, Buffer.from(''), end]
+  }
+  if (string[vstart] !== '"') {
+    let vend = end
+    let i
+    if ((i = string.indexOf(' ', vstart)) !== -1 && i < end) {
+      // Stop at the delimiter, and consume it.
+      vend = i
+      end = i + 1
+    }
+    if ((i = string.indexOf('"', vstart)) !== -1 && i < vend) {
+      // Forbid internal quotes.
+      return [null, null, i]
+    }
+    const value = Buffer.from(string.slice(vstart, vend), 'ascii')
+    return [keyword, value, end]
+  }
+  const [value, j] = torControlParseQuoted(string, eq + 1, end)
+  if (value === null) {
+    return [null, null, j]
+  }
+  if (j < end) {
+    end = j
+    if (string[j] === ' ') {
+      end++
+    }
+  }
+  return [keyword, value, end]
+}
+
+// LineReadable(readable[, maxlen])
+//
+//      CRLF-based line reader.  Given an underlying stream.Readable
+//      object in unpaused mode, yield an event emitter with line,
+//      end, and error events.  Empty line at end of stream is not
+//      emitted.  Stray CR or LF is reported as error.  Error is
+//      unrecoverable.
+//
+class LineReadable extends EventEmitter {
+  constructor (readable, maxlen) {
+    assert(readable instanceof stream.Readable)
+    assert(!readable.isPaused())
+    super()
+    this._readable = readable
+    this._maxlen = maxlen
+    this._reset()
+    this._on_data_method = this._onData.bind(this)
+    this._on_end_method = this._onEnd.bind(this)
+    readable.on('data', this._on_data_method)
+    readable.on('end', this._on_end_method)
+  }
+
+  // LineReadable._reset()
+  //
+  //    Reset the state of the line-reading machine to the start of a
+  //    line.
+  //
+  _reset () {
+    this._chunks = []
+    this._readlen = 0
+    this._cr_seen = false
+  }
+
+  // LineReadable._tidy()
+  //
+  //    Unhook references to this line reader from the underlying
+  //    readable.
+  //
+  _tidy () {
+    // Should be nothing left.
+    assert(this._readlen === 0)
+    assert(this._chunks.length === 0)
+    assert(this._cr_seen === false)
+    this._readable.removeListener('data', this._on_data_method)
+    this._readable.removeListener('end', this._on_end_method)
+  }
+
+  // LineReadable._onData(chunk)
+  //
+  //    Event handler for receipt of data from the readable.
+  //    Processes octet by octet to find CRLFs, and emits line events
+  //    for each one, or errors if stray CR or LF are found in the
+  //    stream.
+  //
+  _onData (chunk) {
+    assert(this._maxlen === null || this._readlen <= this._maxlen)
+    assert(chunk instanceof Buffer)
+    let start = 0
+    let end = (this._cr_seen ? 0 : chunk.length)
+    for (let i = 0; i < chunk.length; i++) {
+      if (!this._cr_seen) {
+        // No CR yet.  Accept CR or non-LF; reject LF.
+        if (chunk[i] === 0x0d) {        // CR
+          this._cr_seen = true
+          end = i
+        } else if (chunk[i] === 0x0a) { // LF
+          return this._error(chunk, start, 'stray line feed')
+        } else {
+          // Anything else: if there's no more space, return what's
+          // left to the stream and stop here; otherwise consume it
+          // and move on.
+          if (this._maxlen !== null &&
+              i - start === this._maxlen - this._readlen) {
+            assert(start < i)
+            this._chunks.push(chunk.slice(start, i))
+            this._readlen += i - start
+            assert(this._readlen === this._maxlen)
+            this._line(true)
+            start = i
+            end = chunk.length
+          }
+        }
+      } else {
+        // CR seen.  Accept LF; reject all else.
+        if (chunk[i] === 0x0a) {         // LF
+          // CRLF seen.  Concatenate what we have, minus CRLF.
+          assert(start < end)
+          this._chunks.push(chunk.slice(start, end))
+          this._readlen += end - start
+          this._line(false)
+          start = i + 1
+          end = chunk.length
+        } else {
+          // CR seen, but not LF.  Bad.
+          return this._error(chunk, start, 'stray carriage return')
+        }
+      }
+    }
+    // No CRLF in the chunk.  Store up to CR from chunk and go on.
+    assert(start <= end)
+    assert(this._maxlen === null || this._readlen <= this._maxlen)
+    assert(this._maxlen === null || end - start <= this._maxlen - this._readlen)
+    if (start < end) {
+      this._chunks.push(chunk.slice(start, end))
+      this._readlen += end - start
+    }
+    assert(this._maxlen === null || this._readlen <= this._maxlen)
+  }
+
+  // LineReadable._onEnd()
+  //
+  //    Event handler for end of underlying readable stream.  Reports
+  //    a final line if we have any data, tidies up after ourselves,
+  //    and emits an end event.
+  //
+  _onEnd () {
+    // If there's anything stored, report it.
+    if (this._readlen !== 0) {
+      this._line(false)
+    }
+    // Tidy up after ourselves.
+    this._tidy()
+    // Emit the event.
+    this.emit('end')
+  }
+
+  // LineReadable._line(trunc)
+  //
+  //    Report a line event, possibly truncated, with the chunks of
+  //    data so far accumulated.  Reset the state to the beginning of
+  //    a line.
+  //
+  _line (trunc) {
+    // Compute the line.
+    const line = Buffer.concat(this._chunks, this._readlen)
+    // Reset the state.
+    this._reset()
+    // Emit the event.
+    this.emit('line', line, trunc)
+  }
+
+  // LineReadable._error(chunk, start, msg)
+  //
+  //    Report an error event with the specified message.  Return any
+  //    data -- chunk[start], chunk[start+1], ..., chunk[n-1] -- to
+  //    the stream.  Reset and tidy up, since we're presumed wedged.
+  //
+  _error (chunk, start, msg) {
+    // Add what's left of the current chunk.
+    assert(start < chunk.length)
+    this._chunks.push(chunk.slice(start))
+    this._readlen += chunk.length - start
+    // Restore the chunks we've consumed to the stream.
+    this._readable.unshift(Buffer.concat(this._chunks, this._readlen))
+    // Reset the state.  No need to hang onto garbage we won't use.
+    this._reset()
+    // Tidy up after ourselves: we are wedged and uninterested in
+    // further events.
+    this._tidy()
+    // Emit the event.
+    this.emit('error', new Error(msg))
+  }
+}
+
+module.exports.TorControl = TorControl
+module.exports.TorDaemon = TorDaemon
+module.exports.torControlParseKV = torControlParseKV
+module.exports.torControlParseQuoted = torControlParseQuoted
+module.exports.torrcEscapeBuffer = torrcEscapeBuffer
+module.exports.torrcEscapePath = torrcEscapePath
+module.exports.torrcEscapeString = torrcEscapeString

--- a/app/tor.js
+++ b/app/tor.js
@@ -592,6 +592,7 @@ class TorDaemon extends EventEmitter {
           }
         }
         if (err) {
+          // TODO(riastradh): Unsubscribe and remove listener or not?
           return callback(err)
         }
         // Success!

--- a/app/tor.js
+++ b/app/tor.js
@@ -298,13 +298,13 @@ class TorDaemon extends EventEmitter {
     // First, open the control port file.
     fs.open(torControlPortPath(), 'r', (err, fd) => {
       if (err) {
-        return callback(err)
+        return callback(err, null, null)
       }
 
       // Get the mtime.
       fs.fstat(fd, (err, stat) => {
         if (err) {
-          return callback(err)
+          return callback(err, null, null)
         }
 
         // Read up to 27 octets, the maximum we will ever need.
@@ -364,13 +364,13 @@ class TorDaemon extends EventEmitter {
     // First, open the control cookie file.
     fs.open(torControlCookiePath(), 'r', (err, fd) => {
       if (err) {
-        return callback(err, null)
+        return callback(err, null, null)
       }
 
       // Get the mtime.
       fs.fstat(fd, (err, stat) => {
         if (err) {
-          return callback(err, null)
+          return callback(err, null, null)
         }
 
         // Read up to 33 octets.  We should need no more than 32, so 33

--- a/app/tor.js
+++ b/app/tor.js
@@ -153,7 +153,6 @@ class TorDaemon extends EventEmitter {
     if (!this._process) {
       assert(this._process === null)
       assert(this._control === null)
-      console.log("tor: not running, can't kill")
       return
     }
     if (this._control) {
@@ -184,10 +183,11 @@ class TorDaemon extends EventEmitter {
       return
     }
 
+    // If the control connection is already open, nothing to do.
     if (this._control) {
-      console.log('tor: ignoring watch event, control already open')
       return
     }
+
     this._poll()
   }
 
@@ -201,7 +201,6 @@ class TorDaemon extends EventEmitter {
     assert(this._control === null)
 
     if (this._polling) {
-      console.log('tor: already polling, will retry if it fails')
       this._retry_poll = true
       return
     } else {
@@ -237,7 +236,6 @@ class TorDaemon extends EventEmitter {
         // written incompletely, and we will, with any luck, be notified
         // again when it has been written completely and renamed to its
         // permanent location.
-        console.log(`tor: failed to read control port: ${err}`)
         return this._polled()
       }
 
@@ -254,7 +252,8 @@ class TorDaemon extends EventEmitter {
 
       this._readControlCookie((err, cookie, cookieMtime) => {
         if (err) {
-          console.log(`tor: failed to read control cookie: ${err}`)
+          // If there's an error, don't worry: the file may not be
+          // ready yet, and we'll be notified when it is.
           return this._polled()
         }
 
@@ -1052,7 +1051,7 @@ class TorControl extends EventEmitter {
     let listeners = null
     const perline = (status, reply) => {
       if (status !== '250' || !reply.startsWith(`${keyword}=`) || listeners) {
-        console.log(`unexpected GETINFO ${keyword} reply`)
+        console.log(`tor: unexpected GETINFO ${keyword} reply`)
         return
       }
       listeners = []

--- a/app/tor.js
+++ b/app/tor.js
@@ -138,7 +138,12 @@ class TorDaemon extends EventEmitter {
     })
 
     this._process = 'i am the very seeming of a child process daemon'
-    this._poll()
+
+    // Defer to the next tick so that the user can reliably do
+    //
+    //          torDaemon.start()
+    //          torDaemon.on('launch', ...)
+    process.nextTick(() => this._poll())
   }
 
   /**

--- a/app/tor.js
+++ b/app/tor.js
@@ -1286,8 +1286,11 @@ class LineReadable extends EventEmitter {
 
 module.exports.TorControl = TorControl
 module.exports.TorDaemon = TorDaemon
+module.exports.torControlCookiePath = torControlCookiePath
 module.exports.torControlParseKV = torControlParseKV
 module.exports.torControlParseQuoted = torControlParseQuoted
+module.exports.torControlPortPath = torControlPortPath
+module.exports.torDataDirPath = torDataDirPath
 module.exports.torrcEscapeBuffer = torrcEscapeBuffer
 module.exports.torrcEscapePath = torrcEscapePath
 module.exports.torrcEscapeString = torrcEscapeString

--- a/app/tor.js
+++ b/app/tor.js
@@ -684,7 +684,7 @@ class TorDaemon extends EventEmitter {
         handler(err, false)
       } else {
         const err = new Error(`tor: bogus circuit establishment info: ${data}`)
-        handler(err, false)
+        handler(err, null)
       }
     }
     const handleInfo = (err, s) => {

--- a/test/unit/app/torTest.js
+++ b/test/unit/app/torTest.js
@@ -1,0 +1,80 @@
+/* global describe, before, after, it */
+
+const assert = require('assert')
+const mockery = require('mockery')
+
+describe('tor unit tests', () => {
+  let tor
+  const fakeElectron = require('../lib/fakeElectron')
+  before(() => {
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    })
+    mockery.registerMock('electron', fakeElectron)
+    tor = require('../../../app/tor')
+  })
+  after(() => {
+    mockery.disable()
+  })
+
+  it('torrcEscapeString', () => {
+    assert.strictEqual('foobar', tor.torrcEscapeString('foobar'))
+    assert.strictEqual('" foobar"', tor.torrcEscapeString(' foobar'))
+    assert.strictEqual('"\\x09foobar"', tor.torrcEscapeString('\tfoobar'))
+    assert.strictEqual('"foo\\\\\\x0abar"', tor.torrcEscapeString('foo\\\nbar'))
+    assert.strictEqual('"foo bar"', tor.torrcEscapeString('foo bar'))
+    assert.strictEqual('"foo#bar"', tor.torrcEscapeString('foo#bar'))
+    assert.strictEqual('"foo\\"bar"', tor.torrcEscapeString('foo"bar'))
+    assert.strictEqual('"foo\\\\bar"', tor.torrcEscapeString('foo\\bar'))
+    assert.strictEqual('"fno\\xcc\\x88rd"', tor.torrcEscapeString('fnörd'))
+    assert.strictEqual('"C:\\\\Ronald\\xe2\\x80\\x99s laptop\'s disk"',
+      tor.torrcEscapeString('C:\\Ronald’s laptop\'s disk'))
+  })
+
+  it('torrcEscapeBuffer', () => {
+    assert.strictEqual('"\\x00\\x01\\x1f \\x7f\\x80\\xfe\\xff"',
+      tor.torrcEscapeBuffer(Buffer.from([0, 1, 31, 32, 127, 128, 254, 255])))
+  })
+
+  it('torControlParseQuoted', () => {
+    assert.deepStrictEqual([Buffer.from('127.0.0.1:41159', 'ascii'), 17],
+      tor.torControlParseQuoted('"127.0.0.1:41159"', 0, 17))
+    assert.deepStrictEqual([Buffer.from('unix:/a b/c', 'ascii'), 13],
+      tor.torControlParseQuoted('"unix:/a b/c"', 0, 13))
+    assert.deepStrictEqual([Buffer.from('unix:/a\rb/c', 'ascii'), 14],
+      tor.torControlParseQuoted('"unix:/a\\rb/c"', 0, 14))
+    assert.deepStrictEqual([Buffer.from('unix:/a\nb/c', 'ascii'), 14],
+      tor.torControlParseQuoted('"unix:/a\\nb/c"', 0, 14))
+    assert.deepStrictEqual([Buffer.from('unix:/a\tb/c', 'ascii'), 14],
+      tor.torControlParseQuoted('"unix:/a\\tb/c"', 0, 14))
+    assert.deepStrictEqual([Buffer.from('unix:/a\\b/c', 'ascii'), 14],
+      tor.torControlParseQuoted('"unix:/a\\\\b/c"', 0, 14))
+    assert.deepStrictEqual([Buffer.from('unix:/a"b/c', 'ascii'), 14],
+      tor.torControlParseQuoted('"unix:/a\\"b/c"', 0, 14))
+    assert.deepStrictEqual([Buffer.from('unix:/a\'b/c', 'ascii'), 14],
+      tor.torControlParseQuoted('"unix:/a\\\'b/c"', 0, 14))
+    assert.deepStrictEqual([Buffer.from('unix:/a b/c', 'ascii'), 13],
+      tor.torControlParseQuoted('"unix:/a b/c" "127.0.0.1:9050"', 0, 30))
+    assert.deepStrictEqual([null, 12],
+      tor.torControlParseQuoted('"unix:/a b/c', 0, 12))
+    assert.deepStrictEqual([null, 9],
+      tor.torControlParseQuoted('"unix:/a\\fb/c"', 0, 13))
+  })
+
+  it('torControlParseKV', () => {
+    assert.deepStrictEqual(['foo', Buffer.from('bar'), 8],
+      tor.torControlParseKV('xfoo=bary', 1, 8))
+    assert.deepStrictEqual(['foo', Buffer.from('bar'), 10],
+      tor.torControlParseKV('xfoo="bar"y', 1, 10))
+    assert.deepStrictEqual(['foo', Buffer.from('bar baz'), 14],
+      tor.torControlParseKV('xfoo="bar baz"y', 1, 14))
+    assert.deepStrictEqual(['foo', Buffer.from('bar"baz'), 15],
+      tor.torControlParseKV('xfoo="bar\\"baz"y', 1, 15))
+    assert.deepStrictEqual(['foo', Buffer.from('bar"baz'), 16],
+      tor.torControlParseKV('xfoo="bar\\"baz" quux="zot"y', 1, 26))
+    assert.deepStrictEqual(['foo', Buffer.from('barbaz'), 12],
+      tor.torControlParseKV('xfoo=barbaz quux=zoty', 1, 20))
+  })
+})

--- a/test/unit/app/torTest.js
+++ b/test/unit/app/torTest.js
@@ -249,19 +249,30 @@ describe('tor unit tests', function () {
           const bootstrapTimeout = setTimeout(() => {
             assert.fail('tor daemon failed to begin bootstrapping after 2sec')
           }, 2000)
+          const done = () => {
+            torProcess.kill('SIGTERM')
+            const timeoutKill = setTimeout(() => {
+              assert.fail('tor daemon failed to exit after 2sec')
+            }, 2000)
+            torProcess.once('exit', () => {
+              clearTimeout(timeoutKill)
+              // Success!
+              callback()
+            })
+          }
           let countdown = 2
           const bootstrapped = (err, progress) => {
             assert.ifError(err)
             clearTimeout(bootstrapTimeout)
             console.log(`tor: bootstrapped ${progress}%`)
             if (--countdown === 0) {
-              return callback()
+              return done()
             }
           }
           torDaemon.onBootstrap(bootstrapped, (err) => {
             assert.ifError(err)
             if (--countdown === 0) {
-              return callback()
+              return done()
             }
           })
         })

--- a/test/unit/app/torTest.js
+++ b/test/unit/app/torTest.js
@@ -4,6 +4,7 @@ const assert = require('assert')
 const child_process = require('child_process') // eslint-disable-line camelcase
 const fs = require('fs')
 const mockery = require('mockery')
+const rimraf = require('rimraf')
 
 describe('tor unit tests', () => {
   let tor
@@ -149,7 +150,7 @@ describe('tor unit tests', () => {
     })
   })
   after((cb) => {
-    fs.rmdir(bravePath(), (err) => {
+    rimraf(bravePath(), (err) => {
       assert.ifError(err)
       cb()
     })

--- a/test/unit/app/torTest.js
+++ b/test/unit/app/torTest.js
@@ -150,7 +150,7 @@ describe('tor unit tests', () => {
   })
   after((cb) => {
     fs.rmdir(bravePath(), (err) => {
-      assert.ifError(!err)
+      assert.ifError(err)
       cb()
     })
   })

--- a/test/unit/app/torTest.js
+++ b/test/unit/app/torTest.js
@@ -188,14 +188,14 @@ describe('tor unit tests', function () {
             assert.fail('tor daemon failed to start after 2.5sec')
           }, 2000)
           // Wait for it to launch.
-          torDaemon.on('launch', (socksAddr) => {
+          torDaemon.once('launch', (socksAddr) => {
             clearTimeout(timeoutLaunch)
             // All done.  Kill it gently and wait for it to exit.
             torProcess.kill('SIGTERM')
             const timeoutKill = setTimeout(() => {
               assert.fail('tor daemon failed to exit after 2sec')
             }, 2000)
-            torProcess.on('exit', () => {
+            torProcess.once('exit', () => {
               clearTimeout(timeoutKill)
               // Success!
               callback()
@@ -220,14 +220,14 @@ describe('tor unit tests', function () {
             assert.fail('tor daemon failed to start after 2.5sec')
           }, 2000)
           // Wait for it to launch.
-          torDaemon.on('launch', (socksAddr) => {
+          torDaemon.once('launch', (socksAddr) => {
             clearTimeout(timeoutLaunch)
             // All done.  Kill it gently and wait for it to exit.
             torProcess.kill('SIGTERM')
             const timeoutKill = setTimeout(() => {
               assert.fail('tor daemon failed to exit after 2sec')
             }, 2000)
-            torProcess.on('exit', () => {
+            torProcess.once('exit', () => {
               clearTimeout(timeoutKill)
               // Success!
               callback()

--- a/test/unit/app/torTest.js
+++ b/test/unit/app/torTest.js
@@ -20,6 +20,7 @@ describe('tor unit tests', function () {
   })
   after(function () {
     mockery.disable()
+    mockery.deregisterAll()
   })
 
   it('torrcEscapeString', function () {

--- a/test/unit/app/torTest.js
+++ b/test/unit/app/torTest.js
@@ -217,7 +217,7 @@ describe('tor unit tests', function () {
           assert(torDaemon)
           torProcess = spawnTor(torDaemon)
           const timeoutLaunch = setTimeout(() => {
-            assert.fail('tor daemon failed to start after 2.5sec')
+            assert.fail('tor daemon failed to start after 2sec')
           }, 2000)
           // Wait for it to launch.
           torDaemon.once('launch', (socksAddr) => {

--- a/test/unit/app/torTest.js
+++ b/test/unit/app/torTest.js
@@ -6,10 +6,10 @@ const fs = require('fs')
 const mockery = require('mockery')
 const rimraf = require('rimraf')
 
-describe('tor unit tests', () => {
+describe('tor unit tests', function () {
   let tor
   const fakeElectron = require('../lib/fakeElectron')
-  before(() => {
+  before(function () {
     mockery.enable({
       warnOnReplace: false,
       warnOnUnregistered: false,
@@ -18,11 +18,11 @@ describe('tor unit tests', () => {
     mockery.registerMock('electron', fakeElectron)
     tor = require('../../../app/tor')
   })
-  after(() => {
+  after(function () {
     mockery.disable()
   })
 
-  it('torrcEscapeString', () => {
+  it('torrcEscapeString', function () {
     assert.strictEqual('foobar', tor.torrcEscapeString('foobar'))
     assert.strictEqual('" foobar"', tor.torrcEscapeString(' foobar'))
     assert.strictEqual('"\\x09foobar"', tor.torrcEscapeString('\tfoobar'))
@@ -36,12 +36,12 @@ describe('tor unit tests', () => {
       tor.torrcEscapeString('C:\\Ronald’s laptop\'s disk'))
   })
 
-  it('torrcEscapeBuffer', () => {
+  it('torrcEscapeBuffer', function () {
     assert.strictEqual('"\\x00\\x01\\x1f \\x7f\\x80\\xfe\\xff"',
       tor.torrcEscapeBuffer(Buffer.from([0, 1, 31, 32, 127, 128, 254, 255])))
   })
 
-  it('torControlParseQuoted', () => {
+  it('torControlParseQuoted', function () {
     assert.deepStrictEqual([Buffer.from('127.0.0.1:41159', 'ascii'), 17],
       tor.torControlParseQuoted('"127.0.0.1:41159"', 0, 17))
     assert.deepStrictEqual([Buffer.from('unix:/a b/c', 'ascii'), 13],
@@ -66,7 +66,7 @@ describe('tor unit tests', () => {
       tor.torControlParseQuoted('"unix:/a\\fb/c"', 0, 13))
   })
 
-  it('torControlParseKV', () => {
+  it('torControlParseKV', function () {
     assert.deepStrictEqual(['foo', Buffer.from('bar'), 8],
       tor.torControlParseKV('xfoo=bary', 1, 8))
     assert.deepStrictEqual(['foo', Buffer.from('bar'), 10],
@@ -156,7 +156,7 @@ describe('tor unit tests', () => {
     })
   })
 
-  it('tor daemon start then watch', (callback) => {
+  it('tor daemon start then watch', function (callback) {
     // TODO(riastradh): broken test
     return callback()
     /* eslint-disable no-unreachable */
@@ -186,7 +186,7 @@ describe('tor unit tests', () => {
     /* eslint-enable no-unreachable */
   })
 
-  it('tor daemon watch then start', (callback) => {
+  it('tor daemon watch then start', function (callback) {
     // TODO(riastradh): broken test
     return callback()
     /* eslint-disable no-unreachable */

--- a/test/unit/app/torTest.js
+++ b/test/unit/app/torTest.js
@@ -1,4 +1,8 @@
-/* global describe, before, after, it */
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* global after, afterEach, before, beforeEach, describe, it */
 
 const assert = require('assert')
 const child_process = require('child_process') // eslint-disable-line camelcase

--- a/test/unit/app/torTest.js
+++ b/test/unit/app/torTest.js
@@ -260,17 +260,24 @@ describe('tor unit tests', function () {
           }, 2000)
           const done = () => killTor(torDaemon, torProcess, callback)
           let countdown = 2
+          let bootstrapped1 = false
           const bootstrapped = (err, progress) => {
             assert.ifError(err)
             clearTimeout(bootstrapTimeout)
             console.log(`tor: bootstrapped ${progress}%`)
-            if (--countdown === 0) {
-              return done()
+            if (!bootstrapped1) {
+              // Got at least one bootstrap progress notification.
+              bootstrapped1 = true
+              if (--countdown === 0) {
+                // And onBootstrap returned.
+                return done()
+              }
             }
           }
           torDaemon.onBootstrap(bootstrapped, (err) => {
             assert.ifError(err)
             if (--countdown === 0) {
+              // Got at least one bootstrap progress notification too.
               return done()
             }
           })


### PR DESCRIPTION
This doesn't solve #14043 yet, but it provides a candidate place to hook up a progress indicator.  See the `TODO(riastradh): Visually update a progress bar!` comment for the place where we should update a progress bar, currently https://github.com/brave/browser-laptop/pull/14146/commits/c2b3edab0024684f755be088715667edb7ce21b4#diff-8a9bac13ef6264feb2b6da7c18d86b3cR751.

- [x] Depends on https://github.com/brave/muon/pull/592 to launch tor with a control port.
- [x] Depends on https://github.com/brave/browser-laptop/pull/14145 to update the version of tor to one that has functional control ports, since apparently they were broken in the alpha version we had been using before.
- [ ] Depends on https://github.com/brave/browser-laptop/pull/14168, currently cherry-picked into the branch, to make the tests function.  Should be rebased once tor/0.23.x is rebased to have that commit.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
Launch Brave.  Confirm that the console output mentions tor bootstrapping.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


