### PR TITLE
Adjust content area fade for preview tabs

### DIFF
--- a/less/window.less
+++ b/less/window.less
@@ -61,7 +61,7 @@ html,
     left: 0;
     right: 0;
     bottom: 0;
-    background: linear-gradient(to top, rgb(125, 125, 125) 0%, rgba(255, 255, 255, .3) 60%);
+    background: linear-gradient(to top, rgba(0, 0, 0, .5) 0%, rgba(0, 0, 0, 0) 100%);
     display: block;
     opacity: 0;
     transition: opacity .2s ease-in; // TODO: get from theme.tab


### PR DESCRIPTION
Fix #14514
Changes the fade from:
previously - a gradient that starts as solid color with a gradient stop at 60% height of another color with 30% transparency
with this commit - a gradient that starts as 50% transparent black, and stops at 100% with full transparency

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


