### PR TITLE
Add content setting for media device access

### DIFF
--- a/app/extensions/brave/content/scripts/navigator.js
+++ b/app/extensions/brave/content/scripts/navigator.js
@@ -27,3 +27,13 @@ if (chrome.contentSettings.ads == 'block') {
 
 // Spectre hotfix (https://github.com/brave/browser-laptop/issues/12570)
 chrome.webFrame.setGlobal('window.SharedArrayBuffer', false)
+
+if (chrome.contentSettings.mediaPermission == 'block') {
+  // Needed for https://github.com/brave/browser-laptop/issues/14889
+  // Note this is not necessary in non-Electron-based codebases since Chromium
+  // automatically handles the permission for device enumeration.
+  // Also: chromium doesn't have mediaPermission in content setting. It is actually
+  // microphone && camera in chromium.
+  executeScript("window.MediaDeviceInfo.prototype.__defineGetter__('label', () => { return '' })")
+  executeScript("window.InputDeviceInfo.prototype.__defineGetter__('label', () => { return '' })")
+}

--- a/js/state/contentSettings.js
+++ b/js/state/contentSettings.js
@@ -93,6 +93,10 @@ const getDefaultUserPrefContentSettings = (braveryDefaults, appSettings, appConf
       setting: getSetting(settings.DO_NOT_TRACK, appSettings) ? 'allow' : 'block',
       primaryPattern: '*'
     }],
+    mediaPermission: [{
+      setting: 'block',
+      primaryPattern: '*'
+    }],
     passwordManager: getDefaultPasswordManagerSettings(braveryDefaults, appSettings, appConfig),
     javascript: [{
       setting: braveryDefaults.get('noScript') ? 'block' : 'allow',
@@ -283,10 +287,12 @@ const siteSettingsToContentSettings = (currentSiteSettings, defaultContentSettin
         }
       })
     }
-    if (typeof siteSetting.get('runInsecureContent') === 'boolean') {
-      contentSettings = addContentSettings(contentSettings, 'runInsecureContent', primaryPattern, '*',
-        siteSetting.get('runInsecureContent') ? 'allow' : 'block')
-    }
+    ['runInsecureContent', 'autoplay', 'mediaPermission'].forEach((permission) => {
+      if (typeof siteSetting.get(permission) === 'boolean') {
+        contentSettings = addContentSettings(contentSettings, permission, primaryPattern, '*',
+          siteSetting.get(permission) ? 'allow' : 'block')
+      }
+    })
     if (siteSetting.get('cookieControl')) {
       if (siteSetting.get('cookieControl') === 'block3rdPartyCookie') {
         contentSettings = addContentSettings(contentSettings, 'cookies', primaryPattern, '*', 'block')
@@ -325,9 +331,6 @@ const siteSettingsToContentSettings = (currentSiteSettings, defaultContentSettin
     }
     if (typeof siteSetting.get('widevine') === 'number' && braveryDefaults.get('widevine')) {
       contentSettings = addContentSettings(contentSettings, 'plugins', primaryPattern, '*', 'allow', widevineResourceId)
-    }
-    if (typeof siteSetting.get('autoplay') === 'boolean') {
-      contentSettings = addContentSettings(contentSettings, 'autoplay', primaryPattern, '*', siteSetting.get('autoplay') ? 'allow' : 'block')
     }
   })
   // On the second pass we consider only shieldsUp === false settings since we want those to take precedence.


### PR DESCRIPTION
fix #14889

Test plan:
1. go to https://www.webrtc-experiment.com/DetectRTC/
2. confirm that (1) the results are the same as what chrome shows on
   that site and (2) you see a permission prompt for media access
3. click 'remember this decision' and 'allow' on the permission prompt
   and reload the page.
4. confirm that in the "System has Speakers?", "System has Microphone?", "System has Webcam" section, it now shows descriptions of all your devices.

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


