### PR TITLE
fix some favicon leaks

### DIFF
--- a/app/renderer/components/common/contextMenu/contextMenu.js
+++ b/app/renderer/components/common/contextMenu/contextMenu.js
@@ -19,6 +19,7 @@ const keyCodes = require('../../../../common/constants/keyCodes')
 const contextMenuState = require('../../../../common/state/contextMenuState')
 const tabState = require('../../../../common/state/tabState')
 const appStore = require('../../../../../js/stores/appStoreRenderer')
+const { getActiveFrame, isTor } = require('../../../../../js/state/frameStateUtil')
 const { getCurrentWindowId } = require('../../../currentWindow')
 
 // Utils
@@ -227,6 +228,8 @@ class ContextMenu extends React.Component {
 
     const props = {}
     const activeTab = tabState.getActiveTab(appStore.state, getCurrentWindowId())
+    const activeFrame = getActiveFrame(currentWindow)
+    props.isTor = activeFrame && isTor(activeFrame)
     props.lastZoomPercentage = activeTab && activeTab.get('zoomPercent')
     props.contextMenuDetail = contextMenuDetail  // TODO (nejc) only primitives
     props.selectedIndex = typeof selectedIndex === 'object' &&
@@ -284,6 +287,7 @@ class ContextMenu extends React.Component {
       style={contextStyles}
     >
       <ContextMenuSingle contextMenuDetail={this.props.contextMenuDetail}
+        isTor={this.props.isTor}
         submenuIndex={0}
         lastZoomPercentage={this.props.lastZoomPercentage}
         template={this.props.template}

--- a/app/renderer/components/common/contextMenu/contextMenuItem.js
+++ b/app/renderer/components/common/contextMenu/contextMenuItem.js
@@ -179,7 +179,7 @@ class ContextMenuItem extends ImmutableComponent {
       width: iconSize
     }
 
-    const icon = this.props.contextMenuItem.get('icon')
+    const icon = !this.props.isTor && this.props.contextMenuItem.get('icon')
     let faIcon
     if (icon) {
       iconStyle = Object.assign(iconStyle, {

--- a/app/renderer/components/common/contextMenu/contextMenuSingle.js
+++ b/app/renderer/components/common/contextMenu/contextMenuSingle.js
@@ -43,6 +43,7 @@ class ContextMenuSingle extends ImmutableComponent {
         visibleMenuItems.map((contextMenuItem) => {
           let props = {
             contextMenuItem: contextMenuItem,
+            isTor: this.props.isTor,
             submenuIndex: this.props.submenuIndex,
             lastZoomPercentage: this.props.lastZoomPercentage,
             contextMenuDetail: this.props.contextMenuDetail,

--- a/app/renderer/components/navigation/urlBarIcon.js
+++ b/app/renderer/components/navigation/urlBarIcon.js
@@ -116,7 +116,8 @@ class UrlBarIcon extends React.Component {
     const instanceStyles = {}
 
     if (this.props.activateSearchEngine) {
-      instanceStyles['--search-engine-favicon-url'] = `url(${this.props.searchSelectImage})`
+      icon = <img src={this.props.searchSelectImage}
+        className={css(styles.searchIcon)} alt='Search provider icon' />
     } else if (this.props.isPotentialPhishingUrl) {
       icon = <WarningIcon />
       iconTestId = 'isPotentialPhishingUrl'
@@ -151,8 +152,7 @@ class UrlBarIcon extends React.Component {
       className={css(
         styles.urlBarIcon,
         isExtendedSecure && styles.urlBarIcon_extendedSecure,
-        isInsecure && styles.urlBarIcon_warning,
-        this.props.activateSearchEngine && styles.urlBarIcon_specificSearchEngine
+        isInsecure && styles.urlBarIcon_warning
       )}
       style={instanceStyles}
     >
@@ -174,19 +174,16 @@ const styles = StyleSheet.create({
     flexShrink: 0
   },
 
+  searchIcon: {
+    width: `${searchIconSize}px`
+  },
+
   urlBarIcon_extendedSecure: {
     '--icon-line-color': '#7ED321'
   },
 
   urlBarIcon_warning: {
     '--icon-line-color': '#ff0000'
-  },
-
-  urlBarIcon_specificSearchEngine: {
-    backgroundImage: 'var(--search-engine-favicon-url)',
-    backgroundSize: `${searchIconSize}px`,
-    backgroundRepeat: 'no-repeat',
-    backgroundPosition: 'center center'
   }
 })
 

--- a/js/data/searchProviders.js
+++ b/js/data/searchProviders.js
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const path = require('path')
 const {braveExtensionId} = require('../constants/config')
 
 /**
@@ -13,12 +14,19 @@ const getFaviconUrl = (name, ext = 'ico') => {
   return `chrome-extension://${braveExtensionId}/img/favicons/${name}.${ext}`
 }
 
+/**
+ * Returns path of a favicon resource
+ */
+const getPath = (name, ext = 'ico') => {
+  return path.join(__dirname, '..', '..', 'img', 'favicons', `${name}.${ext}`)
+}
+
 module.exports = { "providers" :
   [
     {
       "name" : "Amazon",
       "base" : "https://www.amazon.com",
-      "image" : "https://www.amazon.com/favicon.ico",
+      "image" : getPath('amazon'),
       "localImage" : getFaviconUrl('amazon'),
       "search" : "https://www.amazon.com/exec/obidos/external-search/?field-keywords={searchTerms}&mode=blended",
       "autocomplete" : "https://completion.amazon.com/search/complete?method=completion&q={searchTerms}&search-alias=aps&client=amazon-search-ui&mkt=1",
@@ -27,7 +35,7 @@ module.exports = { "providers" :
     {
       "name" : "Bing",
       "base" : "https://www.bing.com",
-      "image" : "https://www.bing.com/favicon.ico",
+      "image" : getPath('bing'),
       "localImage" : getFaviconUrl('bing'),
       "search" : "https://www.bing.com/search?q={searchTerms}",
       "autocomplete" : "https://api.bing.com/osjson.aspx?query={searchTerms}&language={language}&form=OSDJAS",
@@ -36,7 +44,7 @@ module.exports = { "providers" :
     {
       "name" : "DuckDuckGo",
       "base" : "https://duckduckgo.com",
-      "image" : "https://duckduckgo.com/favicon.ico",
+      "image" : getPath('duckduckgo'),
       "localImage" : getFaviconUrl('duckduckgo'),
       "search" : "https://duckduckgo.com/?q={searchTerms}&t=brave",
       "autocomplete" : "https://ac.duckduckgo.com/ac/?q={searchTerms}&type=list",
@@ -45,7 +53,7 @@ module.exports = { "providers" :
     {
       "name" : "Fireball",
       "base" : "https://fireball.com",
-      "image" : "https://fireball.com/favicon.ico",
+      "image" : getPath('fireball'),
       "localImage" : getFaviconUrl('fireball'),
       "search" : "https://fireball.com/?q={searchTerms}",
       "autocomplete" : "https://fireball.com/search/?q={searchTerms}",
@@ -54,7 +62,7 @@ module.exports = { "providers" :
     {
       "name" : "GitHub",
       "base" : "https://github.com/search",
-      "image" : "https://assets-cdn.github.com/favicon.ico",
+      "image" : getPath('github'),
       "localImage" : getFaviconUrl('github'),
       "search" : "https://github.com/search?q={searchTerms}",
       "shortcut" : ":gh"
@@ -62,7 +70,7 @@ module.exports = { "providers" :
     {
       "name" : "Google",
       "base" : "https://www.google.com",
-      "image" : "https://www.google.com/favicon.ico",
+      "image" : getPath('google'),
       "localImage" : getFaviconUrl('google'),
       "search" : "https://www.google.com/search?q={searchTerms}",
       "autocomplete" : "https://suggestqueries.google.com/complete/search?client=chrome&q={searchTerms}",
@@ -71,7 +79,7 @@ module.exports = { "providers" :
     {
       "name" : "Stack Overflow",
       "base" : "https://stackoverflow.com/search",
-      "image" : "https://cdn.sstatic.net/sites/stackoverflow/img/favicon.ico",
+      "image" : getPath('stackoverflow'),
       "localImage" : getFaviconUrl('stackoverflow'),
       "search" : "https://stackoverflow.com/search?q={searchTerms}",
       "shortcut" : ":s"
@@ -79,7 +87,7 @@ module.exports = { "providers" :
     {
       "name" : "MDN Web Docs",
       "base": "https://developer.mozilla.org/search",
-      "image" : "https://developer.cdn.mozilla.net/static/img/favicon32.png",
+      "image" : getPath('mdn', 'png'),
       "localImage" : getFaviconUrl('mdn', 'png'),
       "search" : "https://developer.mozilla.org/search?q={searchTerms}",
       "shortcut" : ":m"
@@ -87,7 +95,7 @@ module.exports = { "providers" :
     {
       "name" : "Twitter",
       "base" : "https://twitter.com",
-      "image" : "https://twitter.com/favicon.ico",
+      "image" : getPath('twitter'),
       "localImage" : getFaviconUrl('twitter'),
       "search" : "https://twitter.com/search?q={searchTerms}&source=desktop-search",
       "shortcut" : ":t"
@@ -95,7 +103,7 @@ module.exports = { "providers" :
     {
       "name" : "Wikipedia",
       "base" : "https://en.wikipedia.org",
-      "image" : "https://en.wikipedia.org/favicon.ico",
+      "image" : getPath('wikipedia'),
       "localImage" : getFaviconUrl('wikipedia'),
       "search" : "https://en.wikipedia.org/wiki/Special:Search?search={searchTerms}",
       "shortcut" : ":w"
@@ -103,7 +111,7 @@ module.exports = { "providers" :
     {
       "name" : "Yahoo",
       "base" : "https://search.yahoo.com",
-      "image" : "https://search.yahoo.com/favicon.ico",
+      "image" : getPath('yahoo'),
       "localImage" : getFaviconUrl('yahoo'),
       "search" : "https://search.yahoo.com/search?p={searchTerms}&fr=opensearch",
       "autocomplete": "https://search.yahoo.com/sugg/os?command={searchTerms}&output=fxjson&fr=opensearch",
@@ -112,7 +120,7 @@ module.exports = { "providers" :
     {
       "name" : "YouTube",
       "base" : "https://www.youtube.com",
-      "image" : "https://www.youtube.com/favicon.ico",
+      "image" : getPath('youtube'),
       "localImage" : getFaviconUrl('youtube'),
       "search" : "https://www.youtube.com/results?search_type=search_videos&search_query={searchTerms}&search_sort=relevance&search_category=0&page=",
       "autocomplete": "https://suggestqueries.google.com/complete/search?output=chrome&client=chrome&hl=it&q={searchTerms}&ds=yt",
@@ -121,7 +129,7 @@ module.exports = { "providers" :
     {
       "name" : "StartPage",
       "base" : "https://www.startpage.com",
-      "image" : "https://www.startpage.com/graphics/favicon/sp-favicon-16x16.png",
+      "image" : getPath('startpage', 'png'),
       "localImage" : getFaviconUrl('startpage', 'png'),
       "search" : "https://www.startpage.com/do/dsearch?query={searchTerms}&cat=web&pl=opensearch",
       "autocomplete": "https://www.startpage.com/cgi-bin/csuggest?query={searchTerms}&limit=10&format=json",
@@ -130,7 +138,7 @@ module.exports = { "providers" :
     {
       "name" : "Infogalactic",
       "base" : "https://infogalactic.com",
-      "image" : "https://infogalactic.com/favicon.ico",
+      "image" : getPath('infogalactic'),
       "localImage" : getFaviconUrl('infogalactic'),
       "search" : "https://infogalactic.com/w/index.php?title=Special:Search&search={searchTerms}",
       "autocomplete": "https://infogalactic.com/w/api.php?action=opensearch&search={searchTerms}&namespace=0",
@@ -139,7 +147,7 @@ module.exports = { "providers" :
     {
       "name" : "Wolfram Alpha",
       "base" : "https://www.wolframalpha.com",
-      "image" : "https://www.wolframalpha.com/favicon.ico?v=2",
+      "image" : getPath('wolframalpha'),
       "localImage" : getFaviconUrl('wolframalpha'),
       "search" : "https://www.wolframalpha.com/input/?i={searchTerms}",
       "shortcut" : ":wa"
@@ -147,7 +155,7 @@ module.exports = { "providers" :
     {
       "name" : "Semantic Scholar",
       "base" : "https://www.semanticscholar.org",
-      "image" : "https://www.semanticscholar.org/img/favicon.png",
+      "image" : getPath('semanticscholar', 'png'),
       "localImage" : getFaviconUrl('semanticscholar', 'png'),
       "search" : "https://www.semanticscholar.org/search?q={searchTerms}",
       "shortcut" : ":ss"
@@ -155,7 +163,7 @@ module.exports = { "providers" :
     {
       "name" : "Qwant",
       "base" : "https://www.qwant.com/",
-      "image" : "https://www.qwant.com/favicon.ico",
+      "image" : getPath('qwant'),
       "localImage" : getFaviconUrl('qwant'),
       "search" : "https://www.qwant.com/?q={searchTerms}&client=brave",
       "autocomplete": "https://api.qwant.com/api/suggest/?q={searchTerms}&client=brave",
@@ -164,7 +172,7 @@ module.exports = { "providers" :
     {
       "name" : "Yandex",
       "base" : "https://yandex.com",
-      "image" : "https://www.yandex.com/favicon.ico",
+      "image" : getPath('yandex'),
       "localImage" : getFaviconUrl('yandex'),
       "search" : "https://yandex.com/search/?text={searchTerms}&clid=2274777",
       "shortcut" : ":ya"
@@ -172,7 +180,7 @@ module.exports = { "providers" :
     {
       "name" : "Ecosia",
       "base" : "https://www.ecosia.org/",
-      "image" : "https://cdn.ecosia.org/assets/images/ico/favicon.ico",
+      "image" : getPath('ecosia'),
       "localImage" : getFaviconUrl('ecosia'),
       "search" : "https://www.ecosia.org/search?q={searchTerms}",
       "autocomplete": "https://ac.ecosia.org/autocomplete?q={searchTerms}&type=list",
@@ -181,7 +189,7 @@ module.exports = { "providers" :
     {
       "name" : "searx",
       "base" : "https://searx.me",
-      "image" : "https://searx.me/favicon.ico",
+      "image" : getPath('searx'),
       "localImage" : getFaviconUrl('searx'),
       "search" : "https://searx.me/?q={searchTerms}&categories=general",
       "shortcut" : ":x"
@@ -189,7 +197,7 @@ module.exports = { "providers" :
     {
       "name": "findx",
       "base": "https://www.findx.com",
-      "image": "https://www.findx.com/favicon.ico",
+      "image": getPath('findx'),
       "localImage" : getFaviconUrl('findx'),
       "search": "https://www.findx.com/search?q={searchTerms}&type=web",
       "autocomplete": "https://www.findx.com/api/web-search/suggestions/?q={searchTerms}&type=opensearch",


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/14653
fix https://github.com/brave/browser-laptop/issues/14641

test plan: 
 1. open browser console and inspect the urlbar icon
 2. hit any search shortcut, ex: ':g' for google
 3. notice that the favicon for the search engine is loaded as a local resource instead of as a 'http(s)://' URL
4. open tor tab
5. browse to a few sites in the tor tab
6. long-click the back button. no favicons should appear.
7. go back a few sites, then repeat step 6 with the forward button.