### PR TITLE
Update Linux Mint versions and codenames

### DIFF
--- a/docs/linuxInstall.md
+++ b/docs/linuxInstall.md
@@ -97,13 +97,13 @@ In the terminal to be used for the below commands, prime the `sudo` command (ent
 sudo echo
 ```
 
-For Sarah, Serena and Sonya:
+For Sarah (18), Serena (18.1), Sonya (18.2) and Sylvia (18.3):
 ```
 curl https://s3-us-west-2.amazonaws.com/brave-apt/keys.asc | sudo apt-key add -
 echo "deb [arch=amd64] https://s3-us-west-2.amazonaws.com/brave-apt xenial main" | sudo tee -a /etc/apt/sources.list.d/brave-xenial.list
 ```
 
-For Qiana, Rebecca, Rafaela and Rosa:
+For Qiana (17), Rebecca (17.1), Rafaela (17.2) and Rosa (17.3):
 ```
 curl https://s3-us-west-2.amazonaws.com/brave-apt/keys.asc | sudo apt-key add -
 echo "deb [arch=amd64] https://s3-us-west-2.amazonaws.com/brave-apt trusty main" | sudo tee -a /etc/apt/sources.list.d/brave-trusty.list


### PR DESCRIPTION
Added Mint Sylvia and version numbers for each Mint codename release. Reasoning is that System Info only gives version number and not codename release name. This change is meant to improve clarity.

## Submitter Checklist:

Stable release of Brave has been tested with Mint Sylvia (18.3) and works as expected.

Not applicable, this is strictly a readme file change suggestion.

## Test Plan:

Not applicable, this is strictly a readme file change suggestion.

## Reviewer Checklist:

Not applicable, this is strictly a readme file change suggestion.

Tests

Not applicable, this is strictly a readme file change suggestion.


