### PR TITLE
Move static-nodes.json write location

### DIFF
--- a/app/ethWallet-geth.js
+++ b/app/ethWallet-geth.js
@@ -30,7 +30,7 @@ const pwPath = path.join(gethDataDir, 'wallets.pw')
 const gethProcessPath = path.join(getExtensionsPath('bin'), gethProcessKey)
 
 const configurePeers = async (dataDir) => {
-  const staticNodePath = path.join(dataDir, 'geth', 'static-nodes.json')
+  const staticNodePath = path.join(dataDir, 'static-nodes.json')
   try {
     const discoveryDomain = `_enode._tcp.${envNet}.${envSubDomain}.brave.com`
     let newNodes = await dns.resolveSrv(discoveryDomain)


### PR DESCRIPTION
This commit moves the static-nodes.json file from being written to
$DATADIR/geth/static-nodes.json to $DATADIR/static-nodes.json.

Testing from bkero and kjowiak confirmed that the file is actually read
from $DATADIR/

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


