### PR TITLE
Adds debug for ledger roundtrip calls

### DIFF
--- a/app/browser/api/ledger.js
+++ b/app/browser/api/ledger.js
@@ -2103,7 +2103,7 @@ const onReferralCodeRead = (code) => {
         referral_code: code,
         platform: platform
       }
-    }, {}, onReferralInit)
+    }, {verboseP: clientOptions.verboseP}, onReferralInit)
   }
 }
 
@@ -2170,7 +2170,7 @@ const fetchReferralHeaders = () => {
     server: referralServer,
     method: 'GET',
     path: '/promo/custom-headers'
-  }, {}, appActions.onFetchReferralHeaders)
+  }, {verboseP: clientOptions.verboseP}, appActions.onFetchReferralHeaders)
 }
 
 const onFetchReferralHeaders = (state, err, response, body) => {
@@ -3098,7 +3098,7 @@ const checkReferralActivity = (state) => {
         download_id: downloadId,
         api_key: referralAPI
       }
-    }, {}, activityRoundTrip)
+    }, {verboseP: clientOptions.verboseP}, activityRoundTrip)
   } else {
     updater.checkForUpdate(false, true)
   }


### PR DESCRIPTION
Fixes: #14874 

This simply ensures that `roundtrip` calls made inside `ledger.js` are debugged appropriately depending on `LEDGER_VERBOSE`

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Build Brave from this pull request
2. Run with `LEDGER_VERBOSE=true npm start`
3. Enable payments, wait a minute or so
4. Confirm response is shown from `/promo/custom-headers`

This affects 3 calls in total, but getting the others to appear requires a different test approach. This change should be small enough that it can be verified through the code changes.

## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


