### PR TITLE
Disable Chromecast since it's not present in Brave

### DIFF
--- a/app/extensions/brave/content/scripts/block3rdPartyContent.js
+++ b/app/extensions/brave/content/scripts/block3rdPartyContent.js
@@ -27,3 +27,8 @@ if (chrome.contentSettings.referer != 'allow' &&
 if (chrome.contentSettings.cookies != 'allow') {
   executeScript(getBlockCookieScript())
 }
+
+// Block Chromecast (unsupported)
+// Necessary otherwise players will try to send the cast_sender.js script
+// https://github.com/brave/browser-laptop/issues/14475
+executeScript('window.chrome.cast = undefined')


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/14475

Twitch.tv for example is just looking if `chrome.cast` is defined. If so, it fetches the cast_sender script which then fails (no extension support).

Auditors: @petemill, @NejcZdovc

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
See https://github.com/brave/browser-laptop/issues/14475

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


