### PR TITLE
Fix error branches, take 3.

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -862,6 +862,7 @@ function setupTor () {
       return
     }
     torDaemon.on('exit', () => onTorError('The Tor process has exited.'))
+    torDaemon.on('error', (err) => onTorError(`${err}`))
     torDaemon.on('launch', (socksAddr) => {
       const version = torDaemon.getVersion()
       console.log(`tor: daemon listens on ${socksAddr}, version ${version}`)

--- a/app/tor.js
+++ b/app/tor.js
@@ -177,7 +177,6 @@ class TorDaemon extends EventEmitter {
    * @param {string} msg - error message
    */
   _error (msg) {
-    console.log(msg)
     this.emit('error', msg)
     this.kill()
   }

--- a/app/tor.js
+++ b/app/tor.js
@@ -149,17 +149,18 @@ class TorDaemon extends EventEmitter {
   }
 
   /**
-   * Kill the tor daemon.
-   *
-   * Idempotent.  Repeated calls have no effect.
+   * Stop watching for the tor daemon to start up.
    */
-  kill () {
-    if (this._watcher === null) {
-      return
-    }
+  stop () {
     assert(this._watcher)
     this._watcher.close()
     this._watcher = null
+  }
+
+  /**
+   * Kill the tor daemon and close the control channel.
+   */
+  kill () {
     if (!this._process) {
       assert(this._process === null)
       assert(this._control === null)

--- a/app/tor.js
+++ b/app/tor.js
@@ -526,16 +526,16 @@ class TorDaemon extends EventEmitter {
           }
         }
         if (err) {
-          return this._error(`tor: authentication failure: ${err}`)
+          return this._error(`authentication failure: ${err}`)
         }
         this._control.getSOCKSListeners((err, listeners) => {
           if (err) {
-            return this._error(`tor: failed to get socks addresses: ${err}`)
+            return this._error(`failed to get socks addresses: ${err}`)
           }
           this._socks_addresses = listeners
           this._control.getVersion((err, version) => {
             if (err) {
-              return this._error(`tor: failed to get version: ${err}`)
+              return this._error(`failed to get version: ${err}`)
             }
             this._tor_version = version
             this.emit('launch', this.getSOCKSAddress())
@@ -1136,7 +1136,7 @@ class TorControl extends EventEmitter {
   _onEnd () {
     assert(!this._destroyed)
     if (this._cmdq.length > 0) {
-      this._error('tor: control connection closed prematurely')
+      this._error('control connection closed prematurely')
     }
     this.emit('end')
   }

--- a/app/tor.js
+++ b/app/tor.js
@@ -312,6 +312,7 @@ class TorDaemon extends EventEmitter {
   _polled () {
     assert(this._polling)
     if (this._retry_poll && this._control === null) {
+      this._retry_poll = false
       return process.nextTick(() => this._doPoll())
     }
     this._polling = false

--- a/test/integration/app/torTest.js
+++ b/test/integration/app/torTest.js
@@ -191,6 +191,7 @@ describe('tor unit tests', function () {
         torProcess = null
       }
       assert(torDaemon)
+      torDaemon.stop()
       torDaemon.kill()
       torDaemon = null
       rimraf(bravePath(), (err) => {


### PR DESCRIPTION
- Make sure we continue watching for tor restart after an error on the control channel.
- If we get a watch event while polling, don't cause us to _spin_ polling as fast as the CPU can go until tor is launched.
- Don't duplicate errors synchronously and asynchronously.
- Handle asynchronous errors gracefully.
- Fix some tor redundancy in tor log messages about tor that say tor a few too many times.

fix #14630 for real, maybe?

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


