### PR TITLE
Fixes verfied check for YouTube

### DIFF
--- a/app/extensions/brave/content/scripts/metaScraper.js
+++ b/app/extensions/brave/content/scripts/metaScraper.js
@@ -98,5 +98,16 @@ const metaScraperRules = {
       requestHandlerApi.strict(wrap(html => requestHandlerApi.getValue(html.querySelectorAll('[class*="author"]')))),
       requestHandlerApi.strict(wrap(html => requestHandlerApi.getValue(html.querySelectorAll('[class*="byline"]'))))
     ]
+  },
+
+  getUrlRules: () => {
+    const wrap = rule => ({htmlDom, url}) => {
+      const value = rule(htmlDom)
+      return requestHandlerApi.isUrl(value, {relative: false}) && requestHandlerApi.getUrl(url, value)
+    }
+
+    return [
+      wrap(html => requestHandlerApi.getHref(html.querySelector('link[rel="canonical"]')))
+    ]
   }
 }

--- a/app/extensions/brave/content/scripts/requestHandler.js
+++ b/app/extensions/brave/content/scripts/requestHandler.js
@@ -51,13 +51,15 @@ const requestHandlerApi = {
       const result = {
         image: await requestHandlerApi.getData({ htmlDom, finalUrl, conditions: metaScraperRules.getImageRules() }),
         title: await requestHandlerApi.getData({ htmlDom, finalUrl, conditions: metaScraperRules.getTitleRules() }),
-        author: await requestHandlerApi.getData({ htmlDom, finalUrl, conditions: metaScraperRules.getAuthorRules() })
+        author: await requestHandlerApi.getData({ htmlDom, finalUrl, conditions: metaScraperRules.getAuthorRules() }),
+        url: await requestHandlerApi.getData({ htmlDom, finalUrl, conditions: metaScraperRules.getUrlRules() })
       }
 
       ipc.send(`got-publisher-info-${url}`, {
         error: null,
         body: {
-          url: finalUrl,
+          finalUrl: finalUrl,
+          url: sanitizeHtml(result.url) || finalUrl,
           title: sanitizeHtml(result.title) || '',
           image: sanitizeHtml(result.image) || '',
           author: sanitizeHtml(result.author) || ''
@@ -114,6 +116,14 @@ const requestHandlerApi = {
     }
 
     return selector.src
+  },
+
+  getHref: (selector) => {
+    if (!selector) {
+      return null
+    }
+
+    return selector.href
   },
 
   urlTest: (url, opts) => {


### PR DESCRIPTION
Resolves #14351

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
- visit verified youtube channels (more in #14351) and make sure that verified check is added to them
- make sure that twitch did not regressed

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


