### PR TITLE
delete did-detach block accidentally brought back in #14734

### DIFF
--- a/app/browser/tabs.js
+++ b/app/browser/tabs.js
@@ -718,16 +718,6 @@ const api = {
         }
       })
 
-      tab.on('did-detach', (e, oldTabId) => {
-        // forget last active trail in window tab
-        // is detaching from
-        const oldTab = getTabValue(oldTabId)
-        const detachedFromWindowId = oldTab ? oldTab.get('windowId') : undefined
-        if (detachedFromWindowId != null) {
-          activeTabHistory.clearTabFromWindow(detachedFromWindowId, oldTabId)
-        }
-      })
-
       tab.on('did-attach', (e, tabId) => {
         // tab has been attached to a webview
       })


### PR DESCRIPTION

fixes #15019

a block removed in the single webview project was added back in due to a rebase issue

see discussion here:
https://github.com/brave/browser-laptop/pull/14734/files#r202442461

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


