### PR TITLE
Fixing UGP captcha issues with Windows 10 scaling

### DIFF
--- a/app/renderer/components/preferences/payment/captcha.js
+++ b/app/renderer/components/preferences/payment/captcha.js
@@ -19,6 +19,9 @@ const closeButton = require('../../../../../img/toolbar/stoploading_btn.svg')
 const dragIcon = require('../../../../extensions/brave/img/ledger/BAT_captcha_dragicon.png')
 const arrowIcon = require('../../../../extensions/brave/img/ledger/BAT_captcha_BG_arrow.png')
 
+// Utils
+const isWindows = require('../../../../common/lib/platformUtil').isWindows()
+
 // TODO: report when funds are too low
 class Captcha extends ImmutableComponent {
   constructor (props) {
@@ -27,6 +30,7 @@ class Captcha extends ImmutableComponent {
     this.onCaptchaDrag = this.onCaptchaDrag.bind(this)
     this.getText = this.getText.bind(this)
     this.captchaBox = null
+    this.offset = 5
     this.dndStartPosition = {
       x: 0,
       y: 0,
@@ -39,8 +43,15 @@ class Captcha extends ImmutableComponent {
     event.preventDefault()
     const target = this.captchaBox.getBoundingClientRect()
 
-    const x = event.clientX - target.left - this.dndStartPosition.x + (this.dndStartPosition.height / 2)
-    const y = event.clientY - target.top - this.dndStartPosition.y + (this.dndStartPosition.width / 2)
+    let x = event.clientX - target.left - this.dndStartPosition.x + (this.dndStartPosition.height / 2)
+    let y = event.clientY - target.top - this.dndStartPosition.y + (this.dndStartPosition.width / 2)
+
+    if (isWindows) {
+      const dpr = window.devicePixelRatio
+      const factor = (dpr <= 1) ? 0 : (this.offset * dpr)
+      x = Math.round(x + factor)
+      y = Math.round(y + factor)
+    }
 
     appActions.onPromotionClaim(x, y)
   }


### PR DESCRIPTION
Fixes #14361

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

## Test Plan:
Tests
  1. Install Brave with a fresh profile on Windows 10
  2. Follow steps 3 - 6 at custom scales 100%, 200%, 250%, etc (Found in Windows Display Settings)
  3. Enable payments, once wallet is created, attempt to claim tokens via "Claim Tokens" button
  4. Ensure the captcha works by first attempting a few invalid solves.
  5. Ensure that the captcha can be solved to claim the tokens by dragging the BAT symbol inside the outlined triange.
  6. In performing step 5, note if there is not a reasonable leniency at that scale (ex: have to line it up visually perfectly, this can be frustrating)
  7. Verify that steps 3 - 6 continue to work as expected on MacOS/Linux
  

- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


