### PR TITLE
Update channel so link doesn't break on non-dev

### DIFF
--- a/js/about/brave.js
+++ b/js/about/brave.js
@@ -61,7 +61,7 @@ class AboutBrave extends React.Component {
           <span data-l10n-id='relNotesInfo1' />
           &nbsp;
           <a className={css(commonStyles.linkText)}
-            href={`https://github.com/brave/browser-laptop/releases/tag/v${this.state.versionInformation.get('Brave')}dev`}
+            href={`https://github.com/brave/browser-laptop/releases/tag/v${this.state.versionInformation.get('Brave')}${this.state.versionInformation.get('Update Channel')}`}
             data-l10n-id='relNotesInfo2'
             rel='noopener' target='_blank'
           />


### PR DESCRIPTION
The link in the about section for release notes breaks in the beta version.

![screenshot from 2018-09-04 16-21-38](https://user-images.githubusercontent.com/9503662/45055716-a5361700-b05e-11e8-9de6-44e48249f750.png)

Just need to add channel to the end, not sure if formatted channel is the same.

Not able to test change because when running from source all I get is white screen on Ubuntu 16.04.