### PR TITLE
fixes empty ad containers on yahoo.com

### DIFF
--- a/app/extensions/brave/content/styles/removeEmptyElements.css
+++ b/app/extensions/brave/content/styles/removeEmptyElements.css
@@ -1,16 +1,17 @@
 .ad-hideable,
-  .ad-div,
-  .masthead-ad-control,
-  .video-ads,
-  #ad_creative_3,
-  #footer-ads,
-  #watch7-sidebar-ads,
-  .ytp-ad-progress-list,
-  .ad-container,
-  #video-masthead,
-  #watch-channel-brand-div,
-  #Billboard-ad {
-    display: none !important;
+.ad-div,
+.masthead-ad-control,
+.video-ads,
+#ad_creative_3,
+#footer-ads,
+#watch7-sidebar-ads,
+.ytp-ad-progress-list,
+.ad-container,
+#video-masthead,
+#watch-channel-brand-div,
+#Billboard-ad,
+div[id^=my-ads] {
+  display: none !important;
 }
 
 /* CoinMarketCap Ads */


### PR DESCRIPTION
fixes indentation

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).

## Test Plan:
Went to Yahoo.com and manually refreshed the page to verify empty containers were removed.

## Reviewer Checklist:

- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header

fixes #12918 
