### PR TITLE
defense in depth against Flash/ledger running on tor tabs

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -33,6 +33,7 @@ const updateState = require('../../common/state/updateState')
 // Constants
 const settings = require('../../../js/constants/settings')
 const messages = require('../../../js/constants/messages')
+const appConfig = require('../../../js/constants/appConfig')
 const ledgerStatuses = require('../../common/constants/ledgerStatuses')
 
 // Utils
@@ -866,7 +867,7 @@ const shouldTrackTab = (state, tabId) => {
   }
   const partition = tabFromState.get('partition', '')
   const ses = session.fromPartition(partition)
-  const isPrivate = (ses && ses.isOffTheRecord()) || tabFromState.get('incognito')
+  const isPrivate = (ses && ses.isOffTheRecord()) || tabFromState.get('incognito') || partition === appConfig.tor.partition
   return !isPrivate && !tabFromState.isEmpty() && ledgerUtil.shouldTrackView(tabFromState)
 }
 

--- a/app/extensions/brave/content/scripts/blockCanvasFingerprinting.js
+++ b/app/extensions/brave/content/scripts/blockCanvasFingerprinting.js
@@ -267,6 +267,6 @@ if (chrome.contentSettings.canvasFingerprinting == 'block') {
   blockWebRTC()
 }
 
-if (chrome.contentSettings.torEnabled == 'block') {
+if (isTorTab()) {
   blockWebRTC()
 }

--- a/app/extensions/brave/content/scripts/blockFlash.js
+++ b/app/extensions/brave/content/scripts/blockFlash.js
@@ -30,7 +30,7 @@ if (adobeRegex.test(window.location.href)) {
   }
 }
 
-if (chrome.contentSettings.flashEnabled == 'allow') {
+if (chrome.contentSettings.flashEnabled == 'allow' && chrome.contentSettings.torEnabled == 'allow') {
   document.addEventListener('click', (e) => {
     let node = e.target
     while (!node.href && node.parentNode)
@@ -46,6 +46,6 @@ if (chrome.contentSettings.flashEnabled == 'allow') {
   })
 }
 
-if (chrome.contentSettings.plugins != 'allow') {
+if (chrome.contentSettings.plugins != 'allow' || chrome.contentSettings.torEnabled == 'block') {
   executeScript(getBlockFlashPageScript())
 }

--- a/app/extensions/brave/content/scripts/blockFlash.js
+++ b/app/extensions/brave/content/scripts/blockFlash.js
@@ -30,7 +30,7 @@ if (adobeRegex.test(window.location.href)) {
   }
 }
 
-if (chrome.contentSettings.flashEnabled == 'allow' && chrome.contentSettings.torEnabled == 'allow') {
+if (chrome.contentSettings.flashEnabled == 'allow' && !isTorTab()) {
   document.addEventListener('click', (e) => {
     let node = e.target
     while (!node.href && node.parentNode)
@@ -46,6 +46,6 @@ if (chrome.contentSettings.flashEnabled == 'allow' && chrome.contentSettings.tor
   })
 }
 
-if (chrome.contentSettings.plugins != 'allow' || chrome.contentSettings.torEnabled == 'block') {
+if (chrome.contentSettings.plugins != 'allow' || isTorTab()) {
   executeScript(getBlockFlashPageScript())
 }

--- a/app/extensions/brave/content/scripts/flashListener.js
+++ b/app/extensions/brave/content/scripts/flashListener.js
@@ -73,7 +73,7 @@ function hasHiddenFlashElement (elem) {
 
 // If Flash is enabled but not runnable, show a permission notification for small
 // Flash elements
-if (chrome.contentSettings.flashEnabled == 'allow' && chrome.contentSettings.flashAllowed != 'allow') {
+if (chrome.contentSettings.flashEnabled == 'allow' && chrome.contentSettings.flashAllowed != 'allow' && chrome.contentSettings.torEnabled == 'allow') {
   const maxFlashAttempts = 3
   let flashAttempts = 0
   const intervalId = window.setInterval(() => {

--- a/app/extensions/brave/content/scripts/flashListener.js
+++ b/app/extensions/brave/content/scripts/flashListener.js
@@ -73,7 +73,7 @@ function hasHiddenFlashElement (elem) {
 
 // If Flash is enabled but not runnable, show a permission notification for small
 // Flash elements
-if (chrome.contentSettings.flashEnabled == 'allow' && chrome.contentSettings.flashAllowed != 'allow' && chrome.contentSettings.torEnabled == 'allow') {
+if (chrome.contentSettings.flashEnabled == 'allow' && chrome.contentSettings.flashAllowed != 'allow' && !isTorTab()) {
   const maxFlashAttempts = 3
   let flashAttempts = 0
   const intervalId = window.setInterval(() => {

--- a/app/extensions/brave/content/scripts/pageInformation.js
+++ b/app/extensions/brave/content/scripts/pageInformation.js
@@ -130,7 +130,7 @@
   if (window.top !== window.self) return
 
   // Don't allow ledger to run in incognito
-  if (chrome.extension.inIncognitoContext) {
+  if (chrome.extension.inIncognitoContext || chrome.contentSettings.torEnabled == 'block') {
     return
   }
 

--- a/app/extensions/brave/content/scripts/pageInformation.js
+++ b/app/extensions/brave/content/scripts/pageInformation.js
@@ -130,7 +130,7 @@
   if (window.top !== window.self) return
 
   // Don't allow ledger to run in incognito
-  if (chrome.extension.inIncognitoContext || chrome.contentSettings.torEnabled == 'block') {
+  if (chrome.extension.inIncognitoContext || isTorTab()) {
     return
   }
 

--- a/app/extensions/brave/content/scripts/util.js
+++ b/app/extensions/brave/content/scripts/util.js
@@ -36,3 +36,7 @@ function isPlatformOSX () {
 function hasWhitespace (text) {
   return /\s/g.test(text);
 }
+
+function isTorTab () {
+  return chrome.contentSettings.torEnabled != 'allow'
+}


### PR DESCRIPTION
use the new torEnabled content script settings to block content scripts that
shouldn't be runnning in Tor tabs

fix https://github.com/brave/browser-laptop/issues/14480

Test Plan:
1. enable flash in about:prefs
2. open tor tab and go to http://www.ultrasounds.com/
3. you should not see a notification to run flash

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


