### PR TITLE
Allow upload script to check if current signature exists.

### DIFF
--- a/tools/upload_to_rpm_repo
+++ b/tools/upload_to_rpm_repo
@@ -15,7 +15,7 @@ echo "%_signature gpg
 
 rm -rf $TMP_REPO
 mkdir -pv $TMP_REPO/x86_64
-if [[ ! $(rpm --checksig dist/*.rpm | grep pgp) ]]; then
+if ! rpm --checksig dist/*.rpm | grep pgp; then
   ./tools/auto_rpm_sign
   rpm --checksig dist/*.rpm | grep pgp
 fi

--- a/tools/upload_to_rpm_repo
+++ b/tools/upload_to_rpm_repo
@@ -15,7 +15,7 @@ echo "%_signature gpg
 
 rm -rf $TMP_REPO
 mkdir -pv $TMP_REPO/x86_64
-if !rpm --checksig dist/*.rpm | grep pgp; then
+if [[ ! $(rpm --checksig dist/*.rpm | grep pgp) ]]; then
   ./tools/auto_rpm_sign
   rpm --checksig dist/*.rpm | grep pgp
 fi


### PR DESCRIPTION
This was always signing the RPM because the test was failing,
now we will test and if the signature exists then move on.

The error seen was:
tools/upload_to_rpm_repo: line 18: !rpm: command not found

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


