### PR TITLE
Revert "Move adblock-data s3 bucket to fastly".

### DIFF
--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -68,14 +68,14 @@ module.exports = {
     shields: false
   },
   adblock: {
-    alternateDataFiles: 'https://adblock-data.s3.brave.com/{version}/{uuid}.dat',
-    url: 'https://adblock-data.s3.brave.com/{version}/ABPFilterParserData.dat',
+    alternateDataFiles: 'https://s3.amazonaws.com/adblock-data/{version}/{uuid}.dat',
+    url: 'https://s3.amazonaws.com/adblock-data/{version}/ABPFilterParserData.dat',
     // version is specified in the ad-block library
     msBetweenRechecks: 1000 * 60 * 60 * 2, // 2 hours
     enabled: true
   },
   safeBrowsing: {
-    url: 'https://adblock-data.s3.brave.com/{version}/SafeBrowsingData.dat',
+    url: 'https://s3.amazonaws.com/adblock-data/{version}/SafeBrowsingData.dat',
     // version is specified in the ad-block library
     msBetweenRechecks: 1000 * 60 * 60 * 2, // 2 hours
     enabled: true


### PR DESCRIPTION
This reverts PR #14254 and commit ba362a27a26694748b81212925ef0324891c1eb8.
This was causing mismatch with etag being passed from clinet to server via If-None-Match request header.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


