### PR TITLE
Replace missing variable for context menu max-height

### DIFF
--- a/app/renderer/components/common/contextMenu/contextMenu.js
+++ b/app/renderer/components/common/contextMenu/contextMenu.js
@@ -322,7 +322,12 @@ const styles = StyleSheet.create({
 
     // This is a reasonable max height and also solves problems for bookmarks menu
     // and bookmarks overflow menu reaching down too low.
-    maxHeight: `calc(100% - ${globalStyles.spacing.navbarHeight} + ${globalStyles.spacing.bookmarksToolbarWithFaviconsHeight})`,
+    // TODO (petemill): This is flakey since it does not cover dynamic 'navbar' height
+    // such as menu bar or notifications presence. It could be much more gracefully achieved
+    // via `bottom: 0` positioning and would look better by creating a container element
+    // which has `max-height: 100%` on it so that the inside of the menu box scrolled rather
+    // than the border scrolling away wierdly.
+    maxHeight: `calc(100% - ((2 * ${globalStyles.spacing.navbarMenubarMargin}) + ${globalStyles.spacing.navbarHeight} + ${globalStyles.spacing.bookmarksToolbarHeight}))`,
 
     '::-webkit-scrollbar': {
       backgroundColor: theme.contextMenu.scrollBar.backgroundColor


### PR DESCRIPTION
Fix #14606
Fixes context menu overflow scroll, returning it to previous behavior. Note that previous behavior is flawed as it only calculates an approximation of available space. It does not cover dynamic 'navbar' height such as menu bar or notifications presence. It could be much more gracefully achieved via `bottom: 0` positioning and would look better by creating a container element which has `max-height: 100%` on it so that the inside of the menu box scrolled rather than the border scrolling away wierdly.


## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
On issue

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


