### PR TITLE
set reloadMatchingUrl to true for URLs ending in a hash

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -892,7 +892,14 @@ const api = {
         return
       }
 
-      const reloadMatchingUrl = action.get('reloadMatchingUrl') || false
+      const parsed = muon.url.parse(url)
+      // Set reloadMatchingUrl to true for hash URLs as workaround for
+      // https://github.com/brave/browser-laptop/issues/14231. (muon emits
+      // security-style-changed to insecure when a hash URL is loaded using
+      // tab.loadURL in a tab with the same URL)
+      const reloadMatchingUrl = action.get('reloadMatchingUrl') ||
+        (parsed && parsed.hash) ||
+        false
       if (reloadMatchingUrl && currentUrl === url) {
         tab.reload(true)
       } else {


### PR DESCRIPTION
fix #14231 (workaround)

## Test Plan:
1. go to a secure URL ending in a hash such as https://github.com/brave/browser-laptop/wiki/Fingerprinting-Protection-Mode#technical-details
2. toggle shields or click 'reload' in the shields menu
3. the page should appear as still secure instead of changing to insecure

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


