### PR TITLE
Block loading .onion sites in non-Tor tabs.

### DIFF
--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -238,6 +238,7 @@ submit=Submit
 tabsSuggestionTitle=Tabs
 topSiteSuggestionTitle=Top Site
 urlBlockedInTor=For your privacy, Brave blocks this URL from loading in a private tab when Tor is enabled.
+urlBlockedOutsideTor=For your privacy, Brave blocks this URL from loading in a tab without Tor.
 urlWarningOk=Ok
 torConnectionError=Unable to connect to the Tor network
 torConnectionErrorInfo=Brave could not make a connection to the Tor network. Disable Tor to continue private browsing without Tor protection.

--- a/app/locale.js
+++ b/app/locale.js
@@ -270,6 +270,7 @@ var rendererIdentifiers = function () {
     'noDownloads',
     'torrentDesc',
     'urlBlockedInTor',
+    'urlBlockedOutsideTor',
     'urlWarningOk',
     'multiSelectionBookmarks',
     // Caption buttons in titlebar (min/max/close - Windows only)


### PR DESCRIPTION
fix #14431

Auditors: @diracdeltas @bsclifton

Test Plan:
I:
1. Open a tab _without_ Tor (private or nonprivate).
2. Enter: https://nyttips4bmquxfzw.onion/
3. Confirm that Brave blocks loading the URL.

II:
1. Open a tab _without_ Tor (private or nonprivate).
2. Enter: https://nyttips4bmquxfzw.onion:12345/
3. Confirm that Brave blocks loading the URL.

III:
1. Open a private tab with Tor.
2. Enter: https://nyttips4bmquxfzw.onion/
3. Confirm that the NYT SecureDrop page loads.
4. Bookmark it.
5. Open a tab _without_ Tor (private or nonprivate).
6. Try to load the bookmark.
7. Confirm that Brave blocks loading the bookmark.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


