### PR TITLE
[NEW FEATURE]: Added the ability for a 24-hour clock display

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -352,6 +352,7 @@ const updateAboutDetails = (tabId) => {
     const newTabDetail = aboutNewTabState.getData(appState)
     const showEmptyPage = settingsStore.getSetting(settings.NEWTAB_MODE) === newTabMode.EMPTY_NEW_TAB
     const showImages = settingsStore.getSetting(settings.SHOW_DASHBOARD_IMAGES) && !showEmptyPage
+    const clockDisplayTwentyFour = settingsStore.getSetting(settings.CLOCK_DISPLAY_TWENTY_FOUR) && !showEmptyPage
     const trackedBlockersCount = appState.getIn(['trackingProtection', 'count'], 0)
     const httpsUpgradedCount = appState.getIn(['httpsEverywhere', 'count'], 0)
     const adblockCount = appState.getIn(['adblock', 'count'], 0)
@@ -359,6 +360,7 @@ const updateAboutDetails = (tabId) => {
     sendAboutDetails(tabId, messages.NEWTAB_DATA_UPDATED, {
       showEmptyPage,
       showImages,
+      clockDisplayTwentyFour,
       trackedBlockersCount,
       adblockCount,
       httpsUpgradedCount,

--- a/app/extensions/brave/locales/en-US/newtab.properties
+++ b/app/extensions/brave/locales/en-US/newtab.properties
@@ -3,6 +3,7 @@ adsBlocked={[plural(adblockCount)]}
 adsBlocked[one]=Ad Blocked
 adsBlocked[other]=Ads Blocked
 bookmarksPage.title=Go to Bookmarks page
+clockDisplayTwentyFour=24 Hour Time
 close.title=Close notification
 days={[plural(value)]}
 days[one]=day

--- a/app/renderer/components/preferences/tabsTab.js
+++ b/app/renderer/components/preferences/tabsTab.js
@@ -154,6 +154,17 @@ class TabsTab extends ImmutableComponent {
               settings={this.props.settings}
               onChangeSetting={this.props.onChangeSetting}
             />
+
+            <SettingCheckbox
+              dataL10nId='clockDisplayTwentyFour'
+              dataTestId='clockDisplayTwentyFour'
+              testIsEnabled={
+                getSetting(settings.CLOCK_DISPLAY_TWENTY_FOUR, this.props.settings) === true
+              }
+              prefKey={settings.CLOCK_DISPLAY_TWENTY_FOUR}
+              settings={this.props.settings}
+              onChangeSetting={this.props.onChangeSetting}
+            />
           </SettingItem>
         </SettingsList>
       </div>

--- a/js/about/newTabComponents/clock.js
+++ b/js/about/newTabComponents/clock.js
@@ -1,13 +1,12 @@
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
-
 const React = require('react')
 
 class Clock extends React.Component {
-  constructor () {
-    super()
-    this.dateTimeFormat = new Intl.DateTimeFormat([], {hour: '2-digit', minute: '2-digit'})
+  constructor (props) {
+    super(props)
+    this.setDateTimeFormat()
     this.state = this.getClockState(new Date())
   }
   get formattedTime () {
@@ -41,14 +40,32 @@ class Clock extends React.Component {
       this.setState(this.getClockState(now))
     }
   }
+  setDateTimeFormat () {
+    this.dateTimeFormat = new Intl.DateTimeFormat([],
+      {
+        hour12: !this.props.displayTwentyFour,
+        hour: '2-digit',
+        minute: '2-digit'
+      }
+    )
+  }
   getClockState (now) {
     return {
       date: now,
       currentTime: this.dateTimeFormat.formatToParts(now)
     }
   }
+  applyUpdatedFormat () {
+    this.setDateTimeFormat()
+    this.setState(this.getClockState(new Date()))
+  }
   componentDidMount () {
     window.setInterval(this.maybeUpdateClock.bind(this), 2000)
+  }
+  componentDidUpdate (prevProps) {
+    if (prevProps.displayTwentyFour !== this.props.displayTwentyFour) {
+      this.applyUpdatedFormat()
+    }
   }
 
   render () {

--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -49,6 +49,7 @@ class NewTabPage extends React.Component {
       showEmptyPage: true,
       showImages: false,
       torEnabled: false,
+      clockDisplayTwentyFour: false,
       backgroundImage: undefined
     }
 
@@ -71,6 +72,7 @@ class NewTabPage extends React.Component {
         showEmptyPage,
         torEnabled: data.get('torEnabled'),
         showImages: !!data.get('showImages') && !showEmptyPage,
+        clockDisplayTwentyFour: !!data.get('clockDisplayTwentyFour') && !showEmptyPage,
         backgroundImage: showImages
           ? this.state.backgroundImage || this.randomBackgroundImage
           : undefined
@@ -297,7 +299,7 @@ class NewTabPage extends React.Component {
         <main className='newTabDashboard'>
           <div className='statsBar'>
             <Stats newTabData={this.state.newTabData} />
-            <Clock />
+            <Clock displayTwentyFour={this.state.clockDisplayTwentyFour} />
           </div>
           <div className='topSitesContainer'>
             <nav className='topSitesGrid'>

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -164,6 +164,7 @@ module.exports = {
     'tabs.show-tab-previews': true,
     'tabs.preview-timing': tabPreviewTiming.SHORT,
     'tabs.show-dashboard-images': true,
+    'tabs.clock-display-twenty-four': false,
     'privacy.history-suggestions': true,
     'privacy.bookmark-suggestions': true,
     'privacy.topsite-suggestions': true,

--- a/js/constants/settings.js
+++ b/js/constants/settings.js
@@ -33,6 +33,7 @@ const settings = {
   SHOW_TAB_PREVIEWS: 'tabs.show-tab-previews',
   TAB_PREVIEW_TIMING: 'tabs.preview-timing',
   SHOW_DASHBOARD_IMAGES: 'tabs.show-dashboard-images',
+  CLOCK_DISPLAY_TWENTY_FOUR: 'tabs.clock-display-twenty-four',
   // Privacy Tab
   HISTORY_SUGGESTIONS: 'privacy.history-suggestions',
   BOOKMARK_SUGGESTIONS: 'privacy.bookmark-suggestions',

--- a/test/unit/app/renderer/components/preferences/tabsTabTest.js
+++ b/test/unit/app/renderer/components/preferences/tabsTabTest.js
@@ -278,5 +278,17 @@ describe('TabsTab component', function () {
         true
       )
     })
+
+    it('dashboard shows a 12/24 hour clock', function () {
+      settingDefaultValue = true
+      const wrapper = shallow(<TabsTab settings={settingDefaultValue} />)
+
+      assert.notEqual(
+        wrapper.find('[dataTestId="clockDisplayTwentyFour"]')
+          .map(option => option.props().value)
+          .includes(settingDefaultValue),
+        true
+      )
+    })
   })
 })


### PR DESCRIPTION
Closes issue #14744 

Thanks, @jonathansampson, this was a fun first-issue to try out. I do have one issue in this PR, the `dataL10nId` doesn't show up on the Dashboard settings page. It keeps defaulting to the tag I've chosen `clockDisplayTwentyFour`. If anyone can explain what I'm missing that would be great! I'm sure it's something simple. I created all the appropriate language translations.

Looking forward to feedback!

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


