### PR TITLE
Avoid crash if the quarantine attribute is not present

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -851,7 +851,7 @@ module.exports.runPreMigrations = (data) => {
     if (process.platform === 'darwin' && (compareVersions(data.lastAppVersion, '0.22.13') === 0 || data.quarantineNeeded)) {
       const unQuarantine = (appPath) => {
         try {
-          execSync(`xattr -d com.apple.quarantine "${appPath}"`)
+          execSync(`xattr -d com.apple.quarantine "${appPath}" || true`)
           console.log(`Quarantine attribute has been removed from ${appPath}`)
         } catch (e) {
           console.error(`Failed to remove quarantine attribute from ${appPath}: `, e)


### PR DESCRIPTION
Fixes: https://github.com/brave/browser-laptop/issues/14353