### PR TITLE
fix search favicon path on windows

### DIFF
--- a/js/data/searchProviders.js
+++ b/js/data/searchProviders.js
@@ -4,6 +4,7 @@
 
 const path = require('path')
 const {braveExtensionId} = require('../constants/config')
+const {isWindows} = require('../../app/common/lib/platformUtil')
 
 /**
  * Returns chrome-extension:// URL of a favicon resource
@@ -18,6 +19,9 @@ const getFaviconUrl = (name, ext = 'ico') => {
  * Returns path of a favicon resource
  */
 const getPath = (name, ext = 'ico') => {
+  if (isWindows()) {
+    return path.join(__dirname, '..', 'img', 'favicons', `${name}.${ext}`)
+  }
   return path.join(__dirname, '..', '..', 'img', 'favicons', `${name}.${ext}`)
 }
 


### PR DESCRIPTION
for some reason, the windows path has an extra `../` prefix compared to
mac so the favicon doesn't load. this works around the issue by removing
a `../` on windows.

fix https://github.com/brave/browser-laptop/issues/14653

Test Plan:
1. open new tab
2. hit `:g` in the urlbar
3. the search favicon should load on all platforms

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


