### PR TITLE
Fix some more error branches, assert sanity, and automatically test it all.

### DIFF
--- a/app/tor.js
+++ b/app/tor.js
@@ -987,7 +987,6 @@ class TorControl extends EventEmitter {
       const [, callback] = this._cmdq.shift()
       callback(err, null, null)
     }
-    setImmediate(() => assert(this._closing === 0))
   }
 
   /**

--- a/app/tor.js
+++ b/app/tor.js
@@ -150,8 +150,13 @@ class TorDaemon extends EventEmitter {
 
   /**
    * Kill the tor daemon.
+   *
+   * Idempotent.  Repeated calls have no effect.
    */
   kill () {
+    if (this._watcher === null) {
+      return
+    }
     assert(this._watcher)
     this._watcher.close()
     this._watcher = null

--- a/app/tor.js
+++ b/app/tor.js
@@ -955,10 +955,14 @@ class TorControl extends EventEmitter {
    * - Mark the control closed so it can't be used any more.
    * - Pass an error to all callbacks waiting for command completion.
    *
+   * Idempotent.  Repeated calls have no effect.
+   *
    * @param {Error} err
    */
   destroy (err) {
-    assert(!this._destroyed)
+    if (this._destroyed) {
+      return
+    }
     this._readable.destroy(err)
     this._writable.end()
     this._writable.destroy(err)

--- a/app/tor.js
+++ b/app/tor.js
@@ -171,6 +171,17 @@ class TorDaemon extends EventEmitter {
   }
 
   /**
+   * Internal subroutine.  Report an error and kill the daemon.
+   *
+   * @param {string} msg - error message
+   */
+  _error (msg) {
+    console.log(msg)
+    this.emit('error', msg)
+    this.kill()
+  }
+
+  /**
    * Internal subroutine.  Called by fs.watch when the tor watch
    * directory is changed.  If the control port file is newly written,
    * then the control socket should be available now.
@@ -514,22 +525,16 @@ class TorDaemon extends EventEmitter {
           }
         }
         if (err) {
-          console.log(`tor: authentication failure: ${err}`)
-          this.kill()
-          return
+          return this._error(`tor: authentication failure: ${err}`)
         }
         this._control.getSOCKSListeners((err, listeners) => {
           if (err) {
-            console.log(`tor: failed to get socks addresses: ${err}`)
-            this.kill()
-            return
+            return this._error(`tor: failed to get socks addresses: ${err}`)
           }
           this._socks_addresses = listeners
           this._control.getVersion((err, version) => {
             if (err) {
-              console.log(`tor: failed to get version: ${err}`)
-              this.kill()
-              return
+              return this._error(`tor: failed to get version: ${err}`)
             }
             this._tor_version = version
             this.emit('launch', this.getSOCKSAddress())


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/14630

Substantive changes:

- Eliminate an assertion that socket closure happens more promptly than it is guaranteed to.
- Allow destruction functions to be idempotent, now that I've convinced myself that this is sensible because there are legitimately multiple paths into them (in asynchronous error events and in synchronous callbacks).

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
#14630

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


