### PR TITLE
Don't register `set-active` handler until web contents is active

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -523,6 +523,22 @@ const api = {
         unloaded: !!newTabValue.get('discarded')
       }
 
+      newTab.on('set-active', (sender, isActive) => {
+        updateTab(tabId, { active: isActive })
+        if (isActive) {
+          const tabValue = getTabValue(tabId)
+          if (tabValue) {
+            const windowId = tabValue.get('windowId')
+            // set-active could be called multiple times even when the index does not change
+            // so make sure we only add this to the active-tab trail for the window
+            // once
+            if (activeTabHistory.getActiveTabForWindow(windowId, 0) !== tabId) {
+              activeTabHistory.setActiveTabForWindow(windowId, tabId)
+            }
+          }
+        }
+      })
+
       appActions.tabCreated(newTabValue)
 
       if (disposition === 'new-window' || disposition === 'new-popup') {
@@ -641,22 +657,6 @@ const api = {
 
       tab.on('will-attach', (e, windowWebContents) => {
         // tab will attach to webview
-      })
-
-      tab.on('set-active', (sender, isActive) => {
-        updateTab(tab.getId(), { active: isActive })
-        if (isActive) {
-          const tabValue = getTabValue(tabId)
-          if (tabValue) {
-            const windowId = tabValue.get('windowId')
-            // set-active could be called multiple times even when the index does not change
-            // so make sure we only add this to the active-tab trail for the window
-            // once
-            if (activeTabHistory.getActiveTabForWindow(windowId, 0) !== tabId) {
-              activeTabHistory.setActiveTabForWindow(windowId, tabId)
-            }
-          }
-        }
       })
 
       tab.on('tab-replaced-at', (e, windowId, tabIndex, newContents) => {


### PR DESCRIPTION
Discovered while looking at https://github.com/brave/browser-laptop/issues/14261

Auditors: @bridiver, @petemill

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


