### PR TITLE
Moved UGP request delay up to 1 minute.

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -1325,13 +1325,11 @@ const checkPromotions = () => {
   }, random.randomInt({min: 20 * ledgerUtil.milliseconds.hour, max: 24 * ledgerUtil.milliseconds.hour}))
 }
 
-const enable = (state, paymentsEnabled) => {
-  if (paymentsEnabled) {
-    if (!getSetting(settings.PAYMENTS_NOTIFICATION_TRY_PAYMENTS_DISMISSED)) {
-      appActions.changeSetting(settings.PAYMENTS_NOTIFICATION_TRY_PAYMENTS_DISMISSED, true)
-    }
-  }
+const runPromotionCheck = () => {
+  appActions.runPromotionCheck()
+}
 
+const onRunPromotionCheck = (state, paymentsEnabled) => {
   if (paymentsEnabled === getSetting(settings.PAYMENTS_ENABLED)) {
     // on start
     if (togglePromotionTimeoutId) {
@@ -1340,7 +1338,10 @@ const enable = (state, paymentsEnabled) => {
 
     togglePromotionTimeoutId = setTimeout(() => {
       checkPromotions()
-    }, random.randomInt({min: 10 * ledgerUtil.milliseconds.second, max: 15 * ledgerUtil.milliseconds.second}))
+    }, process.env.LEDGER_ENVIRONMENT === 'staging'
+      ? random.randomInt({min: 10 * ledgerUtil.milliseconds.second, max: 15 * ledgerUtil.milliseconds.second})
+      : random.randomInt({min: 45 * ledgerUtil.milliseconds.second, max: 60 * ledgerUtil.milliseconds.second})
+    )
   } else if (paymentsEnabled) {
     // toggle on
     if (togglePromotionTimeoutId) {
@@ -1357,6 +1358,15 @@ const enable = (state, paymentsEnabled) => {
   } else {
     // toggle off
     state = ledgerState.setPromotionProp(state, 'promotionStatus', null)
+  }
+  return state
+}
+
+const enable = (state, paymentsEnabled) => {
+  if (paymentsEnabled) {
+    if (!getSetting(settings.PAYMENTS_NOTIFICATION_TRY_PAYMENTS_DISMISSED)) {
+      appActions.changeSetting(settings.PAYMENTS_NOTIFICATION_TRY_PAYMENTS_DISMISSED, true)
+    }
   }
 
   if (synopsis) {
@@ -3343,7 +3353,9 @@ const getMethods = () => {
     getPaymentInfo,
     synopsisNormalizer,
     cacheRuleSet,
-    disablePayments
+    disablePayments,
+    runPromotionCheck,
+    onRunPromotionCheck
   }
 
   let privateMethods = {}

--- a/app/browser/reducers/ledgerReducer.js
+++ b/app/browser/reducers/ledgerReducer.js
@@ -12,6 +12,7 @@ const windowConstants = require('../../../js/constants/windowConstants')
 const settings = require('../../../js/constants/settings')
 const tabActionConstants = require('../../common/constants/tabAction')
 const ledgerStatuses = require('../../common/constants/ledgerStatuses')
+const messages = require('../../../js/constants/messages')
 
 // State
 const ledgerState = require('../../common/state/ledgerState')
@@ -576,8 +577,17 @@ const ledgerReducer = (state, action, immutableAction) => {
         state = ledgerApi.pageDataChanged(state, viewData, true)
         break
       }
+    case appConstants.APP_RUN_PROMOTION_CHECK:
+      {
+        state = ledgerApi.onRunPromotionCheck(state, getSetting(settings.PAYMENTS_ENABLED))
+        break
+      }
   }
   return state
 }
+
+process.on(messages.APP_INITIALIZED, () => {
+  ledgerApi.runPromotionCheck()
+})
 
 module.exports = ledgerReducer

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -2106,6 +2106,12 @@ const appActions = {
       tabId,
       index
     })
+  },
+
+  runPromotionCheck: function () {
+    dispatch({
+      actionType: appConstants.APP_RUN_PROMOTION_CHECK
+    })
   }
 }
 

--- a/js/constants/appConstants.js
+++ b/js/constants/appConstants.js
@@ -215,7 +215,8 @@ const appConstants = {
   APP_ON_TOR_INIT_PERCENTAGE: _,
   APP_SET_TOR_NEW_IDENTITY: _,
   APP_RESTART_TOR: _,
-  APP_RECREATE_TOR_TAB: _
+  APP_RECREATE_TOR_TAB: _,
+  APP_RUN_PROMOTION_CHECK: _
 }
 
 module.exports = mapValuesByKeys(appConstants)

--- a/test/unit/app/browser/api/ledgerTest.js
+++ b/test/unit/app/browser/api/ledgerTest.js
@@ -4161,4 +4161,20 @@ describe('ledger api unit tests', function () {
       assert(onLedgerFuzzingSpy.withArgs(1000, true).calledOnce)
     })
   })
+
+  describe('runPromotionCheck', function () {
+    let onRunPromotionCheckSpy
+
+    before(function () {
+      onRunPromotionCheckSpy = sinon.spy(appActions, 'runPromotionCheck')
+    })
+
+    afterEach(function () {
+      onRunPromotionCheckSpy.reset()
+    })
+    it('calls runPromotionCheck', function () {
+      ledgerApi.runPromotionCheck()
+      assert(onRunPromotionCheckSpy.calledOnce)
+    })
+  })
 })

--- a/test/unit/app/browser/reducers/ledgerReducerTest.js
+++ b/test/unit/app/browser/reducers/ledgerReducerTest.js
@@ -67,7 +67,8 @@ describe('ledgerReducer unit tests', function () {
       clearPaymentHistory: () => {},
       deleteWallet: () => {},
       addNewLocation: dummyModifyState,
-      synopsisNormalizer: dummyModifyState
+      synopsisNormalizer: dummyModifyState,
+      onRunPromotionCheck: () => {}
     }
     fakeLedgerState = {
       resetPublishers: dummyModifyState,
@@ -1123,6 +1124,26 @@ describe('ledgerReducer unit tests', function () {
         actionType: appConstants.APP_ON_WALLET_DELETE
       }))
       assert(deleteWalletSpy.calledOnce)
+    })
+  })
+
+  describe('APP_RUN_PROMOTION_CHECK', function () {
+    let onRunPromotionCheckSpy
+    before(function () {
+      onRunPromotionCheckSpy = sinon.spy(fakeLedgerApi, 'onRunPromotionCheck')
+      returnedState = ledgerReducer(appState, Immutable.fromJS({
+        actionType: appConstants.APP_RUN_PROMOTION_CHECK,
+        stateResult: 'state-result-goes-here'
+      }))
+    })
+    after(function () {
+      onRunPromotionCheckSpy.restore()
+    })
+    it('calls ledgerApi.onRunPromotionCheck', function () {
+      assert(onRunPromotionCheckSpy.calledOnce)
+    })
+    it('returns a modified state', function () {
+      assert.notDeepEqual(returnedState, appState)
     })
   })
 })


### PR DESCRIPTION
Fixes #14616 

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
- Start Brave with `LEDGER_VERBOSE=true`
- Ensure promotion url calls do not occur until between 45 and 60 seconds after Brave startup (Look for requests to `v1/grants`).

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header

Additional Info:
To quickly test that promos are working in the future add `LEDGER_ENVIRONMENT=staging` when running Brave. Promotion url calls will occur between 10 and 15 seconds.