### PR TITLE
Prevents Add Funds overlay from displaying when there is a ledger error

### DIFF
--- a/app/browser/reducers/ledgerReducer.js
+++ b/app/browser/reducers/ledgerReducer.js
@@ -582,6 +582,16 @@ const ledgerReducer = (state, action, immutableAction) => {
         state = ledgerApi.onRunPromotionCheck(state, getSetting(settings.PAYMENTS_ENABLED))
         break
       }
+    case appConstants.APP_ON_NOTIFICATION_RESPONSE:
+      {
+        state = ledgerNotifications.onResponse(
+          state,
+          action.get('message'),
+          action.get('buttonIndex'),
+          action.get('activeWindow')
+        )
+        break
+      }
   }
   return state
 }

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -641,6 +641,21 @@ const appActions = {
   },
 
   /**
+   * Handles user response to a notifcation
+   * @param {string} message
+   * @param {number} buttonIndex
+   * @param {object} activeWindow
+   */
+  onNotificationResponse: function (message, buttonIndex, activeWindow) {
+    dispatch({
+      actionType: appConstants.APP_ON_NOTIFICATION_RESPONSE,
+      message,
+      buttonIndex,
+      activeWindow
+    })
+  },
+
+  /**
    * Adds information about pending basic auth login requests
    * @param {number} tabId - The tabId that generated the request
    * @param {string} detail - login request info

--- a/js/constants/appConstants.js
+++ b/js/constants/appConstants.js
@@ -216,7 +216,8 @@ const appConstants = {
   APP_SET_TOR_NEW_IDENTITY: _,
   APP_RESTART_TOR: _,
   APP_RECREATE_TOR_TAB: _,
-  APP_RUN_PROMOTION_CHECK: _
+  APP_RUN_PROMOTION_CHECK: _,
+  APP_ON_NOTIFICATION_RESPONSE: _
 }
 
 module.exports = mapValuesByKeys(appConstants)

--- a/test/unit/app/browser/api/ledgerNotificationsTest.js
+++ b/test/unit/app/browser/api/ledgerNotificationsTest.js
@@ -10,6 +10,7 @@ const mockery = require('mockery')
 const settings = require('../../../../../js/constants/settings')
 const ledgerUtil = require('../../../../../app/common/lib/ledgerUtil')
 const aboutPreferencesState = require('../../../../../app/common/state/aboutPreferencesState')
+const ledgerStatuses = require('../../../../../app/common/constants/ledgerStatuses')
 
 describe('ledgerNotifications unit test', function () {
   let fakeClock
@@ -565,6 +566,29 @@ describe('ledgerNotifications unit test', function () {
       const state = defaultAppState.setIn(['ledger', 'info', 'userHasFunded'], true)
       const result = ledgerNotificationsApi.hasFunded(state)
       assert.equal(result, true)
+    })
+  })
+
+  describe('shouldShowAddFundsModal', function () {
+    it('false when seed is corrupted', function () {
+      const state = defaultAppState.setIn(['ledger', 'about', 'status'], ledgerStatuses.CORRUPTED_SEED)
+      const result = ledgerNotificationsApi.shouldShowAddFundsModal(state)
+      assert.equal(result, false)
+    })
+    it('false when payments server is unresponsive', function () {
+      const state = defaultAppState.setIn(['ledger', 'about', 'status'], ledgerStatuses.SERVER_PROBLEM)
+      const result = ledgerNotificationsApi.shouldShowAddFundsModal(state)
+      assert.equal(result, false)
+    })
+    it('true when status is blank', function () {
+      const state = defaultAppState.setIn(['ledger', 'about', 'status'], '')
+      const result = ledgerNotificationsApi.shouldShowAddFundsModal(state)
+      assert(result)
+    })
+    it('true when status is a non-error case', function () {
+      const state = defaultAppState.setIn(['ledger', 'about', 'status'], ledgerStatuses.IN_PROGRESS)
+      const result = ledgerNotificationsApi.shouldShowAddFundsModal(state)
+      assert(result)
     })
   })
 


### PR DESCRIPTION
Fixes #14092

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

  1. Launch Brave with `LEDGER_NO_FUZZING=true LEDGER_NOTIFICATION=true` and a clean profile, then enable payments.
  2. Stop Brave and set `reconcileStamp` to less than the current date.
  3. Restart Brave
  4. Disconnect from network and wait for connection error modal to show up
  5. Click on `Add Funds` in the notification bar
  6. Ensure that `about:preferences#payments` is opened in a new tab, but the Add Fund modal is not visible
  7. Corrupt seed by removing indexes `20` and `21` from `seed` in `ledger-state.json`
  8. Trigger Add Funds notification
  9. Click on `Add Funds` in the notification bar
  10. Ensure that `about:preferences#payments` is opened in a new tab, but the Add Funds modal is not visible

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


