### PR TITLE
Only call createTabRequested if window is ready

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -2161,12 +2161,15 @@ const onReferralRead = (state, body, activeWindowId) => {
   if (body.has('offer_page_url')) {
     const url = body.get('offer_page_url')
     if (urlutil.isURL(url)) {
-      if (activeWindowId === windowState.WINDOW_ID_NONE) {
+      if (activeWindowId === windowState.WINDOW_ID_NONE || !state.get('windowReady')) {
+        // write referralPage to state if initial window is not created/visible yet
         state = updateState.setUpdateProp(state, 'referralPage', url)
       } else {
+        // initial window exists and should be ready; create tab directly
         appActions.createTabRequested({
           url,
-          windowId: activeWindowId
+          windowId: activeWindowId,
+          active: true
         })
         state = updateState.setUpdateProp(state, 'referralPage', null)
       }

--- a/app/browser/reducers/tabsReducer.js
+++ b/app/browser/reducers/tabsReducer.js
@@ -525,6 +525,7 @@ const tabsReducer = (state, action, immutableAction) => {
           state = updateState.setUpdateProp(state, 'referralPage', null)
         }
       }
+      state = state.set('windowReady', true)
       break
     }
     case appConstants.APP_ENABLE_PEPPER_MENU: {

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -451,6 +451,11 @@ module.exports.cleanAppData = (immutableData, isShutdown) => {
     console.error('cleanAppData: error cleaning up data: urls', e)
   }
 
+  // delete the window ready state (gets set again on program start)
+  if (immutableData.has('windowReady')) {
+    immutableData = immutableData.delete('windowReady')
+  }
+
   return immutableData
 }
 
@@ -1162,7 +1167,8 @@ module.exports.defaultAppState = () => {
         publishers: {}
       },
       promotion: {}
-    }
+    },
+    windowReady: false
   }
 }
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -649,6 +649,7 @@ AppStore
     autocompleteURL: string, // ditto re: {searchTerms}
     searchURL: string // with replacement var in string: {searchTerms}
   },
+  windowReady: boolean // set to false on start; set to true when first window is ready
 }
 ```
 

--- a/test/unit/app/browser/api/ledgerTest.js
+++ b/test/unit/app/browser/api/ledgerTest.js
@@ -3231,7 +3231,8 @@ describe('ledger api unit tests', function () {
       })
 
       it('window is ready', function () {
-        ledgerApi.onReferralRead(defaultAppState, Immutable.fromJS({
+        const windowReadyState = defaultAppState.set('windowReady', true)
+        ledgerApi.onReferralRead(windowReadyState, Immutable.fromJS({
           download_id: 1,
           referral_code: 'code',
           offer_page_url: url
@@ -3239,7 +3240,8 @@ describe('ledger api unit tests', function () {
         assert(setUpdatePropSpy.withArgs(sinon.match.any, 'referralPage', null).calledOnce)
         assert(createTabRequestedSpy.withArgs({
           url,
-          windowId: 1
+          windowId: 1,
+          active: true
         }).calledOnce)
       })
     })


### PR DESCRIPTION
`referralPage` loads quickly from server and code was previously calling createTabRequested well before window was ready.
This would cause the partner page to load first (before about:welcome).

Fixes https://github.com/brave/browser-laptop/issues/14220

Auditors: @NejcZdovc

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
See https://github.com/brave/browser-laptop/issues/14220

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


