### PR TITLE
Fix about:blank appearing on new tab in new windows

### DIFF
--- a/js/lib/urlutil.js
+++ b/js/lib/urlutil.js
@@ -437,7 +437,7 @@ const UrlUtil = {
    */
   openableByContextMenu: function (url) {
     if (!url) {
-      return false
+      return true
     }
     const protocol = urlParse(url).protocol
     // file: is untrusted but handled in a separate check

--- a/test/unit/lib/urlutilTestComponents.js
+++ b/test/unit/lib/urlutilTestComponents.js
@@ -359,6 +359,9 @@ module.exports = {
       },
       'is about:blank': (test) => {
         test.equal(urlUtil().openableByContextMenu('about:blank'), true)
+      },
+      'is empty': (test) => {
+        test.equal(urlUtil().openableByContextMenu(), true)
       }
     },
     'returns false when input:': {
@@ -367,9 +370,6 @@ module.exports = {
       },
       'is ssh:': (test) => {
         test.equal(urlUtil().openableByContextMenu('ssh://test@127.0.0.1'), false)
-      },
-      'is null': (test) => {
-        test.equal(urlUtil().openableByContextMenu(null), false)
       }
     }
   },


### PR DESCRIPTION
fix https://github.com/brave/browser-laptop/issues/15162

openableByContextMenu returned false if URL is empty for paranoia
reasons, but it turns out this breaks some edge cases. See
https://github.com/brave/browser-laptop/pull/15061 for instance.

Test Plan:
1. unit tests pass
2. on MacOS, close all windows
3. click 'New tab'
4. new window should appear and show the new tab page
5. repeat step 3 and 4 with private tab, tor tab, session tab, and new window

## Submitter Checklist:

- [x] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [x] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [x] Added/updated tests for this change (for new code or code which already has tests).
- [x] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [x] Adequate test coverage exists to prevent regressions
- [x] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [x] New files have MPL2 license header


