### PR TITLE
Obsoletion UX: Do not open an OS-provided URL at startup

### DIFF
--- a/app/browser/reducers/windowsReducer.js
+++ b/app/browser/reducers/windowsReducer.js
@@ -14,6 +14,7 @@ const windowConstants = require('../../../js/constants/windowConstants')
 
 // State
 const windowState = require('../../common/state/windowState')
+const {getIsObsolete} = require('../../common/state/obsoletionStateHelper')
 
 // Utils
 const windows = require('../windows')
@@ -162,6 +163,9 @@ const handleCreateWindowAction = (state, action = Immutable.Map()) => {
   const frameOpts = (action.get('frameOpts') || Immutable.Map()).toJS()
   let browserOpts = (action.get('browserOpts') || Immutable.Map()).toJS()
   let immutableWindowState = action.get('restoredState') || Immutable.Map()
+  if (frameOpts.isObsoleteAction && frameOpts.location && getIsObsolete(state)) {
+    delete frameOpts.location
+  }
   state = setDefaultWindowSize(state)
   const defaults = windowDefaults(state)
   const isMaximized = setMaximized(state, browserOpts, immutableWindowState)

--- a/app/index.js
+++ b/app/index.js
@@ -274,7 +274,8 @@ app.on('ready', () => {
 
     if (CmdLine.newWindowURL()) {
       appActions.newWindow(Immutable.fromJS({
-        location: CmdLine.newWindowURL()
+        location: CmdLine.newWindowURL(),
+        isObsoleteAction: true
       }))
     }
 


### PR DESCRIPTION
Fixes issue raised in comment at https://github.com/brave/browser-laptop/pull/15349#issuecomment-481884322

Note that the following unit test errors were received:

```
  2758 passing (12s)
  60 pending
  5 failing

  1) ledger api unit tests
       when timing does not need to be checked
         initialize
           calls notifications.init:

      AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  it('doesn\'t check for verified publisher updates when payments are disabled', function () {
   ledgerApi.initialize(defaultAppState, false)
   assert(checkPublisherInfoUpdateSpy.notCalled)
  })

      + expected - actual

      -false
      +true

      at Context.<anonymous> (test/unit/app/browser/api/ledgerTest.js:258:9)

  2) ledger api unit tests
       observeTransactions
         show notification (first transaction in the array):

      AssertionError [ERR_ASSERTION]: false == true
      + expected - actual

      -false
      +true

      at Context.<anonymous> (test/unit/app/browser/api/ledgerTest.js:1182:7)

  3) ledger api unit tests
       onPromotionResponse
         execute:

      AssertionError [ERR_ASSERTION]: false == true
      + expected - actual

      -false
      +true

      at Context.<anonymous> (test/unit/app/browser/api/ledgerTest.js:1755:7)

  4) sessionStore unit tests
       loadAppState
         merge default state with the existing one
           deep objects merge:

      AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:

  it('calls runPreMigrations', function () {
   runPreMigrationsSpy.reset()
   return sessionStore.loadAppState()
     .then(function (result) {
       assert.equal(runPreMigrationsSpy.calledOnce, true)
     }, function (result) {
       assert.ok(false, 'promise was rejected: ' + result)
     })
  })

      + expected - actual

      -false
      +true

      at /Users/petemill/Development/Brave/browser-laptop/test/unit/app/sessionStoreTest.js:1151:13

  5) sessionStore unit tests
       loadAppState
         merge default state with the existing one
           deep objects with data:

      AssertionError [ERR_ASSERTION]: false == true
      + expected - actual

      -false
      +true

      at /Users/petemill/Development/Brave/browser-laptop/test/unit/app/sessionStoreTest.js:1177:13
```

## Test Plan:
1. `npm run build-package`, or install a build with this commit in
2. Open the app and make default browser
3. Quit the app

**Test 1:** Whilst the app is still not running, click a link in an external application.
**Expected:** Brave opens without showing the link, and instead shows the NTP.

4. Make the app obsolete, either by changing system time, or by modifying session-store-1 file, e.g. `jq '.deprecatedOn = 1354411655988' ~/Library/Application\ Support/brave-nightly/session-store-1|sponge ~/Library/Application\ Support/brave-nightly/session-store-1` _replace with correct path_

**Test 2:** Whilst the app is still not running, click a link in an external application.
**Expected:** Brave opens without showing the link, and instead shows the NTP.
