### PR TITLE
Move adblock-data s3 bucket to fastly

### DIFF
--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -68,14 +68,14 @@ module.exports = {
     shields: false
   },
   adblock: {
-    alternateDataFiles: 'https://s3.amazonaws.com/adblock-data/{version}/{uuid}.dat',
-    url: 'https://s3.amazonaws.com/adblock-data/{version}/ABPFilterParserData.dat',
+    alternateDataFiles: 'https://adblock-data.s3.brave.com/{version}/{uuid}.dat',
+    url: 'https://adblock-data.s3.brave.com/{version}/ABPFilterParserData.dat',
     // version is specified in the ad-block library
     msBetweenRechecks: 1000 * 60 * 60 * 2, // 2 hours
     enabled: true
   },
   safeBrowsing: {
-    url: 'https://s3.amazonaws.com/adblock-data/{version}/SafeBrowsingData.dat',
+    url: 'https://adblock-data.s3.brave.com/{version}/SafeBrowsingData.dat',
     // version is specified in the ad-block library
     msBetweenRechecks: 1000 * 60 * 60 * 2, // 2 hours
     enabled: true


### PR DESCRIPTION
## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

High S3 usage ticket: https://github.com/brave/internal/issues/319
Sec ticket regrading moving domains under brave.com: https://github.com/brave/internal/issues/187
Terraform change: https://github.com/brave/terraform/pull/61

This changes is intended to reduce S3 usage by changing the domain used for adblock downloads to use fastly under the s3.brave.com domain.


## Test Plan:

Current unit tests pass and no new functionality was added.

From testing on my local machine I can see connections to the new domain and about:adblock shows the adblock list was updated recently (after the date I made the change on my local machine).

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


