### PR TITLE
Allow empty space in tabs toolbar to be used for moving window via mouse-drag again

### DIFF
--- a/app/renderer/components/tabs/tabs.js
+++ b/app/renderer/components/tabs/tabs.js
@@ -19,16 +19,13 @@ const PreviousTabPageIcon = require('../../../../icons/arrow/left')
 const appActions = require('../../../../js/actions/appActions')
 const windowActions = require('../../../../js/actions/windowActions')
 
-// State
-const windowState = require('../../../common/state/windowState')
-
 // Constants
 const dragTypes = require('../../../../js/constants/dragTypes')
 const settings = require('../../../../js/constants/settings')
 
 // Utils
 const contextMenus = require('../../../../js/contextMenus')
-const {getCurrentWindowId, isFocused} = require('../../currentWindow')
+const {getCurrentWindowId} = require('../../currentWindow')
 const dnd = require('../../../../js/dnd')
 const dndData = require('../../../../js/dndData')
 const frameStateUtil = require('../../../../js/state/frameStateUtil')
@@ -132,7 +129,6 @@ class Tabs extends React.Component {
       .slice(startingFrameIndex, startingFrameIndex + tabsPerTabPage)
       .map((tab) => tab.get('key'))
     const totalPages = Math.ceil(unpinnedTabs.size / tabsPerTabPage)
-    const activeFrame = frameStateUtil.getActiveFrame(currentWindow) || Immutable.Map()
     const dragData = (state.getIn(['dragData', 'type']) === dragTypes.TAB && state.get('dragData')) || Immutable.Map()
 
     const props = {}
@@ -143,7 +139,6 @@ class Tabs extends React.Component {
     props.partOfFullPageSet = currentTabs.size === tabsPerTabPage
     props.onNextPage = currentTabs.size >= tabsPerTabPage && totalPages > pageIndex + 1
     props.onPreviousPage = pageIndex > 0
-    props.shouldAllowWindowDrag = windowState.shouldAllowWindowDrag(state, currentWindow, activeFrame, isFocused(state))
 
     // used in other functions
     props.tabPageIndex = currentWindow.getIn(['ui', 'tabs', 'tabPageIndex'])
@@ -162,7 +157,6 @@ class Tabs extends React.Component {
       <span className={css(
         styles.tabs__tabStrip,
         (this.props.previewTabPageIndex != null) && styles.tabs__tabStrip_isPreview,
-        this.props.shouldAllowWindowDrag && styles.tabs__tabStrip_allowDragging,
         isTabPreviewing && styles.tabs__tabStrip_isTabPreviewing
       )}
         data-test-preview-tab={this.props.previewTabPageIndex != null}
@@ -242,11 +236,9 @@ const styles = StyleSheet.create({
 
   tabs__tabStrip_isPreview: globalStyles.animations.tabFadeIn,
 
-  tabs__tabStrip_allowDragging: {
-    WebkitAppRegion: 'drag'
-  },
-
   tabs__tabStrip__navigation: {
+    // no-drag is applied to each button and tab
+    WebkitAppRegion: 'no-drag',
     '--icon-line-color': globalStyles.color.buttonColor,
     display: 'flex',
     justifyContent: 'center',

--- a/app/renderer/components/tabs/tabsToolbar.js
+++ b/app/renderer/components/tabs/tabsToolbar.js
@@ -14,9 +14,13 @@ const PinnedTabs = require('./pinnedTabs')
 // Actions
 const windowActions = require('../../../../js/actions/windowActions')
 
+// State
+const windowState = require('../../../common/state/windowState')
+
 // Utils
 const contextMenus = require('../../../../js/contextMenus')
 const frameStateUtil = require('../../../../js/state/frameStateUtil')
+const {isFocused} = require('../../currentWindow')
 
 const globalStyles = require('../styles/global')
 const {theme} = require('../styles/theme')
@@ -61,6 +65,7 @@ class TabsToolbar extends React.Component {
     // used in renderer
     props.hasPinnedTabs = !pinnedTabs.isEmpty()
     props.hasPreview = (frameStateUtil.getPreviewFrameKey(currentWindow) != null)
+    props.shouldAllowWindowDrag = windowState.shouldAllowWindowDrag(state, currentWindow, activeFrame, isFocused(state))
 
     // used in other functions
     props.activeFrameKey = activeFrame.get('key')
@@ -75,6 +80,7 @@ class TabsToolbar extends React.Component {
     return <div
       className={css(
         styles.tabsToolbar,
+        this.props.shouldAllowWindowDrag && styles.tabsToolbar_allowWindowDragging,
         this.props.hasPreview && styles.tabsToolbar_hasPreview
       )}
       data-test-id='tabsToolbar'
@@ -98,7 +104,6 @@ const styles = StyleSheet.create({
     backgroundColor: theme.tabsToolbar.backgroundColor,
     display: 'flex',
     userSelect: 'none',
-    WebkitAppRegion: 'no-drag',
 
     // This element is set as border-box so it does not
     // take into account the borders as width gutter, so we
@@ -123,6 +128,10 @@ const styles = StyleSheet.create({
       content: '" "',
       willChange: 'box-shadow'
     }
+  },
+
+  tabsToolbar_allowWindowDragging: {
+    WebkitAppRegion: 'drag'
   },
 
   tabsToolbar_hasPreview: {


### PR DESCRIPTION
Fix #14469

Use tabsToolbar element which has full-width layout. The previous tabs container element now only occupies the width of its tab children, so does not cover the empty space.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
On issue (should test on mac and windows)

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


