### PR TITLE
Prevent non-extension origins from navigating to chrome-extension://

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -615,6 +615,13 @@ const api = {
       }
 
       tab.on('did-start-navigation', (e, navigationHandle) => {
+        if (navigationHandle.isRendererInitiated() &&
+          navigationHandle.getURL().startsWith('chrome-extension://') &&
+          !tab.getURL().startsWith('chrome-extension://')) {
+          // XXX: tab.stop and tab.loadURL cause a crash here
+          appActions.loadURLRequested(tabId, 'about:blank')
+          return
+        }
         if (!tab.isDestroyed() && navigationHandle.isValid() && navigationHandle.isInMainFrame()) {
           const controller = tab.controller()
           if (!controller.isValid()) {


### PR DESCRIPTION
fix #14772

test plan: 
Follow test plan in https://github.com/brave/browser-laptop/issues/14772. At the last step, it should navigate to about:blank instead of about:preferences.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


