### PR TITLE
Adding script to push back reconcileStamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "port": "8080"
   },
   "scripts": {
+    "push-back-next-reconcile-stamp": "node ./tools/pushBackNextReconcileStamp.js",
     "add-simulated-payment-history": "node ./tools/addSimulatedPaymentHistory.js",
     "add-simulated-synopsis-visits": "node ./tools/addSimulatedSynopsisVisits.js",
     "build-installer": "node ./tools/buildInstaller.js",

--- a/tools/lib/utilApp/index.js
+++ b/tools/lib/utilApp/index.js
@@ -18,6 +18,13 @@ const cleanUserData = (location) => {
 const simulateLedgerTransactions = require('../simulateLedgerTransactions')
 const fs = require('fs')
 
+function ledgerStateFileError (func, path, exc) {
+  console.error(`\nERROR in ${func}: could not find/open/parse Ledger data file.`)
+  console.error(`\nExpected path to Ledger data file: ${path}`)
+  console.error('\nProbable solution: Run Brave and enable Payments, then execute this script. Enabling/disabling Payments (or restarting Brave) should then show the generated transactions in Brave.')
+  console.error(exc.toString())
+}
+
 function addSimulatedLedgerTransactions (numTx) {
   let userDataPath = app.getPath('userData')
   let ledgerStatePath = path.join(userDataPath, 'ledger-state.json')
@@ -33,10 +40,7 @@ function addSimulatedLedgerTransactions (numTx) {
 
     console.log(`Updated Ledger data file at ${ledgerStatePath}`)
   } catch (exc) {
-    console.error('ERROR in addSimulatedLedgerTransactions: could not find/open/parse Ledger data file.')
-    console.error(`Expected path to Ledger data file: ${ledgerStatePath}`)
-    console.error('Probable solution: Run Brave and enable Payments, then execute this script. Enabling/disabling Payments (or restarting Brave) should then show the generated transactions in Brave.')
-    console.error(exc.toString())
+    ledgerStateFileError('addSimulatedLedgerTransactions', ledgerStatePath, exc)
   }
 }
 
@@ -56,6 +60,43 @@ function addSimulatedSynopsisVisits (numPublishers) {
   }
 }
 
+/**
+ * Usage:
+ * npm push-back-next-reconcile-stamp {numWeeks}
+ *
+ * @param numWeeks - Number of weeks to subtract from the current reconcileStamp
+ *
+ * If numWeeks is not provided, reconcileStamp will be set to the current
+ * time minus one week. (This serves to set the payment status as overdue to trigger reconcilation)
+ */
+function pushBackNextReconcileStamp (numWeeks) {
+  numWeeks = parseInt(numWeeks) || -1
+
+  const userDataPath = app.getPath('userData')
+  const ledgerStatePath = path.join(userDataPath, 'ledger-state.json')
+
+  try {
+    let ledgerState = JSON.parse(fs.readFileSync(ledgerStatePath).toString())
+
+    if (!ledgerState.reconcileStamp) {
+      console.error('ERROR in setReconcileStamp: reconcileStamp not found in ledger-state.json')
+      return
+    }
+
+    const now = new Date().getTime()
+    const oneWeek = (1000 * 60 * 60 * 24 * 7)
+
+    ledgerState.reconcileStamp = (numWeeks === -1)
+      ? (now - oneWeek)
+      : (ledgerState.reconcileStamp - (numWeeks * oneWeek))
+
+    fs.writeFileSync(ledgerStatePath, JSON.stringify(ledgerState, null, 2))
+    console.log(`Successfully set reconcileStamp to: ${ledgerState.reconcileStamp}`)
+  } catch (exc) {
+    ledgerStateFileError('pushBackNextReconcileStamp', ledgerStatePath, exc)
+  }
+}
+
 app.on('ready', () => {
   const cmd = process.argv[2]
   switch (cmd) {
@@ -67,6 +108,9 @@ app.on('ready', () => {
       break
     case 'addSimulatedSynopsisVisits':
       addSimulatedSynopsisVisits(parseInt(process.argv[3]))
+      break
+    case 'pushBackNextReconcileStamp':
+      pushBackNextReconcileStamp(process.argv[3])
       break
   }
 

--- a/tools/pushBackNextReconcileStamp.js
+++ b/tools/pushBackNextReconcileStamp.js
@@ -1,0 +1,9 @@
+let runUtilApp = require('./utilAppRunner')
+
+let cmd = 'pushBackNextReconcileStamp'
+
+if (process.argv[2]) {
+  cmd += ' ' + process.argv[2]
+}
+
+runUtilApp(cmd, undefined, ['inherit', 'inherit', 'inherit'])


### PR DESCRIPTION
## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

1. Run Brave with a fresh profile using: `LEDGER_ENVIRONMENT=staging LEDGER_NO_FUZZING=true LEDGER_NO_DELAY=true npm start`
2. Note the current contribution date in `about:preferences#payments`
3. Add a few publishers to the synopsis
4. Close Brave
5. Run `npm push-back-next-reconcile-stamp`
6. Restart Brave with the command in step 1. Ensure that the contribution is overdue and attempts to Process.
7. Repeat steps 1 - 4.
8. Run `npm push-back-next-reconcile-stamp numWeeks` (Where numWeeks is a single integer, such as 3. This best left under 4 so that the new contribution date can be noted without pushing it to overdue)
9. Confirm that the contribution date matches as expected (Ex: Was July 21st, ran with numWeeks as 2, is now July 7th)

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


