### PR TITLE
Fixing undefined currency value for contribution notification

### DIFF
--- a/app/browser/api/ledgerNotifications.js
+++ b/app/browser/api/ledgerNotifications.js
@@ -329,7 +329,7 @@ const showAddFunds = () => {
 const showPaymentDone = (transactionContribution) => {
   text.paymentDone = locale.translation('notificationPaymentDone')
     .replace(/{{\s*amount\s*}}/, ledgerUtil.probiToFormat(transactionContribution.get('probi')))
-    .replace(/{{\s*currency\s*}}/, transactionContribution.getIn(['currency', 'fiat']))
+    .replace(/{{\s*currency\s*}}/, transactionContribution.getIn(['fiat', 'currency']))
   // Hide the 'waiting for deposit' message box if it exists
   appActions.hideNotification(text.addFunds)
   appActions.showNotification({


### PR DESCRIPTION
Fixes: #14417 

Basically the transaction keys were swapped, trying to access the `currency` prop first as opposed to `fiat`. Contribution map is structured like so:

`{ "fiat": Map { "amount": 10, "currency": "BAT" }, "rates": Map { "EUR": 0.16415440004057, "USD": 0.19355117, "BCH": 0.00022834810733109726, "BTC": 0.0000327, "DASH": 0.0007821603506058262, "BTG": 0.005958015042318794, "XRP": 0.36440067259188086, "ETH": 0.0004051167013833253, "LTC": 0.0020486297689414294 }, "satoshis": undefined, "altcurrency": "BAT", "probi": "10000000000000000000", "fee": undefined }`

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
Defined in #14417 

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


