### PR TITLE
Don't show Tor error immediately on circuit established error

### DIFF
--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -429,6 +429,9 @@ class UrlBar extends React.Component {
       } else if (this.props.torPercentInitialized) {
         // Don't show 100% since it sometimes gets stuck at 100%
         const percentInitialized = this.props.torPercentInitialized === '100' ? '99' : this.props.torPercentInitialized
+        if (percentInitialized === '0') {
+          return `${locale.translation('urlbarPlaceholderTorProgress')}...`
+        }
         return `${locale.translation('urlbarPlaceholderTorProgress')}: ${percentInitialized}%...`
       } else if (this.props.torInitializationError === false) {
         return locale.translation('urlbarPlaceholderTorSuccess')


### PR DESCRIPTION
fix #14483 by not showing the Tor error dialog as soon as a circuit
established error is emitted. Instead just disable the URL bar until the
circuit has been successfully re-established or 10s has passed.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


