### PR TITLE
New npm target: inttest.  Move tor daemon tests under there.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "download-sync-client": "node ./tools/downloadSyncClient",
     "electron-rebuild": "electron-rebuild",
     "flow": "flow; test $? -eq 0 -o $? -eq 2",
+    "inttest": "cross-env NODE_ENV=test mocha \"test/integration/**/*Test.js\"",
     "lint": "standard --verbose | snazzy",
     "lint-standard": "standard",
     "package-tor": "node ./tools/package_tor.js",

--- a/test/integration/app/torTest.js
+++ b/test/integration/app/torTest.js
@@ -12,7 +12,7 @@ const rimraf = require('rimraf')
 
 describe('tor unit tests', function () {
   let tor
-  const fakeElectron = require('../lib/fakeElectron')
+  const fakeElectron = require('../../unit/lib/fakeElectron')
   before(function () {
     mockery.enable({
       warnOnReplace: false,


### PR DESCRIPTION
The tor daemon tests actually launch the tor daemon and may wait a
nontrivial duration, so they shouldn't be run as unit tests.

Tweak torTest.js to use a slightly fuller path for fakeElectron.

fix #14631

Auditors: @bsclifton @diracdeltas

Test Plan:
npm run inttest

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


