### PR TITLE
Fixing crash when ledger-state.json is missing/corrupted 

### DIFF
--- a/test/unit/app/browser/api/ledgerTest.js
+++ b/test/unit/app/browser/api/ledgerTest.js
@@ -3754,6 +3754,17 @@ describe('ledger api unit tests', function () {
     })
   })
 
+  describe('disablePayments', function () {
+    beforeEach(function () {
+      onChangeSettingSpy.reset()
+    })
+
+    it('goes to set PAYMENTS_ENABLED to false', function () {
+      ledgerApi.disablePayments()
+      assert(onChangeSettingSpy.withArgs(settings.PAYMENTS_ENABLED, false).calledOnce)
+    })
+  })
+
   describe('deleteWallet', function () {
     it('data is cleared', function () {
       const state = defaultAppState


### PR DESCRIPTION
Fixes: #14202

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

1. Run Brave with a clean profile
2. Enable payments
3. Run through some payments related test plans, ensure that wallet addresses are populated, publishers can be added, etc.
4. Close preference page
5. Stop Brave
6. Delete/move `ledger-state.json`
7. Start Brave
8. Navigate around some pages (make sure that there are no errors in the terminal)
9. Navigate to `about:preferences#payments` and ensure that payments are disabled
10. Ensure that payments can be re-enabled and behave as expected
11. Ensure that ledger table is the same
12. Use for a couple minutes and confirm no crash happens

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


