### PR TITLE
Ensuring publishers file is read from as little possible

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -703,8 +703,9 @@ const runPublishersUpdate = (state) => {
 const updatePublishers = (state, publisherKeys) => {
   const fs = require('fs')
 
-  if (publisherInfoData && publisherInfoData.length > 0) {
+  if (publisherInfoData && publisherInfoData.size > 0) {
     appActions.onPublishersInfoRead(publisherKeys, publisherInfoData)
+    return state
   }
 
   fs.readFile(pathName(publisherInfoPath), (err, data) => {
@@ -715,7 +716,8 @@ const updatePublishers = (state, publisherKeys) => {
 
     try {
       const result = JSON.parse(data)
-      appActions.onPublishersInfoRead(publisherKeys, result)
+      publisherInfoData = makeImmutable(result)
+      appActions.onPublishersInfoRead(publisherKeys, publisherInfoData)
     } catch (err) {
       console.error(`Error: Could not parse data from publishers file`)
     }
@@ -3168,9 +3170,11 @@ const onPublishersInfo = (state, result) => {
 
   const fs = require('fs')
   const path = pathName(publisherInfoPath)
-  publisherInfoData = result
+  const writeData = JSON.stringify(result)
 
-  fs.writeFile(path, JSON.stringify(result), (err) => {
+  publisherInfoData = makeImmutable(result)
+
+  fs.writeFile(path, writeData, (err) => {
     if (err) {
       console.error(`Error: Could not write file at ${path}`)
       return

--- a/test/unit/app/browser/api/ledgerTest.js
+++ b/test/unit/app/browser/api/ledgerTest.js
@@ -4138,7 +4138,21 @@ describe('ledger api unit tests', function () {
 
       ledgerApi.updatePublishers(defaultAppState, ['brave.com'])
       assert.deepEqual(['brave.com'], onPublishersInfoReadSpy.getCall(0).args[0])
-      assert.deepEqual(JSON.parse(readData), onPublishersInfoReadSpy.getCall(0).args[1])
+      assert.deepEqual(Immutable.fromJS(JSON.parse(readData)), onPublishersInfoReadSpy.getCall(0).args[1])
+    })
+
+    it('does not dispatch file read if publisherInfoData has value', function () {
+      const infoData = Immutable.fromJS([
+        ['brave.com', true, false]
+      ])
+      readFileStub = sinon.stub(fs, 'readFile', (path, callback) => {
+        callback(null, readData)
+      })
+
+      ledgerApi.setPublisherInfoData(infoData)
+      ledgerApi.updatePublishers(defaultAppState, ['brave.com'])
+      assert(onPublishersInfoReadSpy.withArgs(['brave.com'], infoData).calledOnce)
+      assert(readFileStub.notCalled)
     })
 
     it('does not dispatch onPublishersInfoRead if data from file cannot be parsed as JSON', function () {


### PR DESCRIPTION
We have `publisherInfoData` as an in-memory storage of the publisher verification data. When the publishers file is written to, this variable receives a copy of the information. We should look to this variable first for the data rather than reading from the file. In the case that we restart the browser, we should read the file but once then copy that info in to memory. 

This gives a max file read per session of 1.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


