### PR TITLE
fix tor-related webtorrent issues

### DIFF
--- a/app/extensions.js
+++ b/app/extensions.js
@@ -289,7 +289,7 @@ let generateTorrentManifest = () => {
       48: 'img/webtorrent-48.png',
       16: 'img/webtorrent-16.png'
     },
-    incognito: 'not_allowed',
+    incognito: 'split',
     key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyWl+wMvL0wZX3JUs7GeZAvxMP+LWEh2bwMV1HyuBra/lGZIq3Fmh0+AFnvFPXz1NpQkbLS3QWyqhdIn/lepGwuc2ma0glPzzmieqwctUurMGSGManApGO1MkcbSPhb+R1mx8tMam5+wbme4WoW37PI3oATgOs2NvHYuP60qol3U7b/zB3IWuqtwtqKe2Q1xY17btvPuz148ygWWIHneedt0jwfr6Zp+CSLARB9Heq/jqGXV4dPSVZ5ebBHLQ452iZkHxS6fm4Z+IxjKdYs3HNj/s8xbfEZ2ydnArGdJ0lpSK9jkDGYyUBugq5Qp3FH6zV89WqBvoV1dqUmL9gxbHsQIDAQAB'
   }
 }

--- a/app/filtering.js
+++ b/app/filtering.js
@@ -122,7 +122,7 @@ function registerForBeforeRequest (session, partition) {
     }
 
     if ((isMagnetURL(details)) && partition === appConfig.tor.partition) {
-      showTorrentBlockedInTorWarning(details)
+      showTorrentBlockedInTorWarning(details, muonCb)
       return
     }
 
@@ -357,13 +357,16 @@ function registerForBeforeSendHeaders (session, partition) {
   })
 }
 
-function showTorrentBlockedInTorWarning (details) {
+function showTorrentBlockedInTorWarning (details, muonCb) {
+  const cb = () => muonCb({cancel: true})
   if (details.tabId) {
     tabMessageBox.show(details.tabId, {
       message: `${locale.translation('torrentBlockedInTor')}`,
       title: 'Brave',
       buttons: [locale.translation('torrentWarningOk')]
-    })
+    }, cb)
+  } else {
+    cb()
   }
 }
 
@@ -381,7 +384,7 @@ function registerForHeadersReceived (session, partition) {
       return
     }
     if ((isTorrentFile(details)) && partition === appConfig.tor.partition) {
-      showTorrentBlockedInTorWarning(details)
+      showTorrentBlockedInTorWarning(details, muonCb)
       return
     }
     const firstPartyUrl = module.exports.getMainFrameUrl(details)
@@ -670,7 +673,10 @@ function registerForDownloadListener (session) {
   })
 }
 
-function registerForMagnetHandler (session) {
+function registerForMagnetHandler (session, partition) {
+  if (partition === appConfig.tor.partition) {
+    return
+  }
   const webtorrentUrl = appUrlUtil.getTorrentExtUrl('webtorrent.html')
   try {
     if (getSetting(settings.TORRENT_VIEWER_ENABLED)) {


### PR DESCRIPTION
* re-enable webtorrent in private tabs
* stop page loading indicator after torrent warning is shown in a tor
tab

fix https://github.com/brave/browser-laptop/issues/14472
fix https://github.com/brave/browser-laptop/issues/14524

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. open brave and make sure webtorrent is enabled
2. go to https://webtorrent.io/torrents/sintel.torrent in a private tab.
   it should load webtorrent.
3. go to https://webtorrent.io/torrents/sintel.torrent in a tor tab. it
   should show a privacy warning.
4. click 'ok'. the page loading indicator should stop.


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


