### PR TITLE
Make brave unusable to encourage updating

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -92,7 +92,6 @@ app.commandLine.appendSwitch('enable-features', 'BlockSmallPluginContent,PreferH
 // Fix https://github.com/brave/browser-laptop/issues/15337
 app.commandLine.appendSwitch('disable-databases')
 
-
 // Domains to accept bad certs for. TODO: Save the accepted cert fingerprints.
 let acceptCertDomains = {}
 let errorCerts = {}
@@ -195,7 +194,8 @@ app.on('ready', () => {
 
     // Do this after loading the state
     // For tests we always want to load default app state
-    const loadedPerWindowImmutableState = initialImmutableState.get('perWindowState')
+    // Disable tab restore as part of the muon deprecation plan
+    const loadedPerWindowImmutableState = Immutable.List()
     initialImmutableState = initialImmutableState.delete('perWindowState')
     // Restore map order after load
     appActions.setState(initialImmutableState)

--- a/app/renderer/components/navigation/urlBar.js
+++ b/app/renderer/components/navigation/urlBar.js
@@ -41,7 +41,6 @@ const {normalizeLocation, getNormalizedSuggestion} = require('../../../common/li
 const isDarwin = require('../../../common/lib/platformUtil').isDarwin()
 const publisherUtil = require('../../../common/lib/publisherUtil')
 const historyUtil = require('../../../common/lib/historyUtil')
-const locale = require('../../../../js/l10n')
 
 // Icons
 const iconNoScript = require('../../../../img/url-bar-no-script.svg')
@@ -423,24 +422,7 @@ class UrlBar extends React.Component {
   }
 
   get placeholderValue () {
-    if (this.props.isTor) {
-      if (this.props.torError) {
-        console.log(`tor error: ${this.props.torError}`)
-        return `${locale.translation('torConnectionError')}.`
-      } else if (!this.props.torPercentInitialized ||
-                 this.props.torPercentInitialized === '0') {
-        return `${locale.translation('urlbarPlaceholderTorProgress')}...`
-      } else if (this.props.torPercentInitialized !== '100') {
-        const msg = locale.translation('urlbarPlaceholderTorProgress')
-        const percentInitialized = this.props.torPercentInitialized
-        return `${msg}: ${percentInitialized}%...`
-      } else if (!this.props.torOnline) {
-        return `${locale.translation('torConnectionError')}.`
-      } else {
-        return locale.translation('urlbarPlaceholderTorSuccess')
-      }
-    }
-    return locale.translation('urlbarPlaceholder')
+    return 'Please update to the latest version of Brave'
   }
 
   get titleValue () {
@@ -565,8 +547,7 @@ class UrlBar extends React.Component {
   }
 
   get shouldDisable () {
-    return (this.props.displayURL === undefined && this.loadTime === '') ||
-      this.torInitializing
+    return true
   }
 
   setUrlBarRef (ref) {

--- a/app/renderer/components/preferences/syncTab.js
+++ b/app/renderer/components/preferences/syncTab.js
@@ -500,9 +500,9 @@ class SyncTab extends ImmutableComponent {
             settingsListTitle: true
           })}>
             Please download the <a className={css(commonStyles.linkText)}
-            onClick={aboutActions.createTabRequested.bind(null, {
-              url: 'https://brave.com/download'
-            })}>new version of Brave for desktop</a>.
+              onClick={aboutActions.createTabRequested.bind(null, {
+                url: 'https://brave.com/download'
+              })}>new version of Brave for desktop</a>.
           </div>
           {
             this.setupError

--- a/js/about/newtab.js
+++ b/js/about/newtab.js
@@ -9,12 +9,6 @@ const {DragDropContext} = require('react-dnd')
 const HTML5Backend = require('react-dnd-html5-backend')
 
 // Components
-const Stats = require('./newTabComponents/stats')
-const Clock = require('./newTabComponents/clock')
-const Block = require('./newTabComponents/block')
-const SiteRemovalNotification = require('./newTabComponents/siteRemovalNotification')
-const FooterInfo = require('./newTabComponents/footerInfo')
-const NewPrivateTab = require('./newprivatetab')
 const BrowserButton = require('../../app/renderer/components/common/browserButton')
 
 // Constants
@@ -294,7 +288,7 @@ class NewTabPage extends React.Component {
         <div>
           <span className='note'>Note:</span>&nbsp;
           A newer version of Brave {formattedBraveCoreVersion} has already been installed.
-          This version of Brave {formattedMuonVersion} is no longer supported and will not be updated.
+          This version of Brave {formattedMuonVersion} is no longer supported and will no longer work.
         </div>
         <div style={{marginTop: '20px'}}>
           To avoid potential security risks, please move over to the latest version of the Brave Browser.
@@ -315,7 +309,7 @@ class NewTabPage extends React.Component {
 
     return <div className='deprecationNotice'>
       <div>
-        <span className='note'>Hello!</span> This version of Brave {formattedMuonVersion} is no longer supported and will not be updated.
+        <span className='note'>Hello!</span> This version of Brave {formattedMuonVersion} is no longer supported and will no longer work.
         {
           isLinux()
             ? <span>&nbsp;To avoid potential security risks, please follow these <a href='https://brave-browser.readthedocs.io/en/latest/installing-brave.html#linux'>instructions</a> to upgrade to the latest version of the Brave Browser.</span>
@@ -335,94 +329,17 @@ class NewTabPage extends React.Component {
   }
 
   render () {
-    // don't render if user prefers an empty page
-    if (this.state.showEmptyPage && !this.props.isIncognito) {
-      return <div className='empty' />
-    }
-
-    // TODO: use this.props.isIncognito when muon supports it for tor tabs
-    if (this.props.isIncognito) {
-      return <NewPrivateTab newTabData={this.state.newTabData} torEnabled={this.state.torEnabled} />
-    }
-
-    // don't render until object is found
-    if (!this.state.newTabData) {
-      return null
-    }
-    const gridLayout = this.gridLayout
     return <div data-test-id='dynamicBackground' className='dynamicBackground'>
-      {
-        this.showImages &&
-        <div
-          className={cx({
-            imageBackground: true,
-            hasLoaded: this.state.imageLoadComplete
-          }
-        )}>
-          <img
-            src={this.state.backgroundImage.source}
-            onLoad={this.onImageLoadCompleted.bind(this)}
-            onError={this.onImageLoadFailed.bind(this)}
-            data-test-id='backgroundImage' />
-        </div>
-      }
       <div className={cx({
         content: true,
         backgroundLoaded: this.state.imageLoadComplete,
         showImages: this.showImages
       })}>
         <main className='newTabDashboard'>
-          <div className='statsBar'>
-            <Stats newTabData={this.state.newTabData} />
-            <Clock />
-          </div>
-          <div className='topSitesContainer'>
-            <nav className='topSitesGrid'>
-              {
-                gridLayout.map(site => {
-                  // the removal action should be immediate
-                  // which is why the logic is set here in the component
-                  // given that newtab updates can be debounced
-                  if (this.ignoredTopSites.includes(site.get('key'))) {
-                    return
-                  }
-                  return <Block
-                    key={site.get('location')}
-                    id={site.get('key')}
-                    title={site.get('title')}
-                    href={site.get('location')}
-                    favicon={
-                      site.get('favicon') == null
-                      ? this.getLetterFromUrl(site)
-                      : <img src={site.get('favicon')} />
-                    }
-                    style={{backgroundColor: site.get('themeColor')}}
-                    onToggleBookmark={this.onToggleBookmark.bind(this, site)}
-                    onPinnedTopSite={this.onPinnedTopSite.bind(this, site.get('key'))}
-                    onIgnoredTopSite={this.onIgnoredTopSite.bind(this, site.get('key'))}
-                    onDraggedSite={this.onDraggedSite.bind(this)}
-                    isPinned={this.isPinned(site.get('key'))}
-                    isBookmarked={site.get('bookmarked')}
-                  />
-                })
-              }
-            </nav>
-
-            <div>
-              {this.getDeprecatedText()}
-            </div>
+          <div>
+            {this.getDeprecatedText()}
           </div>
         </main>
-        {
-          this.state.showNotification
-            ? <SiteRemovalNotification
-              onUndoIgnoredTopSite={this.onUndoIgnoredTopSite.bind(this)}
-              onRestoreAll={this.onRestoreAll.bind(this)}
-              onCloseNotification={this.hideSiteRemovalNotification.bind(this)}
-              />
-            : null
-        }
-        <FooterInfo backgroundImage={this.state.backgroundImage} />
       </div>
     </div>
   }

--- a/less/about/newtab.less
+++ b/less/about/newtab.less
@@ -20,7 +20,25 @@
 strong, div, span, li, em, p, a {
   font-family: inherit;
   font-weight: inherit;
+  color: white;
   -webkit-font-smoothing: antialiased; // light text on dark backgrounds on macOS looks better with this
+}
+
+.deprecationNotice {
+  margin-top: 20px;
+  display: inline-block;
+  padding: 20px;
+  text-align: left;
+
+  .note {
+    color: @braveOrange;
+  }
+
+  a {
+    color: @braveOrange;
+    text-decoration: underline;
+    cursor: pointer;
+  }
 }
 
 .newTabDashboard
@@ -245,28 +263,6 @@ ul {
             visibility: hidden;
           }
         }
-      }
-    }
-
-    .deprecationNotice {
-      border-radius: @borderRadius;
-      box-shadow: 2px 2px 6px rgba(0,0,0,0.5);
-      background-color: #fff;
-      margin-top: 20px;
-      max-width: 505px;
-      width: 100%;
-      display: inline-block;
-      padding: 20px;
-      text-align: left;
-
-      .note {
-        color: @braveOrange;
-      }
-
-      a {
-        color: @braveOrange;
-        text-decoration: underline;
-        cursor: pointer;
       }
     }
   }


### PR DESCRIPTION
This PR replaces the newtab page with the notice to update Brave and
makes the urlbar unusable.

Test plan:
1. Launch Brave without brave-core installed
2. You should see a notice to update brave.
3. Clicking on it should download Brave.
4. The urlbar should not be usable.
5. With brave-core now installed, launch the old Brave again.
6. Now you should see a notice to launch the newer Brave installation.
7. The urlbar should still be unusable.

Test plan for disabling tab restoration:
1. Open previous version of muon brave and open some tabs/windows
2. Update to this version
3. You should not see any of your tabs/windows restored

Screenshot:
<img width="1057" alt="Screen Shot 2019-03-28 at 4 23 38 PM" src="https://user-images.githubusercontent.com/549654/55199144-3e9d5580-5176-11e9-98eb-e300a888e021.png">



## Submitter Checklist:

- [ ] Submitted a [ticket](https://github.com/brave/browser-laptop/issues) for my issue if one did not already exist.
- [ ] Used Github [auto-closing keywords](https://help.github.com/articles/closing-issues-via-commit-messages/) in the commit message.
- [ ] Added/updated tests for this change (for new code or code which already has tests).
- [ ] Ran `git rebase -i` to squash commits (if needed).
- [ ] Tagged reviewers and labelled the pull request [as needed](https://github.com/brave/browser-laptop/wiki/Pull-request-process).
- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review). (Ask a Brave employee to help if you cannot access this document.)

## Test Plan:


## Reviewer Checklist:

- [ ] Request a security/privacy review [as needed](https://github.com/brave/handbook/blob/master/development/security.md#how-to-request-a-security-review) if one was not already requested.

Tests


- [ ] Adequate test coverage exists to prevent regressions
- [ ] Tests should be independent and work correctly when run individually or as a suite [ref](https://github.com/brave/browser-laptop/wiki/Code-Guidelines#test-dependencies)
- [ ] New files have MPL2 license header


