### PR TITLE
Fix extension browser action webview displaying no content when first opened

### DIFF
--- a/js/actions/windowActions.js
+++ b/js/actions/windowActions.js
@@ -520,6 +520,12 @@ const windowActions = {
     })
   },
 
+  setPopupWindowLoaded: function () {
+    dispatch({
+      actionType: windowConstants.WINDOW_SET_POPUP_WINDOW_LOADED
+    })
+  },
+
   /**
    * Dispatches a message to indicate that the frame should be muted
    *

--- a/js/constants/windowConstants.js
+++ b/js/constants/windowConstants.js
@@ -44,6 +44,7 @@ const windowConstants = {
   WINDOW_SET_CONTEXT_MENU_DETAIL: _, // If set, also indicates that the context menu is shown
   WINDOW_SET_CONTEXT_MENU_SELECTED_INDEX: _,
   WINDOW_SET_POPUP_WINDOW_DETAIL: _, // If set, also indicates that the popup window is shown
+  WINDOW_SET_POPUP_WINDOW_LOADED: _,
   WINDOW_HIDE_BOOKMARK_HANGER: _,
   WINDOW_SET_AUDIO_MUTED: _,
   WINDOW_SET_FAVICON: _,

--- a/js/stores/windowStore.js
+++ b/js/stores/windowStore.js
@@ -509,7 +509,16 @@ const doAction = (action) => {
       if (!action.detail) {
         windowState = windowState.delete('popupWindowDetail')
       } else {
+        const alreadyFinishedLoad = windowState.getIn(['popupWindowDetail', 'didFinishLoad'])
         windowState = windowState.set('popupWindowDetail', action.detail)
+        if (alreadyFinishedLoad) {
+          windowState = windowState.setIn(['popupWindowDetail', 'didFinishLoad'], true)
+        }
+      }
+      break
+    case windowConstants.WINDOW_SET_POPUP_WINDOW_LOADED:
+      if (windowState.has('popupWindowDetail')) {
+        windowState = windowState.setIn(['popupWindowDetail', 'didFinishLoad'], true)
       }
       break
     case windowConstants.WINDOW_SET_AUDIO_MUTED:


### PR DESCRIPTION
Fix #13633 via a workaround to hide and show the webview after the first time it is attached to a new WebContents.
Also avoid flash of different sizes by only setting a new size once the page has finished load (success or fail).

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


