### PR TITLE
Adjust bookmark hanger position to match bookmark button

### DIFF
--- a/app/renderer/components/bookmarks/addEditBookmarkHanger.js
+++ b/app/renderer/components/bookmarks/addEditBookmarkHanger.js
@@ -85,7 +85,6 @@ class AddEditBookmarkHanger extends React.Component {
     const props = {}
     // used in renderer
     props.isModal = ownProps.isModal
-    props.withHomeButton = getSetting(settings.SHOW_HOME_BUTTON)
     props.heading = bookmarkHangerHeading(editMode, isAdded)
     props.location = siteDetail.get('location')
     props.parentFolderId = siteDetail.get('parentFolderId')
@@ -113,8 +112,7 @@ class AddEditBookmarkHanger extends React.Component {
         {
           !this.props.isModal
           ? <div className={cx({
-            [css(styles.bookmarkHanger__arrowUp)]: true,
-            [css(styles.bookmarkHanger__withHomeButton)]: this.props.withHomeButton
+            [css(styles.bookmarkHanger__arrowUp)]: true
           })} />
           : null
         }
@@ -175,7 +173,7 @@ const styles = StyleSheet.create({
   },
   bookmarkHanger__arrowUp: {
     position: 'relative',
-    left: '54px',
+    left: '59px',
 
     '::after': {
       content: '""',
@@ -187,9 +185,6 @@ const styles = StyleSheet.create({
       transformOrigin: '0 0',
       transform: 'rotate(135deg)'
     }
-  },
-  bookmarkHanger__withHomeButton: {
-    left: '83px'
   },
   bookmark__bottomWrapper: {
     display: 'flex',


### PR DESCRIPTION
Fix #14456

The position of the icon had changed relative to the container. Futhermore, the home button being shown / not shown no longer affects the positioning of the bookmark hanger since it is not within the same container anymore.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


