### PR TITLE
Fix to download percent on tooltip bug #14596

### DIFF
--- a/app/renderer/components/download/downloadItem.js
+++ b/app/renderer/components/download/downloadItem.js
@@ -258,7 +258,7 @@ class DownloadItem extends React.Component {
       }
       <div className='downloadInfo'>
         <span>
-          <div data-test-id='downloadFilename' className='downloadFilename' title={this.props.fileName + '\n' + locale.translation(this.props.statel10n)}>
+          <div data-test-id='downloadFilename' className='downloadFilename' title={this.props.fileName + '\n' + locale.translation(this.props.statel10n, l10nStateArgs)}>
             {this.props.fileName}
           </div>
           {
@@ -269,7 +269,7 @@ class DownloadItem extends React.Component {
                     ? <span className='fa fa-unlock isInsecure' />
                     : null
                 }
-                <span data-l10n-id={this.props.isLocalFile ? 'downloadLocalFile' : null} title={this.props.origin + '\n' + locale.translation(this.props.statel10n)}>
+                <span data-l10n-id={this.props.isLocalFile ? 'downloadLocalFile' : null} title={this.props.origin + '\n' + locale.translation(this.props.statel10n, l10nStateArgs)}>
                   {this.props.isLocalFile ? null : this.props.origin}
                 </span>
               </div>


### PR DESCRIPTION
Current issues is the download item is not rendering the downloadPercent in the tooltip. See the following gif, and then the sequential fix. This fixes issue #14596

Current issue:
![bug](https://user-images.githubusercontent.com/7344422/42054425-5e909890-7ae2-11e8-96d9-e9dae05f6749.gif)

Fix:
![nobug](https://user-images.githubusercontent.com/7344422/42054437-67fda63e-7ae2-11e8-9b7f-5592fd3e33da.gif)

## Submitter Checklist:

- [ x ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ x ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ x ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header
