### PR TITLE
Fix up random sampling with brave-crypto random samplers.

### DIFF
--- a/app/common/lib/randomUtil.js
+++ b/app/common/lib/randomUtil.js
@@ -2,4 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-module.exports.random = () => Math.random()
+const crypto = require('brave-crypto')
+
+module.exports.uniform = (n) => crypto.random.uniform(n)

--- a/app/extensions/brave/content/scripts/adInsertion.js
+++ b/app/extensions/brave/content/scripts/adInsertion.js
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const crypto = require('brave-crypto')
+
 if (chrome.contentSettings.adInsertion == 'allow') {
   /**
    * Determines the ad size which should be shown
@@ -72,7 +74,7 @@ if (chrome.contentSettings.adInsertion == 'allow') {
     // generate a random segment
     // @todo - replace with renko targeting
     var segments = ['IAB2', 'IAB17', 'IAB14', 'IAB21', 'IAB20']
-    var segment = segments[Math.floor(Math.random() * 4)]
+    var segment = segments[crypto.random.uniform(segments.length)]
     var time_in_segment = new Date().getSeconds()
     var segment_expiration_time = 0 // no expiration
 

--- a/app/renderer/rendererTabEvents.js
+++ b/app/renderer/rendererTabEvents.js
@@ -3,6 +3,7 @@
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const Immutable = require('immutable')
+const crypto = require('brave-crypto')
 const electron = require('electron')
 
 const windowStore = require('../../js/stores/windowStore')
@@ -535,9 +536,8 @@ function showWidevineNotification (tabId, frame, noWidevineCallback, widevineCal
     return
   }
 
-  // Generate a random string that is unlikely to collide. Not
-  // cryptographically random.
-  const nonce = Math.random().toString()
+  // Generate a random string that is unlikely to collide.
+  const nonce = crypto.uint8ToHex(crypto.getSeed(32))
   const isWidevineEnabled = state.get('widevine') && state.getIn(['widevine', 'enabled'])
   if (isWidevineEnabled) {
     const message = locale.translation('allowWidevine').replace(/{{\s*origin\s*}}/, origin)

--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -29,7 +29,7 @@ const backgrounds = require('../data/backgrounds')
 
 // Utils
 const urlutils = require('../lib/urlutil')
-const {random} = require('../../app/common/lib/randomUtil')
+const random = require('../../app/common/lib/randomUtil')
 const cx = require('../lib/classSet')
 const ipc = window.chrome.ipcRenderer
 
@@ -83,7 +83,7 @@ class NewTabPage extends React.Component {
   }
 
   get randomBackgroundImage () {
-    const image = Object.assign({}, backgrounds[Math.floor(random() * backgrounds.length)])
+    const image = Object.assign({}, backgrounds[random.uniform(backgrounds.length)])
     return image
   }
 

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -10,6 +10,8 @@ const {StyleSheet, css} = require('aphrodite/no-important')
 const globalStyles = require('../../app/renderer/components/styles/global')
 const commonStyles = require('../../app/renderer/components/styles/commonStyles')
 
+const crypto = require('brave-crypto')
+
 // Components
 const PreferenceNavigation = require('../../app/renderer/components/preferences/preferenceNavigation')
 const {SettingsList, SettingItem, SettingCheckbox, SettingItemIcon} = require('../../app/renderer/components/common/settings')
@@ -614,7 +616,7 @@ class AboutPreferences extends React.Component {
     // refresh button is broken.
     let newNumber
     for (let i = 0; i < 10; ++i) {
-      newNumber = Math.random() * hintCount | 0
+      newNumber = crypto.random.uniform(hintCount)
       if (!this.state || newNumber !== this.state.hintNumber) {
         break
       }

--- a/test/about/bookmarksManagerTest.js
+++ b/test/about/bookmarksManagerTest.js
@@ -6,9 +6,10 @@ const {getTargetAboutUrl} = require('../../js/lib/appUrlUtil')
 const siteTags = require('../../js/constants/siteTags')
 const aboutBookmarksUrl = getTargetAboutUrl('about:bookmarks')
 const Immutable = require('immutable')
+const crypto = require('brave-crypto')
 
 describe('about:bookmarks', function () {
-  const folderId = Math.floor(Math.random() * (100 - 1 + 1)) + 1
+  const folderId = 1 + crypto.random.uniform(100)
   const browseableSiteUrl = 'page1.html'
   const browseableSiteTitle = 'Page 1'
 

--- a/test/lib/brave.js
+++ b/test/lib/brave.js
@@ -9,6 +9,7 @@ const series = require('async/series')
 const path = require('path')
 const fs = require('fs-extra')
 const os = require('os')
+const crypto = require('brave-crypto')
 const {getTargetAboutUrl, isSourceAboutUrl, getBraveExtIndexHTML} = require('../../js/lib/appUrlUtil')
 
 var chaiAsPromised = require('chai-as-promised')
@@ -26,7 +27,7 @@ const logVerbose = (string, ...rest) => {
 }
 
 const generateUserDataDir = () => {
-  return process.env.BRAVE_USER_DATA_DIR || path.join(os.tmpdir(), 'brave-test', (new Date().getTime()) + Math.floor(Math.random() * 1000).toString())
+  return process.env.BRAVE_USER_DATA_DIR || path.join(os.tmpdir(), 'brave-test', (new Date().getTime()) + crypto.random.uniform(1000).toString())
 }
 
 const rmDir = (dirPath) => {

--- a/test/unit/about/newTabPageTest.js
+++ b/test/unit/about/newTabPageTest.js
@@ -10,12 +10,13 @@ const sinon = require('sinon')
 const assert = require('assert')
 const Immutable = require('immutable')
 const fakeElectron = require('../lib/fakeElectron')
+const crypto = require('brave-crypto')
 const _ = require('underscore')
 let NewTabPage, randomSpy, Clock, Stats, FooterInfo, NewPrivateTab
 require('../braveUnit')
 
 const randomWrapper = {
-  random: () => Math.random()
+  uniform: (n) => crypto.random.uniform(n)
 }
 
 describe('NewTab component unit tests', function () {
@@ -31,7 +32,7 @@ describe('NewTab component unit tests', function () {
     mockery.registerMock('../../app/extensions/brave/img/newtab/private_tab_pagearea_icon.svg')
     mockery.registerMock('../../app/extensions/brave/img/newtab/private_tab_pagearea_ddgicon.svg')
     mockery.registerMock('../../app/extensions/brave/img/newtab/toricon.svg')
-    randomSpy = sinon.spy(randomWrapper, 'random')
+    randomSpy = sinon.spy(randomWrapper, 'uniform')
     mockery.registerMock('../../app/common/lib/randomUtil', randomWrapper)
     window.chrome = fakeElectron
     window.CustomEvent = {}

--- a/tools/lib/randomHostname.js
+++ b/tools/lib/randomHostname.js
@@ -1,6 +1,8 @@
+const crypto = require('brave-crypto')
+
 const ALPHABET = 'abcdefghijklmnopqrstuvwxyz'
 const _chooseRandomLetter = function () {
-  return ALPHABET[Math.round(Math.random() * (ALPHABET.length - 1))]
+  return ALPHABET[crypto.random.uniform(ALPHABET.length)]
 }
 
 const _generateRandomString = function (len) {
@@ -13,12 +15,12 @@ const generateRandomHostname = function (maxLength, minLength) {
   maxLength = maxLength || 10
   minLength = minLength || 4
 
-  let tld = TLDS[Math.round(Math.random() * (TLDS.length - 1))]
+  let tld = TLDS[crypto.random.uniform(TLDS.length)]
 
-  let numParts = Math.round(Math.random()) + 1
+  let numParts = 1 + crypto.random.uniform(2)
 
   let host = (new Array(numParts)).fill(null).map(function () {
-    let partLen = Math.max(Math.round(Math.random() * maxLength), minLength)
+    let partLen = minLength + crypto.random.uniform(maxLength - minLength + 1)
     return _generateRandomString(partLen)
   }).join('.') + '.' + tld
 

--- a/tools/lib/synopsisHelpers.js
+++ b/tools/lib/synopsisHelpers.js
@@ -1,3 +1,4 @@
+const crypto = require('brave-crypto')
 const randomHostname = require('./randomHostname')
 
 const Synopsis = require('bat-publisher').Synopsis
@@ -5,16 +6,18 @@ const Synopsis = require('bat-publisher').Synopsis
 const PROTOCOL_PREFIXES = ['http://', 'https://']
 
 const generateSynopsisVisits = function (synopsis, numPublishers) {
-  let numHosts = numPublishers || Math.round(Math.random() * 100)
+  let numHosts = numPublishers || crypto.random.uniform(100)
 
   let hosts = (new Array(numHosts)).fill(null).map(function () { return randomHostname() })
 
   hosts.forEach(function (host) {
-    let numVisits = Math.round(Math.random() * 10)
+    let numVisits = crypto.random.uniform(10)
 
     for (let i = 0; i < numVisits; i++) {
-      synopsis.addPublisher(PROTOCOL_PREFIXES[Math.round(Math.random())] + host + '/', {
-        duration: Math.round(Math.random() * 60 * 1000),
+      const nprefixes = PROTOCOL_PREFIXES.length
+      const prefix = PROTOCOL_PREFIXES[crypto.random.uniform(nprefixes)]
+      synopsis.addPublisher(prefix + host + '/', {
+        duration: crypto.random.uniform(60 * 1000),
         revisitP: false
       })
     }

--- a/tools/lib/transactionHelpers.js
+++ b/tools/lib/transactionHelpers.js
@@ -1,4 +1,5 @@
 let Joi = require('joi')
+const braveCrypto = require('brave-crypto')
 let generateRandomHost = require('./randomHostname')
 const BigNumber = require('bignumber.js')
 
@@ -44,7 +45,7 @@ const validateTransaction = function (tx) {
 }
 
 const generateTransaction = function () {
-  const count = Math.round(Math.random() * 100)
+  const count = braveCrypto.random.uniform(100)
 
   const viewingId = generateViewingId()
   const surveyorId = generateSurveyorId()
@@ -104,7 +105,8 @@ const generateSurveyorIds = function (count) {
 }
 
 const generateContribution = function () {
-  let randomContributionAmount = [5.0, 7.5, 10.0, 17.5, 25.0, 50.0, 75.0, 100.0][ Math.round(Math.random() * 3) ]
+  const amounts = [5.0, 7.5, 10.0, 17.5, 25.0, 50.0, 75.0, 100.0]
+  let randomContributionAmount = amounts[braveCrypto.random.uniform(amounts.length)]
   const currency = 'BAT'
 
   let rates = {
@@ -145,7 +147,10 @@ const generateBallots = function (votes) {
   let votesRemaining = votes
 
   while (votesRemaining) {
-    let votesToCast = Math.min(Math.round(Math.random() * votesRemaining) + 1, votesRemaining)
+    let votesToCast = 1
+    if (votesRemaining > 1) {
+      votesToCast += braveCrypto.random.uniform(votesRemaining - 1)
+    }
     let host = generateRandomHost()
     ballots[host] = votesToCast
     votesRemaining -= votesToCast


### PR DESCRIPTION
fix #6944

Some of these changes change the _distribution_ of probabilities to
the possible outcomes, where it seemed obvious that a uniform
distribution was intended but not previously attained.

Some of these changes also change the _support_, the set of possible
outcomes, where it made things simpler and was not obviously intended
one way or another.

Many of these are not _necessarily_ bugs, but if deviations from
uniform are actually intended they should be clearly justified.

Full details:

- Change Math.floor(Math.random() * n) to crypto.random.uniform(n).

  - app/extensions/brave/content/scripts/adInsertion.js
  - js/about/newtab.js (with care to preserve test spying in newTabPageTest.js)
  - js/about/preferences.js (which used |0 rather than Math.floor)
  - test/about/bookmarksManagerTest.js
  - test/lib/brave.js

  - This was obviously intended to be a uniform distribution on
    {0,1,2,...,n-1}.  It is nonuniform only because of IEEE 754
    binary64 floating-point approximation.

- Change Math.round(Math.random() * (n-1)) to crypto.random.uniform(n)
  when used as an index into an n-element array.

  - tools/lib/randomHostname.js, _chooseRandomLetter / ALPHABET
  - tools/lib/randomHostname.js, tld / TLDS
  - tools/lib/synopsisHelpers.js, publisher / PROTOCOL_PREFIXES
  - tools/lib/transactionHelpers.js, generateContribution: amount
    - (Adjusted to use the actual length of the array, not just the
      first four elements of an eight-element array.)

  - This gave half the probability to 0 and n - 1 that it gave to 1,
    2, 3, ..., n - 3, n - 2, a much bigger deviation from uniform than
    IEEE 754 binary64 floating-point approximations of the above.
    There was no obvious reason why this nonuniformity was desirable.

- Change Math.round(Math.random() * n) to crypto.random.uniform(n)
  when _not_ used as an index into an array.

  - tools/lib/synopsisHelpers.js, numHosts
  - tools/lib/synopsisHelpers.js, numVisits
  - tools/lib/transactionHelpers.js, generateTransaction: count
  - tools/lib/synopsisHelpers.js, duration

  - This actually changes the _support_ of the distribution to exclude
    n, but in the only places where this was used, it is not otherwise
    obvious that the caller intended to include n in the support.  It
    could have been a typo for Math.floor(Math.random() * n) without
    adverse consequences in these contexts.

- Change Math.round(Math.random()) to crypto.random.uniform(2).

  - tools/lib/randomHostname.js, numParts

  - This was obviously intended to be a uniform distribution on {0,1},
    and actually it may even be uniform under Math.random as typically
    implemented, but writing crypto.random.uniform(2) is clearer to
    flip a coin and this way we just avoid Math.random() altogether.

- Obscure corner cases:

  - app/renderer/rendererTabEvents.js, nonce
    - This used Math.random().toString() to generate a string `that is
      unlikely to collide'.  There are only 2^64 64-bit floating-point
      values, of which Math.random() returns a small subset.  A
      collision is expected after only a few billion uniform random
      samples, which is far from impossible.  I replaced it by a
      uniform random 256-bit quantity in hex, which will never collide
      even in the view of a conservative paranoid cryptographer unless
      there is a deeper bug breaking the PRNG.

  - tools/lib/randomHostname.js, partLen
    - The distribution originally used here puts higher probability on
      the minimum part length than everything else, and lower
      probability on the maximum part length than anything else.  I
      see no reason why this should not just be uniformly distributed
      on part lengths {minLength, minLength + 1, ..., maxLength - 1,
      maxLength}, so I replaced it by minLength + uniform(maxLength -
      minLength + 1).

  - tools/lib/transactionHelpers.js, generateBallots: votesToCast

    - The previous expression, Math.min(Math.round(Math.random() *
      votesRemaining) + 1, votesRemaining), assigned half weight to 1
      and half-again weight to votesRemaining - 1 (as compared to all
      other numbers) for no obvious reason.  I changed it to use 1, if
      only 1 vote is remaining, or 1 + uniform(votesRemaining - 1), if
      more than one vote is remaining.

P.S.  It is a bit confusing that we have a module named `brave-crypto`
which is usually used as `const crypto = require('brave-crypto')`
while there is also a standard nodejs module called `crypto` which is
usually used as `const crypto = require('crypto')`.  In one case these
are used in the same file, so I named ours `braveCrypto`.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
- npm run unittest
- npm run add-simulated-payment-history
- npm run add-simulated-synopsis-visits
- launch browser and browse around

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


