### PR TITLE
Fix/permission origin v2

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -549,14 +549,16 @@ function registerPermissionHandler (session, partition) {
         requestingOrigin = isPDFOrigin ? 'PDF Viewer' : 'Brave Browser'
         // display on all tabs
         mainFrameOrigin = null
-      } else if (isOpenExternal) {
+      } else {
+        requestingOrigin = getOrigin(requestingUrl) || requestingUrl
+      }
+
+      if (isOpenExternal) {
         // Open external is a special case since we want to apply the permission
         // for the entire scheme to avoid cluttering the saved permissions. See
         // https://github.com/brave/browser-laptop/issues/13642
         const protocol = urlParse(requestingUrl).protocol
         requestingOrigin = protocol ? `${protocol} URLs` : requestingUrl
-      } else {
-        requestingOrigin = getOrigin(requestingUrl) || requestingUrl
       }
 
       // Look up by host pattern since requestingOrigin is not necessarily
@@ -576,10 +578,6 @@ function registerPermissionHandler (session, partition) {
         response.push(true)
       } else if (isFullscreen && alwaysAllowFullscreen) {
         // Always allow fullscreen if setting is ON
-        response.push(true)
-      } else if (isOpenExternal && (
-        // The Brave extension and PDFJS are always allowed to open files in an external app
-        isPDFOrigin || isBraveOrigin)) {
         response.push(true)
       } else {
         const permissionName = permission + 'Permission'


### PR DESCRIPTION
Stop-gap workaround for the most severe aspect of https://github.com/brave/browser-laptop/issues/14679.  Real problem is that we misinterpret the information that muon gives us and the results are bad.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


