### PR TITLE
Disable menu keyboard shortcut hint for 'Open new tor tab' menu item on Windows and Linux, only in certain menus.

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -40,12 +40,14 @@ let appMenu = null
 let closedFrames = new Immutable.OrderedMap()
 let currentLocation = null
 
+const mainMenuIsOSDrawn = isLinux || isDarwin
+
 // Submenu initialization
 const createFileSubmenu = () => {
   const submenu = [
     CommonMenu.newTabMenuItem(),
     CommonMenu.newPrivateTabMenuItem(),
-    CommonMenu.newTorTabMenuItem(),
+    CommonMenu.newTorTabMenuItem(mainMenuIsOSDrawn),
     CommonMenu.newPartitionedTabMenuItem(),
     CommonMenu.newWindowMenuItem(),
     CommonMenu.separatorMenuItem,

--- a/app/common/commonMenu.js
+++ b/app/common/commonMenu.js
@@ -10,10 +10,13 @@ const locale = require('../../js/l10n')
 const settings = require('../../js/constants/settings')
 const {tabs} = require('../../js/constants/config')
 const {getSetting} = require('../../js/settings')
+const platformUtil = require('./lib/platformUtil')
 const communityURL = 'https://community.brave.com/'
-const isDarwin = process.platform === 'darwin'
 const electron = require('electron')
 const menuUtil = require('./lib/menuUtil')
+
+const isDarwin = platformUtil.isDarwin()
+const isLinux = platformUtil.isLinux()
 
 const ensureAtLeastOneWindow = (frameOpts) => {
   // Handle no new tab requested, but need a window
@@ -85,10 +88,17 @@ module.exports.newPrivateTabMenuItem = () => {
   }
 }
 
-module.exports.newTorTabMenuItem = () => {
+module.exports.newTorTabMenuItem = (isOSDrawn = true) => {
+  // On Windows and (often) Linux, a menu drawn by the OS
+  // via Muon will not display the 'Alt' modifier, so
+  // make sure we do not display a hint that is incorrect.
+  // On Windows we can leave it in sometimes since the main app menu is
+  // not OS-drawn, so we are ok to display the accelerator for it.
+  // On Linux, never display since it will be disabled in the OS-drawn App Menu.
+  const shouldShowAccelerator = !isLinux && (!isOSDrawn || isDarwin)
   return {
     label: locale.translation('newTorTab'),
-    accelerator: 'CmdOrCtrl+Alt+N',
+    accelerator: shouldShowAccelerator ? 'CmdOrCtrl+Alt+N' : undefined,
     click: function (item, focusedWindow) {
       ensureAtLeastOneWindow({
         url: 'about:newtab',

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -704,7 +704,7 @@ function hamburgerTemplateInit (location, e) {
   const template = [
     CommonMenu.newTabMenuItem(),
     CommonMenu.newPrivateTabMenuItem(),
-    CommonMenu.newTorTabMenuItem(),
+    CommonMenu.newTorTabMenuItem(false),
     CommonMenu.newPartitionedTabMenuItem(),
     CommonMenu.newWindowMenuItem(),
     CommonMenu.separatorMenuItem,


### PR DESCRIPTION
With the current muon, the 'Alt' modifier of the keyboard shortcut is not displayed for most OS-drawn menus on these platforms, which leads to confusion,
so we disable the shortcut hint but keep the shortcut itself in the main menu where possible.

These locations include:
- Context menus (e.g. '+' New Tab button long-click)
- Main Menu on Linux in some circumstances (which likely results in disabling of the shortcut for that platform).
Fix #14768

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
On issue

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


