### PR TITLE
Make polling for tor restart work.  Call setupTor only once.

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -714,8 +714,6 @@ module.exports.relaunchTor = () => {
   }
   appActions.onTorInitError(null)
   try {
-    // TODO (riastradh): why is calling setupTor again necessary?
-    setupTor()
     ses.relaunchTor()
   } catch (e) {
     appActions.onTorInitError(`Could not restart Tor: ${e}`)

--- a/test/unit/app/torTest.js
+++ b/test/unit/app/torTest.js
@@ -284,5 +284,34 @@ describe('tor unit tests', function () {
         })
       })
     })
+
+    it('notices tor restart', function (callback) {
+      torDaemon.setup(() => {
+        // Start watching.
+        torDaemon.start()
+        // Spawn a process.
+        torProcess = spawnTor(torDaemon)
+        // Wait for it to launch once.
+        const timeoutLaunch = setTimeout(() => {
+          assert.fail('tor daemon failed to start after 2sec')
+        }, 2000)
+        torDaemon.once('launch', (socksAddr) => {
+          clearTimeout(timeoutLaunch)
+          // Kill the _process_ once.
+          killTor(torDaemon, torProcess, () => {
+            // Spawn a new process.
+            torProcess = spawnTor(torDaemon)
+            // Wait for it to launch a second time.
+            const timeoutRelaunch = setTimeout(() => {
+              assert.fail('tor daemon failed to restart after 2sec')
+            }, 2000)
+            torDaemon.once('launch', (socksAddr) => {
+              clearTimeout(timeoutRelaunch)
+              killTor(torDaemon, torProcess, callback)
+            })
+          })
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
Previously, we would never retry polling for tor launch if we ever
made the decision to open a control connection.

1. If we _haven't_ successfully opened a control connection, make
   sure we call this._polled() on all error paths to process a
   deferred file system watch notification.

2. If we have opened a control connection enough to set the `close`
   event handler, call this._polled() to handle a deferred poll
   (which, in the next tick, will either do the work it needs to do,
   or discover that there is already a control connection and do
   nothing).

3. In the `close` event handler for the control connection, poll for
   tor launch in case tor relaunched, and all the watch events were
   received and ignored, before we noticed that the control
   connection had closed.

With this, browser-laptop will notice when the tor daemon has come
back after muon executes ses.relaunchTor, without needing to call
setupTor again -- which might have had unpredictable consequences of
multiple simultaneous file system watchers and control connections to
tor.

fix #14584

Auditors: @diracdeltas

Test Plan:
1. Turn off your network.
2. Launch Brave.
3. Open a private tab with Tor enabled.
4. Check that the console reports `tor: daemon listens on ...`.
5. Wait 20sec for the connection error dialogue box to pop up.
6. Hit 'retry connection'.
7. Check that the console reports `tor: daemon listens on ...` _again_.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


