### PR TITLE
Fixes WebTorrent not being enabled

### DIFF
--- a/app/common/state/extensionState.js
+++ b/app/common/state/extensionState.js
@@ -5,7 +5,6 @@
 const Immutable = require('immutable')
 
 // Constants
-const config = require('../../../js/constants/config')
 const settings = require('../../../js/constants/settings')
 
 // Utils
@@ -220,10 +219,7 @@ const extensionState = {
     }
 
     const settingsState = state.get('settings')
-    const extension = extensionState.getExtensionById(state, config.torrentExtensionId)
-    const extensionEnabled = extension != null ? extension.get('enabled') : false
-    const torrentEnabled = getSetting(settings.TORRENT_VIEWER_ENABLED, settingsState)
-    return extensionEnabled && torrentEnabled
+    return getSetting(settings.TORRENT_VIEWER_ENABLED, settingsState)
   }
 }
 

--- a/test/unit/app/common/state/extensionStateTest.js
+++ b/test/unit/app/common/state/extensionStateTest.js
@@ -1,6 +1,5 @@
 /* global describe, it, before */
 const extensionState = require('../../../../../app/common/state/extensionState')
-const config = require('../../../../../js/constants/config')
 const settings = require('../../../../../js/constants/settings')
 const Immutable = require('immutable')
 const assert = require('assert')
@@ -686,43 +685,25 @@ describe('extensionState', function () {
   })
 
   describe('isWebTorrentEnabled', function () {
-    const torrentId = config.torrentExtensionId
-
     it('null case', function () {
       const result = extensionState.isWebTorrentEnabled()
       assert.equal(result, false)
     })
 
-    it('empty state', function () {
+    it('torrent is enabled by default', function () {
       const result = extensionState.isWebTorrentEnabled(defaultAppState)
-      assert.equal(result, false)
-    })
-
-    it('extension is disabled', function () {
-      const state = defaultAppState
-        .setIn(['extensions', torrentId], Immutable.fromJS({
-          enabled: false
-        }))
-        .setIn(['settings', settings.TORRENT_VIEWER_ENABLED], true)
-      const result = extensionState.isWebTorrentEnabled(state)
-      assert.equal(result, false)
+      assert.equal(result, true)
     })
 
     it('torrent is disabled', function () {
       const state = defaultAppState
-        .setIn(['extensions', torrentId], Immutable.fromJS({
-          enabled: true
-        }))
         .setIn(['settings', settings.TORRENT_VIEWER_ENABLED], false)
       const result = extensionState.isWebTorrentEnabled(state)
       assert.equal(result, false)
     })
 
-    it('everything is enabled', function () {
+    it('torrent is enabled', function () {
       const state = defaultAppState
-        .setIn(['extensions', torrentId], Immutable.fromJS({
-          enabled: true
-        }))
         .setIn(['settings', settings.TORRENT_VIEWER_ENABLED], true)
       const result = extensionState.isWebTorrentEnabled(state)
       assert.equal(result, true)


### PR DESCRIPTION
Resolves #10767

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
- clean profile
- go to https://webtorrent.io/free-torrents/
- try to download torrent file and try to click on magnet link
- make sure that is handled by the WebTorrent
- go to extension page and disable WebTorrent
- go to https://webtorrent.io/free-torrents/
- try to download torrent file and try to click on magnet link
- make sure that file is downloaded and that you see handler for the link
- go to extension page and enable WebTorrent
- try to download torrent file and try to click on magnet link
- make sure that is handled by the WebTorrent


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


