### PR TITLE
Log will-download event to console

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -35,6 +35,7 @@ const extensionState = require('./common/state/extensionState')
 const ledgerUtil = require('./common/lib/ledgerUtil')
 const {cookieExceptions, isRefererException} = require('../js/data/siteHacks')
 const {getBraverySettingsCache, updateBraverySettingsCache} = require('./common/cache/braverySettingsCache')
+const {shouldDebugTabEvents} = require('./cmdLine')
 
 let appStore = null
 
@@ -609,10 +610,17 @@ function registerForDownloadListener (session) {
 
   session.on('will-download', function (event, item, webContents) {
     if (webContents.isDestroyed()) {
+      if (shouldDebugTabEvents) {
+        console.log(`Tab [DESTROYED] will-download`)
+      }
       event.preventDefault()
       return
     }
 
+    if (shouldDebugTabEvents) {
+      const tabId = webContents.getId ? webContents.getId() : 'NOT_TAB'
+      console.log(`Tab [${tabId}] will-download`)
+    }
     const hostWebContents = webContents.hostWebContents || webContents
     const win = BrowserWindow.fromWebContents(hostWebContents) || BrowserWindow.getFocusedWindow()
 


### PR DESCRIPTION
I'm submitting this minor logging PR as it may help investigate will-download issue at #14398 with muon 7.1 that is experienced with tor/0.23.x branch (@jumde @darkdh)

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


