### PR TITLE
eth-wallet: 'enable brave payments' notice

### DIFF
--- a/app/ethWallet-geth.js
+++ b/app/ethWallet-geth.js
@@ -377,6 +377,14 @@ ipcMain.on('eth-wallet-get-compare-password-hash', (e, str, hash) => {
   })
 })
 
+ipcMain.on('eth-wallet-enable-brave-payments', (e) => {
+  appDispatcher.dispatch({
+    actionType: appConstants.APP_CHANGE_SETTING,
+    key: settings.PAYMENTS_ENABLED,
+    value: true
+  })
+})
+
 const launchGeth = async function () {
   await spawnGeth()
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10839,9 +10839,9 @@
       }
     },
     "meteor-dapp-wallet-prebuilt": {
-      "version": "0.2.31",
-      "resolved": "https://registry.npmjs.org/meteor-dapp-wallet-prebuilt/-/meteor-dapp-wallet-prebuilt-0.2.31.tgz",
-      "integrity": "sha512-NFbNkz5XpdG/96tap0Zf0FQaeTkUd0oQ/tI2JuYOB7P5sZZUJwRo5NoDzN78Ul2f52fUmtxpPxUZMzKijOITmA==",
+      "version": "0.2.32",
+      "resolved": "https://registry.npmjs.org/meteor-dapp-wallet-prebuilt/-/meteor-dapp-wallet-prebuilt-0.2.32.tgz",
+      "integrity": "sha512-kKAbuZAE0hqPFIzY7YtDFcEb4rH/Do/D8xGStmr+JpibNuIFg4s7XwFNgtLxxNt5Mm/VOKjmj+MNAx4ZIat/8w==",
       "dev": true
     },
     "methods": {

--- a/package.json
+++ b/package.json
@@ -187,7 +187,7 @@
     "less": "^2.5.3",
     "less-loader": "^2.2.1",
     "lolex": "~1.3.2",
-    "meteor-dapp-wallet-prebuilt": "0.2.31",
+    "meteor-dapp-wallet-prebuilt": "0.2.32",
     "mkdirp": "^0.5.1",
     "mocha": "^2.3.4",
     "mockery": "^2.1.0",


### PR DESCRIPTION
This issue creates UI to enable Brave Payments from Eth-wallet. Also has UI improvements for the following issues:

- "Enable brave payments" UI when "fund brave wallet" is clicked but payments are not enabled (no open issue for this)
- Removed contracts functionality from UI #14982
- Make "fund brave wallet" button work even if you are already on a send screen #14958
- Progress bar is force updated every 2s #14855
- UI is not rendered until the password prompt is shown #14827