### PR TITLE
Tab icon for tor tabs

### DIFF
--- a/app/common/state/tabContentState/privateState.js
+++ b/app/common/state/tabContentState/privateState.js
@@ -25,6 +25,7 @@ module.exports.showPrivateIcon = (state, frameKey) => {
 
   return (
     module.exports.isPrivateTab(state, frameKey) &&
+    !frameStateUtil.isTor(frame) &&
     tabUIState.showTabEndIcon(state, frameKey)
   )
 }

--- a/app/renderer/components/tabs/content/torIcon.js
+++ b/app/renderer/components/tabs/content/torIcon.js
@@ -3,24 +3,20 @@
 * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const React = require('react')
-const ReactDOM = require('react-dom')
-const {StyleSheet} = require('aphrodite/no-important')
+const {StyleSheet, css} = require('aphrodite/no-important')
 
 // Components
 const ReduxComponent = require('../../reduxComponent')
-const TabIcon = require('./tabIcon')
 
 // State helpers
 const frameStateUtil = require('../../../../../js/state/frameStateUtil')
 const tabState = require('../../../../common/state/tabState')
-const privateState = require('../../../../common/state/tabContentState/privateState')
+const tabUIState = require('../../../../common/state/tabUIState')
 
 // Styles
 const globalStyles = require('../../styles/global')
-const {theme} = require('../../styles/theme')
 const {opacityIncreaseElementKeyframes} = require('../../styles/animations')
-
-const torSvg = require('../../../../extensions/brave/img/tabs/tor.svg')
+require('../../../../../fonts/poppins.css')
 
 class TorIcon extends React.Component {
   constructor (props) {
@@ -36,9 +32,8 @@ class TorIcon extends React.Component {
 
     const props = {}
     props.isPinned = tabState.isTabPinned(state, tabId)
-    props.isActive = frameStateUtil.isFrameKeyActive(currentWindow, frameKey)
     props.showTorIcon = frameStateUtil.isTor(frame) &&
-      privateState.showPrivateIcon(currentWindow, frameKey)
+      tabUIState.showTabEndIcon(currentWindow, frameKey)
     props.tabId = tabId
 
     return props
@@ -70,7 +65,7 @@ class TorIcon extends React.Component {
   }
 
   setRef (ref) {
-    this.element = ReactDOM.findDOMNode(ref)
+    this.element = ref
   }
 
   render () {
@@ -78,34 +73,23 @@ class TorIcon extends React.Component {
       return null
     }
 
-    return <TabIcon
+    return <div
       data-test-id='torIcon'
-      className={[
-        styles.icon_private,
-        this.props.isActive && styles.icon_private_active
-      ]}
+      className={css(
+        styles.icon_private
+      )}
       ref={this.setRef}
-    />
+    >
+      Tor
+    </div>
   }
 }
 
 const styles = StyleSheet.create({
   icon_private: {
-    WebkitMaskRepeat: 'no-repeat',
-    WebkitMaskPosition: 'center',
-    WebkitMaskImage: `url(${torSvg})`,
-    WebkitMaskSize: globalStyles.spacing.sessionIconSize,
     marginRight: globalStyles.spacing.defaultTabMargin,
-
-    // Override default properties
-    backgroundSize: 0,
-    height: globalStyles.spacing.sessionIconSize,
-    width: globalStyles.spacing.sessionIconSize,
-    backgroundColor: theme.tab.icon.private.background.notActive
-  },
-
-  icon_private_active: {
-    backgroundColor: theme.tab.icon.private.background.active
+    paddingTop: '1px',
+    font: '600 10px Poppins, sans-serif'
   }
 })
 


### PR DESCRIPTION
A single icon to specify which tab is a tor tab. The regular private-tab icon will no longer display, though the private-tab tab color remains.

Fix #14373 since there is now a single icon displayed for tor-private-tabs, whereas before there were two.

## Screenshots
![image](https://user-images.githubusercontent.com/741836/41704082-1d925fa2-74ea-11e8-92d2-6a3a699a27af.png)

![image](https://user-images.githubusercontent.com/741836/41704094-2a41c1d4-74ea-11e8-8ac2-7214bac55be0.png)


## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
Tor icon displays for tor tabs. Private icon displays for non-tor private tabs.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


