### PR TITLE
Use a different socks port number for channel ''.

### DIFF
--- a/app/channel.js
+++ b/app/channel.js
@@ -67,7 +67,6 @@ exports.getTorSocksProxy = () => {
   let portno
   switch (channel) {
     case 'dev':
-    case '':
     default:
       portno = 9250
       break
@@ -79,6 +78,9 @@ exports.getTorSocksProxy = () => {
       break
     case 'developer':
       portno = 9280
+      break
+    case '':
+      portno = 9290
       break
   }
   return `socks5://127.0.0.1:${portno}`


### PR DESCRIPTION
Channel '' apparently happens for local builds, and we don't want it
to step on the toes of release builds.

fix #14592

This is a stop-gap measure until we use an OS-chosen socks port
number or a local socket as in #12936.

Auditors: @diracdeltas @bsclifton

Test Plan:
1. Launch a local development build of Brave.
2. Laucnh a release build of Brave.
3. Confirm that Tor works in both.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


