### PR TITLE
Ensuring http only sites are not added as https in the ledger table

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -707,6 +707,7 @@ const addSiteVisit = (state, timestamp, location, tabId, manualAdd = false) => {
     return state
   }
 
+  const protocol = urlParse(location).protocol
   location = pageDataUtil.getInfoKey(location)
 
   const minimumVisitTime = getSetting(settings.PAYMENTS_MINIMUM_VISIT_TIME)
@@ -746,6 +747,7 @@ const addSiteVisit = (state, timestamp, location, tabId, manualAdd = false) => {
 
   return module.exports.saveVisit(state, publisherKey, {
     duration,
+    protocol: protocol,
     revisited: revisitP
   })
 }
@@ -764,7 +766,11 @@ const saveVisit = (state, publisherKey, options) => {
     revisitP: options.revisited,
     ignoreMinTime: options.ignoreMinTime || false
   })
+
   state = ledgerState.setPublisher(state, publisherKey, synopsis.publishers[publisherKey])
+  if (options.protocol) {
+    state = ledgerState.setPublishersProp(state, publisherKey, 'protocol', options.protocol)
+  }
   state = updatePublisherInfo(state)
   state = module.exports.checkVerifiedStatus(state, publisherKey)
 

--- a/test/unit/app/browser/api/ledgerTest.js
+++ b/test/unit/app/browser/api/ledgerTest.js
@@ -1162,6 +1162,52 @@ describe('ledger api unit tests', function () {
         assert(visitsByPublisher['clifton.io'])
       })
     })
+    describe('saveVisit', function () {
+      let setPublishersPropSpy
+
+      before(function () {
+        setPublishersPropSpy = sinon.spy(ledgerState, 'setPublishersProp')
+      })
+
+      beforeEach(function () {
+        ledgerApi.setSynopsis({
+          addPublisher: () => {},
+          options: {},
+          publishers: {}
+        })
+      })
+
+      afterEach(function () {
+        setPublishersPropSpy.reset()
+        ledgerApi.setSynopsis(undefined)
+      })
+
+      after(function () {
+        setPublishersPropSpy.restore()
+      })
+
+      it('sets https as protocol for secure site', function () {
+        const options = {
+          duration: 5500,
+          protocol: 'https:',
+          revisited: false
+        }
+        const result = ledgerApi.saveVisit(defaultAppState, 'brave.com', options)
+        assert.equal('https:', setPublishersPropSpy.getCall(0).args[3])
+        assert.equal('https:', result.getIn(['ledger', 'synopsis', 'publishers', 'brave.com', 'protocol']))
+      })
+
+      it('sets http as protocol for non-secure site', function () {
+        const options = {
+          duration: 5500,
+          protocol: 'http:',
+          revisited: false
+        }
+        const result = ledgerApi.saveVisit(defaultAppState, 'espn.com', options)
+        assert.equal('http:', setPublishersPropSpy.getCall(0).args[3])
+        assert.equal('http:', result.getIn(['ledger', 'synopsis', 'publishers', 'espn.com', 'protocol']))
+      })
+    })
     describe('addNewLocation', function () {
       const tabIdNone = -1
       const keepInfo = false


### PR DESCRIPTION
Fixes: #14283 

The publisher's protocol was not being set early enough (it was not being done until the favicon was fetched), thus it was being placed in to the ledger table with `https:` as the default. 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
  1. Install Brave, enable payments
  2. Visit a http site (for exp: http://espn.com/)
  3. Stay on the page for min 8sec to meet min time criteria
  4. Open payments, ensure site is listed in ledger table
  5. Click on ESPN link, ensure that link directs to http://espn.com properly
  6. Ensure that this strategy works when clicking on the publisher toggle when criteria is not met (http://www.nossl.net/)


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


