### PR TITLE
Set frame index immediately when tab inserted to window tab strip.

### DIFF
--- a/app/renderer/reducers/frameReducer.js
+++ b/app/renderer/reducers/frameReducer.js
@@ -84,6 +84,10 @@ const getLocation = (location) => {
 
 function setFrameChangedIndex (state, frame, currentIndex, newIndex) {
   let frames = frameStateUtil.getFrames(state)
+  if (newIndex < 0) {
+    console.error(`Cannot move frame to index ${newIndex} from ${currentIndex} because it is invalid!`)
+    return state
+  }
   if (newIndex >= frames.size) {
     console.error(`Cannot move frame to index ${newIndex} from ${currentIndex} because it is invalid for a frame List of size ${frames.size}!`)
     return state
@@ -130,6 +134,7 @@ const frameReducer = (state, action, immutableAction) => {
       state = state.mergeIn(['frames', index], {
         tabStripWindowId: getCurrentWindowId()
       })
+      state = setFrameChangedIndex(state, frameStateUtil.getFrameByIndex(state, index), index, immutableAction.get('index'))
       break
     }
     case windowConstants.WINDOW_REMOVE_FRAME:


### PR DESCRIPTION
Fix #14281
A recent change in muon (between 6.0.9 and 6.0.11) has meant that certain tabs (usually with opener tabs) have an invalid index (-1) before they are added to the window tab strip. In such a case, we add the frame at the last index in the frame state. When the tab received a valid window tab strip, the window was notified and the tab UI shown. However, the index change event was notified separately, causing a delay, and a flash of the tab at the last index of the tab strip, followed by a move to the correct index.
Instead, with this change, we set the frame index immediately, as soon as we set the property that informs the tab has been inserted to the window's tab strip.

Validates input just in case we receive an invalid index (e.g. -1). However, there is no known scenario where this could happen at the moment.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


