### PR TITLE
Fix/tab close fixed width animation jump

### DIFF
--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -206,11 +206,11 @@ class Tab extends React.Component {
     const frame = this.frame
 
     if (frame && !frame.isEmpty()) {
-      // do not mimic tab size if closed tab is a pinned tab
+      // do not mimic tab size if closed tab is a pinned tab or last tab
       if (!this.props.isPinnedTab) {
         const tabWidth = this.fixTabWidth
         windowActions.onTabClosedWithMouse({
-          fixTabWidth: tabWidth
+          fixTabWidth: this.props.isLastTabOfPage ? null : tabWidth
         })
       }
       appActions.tabCloseRequested(this.props.tabId)
@@ -299,6 +299,7 @@ class Tab extends React.Component {
     // TODO: this should have its own method
     props.notificationBarActive = notificationBarActive
     props.frameKey = frameKey
+    props.isLastTabOfPage = ownProps.isLastTabOfPage
     props.isPinnedTab = isPinned
     props.isPrivateTab = privateState.isPrivateTab(currentWindow, frameKey)
     props.isActive = !!frameStateUtil.isFrameKeyActive(currentWindow, frameKey)

--- a/app/renderer/components/tabs/tab.js
+++ b/app/renderer/components/tabs/tab.js
@@ -332,15 +332,18 @@ class Tab extends React.Component {
 
   componentDidUpdate (prevProps) {
     if (prevProps.tabWidth && !this.props.tabWidth && !this.props.partOfFullPageSet) {
-      this.elementRef.animate([
+      window.requestAnimationFrame(() => {
+        this.elementRef && this.elementRef.animate([
           { flexBasis: `${prevProps.tabWidth}px`, flexGrow: 0, flexShrink: 0 },
           { flexBasis: 0, flexGrow: 1, flexShrink: 1 }
-      ], {
-        duration: 250,
-        iterations: 1,
-        easing: 'ease-in-out'
+        ], {
+          duration: 250,
+          iterations: 1,
+          easing: 'ease-in-out'
+        })
       })
     }
+
     // no transition between:
     // - active <-> inactive state
     // - no theme color and first theme color

--- a/app/renderer/components/tabs/tabs.js
+++ b/app/renderer/components/tabs/tabs.js
@@ -174,9 +174,10 @@ class Tabs extends React.Component {
         }
         {
           this.props.currentTabs
-            .map((frameKey) =>
+            .map((frameKey, i) =>
               <Tab
                 key={'tab-' + frameKey}
+                pageDisplayIndex={i}
                 ref={(node) => this.tabRefs.push(node)}
                 frameKey={frameKey}
                 partOfFullPageSet={this.props.partOfFullPageSet}

--- a/app/renderer/components/tabs/tabs.js
+++ b/app/renderer/components/tabs/tabs.js
@@ -177,7 +177,7 @@ class Tabs extends React.Component {
             .map((frameKey, i) =>
               <Tab
                 key={'tab-' + frameKey}
-                pageDisplayIndex={i}
+                isLastTabOfPage={(i + 1) === this.props.currentTabs.count()}
                 ref={(node) => this.tabRefs.push(node)}
                 frameKey={frameKey}
                 partOfFullPageSet={this.props.partOfFullPageSet}

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -755,7 +755,9 @@ const doAction = (action) => {
           action.frameOpts.tabStripWindowId = existingTabStripWindowId
         }
       }
-
+      // if we get a new frame, we're no longer in a close-tab-with-mouse frenzy
+      windowState = windowState.deleteIn(['ui', 'tabs', 'fixTabWidth'])
+      // add the frame to the state
       windowState = newFrame(windowState, action.frameOpts)
       setImmediate(() => {
         // Inform subscribers that we now have a frame


### PR DESCRIPTION
Address feedback in https://github.com/brave/browser-laptop/issues/14477#issuecomment-399302131 which is really a regression report of #7001 via #11438, concerning jumpiness of tab fixed-width restore animation by:
- waiting a frame before animating tab width from forced width back to normal after closing tabs
- not forcing tab width when closing the last item (didn't make sense anyway since the mouse cursor cannot often still be at the close tab icon after closing the last tab in the strip, and the issue was caused by the mouse becoming in a window-draggable area which behaves erratically with mouse-leave)
- stopping to force tab width once a new tab is created (avoids tabs becoming too wide if a user closes some tabs with the mouse and then opens 1 or more new tabs, without moving the mouse away from the tabs toolbar.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


