### PR TITLE
Fixing deletedSites modal not persisting while clearing sites

### DIFF
--- a/app/renderer/components/preferences/payment/deletedSites.js
+++ b/app/renderer/components/preferences/payment/deletedSites.js
@@ -25,7 +25,9 @@ class DeletedSitesContent extends ImmutableComponent {
   deletePermission (hostPattern) {
     appActions.removeSiteSetting(hostPattern, 'ledgerPayments')
     appActions.removeSiteSetting(hostPattern, 'ledgerPaymentsShown')
-    this.props.onHide()
+    if (this.props.sites.length === 1) {
+      this.props.onHide()
+    }
   }
 
   render () {


### PR DESCRIPTION
Fixes #14137 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
  1. Enable payments and add simulated payments (`npm run add-simulated-synopsis-visits 10`)
  2. Delete a few publishers from the ledger table
  3. Click on `Show Deleted Sites` to bring up the deleted publishers list modal 
  4. Delete a publisher from the list in the modal.
  5. Confirm that the modal stays visible until:
    - There are no publishers left in the list
    - The `Clear all` action is taken
    - The modal is dismissed with `Done`
  6. (Edge case test) confirm that once the deleted sites list is empty, removing a publisher from the table does not immediately trigger the modal to display.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


