### PR TITLE
Force new tab page to show the "dashboard" (which has the deprecation…

### DIFF
--- a/app/sessionStore.js
+++ b/app/sessionStore.js
@@ -48,6 +48,7 @@ const {isImmutable, makeImmutable, deleteImmutablePaths} = require('./common/sta
 const {getSetting} = require('../js/settings')
 const platformUtil = require('./common/lib/platformUtil')
 const historyUtil = require('./common/lib/historyUtil')
+const {newTabMode} = require('./common/constants/settingsEnums')
 
 const sessionStorageVersion = 1
 const sessionStorageName = `session-store-${sessionStorageVersion}`
@@ -693,6 +694,10 @@ module.exports.runPreMigrations = (data) => {
       data.settings[settings.PAYMENTS_NOTIFICATION_TRY_PAYMENTS_DISMISSED] = data.settings['payments.notificationTryPaymentsDismissed']
       delete data.settings['payments.notificationTryPaymentsDismissed']
     }
+
+    // force NEWTAB_MODE to be dashboard so folks can see deprecation notice
+    // preference is also disabled (see js/about/preferences.js)
+    data.settings[settings.NEWTAB_MODE] = newTabMode.NEW_TAB_PAGE
   }
 
   if (data.sites) {

--- a/js/about/preferences.js
+++ b/js/about/preferences.js
@@ -139,6 +139,7 @@ class GeneralTab extends ImmutableComponent {
         </SettingItem>
         <SettingItem dataL10nId='newTabMode'>
           <SettingDropdown value={getSetting(settings.NEWTAB_MODE, this.props.settings)}
+            disabled
             onChange={changeSetting.bind(null, this.props.onChangeSetting, settings.NEWTAB_MODE)} >
             <option data-l10n-id='newTabNewTabPage' value={newTabMode.NEW_TAB_PAGE} />
             <option data-l10n-id='newTabHomePage' value={newTabMode.HOMEPAGE} />


### PR DESCRIPTION
Addresses feedback by @LaurenWags:
https://bravesoftware.slack.com/archives/C0YL5KMA8/p1554929296100800

This change was already in 0.26.0; I just pulled it into this branch and then tested 😄 