### PR TITLE
disable URLbar context menu while tor is initializing

### DIFF
--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -462,6 +462,9 @@ class UrlBar extends React.Component {
   }
 
   onContextMenu (e) {
+    if (this.torInitializing) {
+      return
+    }
     contextMenus.onUrlBarContextMenu(e)
   }
 
@@ -553,10 +556,16 @@ class UrlBar extends React.Component {
     return <span className='evCert' title={this.props.evCert}> {this.props.evCert} </span>
   }
 
+  get torInitializing () {
+    // Returns true if the current tab is a Tor tab and Tor has not yet
+    // initialized successfully
+    return this.props.isTor &&
+      (this.props.torPercentInitialized || this.props.torInitializationError !== false)
+  }
+
   get shouldDisable () {
     return (this.props.displayURL === undefined && this.loadTime === '') ||
-      (this.props.isTor &&
-        (this.props.torPercentInitialized || this.props.torInitializationError !== false))
+      this.torInitializing
   }
 
   setUrlBarRef (ref) {


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/14525

Test Plan:
1. start brave
2. immediately open a tor tab
3. while Tor is still connecting, try to right-click in the urlbar
4. you should not see any context menu popup

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


