### PR TITLE
Allow `view-source` as openable by context menu

### DIFF
--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -442,7 +442,7 @@ const UrlUtil = {
     const protocol = urlParse(url).protocol
     // file: is untrusted but handled in a separate check
     return ['http:', 'https:', 'ws:', 'wss:', 'magnet:', 'file:', 'data:',
-      'blob:', 'about:', 'chrome-extension:'].includes(protocol)
+      'blob:', 'about:', 'chrome-extension:', 'view-source:'].includes(protocol)
   },
 
   /**


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/15075

Auditors: @diracdeltas

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
1. Visit https://brave.com
2. Right click the page, pick `View Page Source`.  Ensure page source comes up. Close it
3. Manually type a view source URL into URL bar: `view-source:https://clifton.io`. Ensure page source comes up. Close it
4. Make a new bookmark for `view-source:https://brianbondy.com/` and launch the bookmark. Ensure page source comes up 


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


