### PR TITLE
Show 'open external' permission in global area instead of tab area

### DIFF
--- a/app/filtering.js
+++ b/app/filtering.js
@@ -527,6 +527,7 @@ function registerPermissionHandler (session, partition) {
     const isBraveOrigin = mainFrameOrigin.startsWith(`chrome-extension://${config.braveExtensionId}/`)
     const isPDFOrigin = mainFrameOrigin.startsWith(`${pdfjsOrigin}/`)
     let response = []
+    let position
 
     if (!requestingUrl) {
       response = new Array(permissionTypes.length)
@@ -559,6 +560,8 @@ function registerPermissionHandler (session, partition) {
         // https://github.com/brave/browser-laptop/issues/13642
         const protocol = urlParse(requestingUrl).protocol
         requestingOrigin = protocol ? `${protocol} URLs` : requestingUrl
+        mainFrameOrigin = null
+        position = 'global'
       }
 
       // Look up by host pattern since requestingOrigin is not necessarily
@@ -608,6 +611,7 @@ function registerPermissionHandler (session, partition) {
             {text: locale.translation('deny')},
             {text: locale.translation('allow')}
           ],
+          position,
           frameOrigin: getOrigin(mainFrameOrigin),
           options: {
             persist: !!requestingOrigin,


### PR DESCRIPTION
Since these permissions are not scoped to any tab, it doesn't make sense
to show them in the tab area.

Fix https://github.com/brave/browser-laptop/issues/14681

1. Go to https://jsfiddle.net/yudr4cxe/ and click the link.
2. It should show a notification above the tab bar.

before:
![screen shot 2018-08-02 at 2 31 30 pm](https://user-images.githubusercontent.com/549654/43612347-f0e3f61c-9660-11e8-8cd5-22493441d084.png)

after:
![screen shot 2018-08-02 at 2 30 34 pm](https://user-images.githubusercontent.com/549654/43612362-fad5383e-9660-11e8-9e99-55a84c6fbdc2.png)
