### PR TITLE
Allow for a per-locale default search engine (value comes from config)

### DIFF
--- a/app/locale.js
+++ b/app/locale.js
@@ -385,24 +385,19 @@ availableLanguages.forEach(function (lang) {
 })
 
 // Return the default locale in xx-XX format I.e. pt-BR
-const defaultLocale = function () {
-  // If electron has the locale
+module.exports.getDefaultLocale = function (allowUnsupported = false) {
   if (app.getLocale()) {
-    // Retrieve the language and convert _ to -
     var lang = app.getLocale().replace('_', '-')
     // If there is no country code designated use the language code
     if (!lang.match(/-/)) {
       lang = lang + '-' + lang.toUpperCase()
     }
     // If we have the language configured
-    if (configuredLanguages[lang]) {
+    if (allowUnsupported || configuredLanguages[lang]) {
       return lang
-    } else {
-      return DEFAULT_LANGUAGE
     }
-  } else {
-    return DEFAULT_LANGUAGE
   }
+  return DEFAULT_LANGUAGE
 }
 
 // Initialize translations for a language
@@ -426,7 +421,7 @@ exports.init = function (language) {
   }
 
   // Currently selected language identifier I.e. 'en-US'
-  lang = language || defaultLocale()
+  lang = language || module.exports.getDefaultLocale()
 
   // Languages to support
   const langs = availableLanguages.map(function (lang) {

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -153,7 +153,7 @@ module.exports = {
     'general.download-always-ask': true,
     'general.spellcheck-enabled': true,
     'general.spellcheck-languages': Immutable.fromJS(['en-US']),
-    'search.default-search-engine': 'Google',
+    'search.default-search-engine': null,
     'search.offer-search-suggestions': false, // false by default for privacy reasons
     'search.use-alternate-private-search-engine': false,
     'search.use-alternate-private-search-engine-tor': true,

--- a/js/constants/config.js
+++ b/js/constants/config.js
@@ -42,6 +42,14 @@ module.exports = {
     defaultSearchSuggestions: false,
     maxHistorySites: 10
   },
+  // NOTE: names here correspond to `name` field in:
+  // js/data/searchProviders.js
+  defaultSearchEngineByLocale: {
+    // Example entries look like this:
+    // 'en-US': 'GitHub',
+    // 'es-MX': 'YouTube',
+    'default': 'Google'
+  },
   defaultOpenSearchPath: 'content/search/google.xml',
   vault: {
     syncUrl: (userId) => `${vaultHost}/v1/users/${userId}/appState`,

--- a/js/settings.js
+++ b/js/settings.js
@@ -5,6 +5,7 @@
 const appConfig = require('./constants/appConfig')
 const Immutable = require('immutable')
 const settings = require('./constants/settings')
+const config = require('./constants/config')
 const {passwordManagers, defaultPasswordManager, extensionIds, displayNames} = require('./constants/passwordManagers')
 const {bookmarksToolbarMode} = require('../app/common/constants/settingsEnums')
 
@@ -54,8 +55,14 @@ const getDefaultSetting = (settingKey, settingsCollection) => {
 
     // 2) Get a default value when no value is set
     // allows for default to change until user locks it in
+    //
+    // These are overridden when:
+    // >> user picks their own setting in about:preferences#payments
     case settings.PAYMENTS_CONTRIBUTION_AMOUNT:
       return contributionDefaultAmount(settingKey, settingsCollection)
+    // >> locale is intialized (which determines default search engine)
+    case settings.DEFAULT_SEARCH_ENGINE:
+      return config.defaultSearchEngineByLocale.default
   }
   return undefined
 }

--- a/test/unit/app/localeTest.js
+++ b/test/unit/app/localeTest.js
@@ -1,0 +1,54 @@
+/* global describe, before, after, it */
+const mockery = require('mockery')
+const assert = require('assert')
+
+require('../braveUnit')
+
+describe('locale unit tests', function () {
+  let locale
+  let testLocale = 'en-US'
+  const fakeElectron = require('../lib/fakeElectron')
+
+  before(function () {
+    fakeElectron.app.getLocale = () => testLocale
+
+    mockery.enable({
+      warnOnReplace: false,
+      warnOnUnregistered: false,
+      useCleanCache: true
+    })
+    mockery.registerMock('electron', fakeElectron)
+    locale = require('../../../app/locale')
+  })
+
+  after(function () {
+    mockery.disable()
+  })
+
+  describe('getDefaultLocale', function () {
+    it('defaults to en-US if locale is falsey', function () {
+      testLocale = undefined
+      assert.equal(locale.getDefaultLocale(), 'en-US')
+    })
+
+    it('defaults to en-US if locale is not in supported locales/languages list', function () {
+      testLocale = 'not-a-real-locale'
+      assert.equal(locale.getDefaultLocale(), 'en-US')
+    })
+
+    it('ignores the supported locales/languages list if you pass `true`', function () {
+      testLocale = 'not-a-real-locale'
+      assert.equal(locale.getDefaultLocale(true), 'not-a-real-locale')
+    })
+
+    it('replaces underscore in locale with hyphen', function () {
+      testLocale = 'en_US'
+      assert.equal(locale.getDefaultLocale(), 'en-US')
+    })
+
+    it('puts a country code in place if one does not exist', function () {
+      testLocale = 'fr'
+      assert.equal(locale.getDefaultLocale(), 'fr-FR')
+    })
+  })
+})


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/14647

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Grab source code
2. Either Delete or move out of the way your `brave-development` profile directory
3. Uncomment these two lines: https://github.com/bsclifton/browser-laptop/blob/bfdba0e5ec440f3f31bf9c87aec12557a0861173/js/constants/config.js#L49-L50
4. If you're not in the US, set your locale as English / US (note: this may not be trivial on macOS if you're using an Apple account; locale seems to be tied to iTunes region. I could be wrong)
5. Launch browser
6. Your default search engine should be GitHub (visit about:preferences#search)
7. Delete the `brave-development` profile directory
8. Set your locale as Spanish / Mexico
9. Launch browser
10. Your default search engine should be YouTube (visit about:preferences#search)

## Automated test plan:
`npm run unittest -- --grep="setDefaultSearchEngine"`

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


