### PR TITLE
Allow for assigning of default search engine based on country

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,7 +1,7 @@
 runtime = electron
 target_arch = x64
-brave_electron_version = 8.0.9
+brave_electron_version = 8.0.10
 chromedriver_version = 2.38
-target = v8.0.9
+target = v8.0.10
 disturl=https://brave-laptop-binaries.s3.amazonaws.com/atom-shell/dist/
 build_from_source = true

--- a/app/browser/reducers/aboutNewTabReducer.js
+++ b/app/browser/reducers/aboutNewTabReducer.js
@@ -13,11 +13,17 @@ const { calculateTopSites } = require('../api/topSites')
 const aboutNewTabReducer = (state, action) => {
   switch (action.actionType) {
     case appConstants.APP_SET_STATE:
+      // only show private search engine override options if needed
+      // (ex: not shown if a region specific default is provided)
       const useAlternativePrivateSearchEngine = getSetting(settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE, state.get('settings'))
-      state = aboutNewTabState.mergeDetails(state, {
-        newTabPageDetail: {
+      let newTabPageDetail = {}
+      if (getSetting(settings.SHOW_ALTERNATIVE_PRIVATE_SEARCH_ENGINE, state.get('settings'))) {
+        newTabPageDetail = {
           useAlternativePrivateSearchEngine
         }
+      }
+      state = aboutNewTabState.mergeDetails(state, {
+        newTabPageDetail: newTabPageDetail
       })
       break
     case appConstants.APP_TOP_SITE_DATA_AVAILABLE:

--- a/app/browser/reducers/aboutNewTabReducer.js
+++ b/app/browser/reducers/aboutNewTabReducer.js
@@ -36,11 +36,25 @@ const aboutNewTabReducer = (state, action) => {
       }
       break
     case appConstants.APP_CHANGE_SETTING:
-      if (action.key === settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE) {
-        state = aboutNewTabState.mergeDetails(state, {
-          newTabPageDetail: {
-            useAlternativePrivateSearchEngine: action.value
+      if (action.key === settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE ||
+          action.key === settings.SHOW_ALTERNATIVE_PRIVATE_SEARCH_ENGINE) {
+        const showAlternativePrivateSearchEngines = action.key === settings.SHOW_ALTERNATIVE_PRIVATE_SEARCH_ENGINE
+          ? action.value
+          : getSetting(settings.SHOW_ALTERNATIVE_PRIVATE_SEARCH_ENGINE, state.get('settings'))
+
+        const useAlternativePrivateSearchEngine = action.key === settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE
+          ? action.value
+          : getSetting(settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE, state.get('settings'))
+
+        let newTabPageDetail = {}
+        if (showAlternativePrivateSearchEngines) {
+          newTabPageDetail = {
+            useAlternativePrivateSearchEngine
           }
+        }
+
+        state = aboutNewTabState.mergeDetails(state, {
+          newTabPageDetail: newTabPageDetail
         })
       }
   }

--- a/app/renderer/reducers/urlBarReducer.js
+++ b/app/renderer/reducers/urlBarReducer.js
@@ -43,7 +43,11 @@ const updateSearchEngineInfoFromInput = (state, frameProps) => {
     if (frameProps.get('isPrivate')) {
       // handle private tab search with default search provider
       const useAlternateDefaultPrivateSearchProvider =
-        getSetting(isTor(frameProps) ? settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE_TOR : settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE)
+        getSetting(settings.SHOW_ALTERNATIVE_PRIVATE_SEARCH_ENGINE)
+          ? getSetting(isTor(frameProps)
+            ? settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE_TOR
+            : settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE)
+          : false
       if (useAlternateDefaultPrivateSearchProvider === true) {
         // DuckDuckGo hard-coded as Private Tab default provider
         // if asked to use a privacy-centric 'alternative'

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -1020,6 +1020,7 @@ const getCanonicalCountryName = () => {
   const countryName = app.getCountryName()
   switch (countryName) {
     case 'US':
+    case 'Vereinigte Staaten':
     case 'en_US.UTF-8':
     case 'es_US.UTF-8':
       return 'USA'

--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -1017,7 +1017,7 @@ module.exports.runImportDefaultSettings = (data) => {
 }
 
 const getCanonicalCountryName = () => {
-  const countryName = app.getCountryName()
+  const countryName = (app.getCountryName() || '').replace(/\0/g, '')
   switch (countryName) {
     case 'US':
     case 'Vereinigte Staaten':

--- a/js/about/newprivatetab.js
+++ b/js/about/newprivatetab.js
@@ -82,6 +82,7 @@ class NewPrivateTab extends React.Component {
           }
           {
             isTor &&
+            this.props.newTabData.hasIn(useAlternativePrivateSearchEngineDataKeys) &&
             <div className={css(styles.privateSearch)}>
               <div className={css(styles.privateSearch__setting)}>
                 <p>

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -277,6 +277,7 @@ class SearchTab extends ImmutableComponent {
   }
 
   hoverCallback (rows) {
+    this.props.onChangeSetting(settings.SHOW_ALTERNATIVE_PRIVATE_SEARCH_ENGINE, true)
     this.props.onChangeSetting(settings.DEFAULT_SEARCH_ENGINE, rows[1].value)
   }
 
@@ -289,11 +290,15 @@ class SearchTab extends ImmutableComponent {
         onClick={this.hoverCallback.bind(this)}
         tableClassNames={css(styles.sortableTable_searchTab)}
       />
-      <SettingsList>
-        <DefaultSectionTitle data-l10n-id='privateTabsSearchSettingsTitle' />
-        <SettingCheckbox dataL10nId='useDuckDuckGoForPrivateSearch' prefKey={settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
-        <SettingCheckbox dataL10nId='useDuckDuckGoForPrivateSearchTor' prefKey={settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE_TOR} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
-      </SettingsList>
+      {
+        getSetting(settings.SHOW_ALTERNATIVE_PRIVATE_SEARCH_ENGINE, this.props.settings)
+        ? <SettingsList>
+          <DefaultSectionTitle data-l10n-id='privateTabsSearchSettingsTitle' />
+          <SettingCheckbox dataL10nId='useDuckDuckGoForPrivateSearch' prefKey={settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
+          <SettingCheckbox dataL10nId='useDuckDuckGoForPrivateSearchTor' prefKey={settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE_TOR} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />
+        </SettingsList>
+        : null
+      }
       <DefaultSectionTitle data-l10n-id='locationBarSettings' />
       <SettingsList>
         <SettingCheckbox dataL10nId='showOpenedTabMatches' prefKey={settings.OPENED_TAB_SUGGESTIONS} settings={this.props.settings} onChangeSetting={this.props.onChangeSetting} />

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -277,7 +277,9 @@ class SearchTab extends ImmutableComponent {
   }
 
   hoverCallback (rows) {
-    this.props.onChangeSetting(settings.SHOW_ALTERNATIVE_PRIVATE_SEARCH_ENGINE, true)
+    if (!getSetting(settings.SHOW_ALTERNATIVE_PRIVATE_SEARCH_ENGINE, this.props.settings)) {
+      this.props.onChangeSetting(settings.SHOW_ALTERNATIVE_PRIVATE_SEARCH_ENGINE, true)
+    }
     this.props.onChangeSetting(settings.DEFAULT_SEARCH_ENGINE, rows[1].value)
   }
 

--- a/js/constants/appConfig.js
+++ b/js/constants/appConfig.js
@@ -155,6 +155,7 @@ module.exports = {
     'general.spellcheck-languages': Immutable.fromJS(['en-US']),
     'search.default-search-engine': null,
     'search.offer-search-suggestions': false, // false by default for privacy reasons
+    'search.show-alternate-private-search-engine': true,
     'search.use-alternate-private-search-engine': false,
     'search.use-alternate-private-search-engine-tor': true,
     'tabs.switch-to-new-tabs': false,

--- a/js/constants/config.js
+++ b/js/constants/config.js
@@ -42,12 +42,12 @@ module.exports = {
     defaultSearchSuggestions: false,
     maxHistorySites: 10
   },
-  // NOTE: names here correspond to `name` field in:
+  // NOTE: values here correspond to `name` field in:
   // js/data/searchProviders.js
-  defaultSearchEngineByLocale: {
+  defaultSearchEngineByCountry: {
     // Example entries look like this:
-    // 'en-US': 'GitHub',
-    // 'es-MX': 'YouTube',
+    // 'Germany': 'YouTube',
+    // 'France': 'GitHub',
     'default': 'Google'
   },
   defaultOpenSearchPath: 'content/search/google.xml',

--- a/js/constants/settings.js
+++ b/js/constants/settings.js
@@ -22,6 +22,7 @@ const settings = {
   SPELLCHECK_LANGUAGES: 'general.spellcheck-languages',
   // Search tab
   DEFAULT_SEARCH_ENGINE: 'search.default-search-engine',
+  SHOW_ALTERNATIVE_PRIVATE_SEARCH_ENGINE: 'search.show-alternate-private-search-engine',
   USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE: 'search.use-alternate-private-search-engine',
   USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE_TOR: 'search.use-alternate-private-search-engine-tor',
   OFFER_SEARCH_SUGGESTIONS: 'search.offer-search-suggestions',

--- a/js/contextMenus.js
+++ b/js/contextMenus.js
@@ -51,8 +51,11 @@ const isLinux = platformUtil.isLinux()
  */
 const getSearchUrl = (activeFrame, searchTerms) => {
   const searchUrl = (
-    (getSetting(settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE_TOR) && frameStateUtil.isTor(activeFrame)) ||
-    (getSetting(settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE) && activeFrame.get('isPrivate'))
+    getSetting(settings.SHOW_ALTERNATIVE_PRIVATE_SEARCH_ENGINE) &&
+    (
+      (getSetting(settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE_TOR) && frameStateUtil.isTor(activeFrame)) ||
+      (getSetting(settings.USE_ALTERNATIVE_PRIVATE_SEARCH_ENGINE) && activeFrame.get('isPrivate'))
+    )
   )
   ? 'https://duckduckgo.com/?q={searchTerms}'
   : appStoreRenderer.state.getIn(['searchDetail', 'searchURL'])

--- a/js/settings.js
+++ b/js/settings.js
@@ -62,7 +62,7 @@ const getDefaultSetting = (settingKey, settingsCollection) => {
       return contributionDefaultAmount(settingKey, settingsCollection)
     // >> locale is intialized (which determines default search engine)
     case settings.DEFAULT_SEARCH_ENGINE:
-      return config.defaultSearchEngineByLocale.default
+      return config.defaultSearchEngineByCountry.default
   }
   return undefined
 }

--- a/test/unit/app/browser/reducers/aboutNewTabsReducerTest.js
+++ b/test/unit/app/browser/reducers/aboutNewTabsReducerTest.js
@@ -47,7 +47,7 @@ describe('aboutNewTabReducerTest', function () {
   })
 
   describe('useAlternativePrivateSearchEngine', function () {
-    const initialState = Immutable.fromJS({
+    let initialState = Immutable.fromJS({
       settings: { },
       about: {
         newtab: { pinnedTopSites: [] }

--- a/test/unit/app/sessionStoreTest.js
+++ b/test/unit/app/sessionStoreTest.js
@@ -69,7 +69,7 @@ describe('sessionStore unit tests', function () {
     }
   }
   const fakeConfig = {
-    defaultSearchEngineByLocale: {
+    defaultSearchEngineByCountry: {
       default: 'MetaCrawler'
     }
   }
@@ -1987,26 +1987,26 @@ describe('sessionStore unit tests', function () {
   })
 
   describe('setDefaultSearchEngine', function () {
-    let getDefaultLocaleSpy
+    let getCountryNameSpy
 
     beforeEach(function () {
-      getDefaultLocaleSpy = sinon.spy(fakeLocale, 'getDefaultLocale')
+      getCountryNameSpy = sinon.spy(fakeElectron.app, 'getCountryName')
     })
 
     afterEach(function () {
-      getDefaultLocaleSpy.restore()
-      if (fakeConfig.defaultSearchEngineByLocale['en-US']) {
-        delete fakeConfig.defaultSearchEngineByLocale['en-US']
+      getCountryNameSpy.restore()
+      if (fakeConfig.defaultSearchEngineByCountry['USA']) {
+        delete fakeConfig.defaultSearchEngineByCountry['USA']
       }
-      if (!fakeConfig.defaultSearchEngineByLocale.default) {
-        fakeConfig.defaultSearchEngineByLocale.default = 'MetaCrawler'
+      if (!fakeConfig.defaultSearchEngineByCountry.default) {
+        fakeConfig.defaultSearchEngineByCountry.default = 'MetaCrawler'
       }
     })
 
-    it('calls getDefaultLocale with true', function () {
+    it('calls app.getCountryName', function () {
       const input = Immutable.fromJS({settings: {}})
       sessionStore.setDefaultSearchEngine(input)
-      assert(getDefaultLocaleSpy.calledOnce)
+      assert(getCountryNameSpy.calledOnce)
     })
 
     it('defaults to `default` entry', function () {
@@ -2016,14 +2016,14 @@ describe('sessionStore unit tests', function () {
     })
 
     it('matches a locale specific entry (if present)', function () {
-      fakeConfig.defaultSearchEngineByLocale['en-US'] = 'Yahoo'
+      fakeConfig.defaultSearchEngineByCountry['USA'] = 'Yahoo'
       const input = Immutable.fromJS({settings: {}})
       const output = sessionStore.setDefaultSearchEngine(input)
       assert.equal(output.getIn(['settings', settings.DEFAULT_SEARCH_ENGINE]), 'Yahoo')
     })
 
     it('does not change input if there is no default in config', function () {
-      delete fakeConfig.defaultSearchEngineByLocale.default
+      delete fakeConfig.defaultSearchEngineByCountry.default
       const input = Immutable.fromJS({settings: {}})
       const output = sessionStore.setDefaultSearchEngine(input)
       assert.deepEqual(input, output)

--- a/test/unit/lib/fakeElectron.js
+++ b/test/unit/lib/fakeElectron.js
@@ -45,6 +45,7 @@ const fakeElectron = {
     getPath: (param) => `${process.cwd()}/${param}`,
     getVersion: () => '0.14.0',
     setLocale: (locale) => {},
+    getCountryName: () => { return 'US' },
     quit: () => {},
     exit: () => {}
   }),

--- a/tools/cibuild.py
+++ b/tools/cibuild.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import sys
 import os.path
-MUON_VERSION = '8.0.9'
+MUON_VERSION = '8.0.10'
 CHROMEDRIVER_VERSION = '2.38'
 SOURCE_ROOT = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 TARGET_ARCH= os.environ['TARGET_ARCH'] if os.environ.has_key('TARGET_ARCH') else 'x64'


### PR DESCRIPTION
Fixes https://github.com/brave/browser-laptop/issues/14647

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:
(perform steps on Windows, macOS, and Linux)

### Changing the country
#### macOS
Settings > Language & Region
![screen shot 2018-09-05 at 8 58 25 am](https://user-images.githubusercontent.com/4733304/45105834-0bb44700-b0ea-11e8-9ea7-5128e40462a3.png)

#### Windows
- Open up settings (on Windows 10, click the notifications icon in bottom right and then pick `All settings`)
- Pick "Time & Language"
- Pick "Region & Language"
![settings](https://user-images.githubusercontent.com/4733304/45106010-74032880-b0ea-11e8-8668-b8ecf4e8ace9.gif)

You'll also need to go into Control Panel > Region and set the `Format` 
![screen shot 2018-09-06 at 1 36 11 pm](https://user-images.githubusercontent.com/4733304/45183854-1fd77180-b1da-11e8-98f0-ed4a8a191bee.png)


#### Linux
- Push the Windows key and search for region (or language)
- Pick `Language Support`
![screen shot 2018-09-05 at 9 10 20 am](https://user-images.githubusercontent.com/4733304/45106594-e7f20080-b0eb-11e8-92ff-680a38089842.png)

- Install other languages as needed
- Pick the appropriate language (all choices should show country)
![screen shot 2018-09-05 at 9 10 57 am](https://user-images.githubusercontent.com/4733304/45106630-fb9d6700-b0eb-11e8-91de-7f6451c5e67d.png)

- reboot for changes to take effect


### Setup
1. Check out source code; do a fresh rebuild
2. Either Delete or move out of the way your `brave-development` profile directory
3. Uncomment these two lines: https://github.com/bsclifton/browser-laptop/blob/222c500977f77a6de63eaa587c4cc11f5d820505/js/constants/config.js#L48-L49

### Test default (new install - country doesn't match any config entry)
1. Delete your `brave-development` profile directory
2. Set your country to `USA`
3. Launch browser (`npm run watch` / `npm start`)
4. Verify default search is Google
5. Open a new PRIVATE tab and ensure `DuckDuckGo` option DOES show on private tab. Try a search and verify it uses the proper engine
5. Open a new PRIVATE TOR tab and ensure `DuckDuckGo` DOES show (is mentioned). Try a search and verify it uses the proper engine
7. Go to about:preferences#search
8. Verify your default search engine is Google
9. Verify the "Private tab" options show up on the page
10. Exit Brave
11. Set your country back to original setting

### Test country matches a config entry (new install)
1. Delete your `brave-development` profile directory
2. Set your country as `France`
3. Re-launch browser
4. Verify default search is GitHub
5. Open a new PRIVATE tab and ensure `DuckDuckGo` option DOES NOT show on private tab. Try a search and verify it uses the proper engine
6. Open a new PRIVATE TOR tab and ensure `DuckDuckGo` DOES NOT show (is NOT mentioned). Try a search and verify it uses the proper engine
7. Go to about:preferences#search
8. Verify your default search engine is GitHub
9. Verify the "Private tab" options DO NOT show up on the page
10. Change your default to Google
11. Verify that "Private tab" options DO show up
12. Exit Brave
13. Set your country back to original setting

### Ensure default not changed for existing profile
1. Delete your `brave-development` profile directory
2. Set your country as `USA`
3. Launch browser
4. Verify default search is `Google`
5. Exit Brave
6. Set your country as `France`
7. Re-launch brave
8. Ensure default search engine is still `Google` (no change made)
9. Exit Brave
10. Set your country back to original setting

## Reviewer Checklist:

- [x] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


