### PR TITLE
Improves prooofing time when doing contribution

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -1666,7 +1666,6 @@ const getStateInfo = (state, parsedData) => {
   }
 
   const info = parsedData.paymentInfo
-  const then = new Date().getTime() - ledgerUtil.milliseconds.year
 
   if (!parsedData.properties || !parsedData.properties.wallet) {
     return state
@@ -1710,23 +1709,29 @@ const getStateInfo = (state, parsedData) => {
     return state
   }
 
+  const current = ledgerState.getInfoProp(state, 'transactions') || Immutable.Map()
+  if (current && current.size === parsedData.transactions.length) {
+    return state
+  }
+
   for (let i = parsedData.transactions.length - 1; i >= 0; i--) {
     let transaction = parsedData.transactions[i]
-    if (transaction.stamp < then) break
 
-    if (!transaction.ballots || transaction.ballots.length < transaction.count) continue
+    if (!transaction.ballots) {
+      continue
+    }
 
-    let ballots = underscore.clone(transaction.ballots || {})
-    parsedData.ballots.forEach((ballot) => {
-      if (ballot.viewingId !== transaction.viewingId) return
+    const ballotsTotal = Object.keys(transaction.ballots).reduce((acc, key) => {
+      return acc + transaction.ballots[key]
+    }, 0)
 
-      if (!ballots[ballot.publisher]) ballots[ballot.publisher] = 0
-      ballots[ballot.publisher]++
-    })
+    if (ballotsTotal < transaction.votes) break
 
-    transactions.push(underscore.extend(underscore.pick(transaction,
-      ['viewingId', 'contribution', 'submissionStamp', 'count']),
-      {ballots: ballots}))
+    transactions.push(underscore.pick(transaction, ['viewingId', 'contribution', 'submissionStamp', 'count', 'ballots']))
+  }
+
+  if (current && current.size === transactions.length) {
+    return state
   }
 
   state = observeTransactions(state, transactions)
@@ -1778,8 +1783,9 @@ const generatePaymentData = (state) => {
 
 const getPaymentInfo = (state) => {
   let amount, currency
+  const inProgress = ledgerState.getAboutProp(state, 'status') === ledgerStatuses.IN_PROGRESS
 
-  if (!client) {
+  if (!client || inProgress) {
     return state
   }
 
@@ -2028,11 +2034,12 @@ const uintKeySeed = (currentSeed) => {
 }
 
 const getBalance = (state) => {
-  if (!client) return
+  const inProgress = ledgerState.getAboutProp(state, 'status') === ledgerStatuses.IN_PROGRESS
+  if (!client || inProgress) return
 
   const balanceFn = module.exports.getBalance.bind(null, state)
   balanceTimeoutId = setTimeout(balanceFn, 1 * ledgerUtil.milliseconds.minute)
-  return getPaymentInfo(state)
+  return module.exports.getPaymentInfo(state)
 }
 
 const callback = (err, result, delayTime) => {
@@ -2079,6 +2086,7 @@ const onCallback = (state, result, delayTime) => {
   }
 
   const regularResults = result.toJS()
+  const notInProgress = ledgerState.getAboutProp(state, 'status') !== ledgerStatuses.IN_PROGRESS
 
   if (client && result.getIn(['properties', 'wallet'])) {
     if (!ledgerState.getInfoProp(state, 'created')) {
@@ -2086,47 +2094,52 @@ const onCallback = (state, result, delayTime) => {
     }
 
     state = getStateInfo(state, regularResults) // TODO optimize if possible
-    state = getPaymentInfo(state)
+
+    if (notInProgress) {
+      state = module.exports.getPaymentInfo(state)
+    }
   }
 
-  state = cacheRuleSet(state, regularResults.ruleset)
-  if (result.has('rulesetV2')) {
-    results = regularResults.rulesetV2 // TODO optimize if possible
-    delete regularResults.rulesetV2
+  if (notInProgress) {
+    state = module.exports.cacheRuleSet(state, regularResults.ruleset)
+    if (result.has('rulesetV2')) {
+      results = regularResults.rulesetV2 // TODO optimize if possible
+      delete regularResults.rulesetV2
 
-    entries = []
-    results.forEach((entry) => {
-      const key = entry.facet + ':' + entry.publisher
+      entries = []
+      results.forEach((entry) => {
+        const key = entry.facet + ':' + entry.publisher
 
-      if (entry.exclude !== false) {
-        entries.push({type: 'put', key: key, value: JSON.stringify(underscore.omit(entry, ['facet', 'publisher']))})
-      } else {
-        entries.push({type: 'del', key: key})
-      }
-    })
-
-    v2RulesetDB.batch(entries, (err) => {
-      if (err) return console.error(v2RulesetPath + ' error: ' + JSON.stringify(err, null, 2))
-
-      if (entries.length === 0) return
-
-      const publishers = ledgerState.getPublishers(state)
-      for (let item of publishers) {
-        const publisherKey = item[0]
-        const publisher = item[1] || Immutable.Map()
-
-        if (!publisher.getIn(['options', 'exclude'])) {
-          excludeP(publisherKey, (unused, exclude) => {
-            appActions.onPublisherOptionUpdate(publisherKey, 'exclude', exclude)
-            savePublisherOption(publisherKey, 'exclude', exclude)
-          })
+        if (entry.exclude !== false) {
+          entries.push({type: 'put', key: key, value: JSON.stringify(underscore.omit(entry, ['facet', 'publisher']))})
+        } else {
+          entries.push({type: 'del', key: key})
         }
-      }
-    })
-  }
+      })
 
-  if (result.has('publishersV2')) {
-    delete regularResults.publishersV2
+      v2RulesetDB.batch(entries, (err) => {
+        if (err) return console.error(v2RulesetPath + ' error: ' + JSON.stringify(err, null, 2))
+
+        if (entries.length === 0) return
+
+        const publishers = ledgerState.getPublishers(state)
+        for (let item of publishers) {
+          const publisherKey = item[0]
+          const publisher = item[1] || Immutable.Map()
+
+          if (!publisher.getIn(['options', 'exclude'])) {
+            excludeP(publisherKey, (unused, exclude) => {
+              appActions.onPublisherOptionUpdate(publisherKey, 'exclude', exclude)
+              savePublisherOption(publisherKey, 'exclude', exclude)
+            })
+          }
+        }
+      })
+    }
+
+    if (result.has('publishersV2')) {
+      delete regularResults.publishersV2
+    }
   }
 
   // persist the new ledger state
@@ -2576,7 +2589,7 @@ const run = (state, delayTime) => {
   if (delayTime > 0) {
     if (runTimeoutId) return
     // useful for QA - #12249
-    if (noDelay) delayTime = 5000
+    if (noDelay) delayTime = 3000
 
     const active = client
     if (delayTime > (1 * ledgerUtil.milliseconds.hour)) {
@@ -3250,7 +3263,9 @@ const getMethods = () => {
     shouldTrackTab,
     deleteWallet,
     resetPublishers,
-    clearPaymentHistory
+    clearPaymentHistory,
+    getPaymentInfo,
+    cacheRuleSet
   }
 
   let privateMethods = {}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1566,9 +1566,9 @@
       }
     },
     "bat-client": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bat-client/-/bat-client-3.0.0.tgz",
-      "integrity": "sha512-SbMpO/5/hJvS38s2uMWltQkBnUI+viR0o3D8zl5U5RH3xRFQOJU6fE008KMHeX/olgsjzwQxy0QntrFBv5qL+g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bat-client/-/bat-client-3.1.0.tgz",
+      "integrity": "sha512-na5kJv/wP3sgFT9Mbwoz30G2TeESZpqKFZdvWHJfvWllpF3hyXkV9F2n3tY1sxwAOJrnqz0ipIzecZcv2e579A==",
       "requires": {
         "@ambassify/backoff-strategies": "1.0.0",
         "bat-balance": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "aphrodite": "1.1.0",
     "async": "^2.0.1",
     "bat-balance": "^1.0.7",
-    "bat-client": "^3.0.0",
+    "bat-client": "^3.1.0",
     "bat-publisher": "^2.0.15",
     "bignumber.js": "^4.0.4",
     "bloodhound-js": "brave/bloodhound",

--- a/test/unit/app/browser/api/ledgerTest.js
+++ b/test/unit/app/browser/api/ledgerTest.js
@@ -163,7 +163,8 @@ describe('ledger api unit tests', function () {
       setTimeUntilReconcile: () => {},
       isReadyToReconcile: () => isReadyToReconcile,
       recoverWallet: () => {},
-      getPromotionCaptcha: () => {}
+      getPromotionCaptcha: () => {},
+      report: () => {}
     }
     window.getWalletPassphrase = (parsedData) => {
       if (walletPassphraseReturn === 'error') {
@@ -2156,6 +2157,108 @@ describe('ledger api unit tests', function () {
         assert(getWalletPassphraseSpy.withArgs(wrongSeed).calledOnce)
       })
     })
+
+    describe('transactions', function () {
+      let setInfoPropSpy, getInfoPropSpy
+
+      before(function () {
+        setInfoPropSpy = sinon.spy(ledgerState, 'setInfoProp')
+        getInfoPropSpy = sinon.spy(ledgerState, 'getInfoProp')
+      })
+
+      afterEach(function () {
+        setInfoPropSpy.reset()
+        getInfoPropSpy.reset()
+      })
+
+      after(function () {
+        setInfoPropSpy.restore()
+        getInfoPropSpy.restore()
+      })
+
+      it('transactions are missing', function () {
+        ledgerApi.getStateInfo(defaultAppState, Immutable.Map())
+        assert(getInfoPropSpy.notCalled)
+        assert(setInfoPropSpy.notCalled)
+      })
+
+      it('no new transactions', function () {
+        const transactions = [{
+          viewingId: 1,
+          votes: 44,
+          ballots: {
+            'site1.com': 10,
+            'site2.com': 18,
+            'site3.com': 9,
+            'site4.com': 7
+          }
+        }]
+        const param = {
+          properties: {
+            wallet: {
+              paymentId: '1'
+            }
+          },
+          transactions
+        }
+        const state = defaultAppState
+          .setIn(['ledger', 'info', 'transactions'], Immutable.fromJS(transactions))
+
+        ledgerApi.getStateInfo(state, param)
+        assert(getInfoPropSpy.calledOnce)
+        assert(setInfoPropSpy.notCalled)
+      })
+
+      it('transaction is still in progress', function () {
+        const param = {
+          properties: {
+            wallet: {
+              paymentId: '1'
+            }
+          },
+          transactions: [{
+            viewingId: 1,
+            votes: 44,
+            ballots: {
+              'site1.com': 10,
+              'site2.com': 18
+            }
+          }]
+        }
+        const state = defaultAppState
+          .setIn(['ledger', 'info', 'transactions'], Immutable.Map())
+
+        ledgerApi.getStateInfo(state, param)
+        assert(getInfoPropSpy.calledOnce)
+        assert(setInfoPropSpy.notCalled)
+      })
+
+      it('new transaction is completed', function () {
+        const param = {
+          properties: {
+            wallet: {
+              paymentId: '1'
+            }
+          },
+          transactions: [{
+            viewingId: 1,
+            votes: 44,
+            ballots: {
+              'site1.com': 10,
+              'site2.com': 18,
+              'site3.com': 9,
+              'site4.com': 7
+            }
+          }]
+        }
+        const state = defaultAppState
+          .setIn(['ledger', 'info', 'transactions'], Immutable.Map())
+
+        ledgerApi.getStateInfo(state, param)
+        assert(getInfoPropSpy.called)
+        assert(setInfoPropSpy.calledOnce)
+      })
+    })
   })
 
   describe('onPublisherTimestamp', function () {
@@ -2312,6 +2415,56 @@ describe('ledger api unit tests', function () {
           }
         }))
         assert.deepEqual(result.toJS(), defaultAppState.toJS())
+      })
+    })
+
+    describe('contribution', function () {
+      let getPaymentInfoSpy, cacheRuleSetSpy
+
+      before(function () {
+        getPaymentInfoSpy = sinon.spy(ledgerApi, 'getPaymentInfo')
+        cacheRuleSetSpy = sinon.spy(ledgerApi, 'cacheRuleSet')
+      })
+
+      afterEach(function () {
+        getPaymentInfoSpy.reset()
+        cacheRuleSetSpy.reset()
+      })
+
+      after(function () {
+        getPaymentInfoSpy.restore()
+        cacheRuleSetSpy.restore()
+      })
+
+      it('do not call if in progress', function () {
+        const state = defaultAppState
+          .setIn(['ledger', 'about', 'status'], ledgerStatuses.IN_PROGRESS)
+
+        ledgerApi.onCallback(state, Immutable.fromJS({
+          properties: {
+            wallet: {
+              paymentId: '1'
+            }
+          }
+        }))
+
+        assert(getPaymentInfoSpy.notCalled)
+        assert(cacheRuleSetSpy.notCalled)
+      })
+
+      it('execute', function () {
+        ledgerApi.setClient(ledgerClientObject)
+        ledgerApi.onCallback(defaultAppState, Immutable.fromJS({
+          properties: {
+            wallet: {
+              paymentId: '1'
+            }
+          }
+        }))
+        ledgerApi.setClient(undefined)
+
+        assert(getPaymentInfoSpy.calledOnce)
+        assert(cacheRuleSetSpy.calledOnce)
       })
     })
   })
@@ -3586,6 +3739,73 @@ describe('ledger api unit tests', function () {
       ledgerApi.resetPublishers(defaultAppState)
       assert(resetPublishersSpy.calledOnce)
       assert.deepEqual(ledgerApi.getSynopsis(), {publishers: {}})
+    })
+  })
+
+  describe('getBalance', function () {
+    let getPaymentInfoSpy
+
+    before(function () {
+      getPaymentInfoSpy = sinon.spy(ledgerApi, 'getPaymentInfo')
+    })
+
+    afterEach(function () {
+      getPaymentInfoSpy.reset()
+    })
+
+    after(function () {
+      getPaymentInfoSpy.restore()
+      ledgerApi.setClient(undefined)
+    })
+
+    it('client is not set up', function () {
+      ledgerApi.setClient(null)
+      ledgerApi.getBalance(defaultAppState)
+      assert(getPaymentInfoSpy.notCalled)
+    })
+
+    it('status is in progress', function () {
+      ledgerApi.setClient(ledgerClientObject)
+      const state = defaultAppState
+        .setIn(['ledger', 'about', 'status'], ledgerStatuses.IN_PROGRESS)
+      ledgerApi.getBalance(state)
+      assert(getPaymentInfoSpy.notCalled)
+    })
+
+    it('executes', function () {
+      ledgerApi.setClient(ledgerClientObject)
+      ledgerApi.getBalance(defaultAppState)
+      assert(getPaymentInfoSpy.calledOnce)
+    })
+  })
+
+  describe('getPaymentInfo', function () {
+    let getWalletPropertiesSpy
+
+    before(function () {
+      ledgerApi.setClient(ledgerClientObject)
+      getWalletPropertiesSpy = sinon.spy(ledgerClientObject, 'getWalletProperties')
+    })
+
+    afterEach(function () {
+      getWalletPropertiesSpy.reset()
+    })
+
+    after(function () {
+      getWalletPropertiesSpy.restore()
+      ledgerApi.setClient(undefined)
+    })
+
+    it('not called when contribution is in progress', function () {
+      const state = defaultAppState
+        .setIn(['ledger', 'about', 'status'], ledgerStatuses.IN_PROGRESS)
+      ledgerApi.getBalance(state)
+      assert(getWalletPropertiesSpy.notCalled)
+    })
+
+    it('executes', function () {
+      ledgerApi.getBalance(defaultAppState)
+      assert(getWalletPropertiesSpy.calledOnce)
     })
   })
 })


### PR DESCRIPTION
Resolves #14211

- removes get balance when doing contribution
- reduce delay time from 5s to 3s when there is NO_DELAY flag enabled
- fixes completed notification triggering in the middle of contribution
- reduces unnecessary transaction checks for every call

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
- make sure that contribution is working correctly
- make sure that you only see notification about successful contribution where there is no more ballots and batch items in `ledger-state.json`
- make sure that there are no balance calls while contribution is in progress (you can check this with `LEDGER_VERBOSE=true` flag)

## Reviewer Checklist:

- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


