### PR TITLE
Fixes ENOENT issues on Windows

### DIFF
--- a/app/ethWallet-geth.js
+++ b/app/ethWallet-geth.js
@@ -25,7 +25,7 @@ const isWindows = process.platform === 'win32'
 const gethProcessKey = isWindows ? 'geth.exe' : 'geth'
 
 const ipcPath = isWindows ? '\\\\.\\pipe\\geth.ipc' : path.join(gethDataDir, 'geth.ipc')
-const pidPath = isWindows ? '\\\\.\\pipe\\geth.pid' : path.join(gethDataDir, 'geth.pid')
+const pidPath = path.join(gethDataDir, 'geth.pid')
 const pwPath = path.join(gethDataDir, 'wallets.pw')
 const gethProcessPath = path.join(getExtensionsPath('bin'), gethProcessKey)
 
@@ -185,9 +185,9 @@ const cleanupGethAndExit = (exitCode) => {
 }
 
 const cleanupGeth = (processId) => {
-  processId = processId || gethProcessId
+  processId = (processId || gethProcessId) || (geth && geth.pid)
 
-  if (!processId) return console.warn('GET: nothing to cleanup')
+  if (!processId) return console.warn('GETH: nothing to cleanup')
 
   // Set geth to null to remove bound listeners
   // Otherwise, geth will attempt to restart itself


### PR DESCRIPTION
Fixes: #15031

`geth.pid` does not need to be a named pipe

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


