### PR TITLE
Start tor lazily, only when a private tab with Tor is created.

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -29,7 +29,7 @@ const {newTabMode} = require('../common/constants/settingsEnums')
 const {tabCloseAction} = require('../common/constants/settingsEnums')
 const webContentsCache = require('./webContentsCache')
 const {FilterOptions} = require('ad-block')
-const {isResourceEnabled} = require('../filtering')
+const {isResourceEnabled, initPartition} = require('../filtering')
 const autofill = require('../autofill')
 const bookmarksState = require('../common/state/bookmarksState')
 const bookmarkFoldersState = require('../common/state/bookmarkFoldersState')
@@ -1103,6 +1103,11 @@ const api = {
             tab.setWebRTCIPHandlingPolicy(webrtcConstants.disableNonProxiedUdp)
           }
           cb && cb(tab)
+          // XXX: Workaround for 'browser-context-created' not emitted for Tor
+          // browsing context
+          if (createProperties.isTor) {
+            initPartition(appConfig.tor.partition)
+          }
         })
       }
 

--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -29,7 +29,7 @@ const {newTabMode} = require('../common/constants/settingsEnums')
 const {tabCloseAction} = require('../common/constants/settingsEnums')
 const webContentsCache = require('./webContentsCache')
 const {FilterOptions} = require('ad-block')
-const {isResourceEnabled, initPartition} = require('../filtering')
+const {isResourceEnabled} = require('../filtering')
 const autofill = require('../autofill')
 const bookmarksState = require('../common/state/bookmarksState')
 const bookmarkFoldersState = require('../common/state/bookmarkFoldersState')
@@ -1103,11 +1103,6 @@ const api = {
             tab.setWebRTCIPHandlingPolicy(webrtcConstants.disableNonProxiedUdp)
           }
           cb && cb(tab)
-          // XXX: Workaround for 'browser-context-created' not emitted for Tor
-          // browsing context
-          if (createProperties.isTor) {
-            initPartition(appConfig.tor.partition)
-          }
         })
       }
 

--- a/app/filtering.js
+++ b/app/filtering.js
@@ -49,7 +49,7 @@ const beforeSendHeadersFilteringFns = []
 const beforeRequestFilteringFns = []
 const beforeRedirectFilteringFns = []
 const headersReceivedFilteringFns = []
-let partitionsToInitialize = ['default', appConfig.tor.partition]
+let partitionsToInitialize = ['default']
 let initializedPartitions = {}
 
 const transparent1pxGif = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/14617

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

1. Delete the tor.log file if it exists from a prior run.
    - macOS: ~/Library/Application Support/brave/tor/data/tor.log
    - Linux: ~/.config/brave/tor/data/tor.log
    - Windows: %appdata%\brave\tor\data\tor.log
      - (Substitute `brave-development` or `brave-beta` for `brave` if a development build or a beta release.)
2. Launch Brave.
3. Confirm tor.log still does not exist.
4. Open a private tab with Tor.
5. Open https://check.torproject.org and confirm we're going through Tor.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


