### PR TITLE
Merge pull request #14715 from brave/riastradh-tor-blocktorlessonion

### DIFF
--- a/app/extensions/brave/locales/en-US/app.properties
+++ b/app/extensions/brave/locales/en-US/app.properties
@@ -238,6 +238,7 @@ submit=Submit
 tabsSuggestionTitle=Tabs
 topSiteSuggestionTitle=Top Site
 urlBlockedInTor=For your privacy, Brave blocks this URL from loading in a private tab when Tor is enabled.
+urlBlockedOutsideTor=For your privacy, Brave blocks this URL from loading in a tab without Tor.
 urlWarningOk=Ok
 torConnectionError=Unable to connect to the Tor network
 torConnectionErrorInfo=Brave could not make a connection to the Tor network. Disable Tor to continue private browsing without Tor protection.

--- a/app/locale.js
+++ b/app/locale.js
@@ -267,6 +267,7 @@ var rendererIdentifiers = function () {
     'noDownloads',
     'torrentDesc',
     'urlBlockedInTor',
+    'urlBlockedOutsideTor',
     'urlWarningOk',
     'multiSelectionBookmarks',
     // Caption buttons in titlebar (min/max/close - Windows only)


### PR DESCRIPTION
Block loading .onion sites in non-Tor tabs.

Was previously merged with https://github.com/brave/browser-laptop/pull/14715 into what is now `0.24.x-legacy`

Uplifting after talking with @riastradh-brave 