### PR TITLE
Add preparation for upcoming Ubuntu 18.10 Cosmic Cuttlefish and other cleanups of the apt install

### DIFF
--- a/tools/upload_to_aptly
+++ b/tools/upload_to_aptly
@@ -7,7 +7,7 @@ GPG_KEY=${2:-4A1B4360}
 KEY_NAME=keys.asc
 KEY_FILE=/tmp/${KEY_NAME}
 SNAP_TAG=`date +'%s'`
-DIST='artful zesty yakkety xenial jessie trusty serena stretch bionic'
+DIST='artful zesty yakkety xenial jessie trusty serena stretch bionic cosmic'
 
 cat <<EOF > $HOME/.aptly.conf
 { "rootDir": "$HOME/.aptly",

--- a/tools/upload_to_aptly
+++ b/tools/upload_to_aptly
@@ -7,7 +7,7 @@ GPG_KEY=${2:-4A1B4360}
 KEY_NAME=keys.asc
 KEY_FILE=/tmp/${KEY_NAME}
 SNAP_TAG=`date +'%s'`
-DIST='artful zesty yakkety xenial jessie trusty serena stretch bionic cosmic'
+DIST='trusty xenial bionic cosmic jessie stretch buster serena'
 
 cat <<EOF > $HOME/.aptly.conf
 { "rootDir": "$HOME/.aptly",


### PR DESCRIPTION
This PR removes all the old Ubuntu releases that are unmaintained and don't get any security updates, adds support for Ubuntu Cosmic and organizes the list a bit better. Brave had a rocky start when 18.04 was released so this should hopefully make Brave work on the new version from day one! 

## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [x] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:

I can't test this since it requires Brave to be built for Apt, but please give it a shot if you can 👍
I am willing to spin up a WM and test installing this on Cosmic CUttlefish when merged...

1. Have a channel ready for build (ex: beta)
2. Connect to our signator box and unlock the GPG key
3. Login to Jenkins and run the `browser-laptop-release-linux` job
  - if we wanted to test before accepting this PR, we can modify that job to checkout from this branch
4. After it finishes, have an Ubuntu 18.10 [Daily Build](http://cdimage.ubuntu.com/daily-live/current/HEADER.html) VM ready 
5. [Follow instructions here](https://github.com/brave/browser-laptop/blob/master/docs/linuxInstall.md)
6. Brave should install

