### PR TITLE
Don't consider openableByContextMenu if URL is falsey

### DIFF
--- a/app/browser/reducers/tabsReducer.js
+++ b/app/browser/reducers/tabsReducer.js
@@ -250,8 +250,8 @@ const tabsReducer = (state, action, immutableAction) => {
         windows.focus(windowId)
       }
       const url = action.getIn(['createProperties', 'url'])
-      if (!openableByContextMenu(url) ||
-        (isFileScheme(url) && !action.get('allowFile'))) {
+      if (url && (!openableByContextMenu(url) ||
+        (isFileScheme(url) && !action.get('allowFile')))) {
         // Don't allow 'open in new tab' to open file:// URLs for security
         action = action.setIn(['createProperties', 'url'], 'about:blank')
       }


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/15057

Auditors: @diracdeltas

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


