### PR TITLE
Fix order of reading notifications for tor launch.

### DIFF
--- a/app/tor.js
+++ b/app/tor.js
@@ -288,7 +288,7 @@ class TorDaemon extends EventEmitter {
    */
   _polled () {
     assert(this._polling)
-    if (this._retry_polling && this._control === null) {
+    if (this._retry_poll && this._control === null) {
       return process.nextTick(() => this._doPoll())
     }
     this._polling = false

--- a/app/tor.js
+++ b/app/tor.js
@@ -228,7 +228,7 @@ class TorDaemon extends EventEmitter {
     assert(this._control === null)
     assert(this._polling)
 
-    this._eatControlPort((err, portno, portMtime) => {
+    this._eatControlCookie((err, cookie, cookieMtime) => {
       if (err) {
         // If there's an error, don't worry: the file may have been
         // written incompletely, and we will, with any luck, be notified
@@ -248,7 +248,7 @@ class TorDaemon extends EventEmitter {
       assert(this._control === null)
       assert(this._polling)
 
-      this._eatControlCookie((err, cookie, cookieMtime) => {
+      this._eatControlPort((err, portno, portMtime) => {
         if (err) {
           // If there's an error, don't worry: the file may not be
           // ready yet, and we'll be notified when it is.


### PR DESCRIPTION
Also fix the polling mechanism, and tidy up after ourselves.

The last commit on this branch adds a bunch of diagnostics that turned out not to be very helpful.  Maybe they would be helpful in the future, so maybe we should have an option to turn them on, but I'm inclined to just remove them because they weren't useful for much of anything besides initial development.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
- #14517
- `npm run unittest`

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


