### PR TITLE
- Restrict full screen notification to window (preventing it being se…

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -712,7 +712,8 @@ const api = {
         if (!tabValue) {
           return
         }
-        appActions.tabSetFullScreen(tabId, false)
+        const windowId = tabValue.get('windowId')
+        appActions.tabSetFullScreen(tabId, false, false, windowId)
       })
 
       tab.on('media-started-playing', (e) => {

--- a/app/renderer/reducers/frameReducer.js
+++ b/app/renderer/reducers/frameReducer.js
@@ -22,6 +22,10 @@ const {getCurrentWindowId} = require('../currentWindow')
 
 const setFullScreen = (state, action) => {
   const index = frameStateUtil.getIndexByTabId(state, action.tabId)
+  if (index < 0) {
+    console.error('frame not found for setFullScreen: ', index)
+    return state
+  }
   return state.mergeIn(['frames', index], {
     isFullScreen: action.isFullScreen !== undefined ? action.isFullScreen : state.getIn(['frames', index].concat('isFullScreen')),
     showFullScreenWarning: action.showFullScreenWarning


### PR DESCRIPTION
…nt to all windows)

- Ensure frame index is valid (not -1) when processing the fullscreen frame logic

Fixes https://github.com/brave/browser-laptop/issues/14031

Auditors: @petemill

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
See https://github.com/brave/browser-laptop/issues/14031#issuecomment-389362275

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


