### PR TITLE
Fixes #14549 : entire div on learn more is clickable

### DIFF
--- a/js/about/newprivatetab.js
+++ b/js/about/newprivatetab.js
@@ -257,7 +257,9 @@ const styles = StyleSheet.create({
     cursor: 'pointer',
     textDecoration: 'underline',
     color: '#FF6000',
-    marginTop: '20px'
+    marginTop: '20px',
+    paddingRight: 0,
+    display: 'inline-block'
   },
 
   text__badge: {


### PR DESCRIPTION
fixes entire div on learn more is clickable

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
Manually refresh and use the dev tools to verify the proper width of the div

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


FIxes #14549

Removing the padding and changing the display to `inline-block` fixed this.
