### PR TITLE
do not generally allow file:// to be opened in new tab

### DIFF
--- a/app/browser/menu.js
+++ b/app/browser/menu.js
@@ -63,7 +63,7 @@ const createFileSubmenu = () => {
               appActions.createTabRequested({
                 url: fileUrl(path),
                 windowId: focusedWindow.id
-              })
+              }, false, false, false, true)
             })
           }
         })

--- a/app/browser/reducers/tabsReducer.js
+++ b/app/browser/reducers/tabsReducer.js
@@ -37,6 +37,7 @@ const {getFlashResourceId} = require('../../../js/flash')
 const {l10nErrorText} = require('../../common/lib/httpUtil')
 const flash = require('../../../js/flash')
 const {isSourceAboutUrl, isTargetAboutUrl, isNavigatableAboutPage} = require('../../../js/lib/appUrlUtil')
+const {isFileScheme} = require('../../../js/lib/urlutil')
 const {shouldDebugTabEvents} = require('../../cmdLine')
 
 const getWebRTCPolicy = (state, tabId) => {
@@ -249,6 +250,10 @@ const tabsReducer = (state, action, immutableAction) => {
         windows.focus(windowId)
       }
       const url = action.getIn(['createProperties', 'url'])
+      if (isFileScheme(url) && !action.get('allowFile')) {
+        // Don't allow 'open in new tab' to open file:// URLs for security
+        action = action.setIn(['createProperties', 'url'], 'about:blank')
+      }
       setImmediate(() => {
         if (action.get('activateIfOpen') ||
             ((isSourceAboutUrl(url) || isTargetAboutUrl(url)) && isNavigatableAboutPage(url))) {

--- a/app/browser/reducers/windowsReducer.js
+++ b/app/browser/reducers/windowsReducer.js
@@ -22,6 +22,7 @@ const {makeImmutable, isImmutable} = require('../../common/state/immutableUtil')
 const electron = require('electron')
 const BrowserWindow = electron.BrowserWindow
 const firstDefinedValue = require('../../../js/lib/functional').firstDefinedValue
+const {isFileScheme} = require('../../../js/lib/urlutil')
 const settings = require('../../../js/constants/settings')
 const getSetting = require('../../../js/settings').getSetting
 
@@ -266,6 +267,11 @@ const handleCreateWindowAction = (state, action = Immutable.Map()) => {
         if (Array.isArray(frameOpts)) {
           frames = frameOpts
         } else {
+          // Don't allow 'open in new window' to open a file:// URL for
+          // security reasons
+          if (isFileScheme(frameOpts.location)) {
+            frameOpts.location = 'about:blank'
+          }
           frames = [ frameOpts ]
         }
       } else {

--- a/js/actions/appActions.js
+++ b/js/actions/appActions.js
@@ -268,13 +268,16 @@ const appActions = {
    * @param {Boolean} activateIfOpen if the tab is already open with the same properties,
    * switch to it instead of creating a new one
    * @param {Boolean} isRestore when true, won't try to activate the new tab, even if the user preference indicates to
+   * @param {Boolean} focusWindow
+   * @param {Boolean} allowFile - When true, allows file:// URLs to be opened
    */
-  createTabRequested: function (createProperties, activateIfOpen = false, isRestore = false, focusWindow = false) {
+  createTabRequested: function (createProperties, activateIfOpen = false, isRestore = false, focusWindow = false, allowFile = false) {
     dispatch({
       actionType: appConstants.APP_CREATE_TAB_REQUESTED,
       createProperties,
       activateIfOpen,
       isRestore,
+      allowFile,
       focusWindow
     })
   },

--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -424,7 +424,10 @@ const UrlUtil = {
    * @return {boolean}
    */
   isFileScheme: function (url) {
-    return this.getScheme(url) === fileScheme
+    if (!url) {
+      return false
+    }
+    return urlParse(url).protocol === 'file:'
   },
 
   /**

--- a/test/unit/lib/urlutilTestComponents.js
+++ b/test/unit/lib/urlutilTestComponents.js
@@ -329,6 +329,11 @@ module.exports = {
       }
     },
     'returns false when input:': {
+      'is falsey': (test) => {
+        test.equal(urlUtil().isFileScheme(''), false)
+        test.equal(urlUtil().isFileScheme(), false)
+        test.equal(urlUtil().isFileScheme(null), false)
+      },
       'is an absolute file path without scheme': (test) => {
         test.equal(urlUtil().isFileScheme('/file/path/to/file'), false)
       },


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/14522

Test Plan:
1. create an HTML file called 'file-load.html' somewhere on your
   computer
2. go to https://jsfiddle.net/L9t0je3h/3/ and replace
   'file:///Users/yan/Downloads/file-load.html' with the path of this
   file
3. in the jsfiddle page, right click on the link that says 'right click
   to open in new tab' and try clicking any of the context menu items to
   open in a new tab/window. they should all load about:blank instead of
   the real file.
4. go to Menu > File > Open files. pick some files to open and make sure
   these open correctly.

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


