### PR TITLE
Avoid depending on requests module in python unittests

### DIFF
--- a/tools/test/mock.py
+++ b/tools/test/mock.py
@@ -3,6 +3,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 
+class MockImport(object):
+ def __import__(self):
+     pass
+
 class Repo():
   def __init__(self):
     self.releases = self.Releases()

--- a/tools/test/test_publish.py
+++ b/tools/test/test_publish.py
@@ -7,12 +7,16 @@ import sys
 import unittest
 import os
 
+from mock import MockImport, Repo
+
+# Mock requests module
+sys.modules['requests'] = MockImport
+
 dirname = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(dirname, '..'))
 
 import publish_release
 
-from mock import Repo
 
 class TestPublishGetDraft(unittest.TestCase):
   def setUp(self):


### PR DESCRIPTION
Git push will fail if the python requests module isn't installed on the local machine. This mocks that import since it isn't needed for the tests.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


