### PR TITLE
Add Facebook CDN to the referrer exceptions list

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -33,7 +33,7 @@ const {fullscreenOption} = require('./common/constants/settingsEnums')
 const isThirdPartyHost = require('./browser/isThirdPartyHost')
 const extensionState = require('./common/state/extensionState')
 const ledgerUtil = require('./common/lib/ledgerUtil')
-const {cookieExceptions, refererExceptions} = require('../js/data/siteHacks')
+const {cookieExceptions, isRefererException} = require('../js/data/siteHacks')
 const {getBraverySettingsCache, updateBraverySettingsCache} = require('./common/cache/braverySettingsCache')
 
 let appStore = null
@@ -293,7 +293,7 @@ module.exports.applyCookieSetting = (requestHeaders, url, firstPartyUrl, isPriva
 
     if (referer &&
         cookieSetting !== 'allowAllCookies' &&
-        !refererExceptions.includes(targetHostname) &&
+        !isRefererException(targetHostname) &&
         isThirdPartyHost(targetHostname, urlParse(referer).hostname)) {
       // Spoof third party referer
       requestHeaders['Referer'] = targetOrigin

--- a/js/data/siteHacks.js
+++ b/js/data/siteHacks.js
@@ -32,7 +32,11 @@ module.exports.cookieExceptions = {
 }
 
 // Third party domains that require a valid referer to work
-module.exports.refererExceptions = ['use.typekit.net', 'cloud.typography.com', 'www.moremorewin.net']
+const refererExceptions = ['use.typekit.net', 'cloud.typography.com', 'www.moremorewin.net']
+const refererExceptionsRegex = [/.*\.fbcdn\.net$/]
+module.exports.isRefererException = (hostname) =>
+  refererExceptions.includes(hostname) || refererExceptionsRegex.some(regex => regex.test(hostname))
+module.exports.getTestRefererException = () => refererExceptions[0]
 
 /**
  * Holds an array of [Primary URL, subresource URL] to allow 3rd party localstorage.

--- a/test/unit/app/filteringTest.js
+++ b/test/unit/app/filteringTest.js
@@ -2,7 +2,7 @@
 const mockery = require('mockery')
 const assert = require('assert')
 const sinon = require('sinon')
-const {cookieExceptions, refererExceptions} = require('../../../js/data/siteHacks')
+const {cookieExceptions, getTestRefererException} = require('../../../js/data/siteHacks')
 
 require('../braveUnit')
 
@@ -197,7 +197,7 @@ describe('filtering unit tests', function () {
 
       describe('when there is a referer exception', function () {
         it('keeps the referer field', function () {
-          const url = 'https://' + refererExceptions[0]
+          const url = 'https://' + getTestRefererException()
           const firstPartyUrl = 'https://slashdot.org/'
           const requestHeaders = {
             Referer: 'https://brave.com'


### PR DESCRIPTION
Fixes #14358

Had to tweak the logic to accept regexs to catch all FBCDN subdomains

Auditors:

Test Plan:
Go to any facebook video page and make sure the video plays at various points
You can use this page as an example: https://www.facebook.com/peopleareawesome/videos/1393626100686564/

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


